### PR TITLE
Small Optimization in Secp256k1 Math

### DIFF
--- a/contracts/src/lib/Secp256k1.sol
+++ b/contracts/src/lib/Secp256k1.sol
@@ -66,7 +66,6 @@ library Secp256k1 {
         //        = λ² - (Px + Qx)
         //     Ry = (2⋅Px + Qx)⋅λ - λ³ - Py
         //        = (2⋅Px + Qx - λ²)⋅λ - Py
-        //        = (Px + (Px + Qx) - λ²)⋅λ - Py
         //        = (Px - (λ² - (Px + Qx)))⋅λ - Py
         //        = (Px - Rx)⋅λ - Py
         // Noting that `Px = Qx` for point doubling.


### PR DESCRIPTION
I stumbled upon a slightly different equasion when reading [this blog](https://paulmillr.com/posts/noble-secp256k1-fast-ecc/#public-keys) when going down the rabbit hole of FROST in TS.

IMO it not only makes the code cleaner with fewer poorly named intermediate variables, but saves a bit of gas as well.