### PR TITLE
Adjust Merkle Tree Structure for Nonces Commitments

### DIFF
--- a/contracts/test/FROSTCoordinator.t.sol
+++ b/contracts/test/FROSTCoordinator.t.sol
@@ -3,7 +3,7 @@ pragma solidity ^0.8.30;
 
 import {Test, Vm} from "@forge-std/Test.sol";
 import {Arrays} from "@oz/utils/Arrays.sol";
-import {Hashes} from "@oz/utils/cryptography/Hashes.sol";
+import {MerkleProof} from "@oz/utils/cryptography/MerkleProof.sol";
 import {Math} from "@oz/utils/math/Math.sol";
 import {CommitmentShareMerkleTree} from "@test/util/CommitmentShareMerkleTree.sol";
 import {ForgeSecp256k1} from "@test/util/ForgeSecp256k1.sol";
@@ -237,11 +237,8 @@ contract FROSTCoordinatorTest is Test {
                 n.d = ForgeSecp256k1.g(FROST.nonce(bytes32(vm.randomUint()), s[index]));
                 n.e = ForgeSecp256k1.g(FROST.nonce(bytes32(vm.randomUint()), s[index]));
                 // forge-lint: disable-next-line(asm-keccak256)
-                bytes32 digest = keccak256(abi.encode(n.d.x(), n.d.y(), n.e.x(), n.e.y()));
-                for (uint256 i = 0; i < nonceProof.length; i++) {
-                    digest = Hashes.efficientKeccak256(digest, 0);
-                }
-                commitments[index] = digest;
+                bytes32 leaf = keccak256(abi.encode(0, n.d.x(), n.d.y(), n.e.x(), n.e.y()));
+                commitments[index] = MerkleProof.processProof(nonceProof, leaf);
             }
             for (uint256 index = 1; index <= COUNT; index++) {
                 vm.prank(participants.addr(index));


### PR DESCRIPTION
We were enforcing a specific "sorted" Merkle tree structure for nonce commiments (where the offset of a signature sequence would determine the position in the Merkle tree, and our Merkle proof would used ordered hashing, meaning the left/right-ness of the node would matter).

It turns out that this is needlessly complicated, and instead we just include the offset in the leaf hash. This makes implementations easier (we have a single Merkle tree structure that we use everywhere) while still preventing the Wagner's Birthday Attack.