### PR TITLE
Fix Signatures for Partially Committed Groups

### DIFF
--- a/contracts/src/FROSTCoordinator.sol
+++ b/contracts/src/FROSTCoordinator.sol
@@ -71,6 +71,7 @@ contract FROSTCoordinator {
 
     error InvalidGroupParameters();
     error InvalidGroupCommitment();
+    error GroupNotInitialized();
     error GroupNotCommitted();
     error InvalidSecretShare();
     error InvalidMessage();
@@ -166,7 +167,8 @@ contract FROSTCoordinator {
         require(message != bytes32(0), InvalidMessage());
         Group storage group = $groups[gid];
         GroupParameters memory parameters = group.parameters;
-        require(parameters.count > 0 && parameters.pending == 0, GroupNotCommitted());
+        require(parameters.count > 0, GroupNotInitialized());
+        require(parameters.pending == 0, GroupNotCommitted());
         uint64 sequence = parameters.sequence++;
         sid = signatureId(gid, sequence);
         Signature storage signature = $signatures[sid];


### PR DESCRIPTION
Once signers have fully commited to a group (i.e. the group's public key has been successfully computed), it can be used for signing. Otherwise, it would be possible for a malicious participant to start a KeyGen ceremony, start a signing ceremony with the partially resolved group, and then "finish" the signature (i.e. make it so the contract's `signatureVerify` function does not revert) atomically, even if other participants were to add new group commitments later on (thereby changing the group key and invalidating the sigature).

This PR adds a "pending" counter that tracks the number of commitments that have happened and prevents certain operations (such as secret sharing and starting signing ceremonies) until the group is fully committed to.