### PR TITLE
Use Callback Mechanism to Stage Epochs

### DIFF
--- a/contracts/src/Consensus.sol
+++ b/contracts/src/Consensus.sol
@@ -108,7 +108,7 @@ contract Consensus is IFROSTCoordinatorCallback {
         bytes4 selector = bytes4(context);
         if (selector == this.stageEpoch.selector) {
             (uint64 proposedEpoch, uint64 rolloverAt, FROSTGroupId.T group) =
-                abi.decode(context, (uint64, uint64, FROSTGroupId.T));
+                abi.decode(context[4:], (uint64, uint64, FROSTGroupId.T));
             stageEpoch(proposedEpoch, rolloverAt, group, signature);
         } else if (selector == "sign") {
             // TODO: post safe transaction signature


### PR DESCRIPTION
With the new callback mechanism introduced in #34, we can now stage the epoch as part of the _KeyGen_ completion callback. This allows validators to only post secret shares and have the epoch rollover proposal happen automatically with the callback mechanism.

There is a placeholder "TODO" for driving Safe transaction signatures.