### PR TITLE
Support Querying Recent Transaction Attestation

### DIFF
--- a/contracts/src/libraries/FROSTSignatureId.sol
+++ b/contracts/src/libraries/FROSTSignatureId.sol
@@ -29,6 +29,10 @@ library FROSTSignatureId {
         }
     }
 
+    function isZero(T self) internal pure returns (bool result) {
+        return T.unwrap(self) == bytes32(0);
+    }
+
     /// @notice Requires that a signature ID is valid.
     function requireValid(T self) internal pure {
         require((uint256(T.unwrap(self)) << 192) != 0, InvalidSignatureId());


### PR DESCRIPTION
In line with our moto of "can use the protocol on Etherscan", this PR adds a new method for querying attestations for recent transactions. That it, it will check for attestions for a given meta transaction given the active and previous epochs (in order for the query to continue working over epoch rollover boundaries).

This makes the whole "use the protocol on Etherscan" quite convenient:

1. You execute the `proposeTransaction` call to the contract with a meta transaction
2. You wait a bit
3. You execute `getRecentAttestation` using the same transaction from step 1

I also think that it would be great to additionally provide a method for building the guard signature on the consensus contract (complete with adding the "epoch rollover signature chain"), but that is for a future PR after we've decided on how the guard will work.