### PR TITLE
Validator Sqlite KeyGen Storage

### DIFF
--- a/validator/src/consensus/storage/sqlite.test.ts
+++ b/validator/src/consensus/storage/sqlite.test.ts
@@ -10,6 +10,22 @@ const participants = [
 	{ id: 3n, address: "0x0000000000000000000000000000000000000003" },
 ] as const;
 
+const coefficients = [11n, 22n];
+const commitments = [
+	{ id: 1n, value: [g(11n), g(22n)] },
+	{ id: 2n, value: [g(33n), g(44n)] },
+	{ id: 3n, value: [g(55n), g(66n)] },
+];
+const secretShares = [
+	{ id: 1n, value: 101n },
+	{ id: 2n, value: 102n },
+	{ id: 3n, value: 103n },
+];
+
+const sortedEntries = <T>(m: Map<bigint, T>): [bigint, T][] => {
+	return [...m.entries()].sort(([a], [b]) => Number(a - b));
+};
+
 describe("sqlite", () => {
 	describe("GroupInfoStorage", () => {
 		it("should register groups with participants", () => {
@@ -86,6 +102,150 @@ describe("sqlite", () => {
 			expect(storage.knownGroups()).toEqual([groups[1]]);
 			expect(() => storage.participantId(groups[0])).toThrowError();
 			expect(() => storage.participants(groups[0])).toThrowError();
+		});
+	});
+
+	describe("KeyGenInfoStorage", () => {
+		it("should register KeyGen coefficients", () => {
+			const storage = new SqliteStorage(participants[0].address, ":memory:");
+
+			expect(() =>
+				storage.registerKeyGen(groups[0], coefficients),
+			).toThrowError();
+			expect(() => storage.coefficients(groups[0])).toThrowError();
+			expect(() => storage.encryptionKey(groups[0])).toThrowError();
+
+			storage.registerGroup(groups[0], participants, 2n);
+
+			expect(() => storage.coefficients(groups[0])).toThrowError();
+			expect(() => storage.encryptionKey(groups[0])).toThrowError();
+
+			storage.registerKeyGen(groups[0], coefficients);
+
+			expect(storage.coefficients(groups[0])).toEqual(coefficients);
+			expect(storage.encryptionKey(groups[0])).toEqual(coefficients[0]);
+
+			storage.clearKeyGen(groups[0]);
+
+			expect(() => storage.coefficients(groups[0])).toThrowError();
+			expect(() => storage.encryptionKey(groups[0])).toThrowError();
+		});
+
+		it("should register commitments", () => {
+			const storage = new SqliteStorage(participants[0].address, ":memory:");
+
+			expect(() =>
+				storage.registerCommitments(
+					groups[0],
+					commitments[1].id,
+					commitments[1].value,
+				),
+			).toThrowError();
+			expect(() =>
+				storage.commitments(groups[0], commitments[1].id),
+			).toThrowError();
+
+			storage.registerGroup(groups[0], participants, 2n);
+
+			storage.registerCommitments(
+				groups[0],
+				commitments[1].id,
+				commitments[1].value,
+			);
+
+			expect(storage.missingCommitments(groups[0])).toEqual([
+				commitments[0].id,
+				commitments[2].id,
+			]);
+			expect(storage.checkIfCommitmentsComplete(groups[0])).toBe(false);
+			expect(() =>
+				storage.registerCommitments(
+					groups[0],
+					commitments[1].id,
+					commitments[1].value,
+				),
+			).toThrowError();
+
+			storage.registerCommitments(
+				groups[0],
+				commitments[0].id,
+				commitments[0].value,
+			);
+			storage.registerCommitments(
+				groups[0],
+				commitments[2].id,
+				commitments[2].value,
+			);
+
+			expect(storage.missingCommitments(groups[0])).toEqual([]);
+			expect(storage.checkIfCommitmentsComplete(groups[0])).toBe(true);
+
+			for (const { id, value } of commitments) {
+				expect(storage.commitments(groups[0], id)).toEqual(value);
+			}
+
+			expect(sortedEntries(storage.commitmentsMap(groups[0]))).toEqual(
+				commitments.map((c) => [c.id, c.value]),
+			);
+
+			storage.clearKeyGen(groups[0]);
+
+			expect(storage.commitmentsMap(groups[0]).size).toBe(0);
+		});
+
+		it("should register secret shares", () => {
+			const storage = new SqliteStorage(participants[0].address, ":memory:");
+
+			expect(() =>
+				storage.registerSecretShare(
+					groups[0],
+					secretShares[1].id,
+					secretShares[1].value,
+				),
+			).toThrowError();
+
+			storage.registerGroup(groups[0], participants, 2n);
+
+			storage.registerSecretShare(
+				groups[0],
+				secretShares[1].id,
+				secretShares[1].value,
+			);
+
+			expect(storage.missingSecretShares(groups[0])).toEqual([
+				secretShares[0].id,
+				secretShares[2].id,
+			]);
+			expect(storage.checkIfSecretSharesComplete(groups[0])).toBe(false);
+			expect(() =>
+				storage.registerSecretShare(
+					groups[0],
+					secretShares[1].id,
+					secretShares[1].value,
+				),
+			).toThrowError();
+
+			storage.registerSecretShare(
+				groups[0],
+				secretShares[0].id,
+				secretShares[0].value,
+			);
+			storage.registerSecretShare(
+				groups[0],
+				secretShares[2].id,
+				secretShares[2].value,
+			);
+
+			expect(storage.missingSecretShares(groups[0])).toEqual([]);
+			expect(storage.checkIfSecretSharesComplete(groups[0])).toBe(true);
+
+			expect(sortedEntries(storage.secretSharesMap(groups[0]))).toEqual(
+				secretShares.map((s) => [s.id, s.value]),
+			);
+
+			storage.clearKeyGen(groups[0]);
+
+			expect(storage.secretSharesMap(groups[0]).size).toBe(0);
 		});
 	});
 });

--- a/validator/src/frost/math.ts
+++ b/validator/src/frost/math.ts
@@ -1,5 +1,4 @@
 import { secp256k1 } from "@noble/curves/secp256k1.js";
-import { bytesToHex, hexToBytes } from "@noble/curves/utils.js";
 import type { FrostPoint } from "./types.js";
 
 export const G_BASE = secp256k1.Point.BASE;
@@ -37,20 +36,16 @@ export const toPoint = (coordinates: { x: bigint; y: bigint }): FrostPoint => {
 	return point;
 };
 
-export const pointFromHex = (hex: string): FrostPoint => {
-	return secp256k1.Point.fromHex(hex);
+export const pointFromBytes = (bytes: Uint8Array): FrostPoint => {
+	return secp256k1.Point.fromBytes(bytes);
 };
 
 export const scalarToBytes = (scalar: bigint): Uint8Array => {
 	return secp256k1.Point.Fn.toBytes(scalar);
 };
 
-export const scalarToHex = (scalar: bigint): string => {
-	return bytesToHex(scalarToBytes(scalar));
-};
-
-export const scalarFromHex = (hex: string): bigint => {
-	return secp256k1.Point.Fn.fromBytes(hexToBytes(hex));
+export const scalarFromBytes = (bytes: Uint8Array): bigint => {
+	return secp256k1.Point.Fn.fromBytes(bytes);
 };
 
 export const createVerificationShare = (

--- a/validator/src/types/schemas.ts
+++ b/validator/src/types/schemas.ts
@@ -39,4 +39,22 @@ export const validatorConfigSchema = z.object({
 	PARTICIPANTS: participantsSchema,
 });
 
+export const chunked = <T>(
+	sz: number,
+	transform: (b: Buffer) => T,
+): ((b: Buffer) => T[]) => {
+	return (b: Buffer) => {
+		if (b.length % sz !== 0) {
+			throw new Error(
+				`buffer of length ${b.length} cannot be chunked in ${sz} bytes`,
+			);
+		}
+		return [...Array(b.length / sz)].map((_, i) => {
+			const start = i * sz;
+			const end = start + sz;
+			return transform(b.subarray(start, end));
+		});
+	};
+};
+
 export type SupportedChain = z.infer<typeof supportedChainsSchema>;


### PR DESCRIPTION
This PR adds the KeyGen storage methods to the Sqlite storage engine.

Note that we also changed the valious data bits to use `BLOB` columns instead of `TEXT` as hex for more efficient storage.