### PR TITLE
Validator Sqlite Nonce Storage

### DIFF
--- a/validator/src/consensus/signing/client.test.ts
+++ b/validator/src/consensus/signing/client.test.ts
@@ -173,7 +173,7 @@ describe("signing", () => {
 				leaves: ["0x" as Hex],
 				root: treeInfo.root as Hex,
 			};
-			storage.registerNonceTree(nonceTree);
+			storage.registerNonceTree(groupId, nonceTree);
 			client.handleNonceCommitmentsHash(
 				groupId,
 				participantId,

--- a/validator/src/consensus/signing/client.ts
+++ b/validator/src/consensus/signing/client.ts
@@ -34,7 +34,7 @@ export class SigningClient {
 		const signingShare = this.#storage.signingShare(groupId);
 		if (signingShare === undefined) throw Error(`No info for ${groupId}`);
 		const nonceTree = createNonceTree(signingShare);
-		const nonceTreeRoot = this.#storage.registerNonceTree(nonceTree);
+		const nonceTreeRoot = this.#storage.registerNonceTree(groupId, nonceTree);
 		return nonceTreeRoot;
 	}
 

--- a/validator/src/consensus/storage/inmemory.ts
+++ b/validator/src/consensus/storage/inmemory.ts
@@ -328,7 +328,7 @@ export class InMemoryStorage
 		return this.signatureRequest(signatureId).signerNonceCommitments;
 	}
 
-	registerNonceTree(tree: NonceTree): Hex {
+	registerNonceTree(_groupId: GroupId, tree: NonceTree): Hex {
 		this.#nonceTrees.set(tree.root, tree);
 		return tree.root;
 	}

--- a/validator/src/consensus/storage/types.ts
+++ b/validator/src/consensus/storage/types.ts
@@ -65,7 +65,7 @@ export type KeyGenInfoStorage = {
 };
 
 export type NonceStorage = {
-	registerNonceTree(tree: NonceTree): Hex;
+	registerNonceTree(groupId: GroupId, tree: NonceTree): Hex;
 	linkNonceTree(groupId: GroupId, chunk: bigint, treeHash: Hex): void;
 	nonceTree(groupId: GroupId, chunk: bigint): NonceTree;
 	burnNonce(groupId: GroupId, chunk: bigint, offset: bigint): void;


### PR DESCRIPTION
This PR adds the nonce storage implementation to the `Sqlite` storage adapter. Additionally, I added `groupId` to the nonce registration call to the interface. This allows a nonce tree to be attached to a particular group and get garbage collected with group unregistration.