### PR TITLE
Use Logging Framework

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -185,6 +185,26 @@
 				"node": ">=14.21.3"
 			}
 		},
+		"node_modules/@colors/colors": {
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/@colors/colors/-/colors-1.6.0.tgz",
+			"integrity": "sha512-Ir+AOibqzrIsL6ajt3Rz3LskB7OiMVHqltZmspbW/TJuTVuyOMirVqAkjfY6JISiLHgyNqicAC8AyHHGzNd/dA==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.1.90"
+			}
+		},
+		"node_modules/@dabh/diagnostics": {
+			"version": "2.0.8",
+			"resolved": "https://registry.npmjs.org/@dabh/diagnostics/-/diagnostics-2.0.8.tgz",
+			"integrity": "sha512-R4MSXTVnuMzGD7bzHdW2ZhhdPC/igELENcq5IjEverBvq5hn1SXCWcsi6eSsdWP0/Ur+SItRRjAktmdoX/8R/Q==",
+			"license": "MIT",
+			"dependencies": {
+				"@so-ric/colorspace": "^1.1.6",
+				"enabled": "2.0.x",
+				"kuler": "^2.0.0"
+			}
+		},
 		"node_modules/@esbuild/aix-ppc64": {
 			"version": "0.25.11",
 			"resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.11.tgz",
@@ -1058,6 +1078,16 @@
 				"url": "https://paulmillr.com/funding/"
 			}
 		},
+		"node_modules/@so-ric/colorspace": {
+			"version": "1.1.6",
+			"resolved": "https://registry.npmjs.org/@so-ric/colorspace/-/colorspace-1.1.6.tgz",
+			"integrity": "sha512-/KiKkpHNOBgkFJwu9sh48LkHSMYGyuTcSFK/qMBdnOAlrRJzRSXAOFB5qwzaVQuDl8wAvHVMkaASQDReTahxuw==",
+			"license": "MIT",
+			"dependencies": {
+				"color": "^5.0.2",
+				"text-hex": "1.0.x"
+			}
+		},
 		"node_modules/@standard-schema/spec": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.0.0.tgz",
@@ -1109,6 +1139,12 @@
 			"dependencies": {
 				"undici-types": "~7.16.0"
 			}
+		},
+		"node_modules/@types/triple-beam": {
+			"version": "1.3.5",
+			"resolved": "https://registry.npmjs.org/@types/triple-beam/-/triple-beam-1.3.5.tgz",
+			"integrity": "sha512-6WaYesThRMCl19iryMYP7/x2OVgCtbIVflDGFpWnb9irXI3UjYE4AzmYuiUKY1AJstGijoY+MgUszMgRxIYTYw==",
+			"license": "MIT"
 		},
 		"node_modules/@vitest/expect": {
 			"version": "4.0.6",
@@ -1278,6 +1314,12 @@
 				"node": ">=12"
 			}
 		},
+		"node_modules/async": {
+			"version": "3.2.6",
+			"resolved": "https://registry.npmjs.org/async/-/async-3.2.6.tgz",
+			"integrity": "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==",
+			"license": "MIT"
+		},
 		"node_modules/base64-js": {
 			"version": "1.5.1",
 			"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
@@ -1372,6 +1414,19 @@
 			"integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
 			"license": "ISC"
 		},
+		"node_modules/color": {
+			"version": "5.0.3",
+			"resolved": "https://registry.npmjs.org/color/-/color-5.0.3.tgz",
+			"integrity": "sha512-ezmVcLR3xAVp8kYOm4GS45ZLLgIE6SPAFoduLr6hTDajwb3KZ2F46gulK3XpcwRFb5KKGCSezCBAY4Dw4HsyXA==",
+			"license": "MIT",
+			"dependencies": {
+				"color-convert": "^3.1.3",
+				"color-string": "^2.1.3"
+			},
+			"engines": {
+				"node": ">=18"
+			}
+		},
 		"node_modules/color-convert": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -1391,6 +1446,48 @@
 			"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
 			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/color-string": {
+			"version": "2.1.4",
+			"resolved": "https://registry.npmjs.org/color-string/-/color-string-2.1.4.tgz",
+			"integrity": "sha512-Bb6Cq8oq0IjDOe8wJmi4JeNn763Xs9cfrBcaylK1tPypWzyoy2G3l90v9k64kjphl/ZJjPIShFztenRomi8WTg==",
+			"license": "MIT",
+			"dependencies": {
+				"color-name": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/color-string/node_modules/color-name": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/color-name/-/color-name-2.1.0.tgz",
+			"integrity": "sha512-1bPaDNFm0axzE4MEAzKPuqKWeRaT43U/hyxKPBdqTfmPF+d6n7FSoTFxLVULUJOmiLp01KjhIPPH+HrXZJN4Rg==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=12.20"
+			}
+		},
+		"node_modules/color/node_modules/color-convert": {
+			"version": "3.1.3",
+			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-3.1.3.tgz",
+			"integrity": "sha512-fasDH2ont2GqF5HpyO4w0+BcewlhHEZOFn9c1ckZdHpJ56Qb7MHhH/IcJZbBGgvdtwdwNbLvxiBEdg336iA9Sg==",
+			"license": "MIT",
+			"dependencies": {
+				"color-name": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=14.6"
+			}
+		},
+		"node_modules/color/node_modules/color-name": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/color-name/-/color-name-2.1.0.tgz",
+			"integrity": "sha512-1bPaDNFm0axzE4MEAzKPuqKWeRaT43U/hyxKPBdqTfmPF+d6n7FSoTFxLVULUJOmiLp01KjhIPPH+HrXZJN4Rg==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=12.20"
+			}
 		},
 		"node_modules/cross-spawn": {
 			"version": "7.0.6",
@@ -1482,6 +1579,12 @@
 			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
 			"integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
 			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/enabled": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/enabled/-/enabled-2.0.0.tgz",
+			"integrity": "sha512-AKrN98kuwOzMIdAizXGI86UFBoo26CL21UM763y1h/GMSJ4/OHU9k2YlsmBpyScFo/wbLzWQJBMCW4+IO3/+OQ==",
 			"license": "MIT"
 		},
 		"node_modules/end-of-stream": {
@@ -1595,10 +1698,22 @@
 				}
 			}
 		},
+		"node_modules/fecha": {
+			"version": "4.2.3",
+			"resolved": "https://registry.npmjs.org/fecha/-/fecha-4.2.3.tgz",
+			"integrity": "sha512-OP2IUU6HeYKJi3i0z4A19kHMQoLVs4Hc+DPqqxI2h/DPZHTm/vjsfC6P0b4jCMy14XizLBqvndQ+UilD7707Jw==",
+			"license": "MIT"
+		},
 		"node_modules/file-uri-to-path": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
 			"integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+			"license": "MIT"
+		},
+		"node_modules/fn.name": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/fn.name/-/fn.name-1.1.0.tgz",
+			"integrity": "sha512-GRnmB5gPyJpAhTQdSZTSp9uaPSvl09KoYcMQtsB9rQoOmzs9dH6ffeccH+Z+cv6P68Hu5bC6JjRh4Ah/mHSNRw==",
 			"license": "MIT"
 		},
 		"node_modules/foreground-child": {
@@ -1724,6 +1839,18 @@
 				"node": ">=8"
 			}
 		},
+		"node_modules/is-stream": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+			"integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
 		"node_modules/isexe": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
@@ -1760,6 +1887,29 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/kuler": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/kuler/-/kuler-2.0.0.tgz",
+			"integrity": "sha512-Xq9nH7KlWZmXAtodXDDRE7vs6DU1gTU8zYDHDiWLSip45Egwq3plLHzPn27NgvzL2r1LMPC1vdqh98sQxtqj4A==",
+			"license": "MIT"
+		},
+		"node_modules/logform": {
+			"version": "2.7.0",
+			"resolved": "https://registry.npmjs.org/logform/-/logform-2.7.0.tgz",
+			"integrity": "sha512-TFYA4jnP7PVbmlBIfhlSe+WKxs9dklXMTEGcBCIvLhE/Tn3H6Gk1norupVW7m5Cnd4bLcr08AytbyV/xj7f/kQ==",
+			"license": "MIT",
+			"dependencies": {
+				"@colors/colors": "1.6.0",
+				"@types/triple-beam": "^1.3.2",
+				"fecha": "^4.2.0",
+				"ms": "^2.1.1",
+				"safe-stable-stringify": "^2.3.1",
+				"triple-beam": "^1.3.0"
+			},
+			"engines": {
+				"node": ">= 12.0.0"
 			}
 		},
 		"node_modules/lru-cache": {
@@ -1839,7 +1989,6 @@
 			"version": "2.1.3",
 			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
 			"integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/nanoid": {
@@ -1886,6 +2035,15 @@
 			"license": "ISC",
 			"dependencies": {
 				"wrappy": "1"
+			}
+		},
+		"node_modules/one-time": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/one-time/-/one-time-1.0.0.tgz",
+			"integrity": "sha512-5DXOiRKwuSEcQ/l0kGCF6Q3jcADFv5tSmRaJck/OqkVFcOzutB134KRSfF0xDrL39MNnqxbHBbUUcjZIhTgb2g==",
+			"license": "MIT",
+			"dependencies": {
+				"fn.name": "1.x.x"
 			}
 		},
 		"node_modules/ox": {
@@ -2165,6 +2323,15 @@
 			],
 			"license": "MIT"
 		},
+		"node_modules/safe-stable-stringify": {
+			"version": "2.5.0",
+			"resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.5.0.tgz",
+			"integrity": "sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=10"
+			}
+		},
 		"node_modules/semver": {
 			"version": "7.7.3",
 			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
@@ -2281,6 +2448,15 @@
 			"license": "BSD-3-Clause",
 			"engines": {
 				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/stack-trace": {
+			"version": "0.0.10",
+			"resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz",
+			"integrity": "sha512-KGzahc7puUKkzyMt+IqAep+TVNbKP+k2Lmwhub39m1AsTSkaDutx56aDCo+HLDzf/D26BIHTJWNiTG1KAJiQCg==",
+			"license": "MIT",
+			"engines": {
+				"node": "*"
 			}
 		},
 		"node_modules/stackback": {
@@ -2447,6 +2623,12 @@
 				"node": ">=6"
 			}
 		},
+		"node_modules/text-hex": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/text-hex/-/text-hex-1.0.0.tgz",
+			"integrity": "sha512-uuVGNWzgJ4yhRaNSiubPY7OjISw4sw4E5Uv0wbjp+OzcbmVU/rsT8ujgcXJhn9ypzsgr5vlzpPqP+MBBKcGvbg==",
+			"license": "MIT"
+		},
 		"node_modules/tinybench": {
 			"version": "2.9.0",
 			"resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
@@ -2486,6 +2668,15 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/triple-beam": {
+			"version": "1.4.1",
+			"resolved": "https://registry.npmjs.org/triple-beam/-/triple-beam-1.4.1.tgz",
+			"integrity": "sha512-aZbgViZrg1QNcG+LULa7nhZpJTZSLm/mXnHXnbAbjmN5aSa0y7V+wvv6+4WaBtpISJzThKy+PIPxc1Nq1EJ9mg==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 14.0.0"
 			}
 		},
 		"node_modules/tsx": {
@@ -2763,6 +2954,42 @@
 				"node": ">=8"
 			}
 		},
+		"node_modules/winston": {
+			"version": "3.19.0",
+			"resolved": "https://registry.npmjs.org/winston/-/winston-3.19.0.tgz",
+			"integrity": "sha512-LZNJgPzfKR+/J3cHkxcpHKpKKvGfDZVPS4hfJCc4cCG0CgYzvlD6yE/S3CIL/Yt91ak327YCpiF/0MyeZHEHKA==",
+			"license": "MIT",
+			"dependencies": {
+				"@colors/colors": "^1.6.0",
+				"@dabh/diagnostics": "^2.0.8",
+				"async": "^3.2.3",
+				"is-stream": "^2.0.0",
+				"logform": "^2.7.0",
+				"one-time": "^1.0.0",
+				"readable-stream": "^3.4.0",
+				"safe-stable-stringify": "^2.3.1",
+				"stack-trace": "0.0.x",
+				"triple-beam": "^1.3.0",
+				"winston-transport": "^4.9.0"
+			},
+			"engines": {
+				"node": ">= 12.0.0"
+			}
+		},
+		"node_modules/winston-transport": {
+			"version": "4.9.0",
+			"resolved": "https://registry.npmjs.org/winston-transport/-/winston-transport-4.9.0.tgz",
+			"integrity": "sha512-8drMJ4rkgaPo1Me4zD/3WLfI/zPdA9o2IipKODunnGDcuqbHwjsbB79ylv04LCGGzU0xQ6vTznOMpQGaLhhm6A==",
+			"license": "MIT",
+			"dependencies": {
+				"logform": "^2.7.0",
+				"readable-stream": "^3.6.2",
+				"triple-beam": "^1.3.0"
+			},
+			"engines": {
+				"node": ">= 12.0.0"
+			}
+		},
 		"node_modules/wrap-ansi": {
 			"version": "8.1.0",
 			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
@@ -2905,6 +3132,7 @@
 				"better-sqlite3": "^12.4.6",
 				"dotenv": "^17.2.1",
 				"viem": "^2.38.5",
+				"winston": "^3.19.0",
 				"zod": "^4.1.12"
 			},
 			"devDependencies": {

--- a/validator/.env.sample
+++ b/validator/.env.sample
@@ -1,3 +1,4 @@
+LOG_LEVEL=info
 RPC_URL=wss://...
 CHAIN_ID=
 CONSENSUS_ADDRESS=

--- a/validator/Dockerfile
+++ b/validator/Dockerfile
@@ -36,5 +36,7 @@ RUN npm ci --workspace=validator --omit=dev --ignore-scripts
 COPY --from=builder /usr/src/app/validator/dist ./validator/dist
 
 USER node
+ENV NODE_ENV production
+
 # Specify the command to run the compiled worker.
 CMD [ "node", "validator/dist/validator.js" ]

--- a/validator/package.json
+++ b/validator/package.json
@@ -17,6 +17,7 @@
 		"better-sqlite3": "^12.4.6",
 		"dotenv": "^17.2.1",
 		"viem": "^2.38.5",
+		"winston": "^3.19.0",
 		"zod": "^4.1.12"
 	},
 	"devDependencies": {

--- a/validator/src/__tests__/config.ts
+++ b/validator/src/__tests__/config.ts
@@ -3,13 +3,17 @@ import { InMemoryClientStorage } from "../consensus/storage/inmemory.js";
 import { SqliteClientStorage } from "../consensus/storage/sqlite.js";
 import { InMemoryStateStorage } from "../machine/storage/inmemory.js";
 import { SqliteStateStorage } from "../machine/storage/sqlite.js";
+import { createLogger } from "../utils/logging.js";
 
 const { SHIELDNET_TEST_VERBOSE, SHIELDNET_TEST_STORAGE } = process.env;
 
-export const log =
-	SHIELDNET_TEST_VERBOSE === "true" || SHIELDNET_TEST_VERBOSE === "1"
-		? (...args: unknown[]) => console.log(...args)
-		: (..._args: unknown[]) => {};
+export const silentLogger = createLogger({ level: "silent" });
+export const testLogger = createLogger({
+	level: SHIELDNET_TEST_VERBOSE === "true" || SHIELDNET_TEST_VERBOSE === "1" ? "debug" : "silent",
+	pretty: true,
+});
+
+export const log = testLogger.debug.bind(testLogger);
 
 export const createClientStorage =
 	SHIELDNET_TEST_STORAGE === "sqlite"

--- a/validator/src/consensus/protocol/onchain.ts
+++ b/validator/src/consensus/protocol/onchain.ts
@@ -1,6 +1,7 @@
 import type { Address, Hex, PublicClient, WalletClient } from "viem";
 import type { FrostPoint, GroupId, SignatureId } from "../../frost/types.js";
 import { CONSENSUS_FUNCTIONS, COORDINATOR_FUNCTIONS } from "../../types/abis.js";
+import type { Logger } from "../../utils/logging.js";
 import type { Queue } from "../../utils/queue.js";
 import { BaseProtocol } from "./base.js";
 import type {
@@ -28,7 +29,7 @@ export class OnchainProtocol extends BaseProtocol {
 		consensus: Address,
 		coordinator: Address,
 		queue: Queue<ActionWithTimeout>,
-		logger?: (msg: unknown) => void,
+		logger: Logger,
 	) {
 		super(queue, logger);
 		this.#publicClient = publicClient;

--- a/validator/src/service/service.ts
+++ b/validator/src/service/service.ts
@@ -26,7 +26,7 @@ import { InMemoryQueue } from "../utils/queue.js";
 import { ShieldnetStateMachine } from "./machine.js";
 
 export class ValidatorService {
-	#logger?: Logger;
+	#logger: Logger;
 	#config: ProtocolConfig;
 	#publicClient: PublicClient;
 	#watcher: OnchainTransitionWatcher;
@@ -43,7 +43,7 @@ export class ValidatorService {
 		transport: Transport;
 		config: ProtocolConfig;
 		chain: Chain;
-		logger?: Logger;
+		logger: Logger;
 	}) {
 		this.#logger = logger;
 		this.#config = config;
@@ -63,13 +63,13 @@ export class ValidatorService {
 			config.consensus,
 			config.coordinator,
 			actionStorage,
-			this.#logger?.info,
+			this.#logger,
 		);
 		const stateStorage = new InMemoryStateStorage();
 		this.#stateMachine = new ShieldnetStateMachine({
 			participants: config.participants,
 			blocksPerEpoch: config.blocksPerEpoch,
-			logger: this.#logger?.info,
+			logger: this.#logger,
 			genesisSalt: config.genesisSalt,
 			protocol,
 			storage: stateStorage,
@@ -97,16 +97,16 @@ export class ValidatorService {
 	}
 }
 
-export const createValidatorService = (account: Account, rpcUrl: string, config: ProtocolConfig): ValidatorService => {
+export const createValidatorService = (
+	account: Account,
+	rpcUrl: string,
+	config: ProtocolConfig,
+	logger: Logger,
+): ValidatorService => {
 	const transport = rpcUrl.startsWith("wss") ? webSocket(rpcUrl) : http(rpcUrl);
 	const chain = extractChain({
 		chains: supportedChains,
 		id: config.chainId,
 	});
-	const logger: Logger = {
-		error: console.error,
-		debug: console.debug,
-		info: console.info,
-	};
 	return new ValidatorService({ account, transport, config, chain, logger });
 };

--- a/validator/src/types/schemas.ts
+++ b/validator/src/types/schemas.ts
@@ -2,6 +2,8 @@ import { type Address, getAddress, type Hex, isAddress, isHex, size, zeroHash } 
 import { z } from "zod";
 import { supportedChains } from "./chains.js";
 
+export const logLevelSchema = z.enum(["error", "warn", "info", "debug", "silent"]);
+
 export const checkedAddressSchema = z
 	.string()
 	// Strict is disabled here, as a manual check for the correct checksum is performed.
@@ -39,6 +41,7 @@ export const genesisSaltSchema = z.preprocess((val) => {
 }, hexBytes32Schema);
 
 export const validatorConfigSchema = z.object({
+	LOG_LEVEL: logLevelSchema.optional(),
 	RPC_URL: z.url(),
 	PRIVATE_KEY: hexBytes32Schema,
 	CONSENSUS_ADDRESS: checkedAddressSchema,

--- a/validator/src/utils/logging.ts
+++ b/validator/src/utils/logging.ts
@@ -1,5 +1,39 @@
-export type Logger = {
-	error(error: Error): void;
-	debug(msg: unknown): void;
-	info(msg: unknown): void;
+import util from "node:util";
+import winston, { type Logger } from "winston";
+
+export type { Logger } from "winston";
+
+export type LoggingOptions = {
+	level?: "error" | "warn" | "info" | "debug" | "silent";
+	pretty?: boolean;
+};
+
+const SPLAT = Symbol.for("splat");
+const prettyFormat = winston.format.printf(({ timestamp, level, message, [SPLAT]: splat }) => {
+	// We need to turn the "splat", i.e. the extra parameters passed to the log
+	// after the message, into an array for inspecting. AFAICT, `winston` always
+	// gives us an `array | undefined`, but the type-system says otherwise so
+	// handle as following:
+	// - If we have an array, then "yay"
+	// - If we have some other value, then arrayify it
+	// - If we have undefined, then there are no additional args
+	const args = Array.isArray(splat) ? splat : splat !== undefined ? [splat] : [];
+
+	const text = [message, ...args]
+		.map((part) => (typeof part === "string" ? part : util.inspect(part, { colors: true })))
+		.join(" ");
+	return `[${timestamp} ${level}]: ${text}`;
+});
+
+export const createLogger = (options: LoggingOptions): Logger => {
+	const level = options.level === "silent" ? { silent: true } : { level: options.level ?? "info" };
+	const format =
+		options.pretty === true
+			? winston.format.combine(winston.format.timestamp(), winston.format.colorize(), prettyFormat)
+			: winston.format.json();
+	return winston.createLogger({
+		...level,
+		format,
+		transports: [new winston.transports.Console()],
+	});
 };


### PR DESCRIPTION
This PR adds a logging framework to the project. I chose between `winston` and `pino`, by far the two most recommended ones on Reddit.

I ended up going with `winston`, even if I had originally opted for `pino` (as it was smaller, faster, and more widely used according to NPM.js statistics) because:
- `pino` uses `WebWorker` API to send all logging to a separate thread to ensure it doesn't impact the app's performance. This has some downsides that affected how we use logging. In particular, not all options are serializable which requires a custom transport [1] to correctly configure, which doesn't work well with TypeScript [2].
- `pino-pretty`, which we used to make the logging output look nice when connected to a TTY, did not work with `vitest`; logs were not appearing in `stdout`, and I believe it is something related to how `vitest` captures all `stdout` and how `pino-pretty` uses stdout redirection [3].

In the end, `winston` just worked, had a much simpler setup, and I don't think logging performance impact is an issue for us.

[1]: <https://github.com/pinojs/pino-pretty?tab=readme-ov-file#handling-non-serializable-options>
[2]: <https://github.com/pinojs/pino/issues/2203>
[3]: <https://github.com/pinojs/pino-pretty#limitations>