### PR TITLE
Publish Docker Images

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -4,7 +4,7 @@ on:
   pull_request:
   push:
     branches:
-	  - main
+      - main
 
 jobs:
   docker:


### PR DESCRIPTION
This PR adds GitHub workflow that:

- Builds the Validator docker image in CI (to make sure that we don't break image builds in PRs)
- When PRs are merged into main, automatically publishes a Docker image to GHCR

The image can then be pulled with `docker pull
ghcr.io/safe-research/shieldnet-validator:main`.