### PR TITLE
Add Missing Step ID for Metadata Action

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -24,7 +24,8 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - uses: docker/metadata-action@v5
+      - id: meta
+        uses: docker/metadata-action@v5
         with:
           images: ghcr.io/safe-research/shieldnet-validator
 


### PR DESCRIPTION
The step ID is used for getting metadata tag output when building and pushing, and was left out by accident.