### PR TITLE
Work-Around for Missing SQLite Bindings

### DIFF
--- a/validator/Dockerfile
+++ b/validator/Dockerfile
@@ -35,6 +35,11 @@ RUN npm ci --workspace=validator --omit=dev --ignore-scripts
 # Copy the compiled code from the builder stage.
 COPY --from=builder /usr/src/app/validator/dist ./validator/dist
 
+# Additionally, `better-sqlite3` builds native code which is needed when
+# running, so make sure to copy that as well. This is a hacky work-around for
+# now, but should be revisited in the future.
+COPY --from=builder /usr/src/app/node_modules/better-sqlite3 ./node_modules/better-sqlite3
+
 USER node
 ENV NODE_ENV production
 


### PR DESCRIPTION
`better-sqlite3` requires bindings that are compiled during `npm install`, so we need to make sure to copy that over as well. We do this instead of just removing the `--ignore-scripts` flag to make sure we don't run build scripts for the `validator` package as well.

In the long run, we should consider moving to PNPM that has a bit more fine-grained control over which build scripts run, or change the Dockerfile to run the `npm ci --omit=dev` without any `validator` package scripts (as the current solution only ensures `better-sqlite3` build scripts are run, and is generally brittle against other dependencies that may also require build scripts to function correctly).