### PR TITLE
More Genesis Context

### DIFF
--- a/validator/src/cmd/derive-genesis.ts
+++ b/validator/src/cmd/derive-genesis.ts
@@ -45,8 +45,12 @@ const main = async (): Promise<void> => {
 		salt: zeroHash,
 	});
 
-	console.log(`Genesis group ID: ${genesisGroup.id}`);
-	console.log(`Consensus contract address: ${consensus}`);
+	console.log(`Genesis group ID:                ${genesisGroup.id}`);
+	console.log(`Genesis group participants root: ${genesisGroup.participantsRoot}`);
+	console.log(`Genesis group count:             ${genesisGroup.count}`);
+	console.log(`Genesis group threshold:         ${genesisGroup.threshold}`);
+	console.log(`Genesis group context:           ${genesisGroup.context}`);
+	console.log(`Consensus contract address:      ${consensus}`);
 };
 
 main().catch((err) => {

--- a/validator/src/machine/keygen/group.ts
+++ b/validator/src/machine/keygen/group.ts
@@ -23,6 +23,9 @@ export const calcGroupContext = (consensus: Address, epoch: bigint): Hex => {
 
 export type GenesisGroup = {
 	id: GroupId;
+	participantsRoot: Hex;
+	count: bigint;
+	threshold: bigint;
 	context: Hex;
 };
 
@@ -42,6 +45,9 @@ export const calcGenesisGroup = ({
 		genesisSalt === zeroHash ? zeroHash : keccak256(encodePacked(["string", "bytes32"], ["genesis", genesisSalt]));
 	return {
 		id: calcGroupId(participantsRoot, count, threshold, context),
+		participantsRoot,
+		count,
+		threshold,
 		context,
 	};
 };

--- a/validator/src/machine/keygen/secretShares.test.ts
+++ b/validator/src/machine/keygen/secretShares.test.ts
@@ -5,7 +5,7 @@ import type { KeyGenClient } from "../../consensus/keyGen/client.js";
 import { toPoint } from "../../frost/math.js";
 import type { FrostPoint } from "../../frost/types.js";
 import type { KeyGenSecretSharedEvent } from "../transitions/types.js";
-import type { ConsensusState, MachineConfig, MachineStates } from "../types.js";
+import type { MachineConfig, MachineStates } from "../types.js";
 import { handleKeyGenSecretShared } from "./secretShares.js";
 
 // --- Test Data ---


### PR DESCRIPTION
This PR adds some additional context to the result of the `calcGenesisGroup` function so that we can print out more information when creating the Genesis group.