### PR TITLE
Improve Error Log

### DIFF
--- a/validator/src/service/machine.ts
+++ b/validator/src/service/machine.ts
@@ -110,7 +110,7 @@ export class ShieldnetStateMachine {
 				}
 			})
 			.catch((err) => {
-				this.#logger.warn("Error performing state transition:", err);
+				this.#logger.warn(`Error performing state transition '${transition.id}':`, err);
 			})
 			.finally(() => {
 				this.#transitionQueue.pop();


### PR DESCRIPTION
This PR improves the error logging for failed transitions. It now looks something like this in JSON logs:

```json
{"level":"warn","message":"Error performing state transition: foo","stack":"Error: foo\n    at ShieldnetStateMachine.progressToBlock (/var/home/nlordell/Developer/safe-research/shieldnet/validator/src/service/machine.ts:139:9)\n    at ShieldnetStateMachine.performTransition (/var/home/nlordell/Developer/safe-research/shieldnet/validator/src/service/machine.ts:125:17)\n    at ShieldnetStateMachine.checkNextTransition (/var/home/nlordell/Developer/safe-research/shieldnet/validator/src/service/machine.ts:102:8)\n    at ShieldnetStateMachine.transition (/var/home/nlordell/Developer/safe-research/shieldnet/validator/src/service/machine.ts:92:8)\n    at OnchainTransitionWatcher.onTransition (/var/home/nlordell/Developer/safe-research/shieldnet/validator/src/service/service.ts:86:24)\n    at OnchainTransitionWatcher.handleTransition (/var/home/nlordell/Developer/safe-research/shieldnet/validator/src/machine/transitions/watcher.ts:75:10)\n    at Timeout._onTimeout (/var/home/nlordell/Developer/safe-research/shieldnet/validator/src/machine/transitions/watcher.ts:113:12)\n    at listOnTimeout (node:internal/timers:588:17)\n    at process.processTimers (node:internal/timers:523:7)"}
```

And like this for the pretty-printed logs:

```
[2025-12-16T14:28:01.284Z warn]: Error performing state transition: foo Error: foo
    at ShieldnetStateMachine.progressToBlock (/var/home/nlordell/Developer/safe-research/shieldnet/validator/src/service/machine.ts:139:9)
    at ShieldnetStateMachine.performTransition (/var/home/nlordell/Developer/safe-research/shieldnet/validator/src/service/machine.ts:125:17)
    at ShieldnetStateMachine.checkNextTransition (/var/home/nlordell/Developer/safe-research/shieldnet/validator/src/service/machine.ts:102:8)
    at ShieldnetStateMachine.transition (/var/home/nlordell/Developer/safe-research/shieldnet/validator/src/service/machine.ts:92:8)
    at OnchainTransitionWatcher.onTransition (/var/home/nlordell/Developer/safe-research/shieldnet/validator/src/service/service.ts:86:24)
    at OnchainTransitionWatcher.handleTransition (/var/home/nlordell/Developer/safe-research/shieldnet/validator/src/machine/transitions/watcher.ts:75:10)
    at Timeout._onTimeout (/var/home/nlordell/Developer/safe-research/shieldnet/validator/src/machine/transitions/watcher.ts:113:12)
    at listOnTimeout (node:internal/timers:588:17)
    at process.processTimers (node:internal/timers:523:7)
```

Note that the log, as it previously was, already would display the `err.message`, so I am not exactly sure why we observed the warning log with an empty message. That being said, in the second position we additionally get a stack trace, which is a marginal improvement.