### PR TITLE
Handle SIGTERM in Validator

### DIFF
--- a/validator/src/validator.ts
+++ b/validator/src/validator.ts
@@ -40,12 +40,15 @@ logger.info(`Using validator account ${account.address}`);
 
 const service = createValidatorService(account, rpcUrl, config, logger);
 
-// Handle graceful shutdown
-process.on("SIGINT", () => {
+// Handle graceful shutdown, for both `SIGINT` (i.e. Ctrl-C) and `SIGTERM` which
+// gets send when stopping a container or `kill`.
+const shutdown = () => {
 	logger.info("Shutting down service...");
 	service.stop();
 	process.exit(0);
-});
+};
+process.on("SIGINT", shutdown);
+process.on("SIGTERM", shutdown);
 
 service.start().catch((error: unknown) => {
 	logger.error("Service failed to start:");


### PR DESCRIPTION
When stopping containers with Podman or Docker, `SIGTERM` and not `SIGINT` is sent to the process. This PR adds graceful shutdown for both signals.