### PR TITLE
Staking change based on user stories

### DIFF
--- a/contracts/src/Staking.sol
+++ b/contracts/src/Staking.sol
@@ -286,6 +286,11 @@ contract Staking is Ownable {
     error InvalidParameter();
 
     /**
+     * @notice Thrown when a specified withdrawal node does not exist.
+     */
+    error InvalidWithdrawalNode();
+
+    /**
      * @notice Thrown when the specified ordering in the withdrawal queue is invalid.
      */
     error InvalidOrdering();
@@ -435,6 +440,7 @@ contract Staking is Ownable {
             // Inserting at head - get the current head as nextId.
             nextId = withdrawalQueues[msg.sender][validator].head;
         } else {
+            require(withdrawalNodes[previousId].claimableAt > 0, InvalidWithdrawalNode());
             require(withdrawalNodes[previousId].claimableAt <= claimableAt, InvalidOrdering());
 
             nextId = withdrawalNodes[previousId].next;


### PR DESCRIPTION
These changes are inspired by the user stories:
- Mutable value change in the constructor is now logged
- Total stakes by the staker (required for the snapshot voting mechanism)

Other changes:
- Small naming change of the internal function to be consistent with the public function.
- Redundant event removed