### PR TITLE
Fix Handling of Own Share in Spec

### DIFF
--- a/spec/validator.ml
+++ b/spec/validator.ml
@@ -467,34 +467,29 @@ struct
       when GroupId.equal st.group.id group_id -> begin
         let (Local me) = st.group.me in
         let (Local coefficients) = st.vss.coefficients in
-        let (Local shares) = st.shares in
-        let shares', actions_complaint =
+        let secret_share, actions_complaint =
           if FROST.Identifier.equal me identifier then
             let my_share = FROST.KeyGen.secret_share coefficients me in
-            let shares' = ParticipantMap.add me (Some my_share) shares in
-            (shares', [])
+            (Some my_share, [])
           else
-            let secret_share, actions_complaint =
-              let i =
-                FROST.Identifier.to_int me
-                - if FROST.Identifier.compare me identifier < 0 then 1 else 2
-              in
-              let encrypted = List.nth secret_shares i in
-              let participant_commitments =
-                ParticipantMap.find identifier st.vss.commitments
-              in
-              let value =
-                FROST.KeyGen.decrypt_secret_share coefficients
-                  participant_commitments encrypted
-              in
-              if FROST.KeyGen.verify_secret_share participant_commitments value
-              then (Some value, [])
-              else
-                (None, [ `Coordinator_key_gen_complain (group_id, identifier) ])
+            let i =
+              FROST.Identifier.to_int me
+              - if FROST.Identifier.compare me identifier < 0 then 1 else 2
             in
-            let shares' = ParticipantMap.add identifier secret_share shares in
-            (shares', actions_complaint)
+            let encrypted = List.nth secret_shares i in
+            let participant_commitments =
+              ParticipantMap.find identifier st.vss.commitments
+            in
+            let value =
+              FROST.KeyGen.decrypt_secret_share coefficients
+                participant_commitments encrypted
+            in
+            if FROST.KeyGen.verify_secret_share participant_commitments value
+            then (Some value, [])
+            else (None, [ `Coordinator_key_gen_complain (group_id, identifier) ])
         in
+        let (Local shares) = st.shares in
+        let shares' = ParticipantMap.add identifier secret_share shares in
         let state', actions_confirm =
           if
             AddressSet.cardinal st.group.participants


### PR DESCRIPTION
As @rmeissner pointed out to me, the current spec has different global states per participant: the last one to emit a `KeyGenSecretShared` event will eagerly transition into a "confirming" state (as they already know their share even before it gets included in a block).

In fixing this, I also realized that the spec wasn't correctly handling the self-share in the first place (as they would try to verify the secret share from their own event).

In this PR, we fix the spec to correctly:
1. Only register their own share once they see their secret share event
2. Do not try to extract, decrypt and verify their a secret share from their own event

This should also already be more inline with the changes being made to the confirmation flow, so we don't need to change the validator as a result of this change.