### PR TITLE
Abort After `threshold` Complaints

### DIFF
--- a/validator/src/consensus/keyGen/client.ts
+++ b/validator/src/consensus/keyGen/client.ts
@@ -48,7 +48,7 @@ export class KeyGenClient {
 		return this.#storage.participantId(groupId);
 	}
 
-	participants(groupId: GroupId): Participant[] {
+	participants(groupId: GroupId): readonly Participant[] {
 		return this.#storage.participants(groupId);
 	}
 

--- a/validator/src/consensus/storage/inmemory.ts
+++ b/validator/src/consensus/storage/inmemory.ts
@@ -5,7 +5,7 @@ import type { GroupInfoStorage, KeyGenInfoStorage, Participant, SignatureRequest
 
 type GroupInfo = {
 	groupId: GroupId;
-	participants: Participant[];
+	participants: readonly Participant[];
 	participantId: bigint;
 	threshold: bigint;
 	verificationShare?: FrostPoint;
@@ -14,8 +14,8 @@ type GroupInfo = {
 };
 
 type KeyGenInfo = {
-	coefficients: bigint[];
-	commitments: Map<ParticipantId, FrostPoint[]>;
+	coefficients: readonly bigint[];
+	commitments: Map<ParticipantId, readonly FrostPoint[]>;
 	secretShares: Map<ParticipantId, bigint>;
 };
 
@@ -69,7 +69,7 @@ export class InMemoryClientStorage implements KeyGenInfoStorage, GroupInfoStorag
 		this.groupInfo(groupId);
 		if (this.#keyGenInfo.has(groupId)) throw new Error(`KeyGen for ${groupId} already registered!`);
 		this.#keyGenInfo.set(groupId, {
-			coefficients: [...coefficients],
+			coefficients,
 			commitments: new Map(),
 			secretShares: new Map(),
 		});
@@ -78,7 +78,7 @@ export class InMemoryClientStorage implements KeyGenInfoStorage, GroupInfoStorag
 		const info = this.keyGenInfo(groupId);
 		if (info.commitments.has(participantId))
 			throw new Error(`Commitments for ${groupId}:${participantId} already registered!`);
-		info.commitments.set(participantId, [...commitments]);
+		info.commitments.set(participantId, commitments);
 	}
 	registerSecretShare(groupId: GroupId, participantId: ParticipantId, share: bigint): void {
 		const info = this.keyGenInfo(groupId);
@@ -128,17 +128,17 @@ export class InMemoryClientStorage implements KeyGenInfoStorage, GroupInfoStorag
 		const info = this.keyGenInfo(groupId);
 		return info.coefficients[0];
 	}
-	coefficients(groupId: GroupId): bigint[] {
+	coefficients(groupId: GroupId): readonly bigint[] {
 		const info = this.keyGenInfo(groupId);
 		return info.coefficients;
 	}
-	commitments(groupId: GroupId, participantId: ParticipantId): FrostPoint[] {
+	commitments(groupId: GroupId, participantId: ParticipantId): readonly FrostPoint[] {
 		const info = this.keyGenInfo(groupId);
 		const commitments = info.commitments.get(participantId);
 		if (commitments === undefined) throw new Error(`No commitments for ${participantId} available!`);
 		return commitments;
 	}
-	commitmentsMap(groupId: GroupId): Map<ParticipantId, FrostPoint[]> {
+	commitmentsMap(groupId: GroupId): Map<ParticipantId, readonly FrostPoint[]> {
 		const info = this.keyGenInfo(groupId);
 		return info.commitments;
 	}
@@ -159,7 +159,7 @@ export class InMemoryClientStorage implements KeyGenInfoStorage, GroupInfoStorag
 		this.#groupInfo.set(groupId, {
 			participantId,
 			groupId,
-			participants: [...participants],
+			participants,
 			threshold,
 		});
 		return participantId;
@@ -182,7 +182,7 @@ export class InMemoryClientStorage implements KeyGenInfoStorage, GroupInfoStorag
 	publicKey(groupId: GroupId): FrostPoint | undefined {
 		return this.groupInfo(groupId).groupPublicKey;
 	}
-	participants(groupId: GroupId): Participant[] {
+	participants(groupId: GroupId): readonly Participant[] {
 		return this.groupInfo(groupId).participants;
 	}
 	threshold(groupId: GroupId): bigint {

--- a/validator/src/consensus/storage/sqlite.ts
+++ b/validator/src/consensus/storage/sqlite.ts
@@ -274,7 +274,7 @@ export class SqliteClientStorage implements GroupInfoStorage, KeyGenInfoStorage,
 		this.setGroupThisParticipantColumn(groupId, "signing_share", scalarToBytes(signingShare));
 	}
 
-	participants(groupId: GroupId): Participant[] {
+	participants(groupId: GroupId): readonly Participant[] {
 		const result = this.#db
 			.prepare("SELECT id, address FROM group_participants WHERE group_id = ? ORDER BY id ASC")
 			.all(groupId)
@@ -458,15 +458,15 @@ export class SqliteClientStorage implements GroupInfoStorage, KeyGenInfoStorage,
 		return this.getGroupThisParticipantColumn(groupId, "SUBSTRING(coefficients, 1, 32)", dbScalarSchema);
 	}
 
-	coefficients(groupId: GroupId): bigint[] {
+	coefficients(groupId: GroupId): readonly bigint[] {
 		return this.getGroupThisParticipantColumn(groupId, "coefficients", dbScalarArraySchema);
 	}
 
-	commitments(groupId: GroupId, participantId: ParticipantId): FrostPoint[] {
+	commitments(groupId: GroupId, participantId: ParticipantId): readonly FrostPoint[] {
 		return this.getGroupParticipantColumn(groupId, participantId, "commitments", dbPointArraySchema);
 	}
 
-	commitmentsMap(groupId: GroupId): Map<ParticipantId, FrostPoint[]> {
+	commitmentsMap(groupId: GroupId): Map<ParticipantId, readonly FrostPoint[]> {
 		// Use the `LEFT JOIN` trick described in `dbList` and in the
 		// `missingCommitments` query, adapted to mappings.
 

--- a/validator/src/consensus/storage/types.ts
+++ b/validator/src/consensus/storage/types.ts
@@ -15,7 +15,7 @@ export type GroupInfoStorage = {
 
 	participantId(groupId: GroupId): ParticipantId;
 	publicKey(groupId: GroupId): FrostPoint | undefined;
-	participants(groupId: GroupId): Participant[];
+	participants(groupId: GroupId): readonly Participant[];
 	threshold(groupId: GroupId): bigint;
 	signingShare(groupId: GroupId): bigint | undefined;
 	verificationShare(groupId: GroupId): FrostPoint;
@@ -33,9 +33,9 @@ export type KeyGenInfoStorage = {
 	checkIfSecretSharesComplete(groupId: GroupId): boolean;
 
 	encryptionKey(groupId: GroupId): bigint;
-	coefficients(groupId: GroupId): bigint[];
-	commitments(groupId: GroupId, participantId: ParticipantId): FrostPoint[];
-	commitmentsMap(groupId: GroupId): Map<ParticipantId, FrostPoint[]>;
+	coefficients(groupId: GroupId): readonly bigint[];
+	commitments(groupId: GroupId, participantId: ParticipantId): readonly FrostPoint[];
+	commitmentsMap(groupId: GroupId): Map<ParticipantId, readonly FrostPoint[]>;
 	secretSharesMap(groupId: GroupId): Map<ParticipantId, bigint>;
 	clearKeyGen(groupId: GroupId): void;
 };


### PR DESCRIPTION
This PR changes the complaint handler to retry keygen after it has received `threshold` or more complaints to a single participant. The participant that received at least `threshold` complaints is removed from the active participant set (as they are assumed to be dishonest - given that we assume there is always fewer than `threshold` dishonest participants).

`threshold` is a critical amount for a few reasons:
- If a participant reveals `threshold` secret shares publicly, then anyone can interpolate its random secret polynomial (meaning they can, critically, compute `C(0)` which is that participant's contribution to the group secret key).
- If we have `threshold` or more malicious actors that are falsely accusing honest participants, then our consensus is broken anyway.