### PR TITLE
Remove `USER=node` From Dockerfile

### DIFF
--- a/validator/Dockerfile
+++ b/validator/Dockerfile
@@ -43,7 +43,7 @@ COPY --from=builder /usr/src/app/node_modules/better-sqlite3/build node_modules/
 # Copy the container entry point script.
 COPY validator/bin/entrypoint.sh validator/bin/entrypoint.sh
 
-USER node
+# Set the Node environment to "production"
 ENV NODE_ENV=production
 
 # Specify the command to run the compiled worker.


### PR DESCRIPTION
User can be specified when starting the container with `--user` if something else is needed. We are running the containers as unprivileged users already (with Quadlets) and the default non-root user makes mounting volumes annoying, and doesn't add much security for us.