### PR TITLE
Introduce Block Intexer

### DIFF
--- a/validator/src/watcher/blocks.test.ts
+++ b/validator/src/watcher/blocks.test.ts
@@ -1,7 +1,7 @@
 import { type Block, BlockNotFoundError, type GetBlockParameters, keccak256, numberToHex, toHex } from "viem";
 import { describe, expect, it, vi } from "vitest";
 
-import { BlockIndexer, type Client, type Timer } from "./blocks.js";
+import { BlockWatcher, type Client, type Timer } from "./blocks.js";
 
 const CONFIG = {
 	blockTime: 2000,
@@ -17,7 +17,7 @@ const setupCreate = (config: { lastIndexedBlock: bigint | null; maxReorgDepth?: 
 
 	return {
 		create() {
-			return BlockIndexer.create({
+			return BlockWatcher.create({
 				...CONFIG,
 				...config,
 				client: {
@@ -43,7 +43,7 @@ const setupNext = async (config: { latestBlock: bigint; startTime: number; maxRe
 		...config,
 	});
 
-	let created: BlockIndexer | null = null;
+	let created: BlockWatcher | null = null;
 	await mocks.getBlock.withImplementation(
 		({ blockTag, blockNumber }: GetBlockParameters) => {
 			if (blockTag === "latest") {
@@ -62,7 +62,7 @@ const setupNext = async (config: { latestBlock: bigint; startTime: number; maxRe
 
 	// We have to trick the type-system here, it doesn't understand that the callback in the
 	// `withImplementation` call can change the value and thinks `created: null`.
-	const blocks = created as unknown as BlockIndexer;
+	const blocks = created as unknown as BlockWatcher;
 
 	// Skip the queued records.
 	blocks.queued();
@@ -106,9 +106,9 @@ const newBlockRecord = (
 	logsBloom: b.logsBloom ?? numberToHex(b.number, { size: 512 }),
 });
 
-describe("BlockIndexer", () => {
+describe("BlockWatcher", () => {
 	describe("create", () => {
-		it("initialize an indexer", async () => {
+		it("initialize a watcher", async () => {
 			const { create, mocks } = setupCreate({ lastIndexedBlock: null });
 
 			mocks.getBlock.mockReturnValueOnce(block({ number: 1000n }));


### PR DESCRIPTION
This PR introduces a block indexer that (hopefully - fingers crossed) produces records for:

- "Warping" to a particular block; this record is produced when moving historic blocks (i.e. not within the maximum reorg range) and allows the event indexing (which will be added later) to use ranged `eth_getLogs` queries safely. This is done as a startup optimization, when the validator restarts it can catch up to the current block with fewer node round-trips.
- "Uncling" a block and its children, which happens when the indexer detects a reorg.
- "New" block, with a hash and logs bloom filter (to do some client filtering before deciding whether or not it needs to get logs).

We also have some tricks to try and reduce the total number of RPC queries needed for the indexer:

- We estimate when the next block is likely to be ready, and sleep until then before attempting an `eth_getBlock` call.
- We retry with small sleep increments to account for small delays in block propagation
- If we detect that a block is not likely to come, then we assume that slot was skipped (which happens fairly often in low-traffic networks) and wait until the next slot + propagation delay before retrying again.

Additionally, I added some unit tests to verify some of the logic (and should have pretty good coverage).