### PR TITLE
Docs: Rename Shieldnet -> Safenet

### DIFF
--- a/docs/docs/integration/wallets.md
+++ b/docs/docs/integration/wallets.md
@@ -2,5 +2,5 @@
 
 TODO
 
-- Mention how wallets can integrate Shieldnet including limitations.
+- Mention how wallets can integrate Safenet including limitations.
 - CTA to reach out.

--- a/docs/docs/introduction.md
+++ b/docs/docs/introduction.md
@@ -1,13 +1,13 @@
 ---
 title: Introduction
-description: Shieldnet enforces transaction security onchain by preventing high-risk transactions from executing.
+description: Safenet enforces transaction security onchain by preventing high-risk transactions from executing.
 ---
 
-Shieldnet is a protocol for **onchain transaction security enforcement**.
+Safenet is a protocol for **onchain transaction security enforcement**.
 
 It acts as a **last line of defense** against malicious or high-risk transactions by ensuring that transactions are **validated before execution**, rather than merely displaying non-binding warnings.
 
-Shieldnet replaces centralized transaction-checking services with a **resilient, validator-based network** that enforces security guarantees onchain.
+Safenet replaces centralized transaction-checking services with a **resilient, validator-based network** that enforces security guarantees onchain.
 
 ## Core problem
 
@@ -22,18 +22,18 @@ Even simple onchain actions (e.g. approvals, signer changes) can be embedded in 
 
 ## Goals and value proposition
 
-Shieldnet is designed to:
+Safenet is designed to:
 
 - **Prevent malicious transactions from executing**, not just warn about them
 - Make transaction security **accessible to all users**, not only advanced or institutional ones
 - Provide **additive security** that complements existing wallets and protocols
 - Create **public, accountable security guarantees**, enforced onchain
 
-Unlike offchain checkers, Shieldnet produces **binding enforcement**, not advisory signals.
+Unlike offchain checkers, Safenet produces **binding enforcement**, not advisory signals.
 
-## What makes Shieldnet different
+## What makes Safenet different
 
-Shieldnet’s core differentiators are:
+Safenet’s core differentiators are:
 
 - **Onchain enforcement**  
   Transactions deemed malicious are prevented from executing.
@@ -45,17 +45,17 @@ Shieldnet’s core differentiators are:
   Validator attestations are onchain and auditable, increasing trust and reliability.
 
 - **Open integration**  
-  Any wallet, protocol, or transaction-checking service can integrate with Shieldnet.
+  Any wallet, protocol, or transaction-checking service can integrate with Safenet.
 
-## Who is Shieldnet for?
+## Who is Safenet for?
 
 ### Wallet operators
-Integrate Shieldnet to protect users from malicious transactions without relying on centralized infrastructure.
+Integrate Safenet to protect users from malicious transactions without relying on centralized infrastructure.
 
 → See: [Integration → Wallets](/docs/integration/wallets)
 
 ### Node operators / validators
-Participate in transaction validation and enforcement by running a Shieldnet validator.
+Participate in transaction validation and enforcement by running a Safenet validator.
 
 → See: [Operators → Validator overview](/docs/operators/overview)
 
@@ -65,20 +65,20 @@ Delegate stake to validators and earn rewards for securing the network.
 → See: [Protocol → Staking](/docs/protocol/staking)
 
 ### Transaction checkers and security firms
-Provide detection logic and risk signals that can be enforced onchain via Shieldnet.
+Provide detection logic and risk signals that can be enforced onchain via Safenet.
 
 → See: [Integration → Transaction checkers](/docs/integration/tx_checkers)
 
 ## Scope, limitations, and outlook
 
-Shieldnet v1 focuses on:
+Safenet v1 focuses on:
 
 - **Safe transactions on EVM chains**
 - **Permissioned validator set**
 - **Pre-defined security security checks**
 - **Onchain enforcement via Safe guards**
 
-This is a deliberate starting point. Transaction security is complex, and Shieldnet prioritizes correctness, reliability, and measurable guarantees in its initial deployment.
+This is a deliberate starting point. Transaction security is complex, and Safenet prioritizes correctness, reliability, and measurable guarantees in its initial deployment.
 
 As a next step, onchain enforcement will be enabled including more advanced security checks, and transaction checker competition.
 

--- a/docs/docs/protocol/rewards.mdx
+++ b/docs/docs/protocol/rewards.mdx
@@ -1,11 +1,11 @@
 ---
 title: Rewards
-description: How rewards are calculated and distributed in Shieldnet
+description: How rewards are calculated and distributed in Safenet
 ---
 
 ## Overview
 
-Shieldnet rewards validators and delegators for securing the network on a per-epoch basis. Rewards are designed to be stake-weighted and resistant to centralization.
+Safenet rewards validators and delegators for securing the network on a per-epoch basis. Rewards are designed to be stake-weighted and resistant to centralization.
 
 #### Time-weighted stake
 - Rewards are calculated using the **average staked balance over the epoch**, not a single snapshot.
@@ -33,7 +33,7 @@ Shieldnet rewards validators and delegators for securing the network on a per-ep
 
 ## Calculation
 
-This section provides a precise mathematical definition of Shieldnet’s reward mechanism.
+This section provides a precise mathematical definition of Safenet’s reward mechanism.
 All stake values are time-averaged over the reward period (epoch).
 
 ### Glossary

--- a/docs/docs/security/threat_model.md
+++ b/docs/docs/security/threat_model.md
@@ -8,6 +8,6 @@ TODO
 - Explicit assumptions about validators, network, and cryptography.
 - Dependencies on external systems or honest majorities.
 - What breaks if an assumption no longer holds.
-- Security guarantees Shieldnet provides **if assumptions hold**.
-- What Shieldnet guarantees vs. what it does not.
+- Security guarantees Safenet provides **if assumptions hold**.
+- What Safenet guarantees vs. what it does not.
 - Scope and limits of each guarantee.

--- a/docs/docs/use_cases.md
+++ b/docs/docs/use_cases.md
@@ -2,6 +2,6 @@
 
 TODO
 
-- Concrete scenarios where we see Shieldnet improving security.
+- Concrete scenarios where we see Safenet improving security.
 - Which actors benefit in each case (users, validators, protocols).
 - If possible, clear before/after comparison

--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -7,7 +7,7 @@ import rehypeKatex from 'rehype-katex';
 // This runs in Node.js - Don't use client-side code here (browser APIs, JSX...)
 
 const config: Config = {
-  title: 'Shieldnet',
+  title: 'Safenet',
   tagline: 'Enforce transaction security onchain',
   // TODO replace with favicon
   favicon: 'img/favicon.ico',
@@ -41,7 +41,7 @@ const config: Config = {
     locales: ['en'],
   },
 
-stylesheets: [
+  stylesheets: [
     {
       href: 'https://cdn.jsdelivr.net/npm/katex@0.13.24/dist/katex.min.css',
       type: 'text/css',
@@ -60,7 +60,7 @@ stylesheets: [
           editUrl:
             'https://github.com/safe-research/shieldnet/tree/main/docs/',
           remarkPlugins: [remarkMath],
-          rehypePlugins: [rehypeKatex],  
+          rehypePlugins: [rehypeKatex],
         },
         blog: false,
         theme: {
@@ -77,10 +77,10 @@ stylesheets: [
       respectPrefersColorScheme: true,
     },
     navbar: {
-      title: 'Shieldnet',
+      title: 'Safenet',
       logo: {
-        alt: 'Shieldnet Logo',
-        // TODO replace with shieldnet logo
+        alt: 'Safenet Logo',
+        // TODO replace with Safenet logo
         src: 'img/logo.svg',
       },
       items: [

--- a/docs/src/pages/index.tsx
+++ b/docs/src/pages/index.tsx
@@ -8,10 +8,10 @@ function HomepageHeader() {
 		<header className={styles.heroBanner}>
 			<div className="container">
 				<Heading as="h1" className="hero__title">
-					Shieldnet
+					Safenet
 				</Heading>
 				<p className="hero__subtitle">
-					Shieldnet enforces transaction security onchain - protecting users from high-risk threats
+					Safenet enforces transaction security onchain - protecting users from high-risk threats
 				</p>
 				<Link className="button button--secondary button--lg" to="/docs/introduction">
 					Get Started
@@ -23,7 +23,7 @@ function HomepageHeader() {
 
 export default function Home() {
 	return (
-		<Layout title="Shieldnet" description="Shieldnet enforces transaction security onchain">
+		<Layout title="Safenet" description="Safenet enforces transaction security onchain">
 			<HomepageHeader />
 			<main>{/* TODO */}</main>
 		</Layout>


### PR DESCRIPTION
- Rename Shieldnet to Safenet in all public docs following the branding decision.
- urls and mentions of the gh repo aren't touched since they remain shieldnet for now.