### PR TITLE
Improve Logging JSON Replacer

### DIFF
--- a/validator/src/utils/json.test.ts
+++ b/validator/src/utils/json.test.ts
@@ -1,0 +1,47 @@
+import { HttpRequestError } from "viem";
+import { describe, expect, it } from "vitest";
+import { g } from "../frost/math.js";
+import { jsonReplacer } from "./json.js";
+
+const json = (value: unknown) => JSON.stringify(value, jsonReplacer, 2);
+
+describe("jsonReplacer", () => {
+	it("should serialize big integers", () => {
+		expect(json(1337n)).toEqual(json("1337"));
+	});
+
+	it("should serialize FROST points", () => {
+		const point = g(42n);
+		expect(json(point)).toEqual(
+			json({
+				x: point.x.toString(),
+				y: point.y.toString(),
+			}),
+		);
+	});
+
+	it("should serialize errors", () => {
+		const cause = new HttpRequestError({
+			url: "https://example.com",
+			status: 418,
+		});
+		const err = new Error("hello", { cause });
+		expect(json(err)).toEqual(
+			json({
+				name: "Error",
+				message: "hello",
+				cause: {
+					name: "HttpRequestError",
+					message: cause.message,
+					stack: cause.stack,
+					metaMessages: cause.metaMessages,
+					shortMessage: cause.shortMessage,
+					version: cause.version,
+					status: 418,
+					url: "https://example.com",
+				},
+				stack: err.stack,
+			}),
+		);
+	});
+});

--- a/validator/src/utils/json.ts
+++ b/validator/src/utils/json.ts
@@ -15,5 +15,20 @@ export function jsonReplacer(_key: string, value: unknown): unknown {
 			y: point.y.toString(), // Convert BigInt to string
 		};
 	}
+	// Handle errors.
+	if (value instanceof Error) {
+		return {
+			// The default Error fields are not enumerable, so we need to manually read them, as
+			// they will not be included by the `...` splat operation.
+			name: value.name,
+			message: value.message,
+			cause: value.cause,
+			stack: value.stack,
+
+			// Type assert to prevert compiler errors saying that `message` field above will be
+			// overwritten (which is not true as `message` is not enumerable for errors).
+			...(value as object),
+		};
+	}
 	return value;
 }

--- a/validator/src/utils/logging.ts
+++ b/validator/src/utils/logging.ts
@@ -1,5 +1,6 @@
 import util from "node:util";
 import winston, { type Logger as WinstonLogger } from "winston";
+import { jsonReplacer } from "./json.js";
 
 const LEVELS = {
 	error: 0,
@@ -34,21 +35,6 @@ const prettyFormat = winston.format.printf(({ timestamp, level, message, [SPLAT]
 		.join(" ");
 	return `[${timestamp} ${level}]: ${text}`;
 });
-
-const jsonReplacer = (key: string, value: unknown) => {
-	if (typeof value === "bigint") {
-		return value.toString();
-	}
-	if (value instanceof Error) {
-		const error = value as unknown as Record<string, unknown>;
-		const fields: Record<string, unknown> = {};
-		for (const propertyName of Object.getOwnPropertyNames(error)) {
-			fields[propertyName] = error[propertyName];
-		}
-		return fields;
-	}
-	return value;
-};
 
 export const createLogger = (options: LoggingOptions): Logger => {
 	winston.addColors({


### PR DESCRIPTION
It turns out we already have a replacer which handles a few more types that we may want to log in a span (specifically, `FrostPoint`s), so refactor the logging setup to use that replacer instead.

I added some tests for the log replacing to make sure it works as expected (including working with Viem errors which we expect to log).

Here an example log (formatted for legibility):

```json
{
    "error": {
        "cause": {
            "message": "HTTP request failed.\n\nURL: https://safe.dev\n\nVersion: viem@2.44.0",
            "metaMessages": [
                "URL: https://safe.dev"
            ],
            "name": "HttpRequestError",
            "shortMessage": "HTTP request failed.",
            "stack": "HttpRequestError: HTTP request failed.\n\nURL: https://safe.dev\n\nVersion: viem@2.44.0\n    at /var/home/nlordell/Developer/safe-research/shieldnet/validator/src/consensus/integration.test.ts:54:74\n    at file:///var/home/nlordell/Developer/safe-research/shieldnet/node_modules/@vitest/runner/dist/index.js:145:11\n    at file:///var/home/nlordell/Developer/safe-research/shieldnet/node_modules/@vitest/runner/dist/index.js:915:26\n    at file:///var/home/nlordell/Developer/safe-research/shieldnet/node_modules/@vitest/runner/dist/index.js:1243:20\n    at new Promise (<anonymous>)\n    at runWithTimeout (file:///var/home/nlordell/Developer/safe-research/shieldnet/node_modules/@vitest/runner/dist/index.js:1209:10)\n    at file:///var/home/nlordell/Developer/safe-research/shieldnet/node_modules/@vitest/runner/dist/index.js:1653:37\n    at Traces.$ (file:///var/home/nlordell/Developer/safe-research/shieldnet/node_modules/vitest/dist/chunks/traces.U4xDYhzZ.js:115:27)\n    at trace (file:///var/home/nlordell/Developer/safe-research/shieldnet/node_modules/vitest/dist/chunks/test.B8ej_ZHS.js:239:21)\n    at runTest (file:///var/home/nlordell/Developer/safe-research/shieldnet/node_modules/@vitest/runner/dist/index.js:1653:12)",
            "url": "https://safe.dev",
            "version": "2.44.0"
        },
        "message": "haha",
        "name": "Error",
        "stack": "Error: haha\n    at /var/home/nlordell/Developer/safe-research/shieldnet/validator/src/consensus/integration.test.ts:54:47\n    at file:///var/home/nlordell/Developer/safe-research/shieldnet/node_modules/@vitest/runner/dist/index.js:145:11\n    at file:///var/home/nlordell/Developer/safe-research/shieldnet/node_modules/@vitest/runner/dist/index.js:915:26\n    at file:///var/home/nlordell/Developer/safe-research/shieldnet/node_modules/@vitest/runner/dist/index.js:1243:20\n    at new Promise (<anonymous>)\n    at runWithTimeout (file:///var/home/nlordell/Developer/safe-research/shieldnet/node_modules/@vitest/runner/dist/index.js:1209:10)\n    at file:///var/home/nlordell/Developer/safe-research/shieldnet/node_modules/@vitest/runner/dist/index.js:1653:37\n    at Traces.$ (file:///var/home/nlordell/Developer/safe-research/shieldnet/node_modules/vitest/dist/chunks/traces.U4xDYhzZ.js:115:27)\n    at trace (file:///var/home/nlordell/Developer/safe-research/shieldnet/node_modules/vitest/dist/chunks/test.B8ej_ZHS.js:239:21)\n    at runTest (file:///var/home/nlordell/Developer/safe-research/shieldnet/node_modules/@vitest/runner/dist/index.js:1653:12)"
    },
    "level": "error",
    "message": "testing errors"
}
```