### PR TITLE
[I-01]: Document Staking Is Allowed for Deregistering Validators

### DIFF
--- a/contracts/src/Staking.sol
+++ b/contracts/src/Staking.sol
@@ -330,7 +330,8 @@ contract Staking is Ownable {
     // ============================================================
 
     /**
-     * @notice Stake tokens toward a validator.
+     * @notice Stake tokens toward a validator. Note that it is possible to stake towards validators that have been
+     *         proposed for deregistration.
      * @param validator The validator address to stake toward.
      * @param amount The amount of tokens to stake.
      */

--- a/docs/internal/staking.md
+++ b/docs/internal/staking.md
@@ -133,6 +133,7 @@ Custom errors are used for gas efficiency and precise revert reasons:
   - **Purpose**: Increase stake for a validator.
   - **Invariants**: Validator must be registered; amount must be non-zero.
   - **Security**: State updates precede `safeTransferFrom` (reverts roll back state).
+  - **Edge case**: Staking towards validators that are pending deregistration is allowed.
 
 - `initiateWithdrawal(validator, amount)`
   - **Purpose**: Create a withdrawal and insert into a sorted queue automatically.


### PR DESCRIPTION
It is possible to stake for validators that are being deregistered (via `proposeValidators`). Document it as such.