### PR TITLE
[L-03] Document Overwriting Pending Validator Proposals

### DIFF
--- a/contracts/src/Staking.sol
+++ b/contracts/src/Staking.sol
@@ -529,8 +529,8 @@ contract Staking is Ownable {
     }
 
     /**
-     * @notice Propose validator registration/deregistration changes. Proposing validators (de)registration while
-     *         there is already a pending proposal will cause the pending one to be invalidated.
+     * @notice Propose validator registration/deregistration changes. This will overwrite the existing pending proposal
+     *         for validator changes.
      * @param validators Array of validator addresses.
      * @param isRegistration Array of booleans (true = register, false = deregister).
      * @dev It is currently possible to propose duplicate validators in a single proposal.


### PR DESCRIPTION
The behaviour where a pending validator proposal is overwritten is intentional, document it as such.