### PR TITLE
Expose epoch information publicly

### DIFF
--- a/contracts/src/Consensus.sol
+++ b/contracts/src/Consensus.sol
@@ -258,6 +258,25 @@ contract Consensus is IFROSTCoordinatorCallback {
         group = $groups[epoch];
     }
 
+    /**
+     * @notice Gets the current epochs (previous, active, staged).
+     * @return epochs The current active epoch.
+     */
+    function getCurrentEpochs() external view returns (Epochs memory epochs) {
+        (epochs,) = _epochsWithRollover();
+    }
+
+    /**
+     * @notice Gets the group info for a specific epoch
+     * @param epoch The epoch for which the group should be retrieved
+     * @return group The FROST group ID for the active epoch.
+     * @return groupKey The FROST group ID for the active epoch.
+     */
+    function getEpochGroup(uint64 epoch) external view returns (FROSTGroupId.T group, Secp256k1.Point memory groupKey) {
+        group = $groups[epoch];
+        groupKey = _COORDINATOR.groupKey(group);
+    }
+
     // ============================================================
     // EXTERNAL AND PUBLIC STATE-CHANGING FUNCTIONS
     // ============================================================

--- a/contracts/test/Consensus.t.sol
+++ b/contracts/test/Consensus.t.sol
@@ -2,59 +2,105 @@
 pragma solidity ^0.8.30;
 
 import {Test, Vm} from "@forge-std/Test.sol";
-import {Hashes} from "@oz/utils/cryptography/Hashes.sol";
 import {Consensus} from "@/Consensus.sol";
-import {FROSTCoordinator} from "@/FROSTCoordinator.sol";
-import {FROST} from "@/libraries/FROST.sol";
 import {FROSTGroupId} from "@/libraries/FROSTGroupId.sol";
+import {FROSTSignatureId} from "@/libraries/FROSTSignatureId.sol";
 import {Secp256k1} from "@/libraries/Secp256k1.sol";
 
+contract MockCoordinator {
+    mapping(FROSTGroupId.T => Secp256k1.Point) groupKeys;
+
+    function setGroupKey(FROSTGroupId.T group, Secp256k1.Point memory key) external {
+        groupKeys[group] = key;
+    }
+
+    function groupKey(FROSTGroupId.T group) external view returns (Secp256k1.Point memory key) {
+        return groupKeys[group];
+    }
+
+    function signatureVerify(FROSTSignatureId.T, FROSTGroupId.T, bytes32) external view {}
+}
+
 contract ConsensusTest is Test {
+    FROSTGroupId.T immutable GENESIS_GROUP = FROSTGroupId.T.wrap(keccak256("genesisGroup"));
+
     Vm.Wallet public group;
 
-    FROSTCoordinator public coordinator;
+    MockCoordinator public coordinator;
     Consensus public consensus;
 
     function setUp() public {
         group = vm.createWallet("group");
-        coordinator = new FROSTCoordinator();
-        FROSTGroupId.T gid = _keyGen(0);
-        consensus = new Consensus(address(coordinator), gid);
+
+        coordinator = new MockCoordinator();
+        consensus = new Consensus(address(coordinator), GENESIS_GROUP);
     }
 
-    function test_Placeholder() public pure {
-        assertTrue(true);
+    function test_GetEpochGroup_ExistingGroup() public {
+        (uint64 epoch, FROSTGroupId.T expectedGroupId) = consensus.getActiveEpoch();
+        Secp256k1.Point memory expectedKey = Secp256k1.Point({x: 0x5afe01, y: 0x5afe02});
+        coordinator.setGroupKey(expectedGroupId, expectedKey);
+        (FROSTGroupId.T groupId, Secp256k1.Point memory groupKey) = consensus.getEpochGroup(epoch);
+        assertEq32(FROSTGroupId.T.unwrap(expectedGroupId), FROSTGroupId.T.unwrap(groupId));
+        assertEq(expectedKey.x, groupKey.x);
+        assertEq(expectedKey.y, groupKey.y);
     }
 
-    function _keyGen(uint64 epoch) private returns (FROSTGroupId.T gid) {
-        // Perform a partial key generation ceremony where leading to a group
-        // key equal to `group`. This makes signing very easy for testing. Use a
-        // random second participant in order to always generate a fresh group
-        // ID. We don't need to complete the ceremony in order to use it with
-        // the consensus contract.
+    function test_GetEpochGroup_EmptyForUnknownEpoch() public view {
+        (FROSTGroupId.T groupId, Secp256k1.Point memory groupKey) = consensus.getEpochGroup(10000);
+        assertEq32(bytes32(uint256(0)), FROSTGroupId.T.unwrap(groupId));
+        assertEq(0, groupKey.x);
+        assertEq(0, groupKey.y);
+    }
 
-        bytes32 context = bytes32((uint256(uint160(address(consensus))) << 96) | uint256(epoch));
-        bytes32 participantsRoot;
-        bytes32[] memory participationProof = new bytes32[](1);
-        {
-            participationProof[0] =
-                Hashes.efficientKeccak256(bytes32(uint256(2)), bytes32(uint256(uint160(vm.randomAddress()))));
-            bytes32 leaf = Hashes.efficientKeccak256(bytes32(uint256(1)), bytes32(uint256(uint160(address(this)))));
-            (bytes32 left, bytes32 right) =
-                leaf < participationProof[0] ? (leaf, participationProof[0]) : (participationProof[0], leaf);
-            participantsRoot = Hashes.efficientKeccak256(left, right);
-        }
+    function test_GetCurrentEpochs_GenesisInfo() public view {
+        (Consensus.Epochs memory epochs) = consensus.getCurrentEpochs();
+        assertEq(0, epochs.previous);
+        assertEq(0, epochs.active);
+        assertEq(0, epochs.staged);
+        assertEq(0, epochs.rolloverBlock);
+    }
 
-        FROSTCoordinator.KeyGenCommitment memory commitment;
-        commitment.c = new Secp256k1.Point[](2);
-        commitment.c[0].x = group.publicKeyX;
-        commitment.c[0].y = group.publicKeyY;
-        (gid,) = coordinator.keyGenAndCommit(
-            participantsRoot, 2, 2, context, FROST.newIdentifier(1), participationProof, commitment
+    function test_GetCurrentEpochs_StagedEpoch() public {
+        consensus.stageEpoch(0x5afe, 0x100, FROSTGroupId.T.wrap(keccak256("testGroup")), FROSTSignatureId.T.wrap(""));
+        // Use vm.expectCall(address(dep), abi.encodeWithSelector(dep.foo.selector, param1, paramN));
+        (Consensus.Epochs memory epochs) = consensus.getCurrentEpochs();
+        assertEq(0, epochs.previous);
+        assertEq(0, epochs.active);
+        assertEq(0x5afe, epochs.staged);
+        assertEq(0x100, epochs.rolloverBlock);
+    }
+
+    function test_GetCurrentEpochs_NewEpoch() public {
+        consensus.stageEpoch(
+            0x5afe, uint64(block.number + 1), FROSTGroupId.T.wrap(keccak256("testGroup")), FROSTSignatureId.T.wrap("")
         );
+        // Use vm.expectCall(address(dep), abi.encodeWithSelector(dep.foo.selector, param1, paramN));
+        vm.roll(block.number + 1);
+        (Consensus.Epochs memory epochs) = consensus.getCurrentEpochs();
+        assertEq(0, epochs.previous);
+        assertEq(0x5afe, epochs.active);
+        assertEq(0, epochs.staged);
+        assertEq(0, epochs.rolloverBlock);
+    }
 
-        assertEq(
-            keccak256(abi.encode(coordinator.groupKey(gid))), keccak256(abi.encode(group.publicKeyX, group.publicKeyY))
+    function test_GetCurrentEpochs_MultipleEpochs() public {
+        consensus.stageEpoch(
+            0x5afe01, uint64(block.number + 1), FROSTGroupId.T.wrap(keccak256("testGroup")), FROSTSignatureId.T.wrap("")
         );
+        vm.roll(block.number + 1);
+        consensus.stageEpoch(
+            0x5afe02, uint64(block.number + 1), FROSTGroupId.T.wrap(keccak256("testGroup")), FROSTSignatureId.T.wrap("")
+        );
+        vm.roll(block.number + 1);
+        // Use vm.expectCall(address(dep), abi.encodeWithSelector(dep.foo.selector, param1, paramN));
+        consensus.stageEpoch(
+            0x5afe03, uint64(block.number + 1), FROSTGroupId.T.wrap(keccak256("testGroup")), FROSTSignatureId.T.wrap("")
+        );
+        (Consensus.Epochs memory epochs) = consensus.getCurrentEpochs();
+        assertEq(0x5afe01, epochs.previous);
+        assertEq(0x5afe02, epochs.active);
+        assertEq(0x5afe03, epochs.staged);
+        assertEq(block.number + 1, epochs.rolloverBlock);
     }
 }


### PR DESCRIPTION
- Add getCurrentEpochs to return current Epochs struct
- Add getEpochGroup to return group info for a specific epoch
- Added tests with mocks