### PR TITLE
Remove unused state prop

### DIFF
--- a/validator/src/machine/consensus/epochStaged.test.ts
+++ b/validator/src/machine/consensus/epochStaged.test.ts
@@ -43,7 +43,6 @@ const MACHINE_STATES: MachineStates = {
 		groupId: "0x5afe5af3",
 		nextEpoch: 2n,
 		message: "0x5afe5afe",
-		responsible: 1n,
 	},
 	signing: {
 		"0x5afe5afe": SIGNING_STATE,

--- a/validator/src/machine/keygen/confirmed.test.ts
+++ b/validator/src/machine/keygen/confirmed.test.ts
@@ -309,7 +309,6 @@ describe("key gen confirmed", () => {
 			groupId: "0x06cb03baac74421225341827941e88d9547e5459c4b3715c0000000000000000",
 			nextEpoch: 10n,
 			message: keccak256("0x5afe01020304"),
-			responsible: 2n,
 		};
 		expect(diff).toStrictEqual({
 			rollover,

--- a/validator/src/machine/keygen/confirmed.ts
+++ b/validator/src/machine/keygen/confirmed.ts
@@ -109,7 +109,6 @@ export const handleKeyGenConfirmed = async (
 			groupId,
 			nextEpoch,
 			message,
-			responsible: event.identifier,
 		},
 		signing: [
 			message,

--- a/validator/src/machine/keygen/timeout.test.ts
+++ b/validator/src/machine/keygen/timeout.test.ts
@@ -61,7 +61,6 @@ describe("key gen timeouts", () => {
 				groupId: "0x5afe01",
 				nextEpoch: 1n,
 				message: "0x5afe5afe5afe",
-				responsible: 3n,
 			},
 			signing: {},
 		};

--- a/validator/src/machine/signing/nonces.test.ts
+++ b/validator/src/machine/signing/nonces.test.ts
@@ -35,7 +35,6 @@ const MACHINE_STATES: MachineStates = {
 		groupId: "0x0000000000000000000000007fa9385be102ac3eac297483dd6233d62b3e1496",
 		message: "0x5afe5afe",
 		nextEpoch: 3n,
-		responsible: 1n,
 	},
 	signing: {
 		"0x5afe5afe": SIGNING_STATE,
@@ -226,7 +225,6 @@ describe("nonces revealed", () => {
 				groupId: "0x0000000000000000000000007fa9385be102ac3eac297483dd6233d62b3e1496",
 				message: "0x5afe5af3",
 				nextEpoch: 3n,
-				responsible: 1n,
 			},
 			signing: {
 				"0x5afe5afe": signingState,
@@ -296,7 +294,6 @@ describe("nonces revealed", () => {
 				groupId: "0x0000000000000000000000007fa9385be102ac3eac297483dd6233d62b3e1496",
 				message: "0x5afe5af3",
 				nextEpoch: 3n,
-				responsible: 1n,
 			},
 		};
 		const signatureShareData = {

--- a/validator/src/machine/signing/timeouts.test.ts
+++ b/validator/src/machine/signing/timeouts.test.ts
@@ -56,7 +56,6 @@ const MACHINE_STATES: MachineStates = {
 		groupId: "0x0000000000000000000000007fa9385be102ac3eac297483dd6233d62b3e1496",
 		message: "0x5afe5afe",
 		nextEpoch: 3n,
-		responsible: 1n,
 	},
 	signing: {
 		"0x5afe5afe": SIGNING_STATE,

--- a/validator/src/machine/types.ts
+++ b/validator/src/machine/types.ts
@@ -50,7 +50,6 @@ export type RolloverState = Readonly<
 			groupId: GroupId;
 			nextEpoch: bigint;
 			message: Hex;
-			responsible: ParticipantId;
 	  }
 >;
 


### PR DESCRIPTION
Related to #86 
- https://github.com/safe-research/shieldnet/pull/81/changes/BASE..031066b637b10b6b611d6af9dbb201f42e38c2ee#r2622637685
- Remove unused Rollover state prop `responsible`, this is covered by the corresponding signing state