### PR TITLE
Fix epoch signing, with increased singer set

### DIFF
--- a/validator/src/consensus/integration.test.ts
+++ b/validator/src/consensus/integration.test.ts
@@ -263,6 +263,27 @@ describe("integration", () => {
 		});
 		const stagedGroupKey = stagedEpochs[0].args.groupKey;
 		expect(stagedGroupKey).toStrictEqual(expectedKey);
+
+		// Restart client and calculate next group
+		clients[2].service.start();
+
+		// Wait for end of epoch
+		await waitForBlock(testClient, 60n);
+
+		const expectedGroupEpoch2 = calcGroupId(
+			calculateParticipantsRoot([participants[0], participants[1], participants[2], participants[3]]),
+			4,
+			3,
+			calcGroupContext(consensus.address, 2n),
+		);
+		const expectedKeyEpoch2 = await testClient.readContract({
+			...coordinator,
+			functionName: "groupKey",
+			args: [expectedGroupEpoch2],
+		});
+		expect(expectedKeyEpoch2.x).not.toBe(0n);
+		expect(expectedKeyEpoch2.y).not.toBe(0n);
+		expect(stagedGroupKey).not.toStrictEqual(expectedKeyEpoch2);
 	});
 
 	it("keygen abort", { timeout: TEST_RUNTIME_IN_SECONDS * 1000 * 5 }, async ({ skip }) => {

--- a/validator/src/machine/consensus/epochStaged.ts
+++ b/validator/src/machine/consensus/epochStaged.ts
@@ -1,7 +1,7 @@
 import type { ProtocolAction } from "../../consensus/protocol/types.js";
 import type { SigningClient } from "../../consensus/signing/client.js";
 import type { EpochStagedEvent } from "../transitions/types.js";
-import type { MachineStates, StateDiff } from "../types.js";
+import type { ConsensusDiff, MachineStates, StateDiff } from "../types.js";
 
 export const handleEpochStaged = async (
 	signingClient: SigningClient,
@@ -14,19 +14,29 @@ export const handleEpochStaged = async (
 		return {};
 	}
 
-	// Check that signing state is waiting for attestation
+	const signatureIdDiff: ConsensusDiff = {};
+	// Check if there is a signatureId that needs to be cleaned up
 	const status = machineStates.signing[machineStates.rollover.message];
-	if (status?.id !== "waiting_for_attestation") return {};
-
+	if (status !== undefined && status.id !== "waiting_for_request") {
+		signatureIdDiff.signatureIdToMessage = [status.signatureId, undefined];
+	}
 	const groupId = machineStates.rollover.groupId;
+	// The signing state should be cleaned up in any case, as the rollover was attested
+	const diff: StateDiff = {
+		consensus: {
+			...signatureIdDiff,
+		},
+		rollover: { id: "epoch_staged", nextEpoch: event.proposedEpoch },
+		signing: [machineStates.rollover.message, undefined],
+	};
 
 	try {
 		// Check if validator is part of group, method will throw if not
 		signingClient.participantId(groupId);
 	} catch {
 		// If there is no participant id, then this validator is not part of the group
-		// In this case ignore this request
-		return {};
+		// In this case don't generate a nonce tree
+		return diff;
 	}
 
 	// Start preprocessing for the new group (per spec's epoch_staged handler)
@@ -38,15 +48,14 @@ export const handleEpochStaged = async (
 			nonceCommitmentsHash: nonceTreeRoot,
 		},
 	];
+	diff.consensus = {
+		...diff.consensus,
+		groupPendingNonces: [groupId, true],
+	};
 
 	// Clean up internal state and mark group as ready for signing
 	return {
-		consensus: {
-			signatureIdToMessage: [status.signatureId],
-			groupPendingNonces: [groupId, true],
-		},
-		signing: [machineStates.rollover.message],
-		rollover: { id: "epoch_staged", nextEpoch: event.proposedEpoch },
+		...diff,
 		actions,
 	};
 };


### PR DESCRIPTION
When signing epoch rollover instead of the participants of the active group the participants of the new group were selected. This causes an error when signing. 

Changes:
- Use correct group id to get signers for epoch rollover (aka use participants of active group)
- Adjust integration test to test this
- Clean up signing state even if not part of epoch signing