### PR TITLE
Remove 'rollback' of transaction on submission error

### DIFF
--- a/validator/src/consensus/protocol/onchain.test.ts
+++ b/validator/src/consensus/protocol/onchain.test.ts
@@ -1084,7 +1084,7 @@ describe("OnchainProtocol", () => {
 		expect(setHash).toBeCalledWith(11, hash);
 	});
 
-	it("should delete tx on error if no additional tx was submitted", async () => {
+	it("should not delete tx on error", async () => {
 		const queue = new InMemoryQueue<ActionWithTimeout>();
 		const getTransactionCount = vi.fn();
 		const publicClient = {
@@ -1122,83 +1122,6 @@ describe("OnchainProtocol", () => {
 		sendTransaction.mockRejectedValueOnce(new Error("Test unexpected!"));
 		register.mockReturnValueOnce(10);
 		maxNonce.mockReturnValueOnce(10);
-		const protocol = new OnchainProtocol({
-			publicClient,
-			signingClient,
-			gasFeeEstimator,
-			consensus: TEST_CONSENSUS,
-			coordinator: TEST_COORDINATOR,
-			queue,
-			txStorage,
-			logger: testLogger,
-		});
-		protocol.process(action);
-		// Action was submitted and should be in the queue
-		expect(queue.peek()).toBeDefined();
-		await vi.waitFor(() => {
-			expect(deleteTx).toHaveBeenCalled();
-		});
-		// Tx was not stored, action should be kept
-		expect(queue.peek()).toBeDefined();
-		expect(getTransactionCount).toBeCalledTimes(1);
-		expect(getTransactionCount).toBeCalledWith({
-			address: entryPoint09Address,
-			blockTag: "latest",
-		});
-		expect(register).toBeCalledTimes(1);
-		expect(register).toBeCalledWith(tx, 10);
-		expect(estimateFees).toBeCalledTimes(1);
-		expect(sendTransaction).toBeCalledTimes(1);
-		expect(sendTransaction).toBeCalledWith({
-			...tx,
-			nonce: 10,
-			account,
-			chain,
-			maxFeePerGas: 200n,
-			maxPriorityFeePerGas: 100n,
-		});
-		expect(deleteTx).toBeCalledTimes(1);
-		expect(deleteTx).toBeCalledWith(10);
-	});
-
-	it("should not delete tx on error if additional tx was submitted", async () => {
-		const queue = new InMemoryQueue<ActionWithTimeout>();
-		const getTransactionCount = vi.fn();
-		const publicClient = {
-			getTransactionCount,
-		} as unknown as PublicClient;
-		const sendTransaction = vi.fn();
-		const chain = gnosisChiado;
-		const account = { address: entryPoint09Address };
-		const signingClient = {
-			account,
-			chain,
-			sendTransaction,
-		} as unknown as WalletClient<Transport, Chain, Account>;
-		const estimateFees = vi.fn();
-		const gasFeeEstimator = {
-			estimateFees,
-		} as unknown as GasFeeEstimator;
-		const register = vi.fn();
-		const setFees = vi.fn();
-		const maxNonce = vi.fn();
-		const deleteTx = vi.fn();
-		const txStorage = {
-			register,
-			setFees,
-			maxNonce,
-			delete: deleteTx,
-		} as unknown as TransactionStorage;
-
-		const [action, , tx] = TEST_ACTIONS[0];
-		getTransactionCount.mockResolvedValueOnce(10);
-		estimateFees.mockResolvedValueOnce({
-			maxFeePerGas: 200n,
-			maxPriorityFeePerGas: 100n,
-		});
-		sendTransaction.mockRejectedValueOnce(new Error("Test unexpected!"));
-		register.mockReturnValueOnce(10);
-		maxNonce.mockReturnValueOnce(11);
 		const protocol = new OnchainProtocol({
 			publicClient,
 			signingClient,

--- a/validator/src/consensus/protocol/sqlite.test.ts
+++ b/validator/src/consensus/protocol/sqlite.test.ts
@@ -431,60 +431,6 @@ describe("protocol - sqlite", () => {
 			]);
 		});
 
-		it("should not return deleted transactions", () => {
-			const db = new Sqlite3(":memory:");
-			const storage = new SqliteTxStorage(db);
-			storage.register(
-				{
-					to: entryPoint06Address,
-					value: 0n,
-					data: "0x5afe01",
-				},
-				1,
-			);
-			storage.register(
-				{
-					to: entryPoint06Address,
-					value: 0n,
-					data: "0x5afe02",
-					gas: 200_000n,
-				},
-				1,
-			);
-			storage.setSubmittedForPending(0n);
-			expect(storage.submittedUpTo(0n)).toStrictEqual([
-				{
-					to: entryPoint06Address,
-					value: 0n,
-					data: "0x5afe01",
-					hash: null,
-					nonce: 1,
-					fees: null,
-				},
-				{
-					to: entryPoint06Address,
-					value: 0n,
-					data: "0x5afe02",
-					hash: null,
-					gas: 200_000n,
-					nonce: 2,
-					fees: null,
-				},
-			]);
-			storage.delete(1);
-			expect(storage.submittedUpTo(0n)).toStrictEqual([
-				{
-					to: entryPoint06Address,
-					value: 0n,
-					data: "0x5afe02",
-					hash: null,
-					gas: 200_000n,
-					nonce: 2,
-					fees: null,
-				},
-			]);
-		});
-
 		it("should not return executed transactions", () => {
 			const db = new Sqlite3(":memory:");
 			const storage = new SqliteTxStorage(db);

--- a/validator/src/consensus/protocol/sqlite.ts
+++ b/validator/src/consensus/protocol/sqlite.ts
@@ -225,14 +225,6 @@ export class SqliteTxStorage implements TransactionStorage {
 		return Number(result.lastInsertRowid);
 	}
 
-	delete(nonce: number): void {
-		const updateStmt = this.#db.prepare(`
-			DELETE FROM transaction_storage
-			WHERE nonce = ?;
-		`);
-		updateStmt.run(nonce);
-	}
-
 	maxNonce(): number | null {
 		const result = this.#db
 			.prepare(`
@@ -295,7 +287,11 @@ export class SqliteTxStorage implements TransactionStorage {
 
 	setExecuted(nonce: number): void {
 		// Executed txs are delete to avoid the database from growing
-		this.delete(nonce);
+		const updateStmt = this.#db.prepare(`
+			DELETE FROM transaction_storage
+			WHERE nonce = ?;
+		`);
+		updateStmt.run(nonce);
 	}
 
 	setAllBeforeAsExecuted(nonce: number): number {


### PR DESCRIPTION
When an error occurred during transaction submission the tx was deleted from the database, to allow reusing the nonce. This is error prone, as the transaction might already be in the mempool, therefore specific gas price restrictions apply to the transaction (otherwise an "transaction is underpriced" error is thrown). 

To avoid this the "rollback" logic is removed. Transaction will be now resubmitted with increasing gas prices until they have been accepted (even if they revert).

Notable changes:
- Remove option to explicitly delete a tx from storage
- Remove that a tx is removed from storage on submission error 

Alternative solution:
- Check if the fees are set, if not it is safe to remove the tx -> was not chosen because of increased complexity