### PR TITLE
Annotate Docker Image with Git Commit Hash

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -28,6 +28,8 @@ jobs:
         uses: docker/metadata-action@v5
         with:
           images: ghcr.io/safe-research/safenet-validator
+          labels: |
+            org.opencontainers.image.revision=${{ github.sha }}
 
       - uses: docker/build-push-action@v6
         with:


### PR DESCRIPTION
This PR adds a new label to annotate our docker images with the commit hash that they were built with. This allows us to more easily identify what exact version of the validator we are running.

The choice of label key was chosen from the [Open Container Standard](https://specs.opencontainers.org/image-spec/annotations/#pre-defined-annotation-keys).