### PR TITLE
Rework Transaction Packet Logging

### DIFF
--- a/validator/src/consensus/verify/engine.ts
+++ b/validator/src/consensus/verify/engine.ts
@@ -13,7 +13,7 @@ export type PacketVerificationResult =
 			status: "valid";
 			packetId: Hex;
 	  }
-	| { status: "invalid"; error: unknown };
+	| { status: "invalid"; error: Error };
 
 export class VerificationEngine {
 	#typeHandlers: Map<string, PacketHandler<Typed>>;
@@ -36,7 +36,8 @@ export class VerificationEngine {
 				status: "valid",
 				packetId,
 			};
-		} catch (error: unknown) {
+		} catch (err: unknown) {
+			const error = err instanceof Error ? err : new Error(`unknown error: ${err}`);
 			return {
 				status: "invalid",
 				error,


### PR DESCRIPTION
This PR slightly adjusts the logs around the Safe transaction proposal packet. It makes it not include all the error information (for example, the stack trace), as it adds quite a bit of noise to the logs, and (AFAIU) isn't particularly interesting information.

Additionally, to make matching up of the transaction with an actual Safe Tx easier, I added the `safeTxHash` to the span.