### PR TITLE
Add CoW Extensible Fallback Handler

### DIFF
--- a/validator/src/consensus/verify/safeTx/checks/config/fallback.ts
+++ b/validator/src/consensus/verify/safeTx/checks/config/fallback.ts
@@ -3,10 +3,11 @@ import { buildSelectorCheck } from "../basic.js";
 
 const ALLOWED_FALLBACK_HANDLERS: Address[] = [
 	"0x85a8ca358D388530ad0fB95D0cb89Dd44Fc242c3", // ExtensibleFallbackHandler - 1.5.0
+	"0x2f55e8b20D0B9FEFA187AA7d00B6Cbe563605bF5", // ExtensibleFallbackHandler - CoW
 	"0x3EfCBb83A4A7AfcB4F68D501E2c2203a38be77f4", // CompatibilityFallbackHandler - 1.5.0
 	"0xfd0732Dc9E303f09fCEf3a7388Ad10A83459Ec99", // CompatibilityFallbackHandler - 1.4.1
 	"0xf48f2B2d2a534e402487b3ee7C18c33Aec0Fe5e4", // CompatibilityFallbackHandler - 1.3.0 - canonical
-	"0x017062a1dE2FE6b99BE3d9d37841FeD19F573804", // CompatibilityFallbackHandler - 1.4.1 - eip155
+	"0x017062a1dE2FE6b99BE3d9d37841FeD19F573804", // CompatibilityFallbackHandler - 1.3.0 - eip155
 ];
 
 export const buildSetFallbackHandlerCheck = () =>


### PR DESCRIPTION
We used it ;).

The address of the contract can be verified from the CoW repository: https://github.com/cowprotocol/composable-cow?tab=readme-ov-file#deployed-contracts

---

Joking aside some other handlers/modules/adapters we should consider adding as safe:

- 4337 adapter
- 7579 adapter
- Candide recovery module
- allowance module v1

If we agree, I would add them here as well.

> [!TIP]
> An _adapter_ is a contract that integrates with a Safe by being configured as both a fallback handler and a module.