### PR TITLE
Build `arm64` Images

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -29,10 +29,14 @@ jobs:
         with:
           images: ghcr.io/safe-research/safenet-validator
 
+      - uses: docker/setup-qemu-action@v3
+      - uses: docker/setup-buildx-action@v3
+
       - uses: docker/build-push-action@v6
         with:
           context: .
           file: validator/Dockerfile
+          platforms: linux/amd64,linux/arm64
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
This PR adds `arm64` builds for the validator images. This makes running a validator on Apple Silicon for developers with Apple devices a bit easier. Additionally, this allows the images to be used on Arm hosting providers (such as AWS ECS A1 instances).