### PR TITLE
Validator `env` description

### DIFF
--- a/validator/.env.sample
+++ b/validator/.env.sample
@@ -16,7 +16,7 @@ CONSENSUS_ADDRESS=
 COORDINATOR_ADDRESS=
 # The chain ID of the network to connect to
 CHAIN_ID=
-# The address array of the validators participating in the consensus (hex string, comma separated)
+# The address array of the validators participating in the consensus (checksummed addresses, comma separated)
 PARTICIPANTS=
 # The salt for the genesis group parameter creation (hex string, with 0x prefix)
 GENESIS_SALT= # Optional


### PR DESCRIPTION
This provides additional information about `env.sample` to make it easier for validators to configure.