### PR TITLE
Link docs in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,7 +16,7 @@ Technical documentation for the system is in `docs/`, where we can find an overv
 
 ## Documentation
 
-Documentation on the architecture and setup of Safenet can be found in the [docs](./docs/) folder. Further documentation (also including Safe) can be found on the [Safe Foundation docs](https://docs.safefoundation.org). The MCP server for this is https://docs.safefoundation.org/mcp.
+For detailed architecture and setup information, refer to the local [docs](./docs/) folder. Additional documentation, including information about Safe, is available on the [Safe Foundation docs](https://docs.safefoundation.org). The MCP server related to this documentation can be found at https://docs.safefoundation.org/mcp.
 
 ## Development Commands
 


### PR DESCRIPTION
Provide a link to the Safenet and Safe documentation in the CLAUDE.md for more context and better integration with Claude.