### PR TITLE
Stable Participant Merkle Tree

### DIFF
--- a/contracts/script/util/Genesis.sol
+++ b/contracts/script/util/Genesis.sol
@@ -1,11 +1,15 @@
 // SPDX-License-Identifier: GPL-3.0-only
 pragma solidity ^0.8.30;
 
+import {Arrays} from "@oz/utils/Arrays.sol";
+
 /**
  * @title Safenet Genesis
  * @notice Library with utilities for computing Safenet genesis parameters.
  */
 library Genesis {
+    using Arrays for bytes32[];
+
     /**
      * @notice Computes the Merkle root for a set of participants. The participant FROST identifiers are assumed to
      *         be sequential starting at 1.
@@ -21,7 +25,9 @@ library Genesis {
         for (uint256 i = 0; i < participants.length; i++) {
             nodes[i] = bytes32(uint256(uint160(participants[i])));
         }
-        for (uint256 l = participants.length; l > 1; l = (l + 1) / 2) {
+        nodes.sort();
+
+        for (uint256 l = nodes.length; l > 1; l = (l + 1) / 2) {
             for (uint256 i = 0; i < l; i += 2) {
                 bytes32 a = nodes[i];
                 bytes32 b = i + 1 < l ? nodes[i + 1] : bytes32(0);

--- a/validator/src/consensus/merkle.test.ts
+++ b/validator/src/consensus/merkle.test.ts
@@ -1,6 +1,12 @@
 import type { Hex } from "viem";
 import { describe, expect, it } from "vitest";
-import { calculateMerkleRoot, generateMerkleProof, verifyMerkleProof } from "./merkle.js";
+import {
+	calculateMerkleRoot,
+	calculateParticipantsRoot,
+	generateMerkleProof,
+	generateParticipantProof,
+	verifyMerkleProof,
+} from "./merkle.js";
 
 describe("merkle", () => {
 	it("should generate the correct merkle root", () => {
@@ -34,5 +40,28 @@ describe("merkle", () => {
 		expect(
 			verifyMerkleProof(root, "0x0000000000000000000000000000000000000000000000000000000000000003", proof),
 		).toBeTruthy();
+	});
+
+	it("participant Merkle trees should be ordfer independant", () => {
+		const ordered = [
+			"0x00000000000000000000000000000000000000a1",
+			"0x00000000000000000000000000000000000000A2",
+			"0x00000000000000000000000000000000000000b3",
+		] as const;
+		const unordered = [ordered[1], ordered[2], ordered[0]];
+
+		const participant = "0x00000000000000000000000000000000000000A2";
+		const participantLeaf = "0x00000000000000000000000000000000000000000000000000000000000000a2";
+		const expectedRoot = calculateMerkleRoot([
+			"0x00000000000000000000000000000000000000000000000000000000000000a1",
+			"0x00000000000000000000000000000000000000000000000000000000000000a2",
+			"0x00000000000000000000000000000000000000000000000000000000000000b3",
+		]);
+
+		for (const participants of [ordered, unordered]) {
+			expect(calculateParticipantsRoot(participants)).toBe(expectedRoot);
+			const proof = generateParticipantProof(participants, participant);
+			expect(verifyMerkleProof(expectedRoot, participantLeaf, proof)).toBe(true);
+		}
 	});
 });

--- a/validator/src/consensus/merkle.ts
+++ b/validator/src/consensus/merkle.ts
@@ -26,10 +26,6 @@ export const calculateMerkleRoot = (leaves: Hex[]): Hex => {
 	return rootLevel[0];
 };
 
-export const calculateParticipantsRoot = (participants: readonly Address[]): Hex => {
-	return calculateMerkleRoot(participants.map((p) => pad(p)));
-};
-
 export const verifyMerkleProof = (root: Hex, leaf: Hex, proof: Hex[]): boolean => {
 	let node: Hex = leaf;
 	for (const part of proof) {
@@ -67,10 +63,19 @@ export const generateMerkleProof = (leaves: Hex[], index: number): Hex[] => {
 	return proof;
 };
 
+const sortedParticipantLeaves = (participants: readonly Address[]): Hex[] => {
+	// In order to ensure stable participation roots, we make sure that we sort the addresses
+	// lexographically (i.e. based on their value and not checksummed string representation)
+	// before building our participant Merkle tree.
+	return participants.map((p) => pad(p).toLowerCase() as Hex).sort();
+};
+
+export const calculateParticipantsRoot = (participants: readonly Address[]): Hex => {
+	return calculateMerkleRoot(sortedParticipantLeaves(participants));
+};
+
 export const generateParticipantProof = (participants: readonly Address[], participant: Address): Hex[] => {
-	const index = participants.findIndex((p) => p === participant);
-	return generateMerkleProof(
-		participants.map((p) => pad(p)),
-		index,
-	);
+	const leaves = sortedParticipantLeaves(participants);
+	const index = leaves.findIndex((p) => BigInt(p) === BigInt(participant));
+	return generateMerkleProof(sortedParticipantLeaves(participants), index);
 };


### PR DESCRIPTION
Now that we have stable participant indices, it makes sense to also make the participant root (i.e. the root hash of the Merkle tree that contains all participants in a group) also stable.

This PR changes the Merkle root and proof computation for participants to use a sorted list.