### PR TITLE
Demonstrate Flaky SQLite Integration Tests

### DIFF
--- a/validator/src/__tests__/config.ts
+++ b/validator/src/__tests__/config.ts
@@ -21,3 +21,5 @@ export const createClientStorage =
 	SAFENET_TEST_STORAGE === "sqlite"
 		? (account: Address, database?: Database) => new SqliteClientStorage(account, database ?? new Sqlite3(":memory:"))
 		: (account: Address) => new InMemoryClientStorage(account);
+
+export const serviceConfig = SAFENET_TEST_STORAGE === "sqlite" ? { storageFile: ":memory:" } : {};

--- a/validator/src/consensus/integration.test.ts
+++ b/validator/src/consensus/integration.test.ts
@@ -15,7 +15,7 @@ import {
 import { type Account, type PrivateKeyAccount, privateKeyToAccount } from "viem/accounts";
 import { anvil } from "viem/chains";
 import { afterEach, beforeAll, describe, expect, it } from "vitest";
-import { silentLogger, testLogger, testMetrics } from "../__tests__/config.js";
+import { serviceConfig, silentLogger, testLogger, testMetrics } from "../__tests__/config.js";
 import { waitForBlock, waitForBlocks } from "../__tests__/utils.js";
 import { toPoint } from "../frost/math.js";
 import { calcGenesisGroup, calcGroupContext, calcThreshold } from "../machine/keygen/group.js";
@@ -155,6 +155,7 @@ describe("integration", () => {
 				blockRetryDelays: [Math.floor(blockTime / 10), Math.floor(blockTime / 20), Math.floor(blockTime / 20)],
 			};
 			const service = createValidatorService({
+				...serviceConfig,
 				account: a,
 				rpcUrl: "http://127.0.0.1:8545",
 				logger,


### PR DESCRIPTION
I opening this PR to demonstrate that integration tests are currently flaky on `main`. I don't know when they started being flaky, but I suspect it is since 9b929306736300d898fda68cb3bbec54e2cec8e5.

I realized that we haven't actually been testing SQLite storage in integration tests since 8cb8096666a60d9801112b4033eaabeaf0138bcd 🙈.