### PR TITLE
Block Indexing Delay

### DIFF
--- a/validator/src/watcher/blocks.test.ts
+++ b/validator/src/watcher/blocks.test.ts
@@ -1,7 +1,7 @@
 import { type Block, BlockNotFoundError, type GetBlockParameters, keccak256, numberToHex, toHex } from "viem";
 import { describe, expect, it, vi } from "vitest";
-
-import { BlockWatcher, type Client, type Timer } from "./blocks.js";
+import { BlockWatcher, type Client } from "./blocks.js";
+import type { Timer } from "./timer.js";
 
 const CONFIG = {
 	blockTime: 2000,
@@ -12,8 +12,8 @@ const CONFIG = {
 
 const setupCreate = (config: { lastIndexedBlock: bigint | null; maxReorgDepth?: number }) => {
 	const getBlock = vi.fn();
-	const now = vi.fn();
 	const sleep = vi.fn();
+	const sleepUntil = vi.fn();
 
 	return {
 		create() {
@@ -24,15 +24,15 @@ const setupCreate = (config: { lastIndexedBlock: bigint | null; maxReorgDepth?: 
 					getBlock,
 				} as unknown as Client,
 				timer: {
-					now,
 					sleep,
+					sleepUntil,
 				} as unknown as Timer,
 			});
 		},
 		mocks: {
 			getBlock,
-			now,
 			sleep,
+			sleepUntil,
 		},
 	};
 };
@@ -69,9 +69,12 @@ const setupNext = async (config: { latestBlock: bigint; startTime: number; maxRe
 
 	// Setup useful default mocks for the timer.
 	let time = config.startTime;
-	mocks.now.mockImplementation(() => time);
 	mocks.sleep.mockImplementation((ms: number) => {
 		time += ms;
+		return Promise.resolve();
+	});
+	mocks.sleepUntil.mockImplementation((unixTimestampMs: number) => {
+		time = Math.max(time, unixTimestampMs);
 		return Promise.resolve();
 	});
 
@@ -98,11 +101,12 @@ const block = (
 const newBlockUpdate = (
 	b: {
 		number: bigint;
-	} & Partial<Pick<Block<bigint, false, "latest">, "hash" | "logsBloom">>,
+	} & Partial<Pick<Block<bigint, false, "latest">, "hash" | "timestamp" | "logsBloom">>,
 ) => ({
 	type: "watcher_update_new_block",
 	blockNumber: b.number,
 	blockHash: b.hash ?? numberToHex(b.number, { size: 32 }),
+	blockTimestamp: b.timestamp ?? (b.number * BigInt(CONFIG.blockTime)) / 1000n,
 	logsBloom: b.logsBloom ?? numberToHex(b.number, { size: 512 }),
 });
 
@@ -202,7 +206,7 @@ describe("BlockWatcher", () => {
 			mocks.getBlock.mockResolvedValueOnce(block({ number: 1001n }));
 
 			const update = await next();
-			expect(mocks.sleep.mock.calls).toEqual([[1900 + 500]]);
+			expect(mocks.sleepUntil.mock.calls).toEqual([[2002500]]);
 			expect(mocks.getBlock.mock.calls).toEqual([[{ blockNumber: 1001n }]]);
 
 			expect(update).toStrictEqual(newBlockUpdate({ number: 1001n }));
@@ -216,7 +220,8 @@ describe("BlockWatcher", () => {
 			mocks.getBlock.mockResolvedValueOnce(block({ number: 1001n }));
 
 			const update = await next();
-			expect(mocks.sleep.mock.calls).toEqual([[1900 + 500], [200], [100]]);
+			expect(mocks.sleepUntil.mock.calls).toEqual([[2002500], [2002500], [2002500]]);
+			expect(mocks.sleep.mock.calls).toEqual([[200], [100]]);
 			expect(mocks.getBlock.mock.calls).toEqual([
 				[{ blockNumber: 1001n }],
 				[{ blockNumber: 1001n }],
@@ -233,10 +238,11 @@ describe("BlockWatcher", () => {
 			mocks.getBlock.mockRejectedValueOnce(new BlockNotFoundError({ blockNumber: 1001n }));
 			mocks.getBlock.mockRejectedValueOnce(new BlockNotFoundError({ blockNumber: 1001n }));
 			mocks.getBlock.mockRejectedValueOnce(new BlockNotFoundError({ blockNumber: 1001n }));
-			mocks.getBlock.mockResolvedValueOnce(block({ number: 1001n }));
+			mocks.getBlock.mockResolvedValueOnce(block({ number: 1001n, timestamp: 2004000n }));
 
 			const update = await next();
-			expect(mocks.sleep.mock.calls).toEqual([[1900 + 500], [200], [100], [50], [1650]]);
+			expect(mocks.sleepUntil.mock.calls).toEqual([[2002500], [2002500], [2002500], [2002500], [2004500]]);
+			expect(mocks.sleep.mock.calls).toEqual([[200], [100], [50]]);
 			expect(mocks.getBlock.mock.calls).toEqual([
 				[{ blockNumber: 1001n }],
 				[{ blockNumber: 1001n }],
@@ -245,7 +251,7 @@ describe("BlockWatcher", () => {
 				[{ blockNumber: 1001n }],
 			]);
 
-			expect(update).toStrictEqual(newBlockUpdate({ number: 1001n }));
+			expect(update).toStrictEqual(newBlockUpdate({ number: 1001n, timestamp: 2004000n }));
 		});
 
 		it("supports deep reorgs", async () => {
@@ -266,7 +272,7 @@ describe("BlockWatcher", () => {
 			);
 
 			const updates = [await next(), await next(), await next(), await next(), await next()];
-			expect(mocks.sleep.mock.calls).toEqual([[1900 + 500]]);
+			expect(mocks.sleepUntil.mock.calls).toEqual([[2002500], [2000500], [1998500], [1996500], [1998500]]);
 			expect(mocks.getBlock.mock.calls).toEqual([
 				[{ blockNumber: 1001n }],
 				[{ blockNumber: 1000n }],

--- a/validator/src/watcher/blocks.ts
+++ b/validator/src/watcher/blocks.ts
@@ -8,12 +8,9 @@
 import { BlockNotFoundError, type Hex, type Prettify, type PublicClient, type Block as ViemBlock } from "viem";
 import { withDefaults } from "../utils/config.js";
 import { maxBigInt } from "../utils/math.js";
+import { DEFAULT_TIMER, type Timer } from "./timer.js";
 
 export type Client = Pick<PublicClient, "getBlock">;
-export type Timer = {
-	now(): number;
-	sleep(ms: number): Promise<void>;
-};
 
 /**
  * Required block watcher settings.
@@ -47,9 +44,22 @@ export type CreateParams = Prettify<
  * Block watcher update.
  */
 export type BlockUpdate =
-	| { type: "watcher_update_warp_to_block"; fromBlock: bigint; toBlock: bigint }
-	| { type: "watcher_update_uncle_block"; blockNumber: bigint }
-	| { type: "watcher_update_new_block"; blockNumber: bigint; blockHash: Hex; logsBloom: Hex };
+	| {
+			type: "watcher_update_warp_to_block";
+			fromBlock: bigint;
+			toBlock: bigint;
+	  }
+	| {
+			type: "watcher_update_uncle_block";
+			blockNumber: bigint;
+	  }
+	| {
+			type: "watcher_update_new_block";
+			blockNumber: bigint;
+			blockHash: Hex;
+			blockTimestamp: bigint;
+			logsBloom: Hex;
+	  };
 
 type Config = Settings & Options;
 type Block = ViemBlock<bigint, false, "latest">;
@@ -61,12 +71,7 @@ type PendingBlock = {
 export const DEFAULT_OPTIONS = {
 	blockPropagationDelay: 500,
 	blockRetryDelays: [200, 100, 100],
-	timer: {
-		now: Date.now,
-		sleep(ms: number): Promise<void> {
-			return new Promise((resolve) => setTimeout(resolve, ms));
-		},
-	},
+	timer: DEFAULT_TIMER,
 };
 
 export class BlockWatcher {
@@ -145,6 +150,7 @@ export class BlockWatcher {
 						type: "watcher_update_new_block",
 						blockNumber: block.number,
 						blockHash: block.hash,
+						blockTimestamp: block.timestamp,
 						logsBloom: block.logsBloom,
 					}) as const,
 			),
@@ -164,12 +170,9 @@ export class BlockWatcher {
 	/**
 	 * Sleeps until the pending block is suspected to be ready.
 	 */
-	async #waitForPendingBlock() {
-		const now = this.#config.timer.now();
-		const delay = Number(this.#pending.timestampMs) + this.#config.blockPropagationDelay - now;
-		if (delay > 0) {
-			await this.#config.timer.sleep(delay);
-		}
+	#waitForPendingBlock() {
+		const until = Number(this.#pending.timestampMs) + this.#config.blockPropagationDelay;
+		return this.#config.timer.sleepUntil(until);
 	}
 
 	/**
@@ -250,6 +253,7 @@ export class BlockWatcher {
 			type: "watcher_update_new_block",
 			blockNumber: block.number,
 			blockHash: block.hash,
+			blockTimestamp: block.timestamp,
 			logsBloom: block.logsBloom,
 		};
 	}

--- a/validator/src/watcher/events.test.ts
+++ b/validator/src/watcher/events.test.ts
@@ -4,6 +4,7 @@ import { describe, expect, it, vi } from "vitest";
 import { testLogger } from "../__tests__/config.js";
 import type { BlockUpdate } from "./blocks.js";
 import { type Client, type Config, EventWatcher, type Log } from "./events.js";
+import type { Timer } from "./timer.js";
 
 const CONFIG = {
 	blockPageSize: 5,
@@ -22,8 +23,12 @@ const WATCH = {
 
 type TestLog = Log<typeof WATCH.events>;
 
-const setup = ({ fallibleEvents }: Partial<Pick<Config, "fallibleEvents">> = {}) => {
+const setup = ({
+	fallibleEvents,
+	blockIndexingDelay,
+}: Partial<Pick<Config, "fallibleEvents" | "blockIndexingDelay">> = {}) => {
 	const getLogs = vi.fn();
+	const sleepUntil = vi.fn();
 
 	return {
 		events: new EventWatcher({
@@ -33,10 +38,15 @@ const setup = ({ fallibleEvents }: Partial<Pick<Config, "fallibleEvents">> = {})
 			client: {
 				getLogs,
 			} as unknown as Client,
+			blockIndexingDelay,
 			fallibleEvents: fallibleEvents ?? CONFIG.fallibleEvents,
+			timer: {
+				sleepUntil,
+			} as unknown as Timer,
 		}),
 		mocks: {
 			getLogs,
+			sleepUntil,
 		},
 	};
 };
@@ -105,7 +115,13 @@ describe("EventWatcher", () => {
 		it("does not process new block updates before the previous is done", async () => {
 			for (const update of [
 				{ type: "watcher_update_warp_to_block", fromBlock: 123n, toBlock: 130n },
-				{ type: "watcher_update_new_block", blockNumber: 0n, blockHash: zeroHash, logsBloom: BLOOM_ZERO },
+				{
+					type: "watcher_update_new_block",
+					blockNumber: 0n,
+					blockHash: zeroHash,
+					blockTimestamp: 0n,
+					logsBloom: BLOOM_ZERO,
+				},
 			] as const) {
 				const { events } = setup();
 
@@ -296,6 +312,7 @@ describe("EventWatcher", () => {
 				type: "watcher_update_new_block",
 				blockNumber: 1337n,
 				blockHash: keccak256(toHex("1337")),
+				blockTimestamp: 42n,
 				logsBloom: BLOOM_ALL,
 			});
 
@@ -320,6 +337,26 @@ describe("EventWatcher", () => {
 			]);
 		});
 
+		it("should wait for configured indexing delay", async () => {
+			const { events, mocks } = setup({ blockIndexingDelay: 1337 });
+
+			events.onBlockUpdate({
+				type: "watcher_update_new_block",
+				blockNumber: 1337n,
+				blockHash: keccak256(toHex("1337")),
+				blockTimestamp: 41n,
+				logsBloom: bloom(WATCH.address[0], toEventSelector(WATCH.events[1])),
+			});
+
+			mocks.sleepUntil.mockResolvedValue(undefined);
+			mocks.getLogs.mockResolvedValue([]);
+
+			await events.next();
+
+			expect(mocks.sleepUntil.mock.calls).toEqual([[42337]]);
+			expect(mocks.getLogs).toBeCalledTimes(1);
+		});
+
 		it("query blocks if at least one address and event is in the bloom filter", async () => {
 			const { events, mocks } = setup();
 
@@ -327,6 +364,7 @@ describe("EventWatcher", () => {
 				type: "watcher_update_new_block",
 				blockNumber: 1337n,
 				blockHash: keccak256(toHex("1337")),
+				blockTimestamp: 42n,
 				logsBloom: bloom(WATCH.address[0], toEventSelector(WATCH.events[1])),
 			});
 
@@ -351,6 +389,7 @@ describe("EventWatcher", () => {
 					type: "watcher_update_new_block",
 					blockNumber: 42n,
 					blockHash: keccak256(toHex("the answer to life, the universe, and everything")),
+					blockTimestamp: 42n,
 					logsBloom,
 				});
 
@@ -368,6 +407,7 @@ describe("EventWatcher", () => {
 				type: "watcher_update_new_block",
 				blockNumber: 42n,
 				blockHash: keccak256(toHex("the answer to life, the universe, and everything")),
+				blockTimestamp: 42n,
 				logsBloom: BLOOM_ALL,
 			});
 
@@ -385,6 +425,7 @@ describe("EventWatcher", () => {
 				type: "watcher_update_new_block",
 				blockNumber: 1337n,
 				blockHash: keccak256(toHex("1337")),
+				blockTimestamp: 42n,
 				logsBloom: BLOOM_ALL,
 			});
 
@@ -407,6 +448,7 @@ describe("EventWatcher", () => {
 				type: "watcher_update_new_block",
 				blockNumber: 1337n,
 				blockHash: keccak256(toHex("1337")),
+				blockTimestamp: 42n,
 				logsBloom: bloom(...WATCH.address, toEventSelector(WATCH.events[1])),
 			});
 
@@ -426,6 +468,7 @@ describe("EventWatcher", () => {
 				type: "watcher_update_new_block",
 				blockNumber: 1337n,
 				blockHash: keccak256(toHex("1337")),
+				blockTimestamp: 42n,
 				logsBloom: BLOOM_ALL,
 			});
 
@@ -440,6 +483,7 @@ describe("EventWatcher", () => {
 				type: "watcher_update_new_block",
 				blockNumber: 1337n,
 				blockHash: keccak256(toHex("1337")),
+				blockTimestamp: 42n,
 				logsBloom: BLOOM_ALL,
 			});
 
@@ -459,6 +503,7 @@ describe("EventWatcher", () => {
 					type: "watcher_update_new_block",
 					blockNumber: 1337n,
 					blockHash: keccak256(toHex("1337")),
+					blockTimestamp: 42n,
 					logsBloom: BLOOM_ALL,
 				},
 				{
@@ -483,6 +528,7 @@ describe("EventWatcher", () => {
 					type: "watcher_update_new_block",
 					blockNumber: 1337n,
 					blockHash: keccak256(toHex("1337")),
+					blockTimestamp: 42n,
 					logsBloom: BLOOM_ALL,
 				},
 				{

--- a/validator/src/watcher/events.ts
+++ b/validator/src/watcher/events.ts
@@ -17,6 +17,7 @@ import { isInBloom } from "../utils/bloom.js";
 import { withDefaults } from "../utils/config.js";
 import type { Logger } from "../utils/logging.js";
 import type { BlockUpdate } from "./blocks.js";
+import { DEFAULT_TIMER, type Timer } from "./timer.js";
 
 export type Client = Pick<PublicClient, "getLogs">;
 export type Events = readonly AbiEvent[];
@@ -26,9 +27,11 @@ export type Events = readonly AbiEvent[];
  */
 export type Config = {
 	blockPageSize: number;
+	blockIndexingDelay: number;
 	blockSingleQueryRetryCount: number;
 	maxLogsPerQuery: number | null;
 	fallibleEvents: string[];
+	timer: Pick<Timer, "sleepUntil">;
 };
 
 export type ConstructorParams<I> = Prettify<
@@ -47,13 +50,24 @@ export type Log<E extends Events> = ViemLog<bigint, number, false, undefined, tr
 
 export const DEFAULT_CONFIG = {
 	blockPageSize: 100,
+	blockIndexingDelay: 0,
 	blockSingleQueryRetryCount: 3,
 	maxLogsPerQuery: null,
 	fallibleEvents: [],
+	timer: DEFAULT_TIMER,
 };
 
-type WarpingStep = { fromBlock: bigint; toBlock: bigint; pageSize: bigint };
-type BlockStep = { blockHash: Hex; logsBloom: Hex; retries: number };
+type WarpingStep = {
+	fromBlock: bigint;
+	toBlock: bigint;
+	pageSize: bigint;
+};
+type BlockStep = {
+	blockHash: Hex;
+	blockTimestamp: bigint;
+	logsBloom: Hex;
+	retries: number;
+};
 type Step = { type: "idle" } | ({ type: "warping" } & WarpingStep) | ({ type: "block" } & BlockStep);
 
 export class EventWatcher<E extends Events> {
@@ -213,8 +227,17 @@ export class EventWatcher<E extends Events> {
 		}
 	}
 
-	async #block({ blockHash, logsBloom, retries }: BlockStep) {
+	async #block({ blockHash, blockTimestamp, logsBloom, retries }: BlockStep) {
 		try {
+			// Some nodes have an additional delay after they see the block for them to index logs
+			// and receipts. Unfortunately, during that time, instead of erroring or waiting for the
+			// indexing to complete, the RPC nodes just return an empty list of events. To work
+			// around this issue wait an additional delay
+			if (this.#config.blockIndexingDelay > 0) {
+				const until = Number(blockTimestamp) * 1000 + this.#config.blockIndexingDelay;
+				await this.#config.timer.sleepUntil(until);
+			}
+
 			const logs =
 				retries < this.#config.blockSingleQueryRetryCount
 					? await this.#getLogsOneQueryAllEvents({ blockHash, logsBloom })
@@ -223,7 +246,7 @@ export class EventWatcher<E extends Events> {
 			return logs;
 		} catch (err) {
 			// Count the number of retries that we hit when fetching logs for a specific block.
-			this.#step = { type: "block", blockHash, logsBloom, retries: retries + 1 };
+			this.#step = { type: "block", blockHash, blockTimestamp, logsBloom, retries: retries + 1 };
 			throw err;
 		}
 	}
@@ -253,6 +276,7 @@ export class EventWatcher<E extends Events> {
 				step = {
 					type: "block",
 					blockHash: update.blockHash,
+					blockTimestamp: update.blockTimestamp,
 					logsBloom: update.logsBloom,
 					retries: 0,
 				};

--- a/validator/src/watcher/timer.ts
+++ b/validator/src/watcher/timer.ts
@@ -1,0 +1,22 @@
+/**
+ * Timer.
+ *
+ * This allows tests to mock timing-related calls.
+ */
+
+export type Timer = {
+	sleep(ms: number): Promise<void>;
+	sleepUntil(unixTimestampMs: number): Promise<void>;
+};
+
+const sleep = (ms: number): Promise<void> => {
+	return new Promise((resolve) => setTimeout(resolve, ms));
+};
+
+export const DEFAULT_TIMER = {
+	sleep,
+	sleepUntil(unixTimestampMs: number): Promise<void> {
+		const delay = unixTimestampMs - Date.now();
+		return delay > 0 ? sleep(delay) : Promise.resolve();
+	},
+};


### PR DESCRIPTION
It turns out that some nodes have a delay between seeing a block and indexing things like receipts and logs. During this time, `eth_getLogs` will return incorrect data (`[]` despite there being logs).

This PR introduces a work around is to have a configurable additional delay for waiting for the RPC to finish indexing a block. This is a fairly un-invasive but heuristic approach to the problem. Unfortunately, it doesn't guarantee a solution, but wanted to suggest it as a pragmatic approach to the issues we are currently seeing with our RPC provider.