### PR TITLE
Keep Track of Seen Reorgs

### DIFF
--- a/validator/src/machine/transitions/watcher.ts
+++ b/validator/src/machine/transitions/watcher.ts
@@ -5,6 +5,7 @@ import { ALL_EVENTS } from "../../types/abis.js";
 import type { ProtocolConfig } from "../../types/interfaces.js";
 import { formatError } from "../../utils/errors.js";
 import type { Logger } from "../../utils/logging.js";
+import type { Metrics } from "../../utils/metrics.js";
 import { type Stop, type WatchParams, watchBlocksAndEvents } from "../../watcher/index.js";
 import { logToTransition } from "./onchain.js";
 import type { StateTransition } from "./types.js";
@@ -33,6 +34,7 @@ export type WatcherConfig = Prettify<
 
 export class OnchainTransitionWatcher {
 	#logger: Logger;
+	#metrics: Metrics;
 	#config: Config;
 	#watcherConfig: WatcherConfig;
 	#db: Database;
@@ -46,6 +48,7 @@ export class OnchainTransitionWatcher {
 		config,
 		watcherConfig,
 		logger,
+		metrics,
 		onTransition,
 	}: {
 		database: Database;
@@ -54,11 +57,13 @@ export class OnchainTransitionWatcher {
 		watcherConfig: WatcherConfig;
 		onTransition: (transition: StateTransition) => void;
 		logger: Logger;
+		metrics: Metrics;
 	}) {
 		this.#db = database;
 		this.#config = config;
 		this.#watcherConfig = watcherConfig;
 		this.#logger = logger;
+		this.#metrics = metrics;
 		this.#publicClient = publicClient;
 		this.#onTransition = onTransition;
 
@@ -125,6 +130,7 @@ export class OnchainTransitionWatcher {
 			handler: (update) => {
 				switch (update.type) {
 					case "watcher_update_warp_to_block": {
+						this.#metrics.blockNumber.labels({ status: "seen" }).set(Number(update.toBlock));
 						// Note that we don't explicitely handle warping in our state machine,
 						// instead if any events are found in the log range, the state machine is
 						// updated to the correct block accordingly.
@@ -132,14 +138,17 @@ export class OnchainTransitionWatcher {
 						break;
 					}
 					case "watcher_update_uncle_block": {
+						this.#metrics.reorgs.inc();
 						this.#logger.warn("Reorg detected, but currently not supported.", { update });
 						break;
 					}
 					case "watcher_update_new_block": {
+						this.#metrics.blockNumber.labels({ status: "seen" }).set(Number(update.blockNumber));
 						this.handleTransition({ id: "block_new", block: update.blockNumber });
 						break;
 					}
 					case "watcher_update_new_logs": {
+						this.#metrics.eventIndex.labels({ status: "seen" }).set(update.logs.at(-1)?.logIndex ?? -1);
 						for (const log of update.logs) {
 							this.handleTransition(logToTransition(log));
 						}

--- a/validator/src/machine/transitions/watcher.ts
+++ b/validator/src/machine/transitions/watcher.ts
@@ -131,6 +131,7 @@ export class OnchainTransitionWatcher {
 				switch (update.type) {
 					case "watcher_update_warp_to_block": {
 						this.#metrics.blockNumber.labels({ status: "seen" }).set(Number(update.toBlock));
+						this.#metrics.eventIndex.labels({ status: "seen" }).set(-1);
 						// Note that we don't explicitely handle warping in our state machine,
 						// instead if any events are found in the log range, the state machine is
 						// updated to the correct block accordingly.
@@ -144,6 +145,7 @@ export class OnchainTransitionWatcher {
 					}
 					case "watcher_update_new_block": {
 						this.#metrics.blockNumber.labels({ status: "seen" }).set(Number(update.blockNumber));
+						this.#metrics.eventIndex.labels({ status: "seen" }).set(-1);
 						this.handleTransition({ id: "block_new", block: update.blockNumber });
 						break;
 					}

--- a/validator/src/service/machine.test.ts
+++ b/validator/src/service/machine.test.ts
@@ -33,8 +33,9 @@ const makeLogger = (): Logger =>
 const makeMetrics = (): Metrics =>
 	({
 		transitions: { labels: vi.fn().mockReturnValue({ inc: vi.fn() }) },
-		blockNumber: { set: vi.fn() },
-		eventIndex: { set: vi.fn() },
+		blockNumber: { labels: vi.fn().mockReturnValue({ set: vi.fn() }) },
+		eventIndex: { labels: vi.fn().mockReturnValue({ set: vi.fn() }) },
+		reorgs: { inc: vi.fn() },
 		frostGroupCleanups: { labels: vi.fn().mockReturnValue({ inc: vi.fn() }) },
 	}) as unknown as Metrics;
 

--- a/validator/src/service/machine.ts
+++ b/validator/src/service/machine.ts
@@ -146,8 +146,8 @@ export class SafenetStateMachine {
 				this.#metrics.transitions.labels({ result: "failure" }).inc();
 			})
 			.finally(() => {
-				this.#metrics.blockNumber.set(Number(this.#lastProcessedBlock));
-				this.#metrics.eventIndex.set(this.#lastProcessedIndex);
+				this.#metrics.blockNumber.labels({ status: "processed" }).set(Number(this.#lastProcessedBlock));
+				this.#metrics.eventIndex.labels({ status: "processed" }).set(this.#lastProcessedIndex);
 				this.#transitionQueue.dequeue();
 				this.#currentTransition = undefined;
 				this.checkNextTransition();

--- a/validator/src/service/service.ts
+++ b/validator/src/service/service.ts
@@ -110,6 +110,7 @@ export class ValidatorService {
 			config,
 			watcherConfig,
 			logger,
+			metrics,
 			onTransition: (t) => {
 				this.#stateMachine.transition(t);
 				// If new block:

--- a/validator/src/utils/metrics.ts
+++ b/validator/src/utils/metrics.ts
@@ -5,6 +5,7 @@ import type { Logger } from "./logging.js";
 export type Metrics = {
 	blockNumber: Gauge;
 	eventIndex: Gauge;
+	reorgs: Counter;
 	transitions: Counter;
 	rpcRequests: Counter;
 	transactionChecks: Counter;
@@ -30,12 +31,19 @@ export class MetricsService {
 		this.#metrics = {
 			blockNumber: new Gauge({
 				name: "validator_block_number",
-				help: "The last processed block number by the validator",
+				help: "Block number by processing stage (seen: received from chain, processed: applied to state machine)",
+				labelNames: ["status"],
 				registers: [this.#register],
 			}),
 			eventIndex: new Gauge({
 				name: "validator_event_index",
-				help: "The last processed event index by the validator",
+				help: "Event index by processing stage (seen: received from chain, processed: applied to state machine)",
+				labelNames: ["status"],
+				registers: [this.#register],
+			}),
+			reorgs: new Counter({
+				name: "validator_reorgs",
+				help: "Number of chain reorgs observed by the validator",
 				registers: [this.#register],
 			}),
 			transitions: new Counter({


### PR DESCRIPTION
This PR adds a new counter to the validator for the number of reorgs they have seen. This gives us a nice counter to have some idea on how often these reorgs are happening for the RPC that the validator is currectly connected to.

Additionally, I split the existing `blockNumber` and `eventIndex` into "seen" and "processed" lables, to distinguish between the last block that was seen by the on-chain watcher and the last block that was processed by the state machine. This can help us find discrepencies from when an onchain event was observed and the state machine actually finished applying the transition.