### PR TITLE
Add oracle transaction proposal and attestation handling

### DIFF
--- a/features/2026_04_20_oracle_interface_and_transaction_checks.md
+++ b/features/2026_04_20_oracle_interface_and_transaction_checks.md
@@ -11,7 +11,7 @@ The implementation is structured in three independently releasable PRs:
 
 1. **PR 1 — Oracle contract interface + Consensus extension**: Define `IOracle.sol`, add `OracleTransactionProposal` as a new FROST-signed package type in `Consensus.sol`.
 2. **PR 2 — Validator new package type** (parallel to PR 1): New `oracle_transaction_packet` handler, EIP-712 hashing, and machine states for `OracleTransactionProposed` / `OracleTransactionAttested` events.
-3. **PR 3 — Validator oracle event integration** (depends on PR 2): Oracle event listener, `wait_for_oracle` signing state with configurable timeout, and `OracleResult` machine handler.
+3. **PR 3 — Validator oracle event integration** (depends on PR 2): Oracle event listener, `waiting_for_oracle` signing state with configurable timeout, and `OracleResult` machine handler.
 
 ---
 
@@ -40,14 +40,14 @@ requestId = keccak256("\x19\x01" || domainSeparator || keccak256(OracleTransacti
 
 When the oracle emits `OracleResult(requestId, result, approved)`, validators correlate it to the pending signing state via this `requestId`.
 
-### New Signing State: `wait_for_oracle`
+### New Signing State: `waiting_for_oracle`
 
 The existing signing state machine for transactions is extended with an intermediate state:
 
 ```
 waiting_for_request
   → [OracleTransactionProposed event]
-wait_for_oracle              ← new state (timeout: ORACLE_TIMEOUT_BLOCKS env var)
+waiting_for_oracle              ← new state (timeout: ORACLE_TIMEOUT_BLOCKS env var)
   → [OracleResult(approved=true) event]
 collect_nonce_commitments
   → ... (existing FROST signing flow)
@@ -249,11 +249,11 @@ EIP-712 hash for `OracleTransactionProposal` — mirrors `safeTxProposalHash` in
 
 #### New: `validator/src/machine/consensus/oracleTransactionProposed.ts`
 
-Handles `OracleTransactionProposed` event. Returns `StateDiff` with a new `wait_for_oracle` signing entry, recording the oracle address, packet, and a deadline of `event.block + oracleTimeout` (read from `MachineConfig.oracleTimeout`, sourced from env var `ORACLE_TIMEOUT_BLOCKS`).
+Handles `OracleTransactionProposed` event. Returns `StateDiff` with a new `waiting_for_oracle` signing entry, recording the oracle address, packet, and a deadline of `event.block + oracleTimeout` (read from `MachineConfig.oracleTimeout`, sourced from env var `ORACLE_TIMEOUT_BLOCKS`).
 
 #### New: `validator/src/machine/consensus/oracleResult.ts`
 
-Handles `OracleResult` event from oracle contracts. If `approved = true` and state is `wait_for_oracle`, transitions to the signing flow (`collect_nonce_commitments`). If `approved = false`, drops state. If the current block exceeds the deadline (checked on each new-block transition), state is also dropped.
+Handles `OracleResult` event from oracle contracts. If `approved = true` and state is `waiting_for_oracle`, transitions to the signing flow (`collect_nonce_commitments`). If `approved = false`, drops state. If the current block exceeds the deadline (checked on each new-block transition), state is also dropped.
 
 #### New: `validator/src/machine/consensus/oracleTransactionAttested.ts`
 
@@ -268,7 +268,7 @@ Add new transition types:
 
 #### Modified: `validator/src/machine/types.ts`
 
-Extend `SigningStateData` union with `wait_for_oracle` state variant, storing the oracle address, packet, and block deadline for later reference.
+Extend `SigningStateData` union with `waiting_for_oracle` state variant, storing the oracle address, packet, and block deadline for later reference.
 
 #### Modified: `validator/src/types/abis.ts`
 
@@ -307,7 +307,7 @@ Add `IOracle.OracleResult` ABI event definition for use by the watcher.
 | `oracleTransactionPacketSchema` rejects invalid oracle address | `validator/src/consensus/verify/oracleTx/handler.test.ts` |
 | `OracleTransactionHandler.hashAndVerify` rejects unlisted oracle | `validator/src/consensus/verify/oracleTx/handler.test.ts` |
 | `OracleTransactionHandler.hashAndVerify` returns correct EIP-712 hash | `validator/src/consensus/verify/oracleTx/handler.test.ts` |
-| `handleOracleTransactionProposed` stores `wait_for_oracle` state | `validator/src/machine/consensus/oracleTransactionProposed.test.ts` |
+| `handleOracleTransactionProposed` stores `waiting_for_oracle` state | `validator/src/machine/consensus/oracleTransactionProposed.test.ts` |
 | `handleOracleResult` (approved) transitions to signing | `validator/src/machine/consensus/oracleResult.test.ts` |
 | `handleOracleResult` (rejected) cleans up state | `validator/src/machine/consensus/oracleResult.test.ts` |
 | `handleOracleTransactionAttested` cleans up signing state | `validator/src/machine/consensus/oracleTransactionAttested.test.ts` |
@@ -360,7 +360,7 @@ Add `IOracle.OracleResult` ABI event definition for use by the watcher.
 - `validator/src/machine/consensus/oracleTransactionAttested.test.ts` — new
 - `validator/src/machine/transitions/types.ts` — add `event_oracle_transaction_proposed`, `event_oracle_transaction_attested`
 - `validator/src/machine/transitions/onchain.ts` — map new events to transitions
-- `validator/src/machine/types.ts` — add `wait_for_oracle` to `SigningStateData` union
+- `validator/src/machine/types.ts` — add `waiting_for_oracle` to `SigningStateData` union
 - `validator/src/service/service.ts` — register `oracle_transaction_packet` handler; add `allowedOracles` to `MachineConfig`
 
 ---

--- a/validator/src/__tests__/data/machine.ts
+++ b/validator/src/__tests__/data/machine.ts
@@ -1,5 +1,7 @@
+import { ethAddress, zeroAddress, zeroHash } from "viem";
 import { toPoint } from "../../frost/math.js";
 import type { FrostPoint } from "../../frost/types.js";
+import type { MachineConfig } from "../../machine/types.js";
 
 export const TEST_POINT: FrostPoint = toPoint({
 	x: 73844941487532555987364396775795076447946974313865618280135872376303125438365n,
@@ -19,4 +21,21 @@ export const makeKeyGenSetup = () => ({
 		mu: 100n,
 	},
 	poap: ["0x5afe5afe5afe01"],
+});
+
+export const makeMachineConfig = (overrides?: Partial<MachineConfig>): MachineConfig => ({
+	account: ethAddress,
+	participantsInfo: [
+		{ address: zeroAddress, activeFrom: 0n },
+		{ address: zeroAddress, activeFrom: 0n },
+		{ address: zeroAddress, activeFrom: 0n },
+		{ address: zeroAddress, activeFrom: 0n },
+	],
+	genesisSalt: zeroHash,
+	keyGenTimeout: 0n,
+	signingTimeout: 0n,
+	blocksPerEpoch: 0n,
+	allowedOracles: [],
+	oracleTimeout: 0n,
+	...overrides,
 });

--- a/validator/src/consensus/verify/oracleTx/handler.test.ts
+++ b/validator/src/consensus/verify/oracleTx/handler.test.ts
@@ -1,0 +1,63 @@
+import { zeroAddress } from "viem";
+import { describe, expect, it } from "vitest";
+import { OracleTransactionHandler } from "./handler.js";
+import { oracleTxPacketHash } from "./hashing.js";
+import type { OracleTransactionPacket } from "./schemas.js";
+
+const ORACLE_ADDRESS = "0x4838B106FCe9647Bdf1E7877BF73cE8B0BAD5f97";
+
+const VALID_PACKET: OracleTransactionPacket = {
+	type: "oracle_transaction_packet",
+	domain: {
+		chain: 23n,
+		consensus: "0x22Cb221caE98D6097082C80158B1472C45FEd729",
+	},
+	proposal: {
+		epoch: 11n,
+		oracle: ORACLE_ADDRESS,
+		transaction: {
+			chainId: 1n,
+			safe: "0x4838B106FCe9647Bdf1E7877BF73cE8B0BAD5f97",
+			to: "0x22Cb221caE98D6097082C80158B1472C45FEd729",
+			value: 0n,
+			data: "0x",
+			operation: 0,
+			safeTxGas: 0n,
+			baseGas: 0n,
+			gasPrice: 0n,
+			gasToken: zeroAddress,
+			refundReceiver: zeroAddress,
+			nonce: 0n,
+		},
+	},
+};
+
+describe("oracle transaction handler", () => {
+	it("should throw on invalid packet (bad oracle address)", async () => {
+		const handler = new OracleTransactionHandler([ORACLE_ADDRESS]);
+		await expect(
+			handler.hashAndVerify({
+				type: "oracle_transaction_packet",
+				domain: { chain: 23n, consensus: "0x22Cb221caE98D6097082C80158B1472C45FEd729" },
+				proposal: {
+					epoch: 11n,
+					oracle: "not-an-address",
+					transaction: VALID_PACKET.proposal.transaction,
+				},
+			} as unknown as OracleTransactionPacket),
+		).rejects.toThrow();
+	});
+
+	it("should throw if oracle is not in the allowlist", async () => {
+		const handler = new OracleTransactionHandler([]);
+		await expect(handler.hashAndVerify(VALID_PACKET)).rejects.toThrow(
+			`Oracle ${ORACLE_ADDRESS} is not in the allowlist`,
+		);
+	});
+
+	it("should return correct EIP-712 hash when oracle is in the allowlist", async () => {
+		const handler = new OracleTransactionHandler([ORACLE_ADDRESS]);
+		const hash = await handler.hashAndVerify(VALID_PACKET);
+		expect(hash).toBe(oracleTxPacketHash(VALID_PACKET));
+	});
+});

--- a/validator/src/consensus/verify/oracleTx/handler.ts
+++ b/validator/src/consensus/verify/oracleTx/handler.ts
@@ -1,0 +1,22 @@
+import { type Address, type Hex, isAddressEqual } from "viem";
+import type { Metrics } from "../../../utils/metrics.js";
+import type { PacketHandler } from "../engine.js";
+import { oracleTxPacketHash } from "./hashing.js";
+import { type OracleTransactionPacket, oracleTransactionPacketSchema } from "./schemas.js";
+
+export class OracleTransactionHandler implements PacketHandler<OracleTransactionPacket> {
+	constructor(
+		private allowedOracles: readonly Address[],
+		private metrics?: Pick<Metrics, "transactionChecks">,
+	) {}
+
+	async hashAndVerify(uncheckedPacket: OracleTransactionPacket): Promise<Hex> {
+		const packet = oracleTransactionPacketSchema.parse(uncheckedPacket);
+		if (!this.allowedOracles.some((o) => isAddressEqual(o, packet.proposal.oracle))) {
+			this.metrics?.transactionChecks.labels({ result: "oracle_not_allowed" }).inc();
+			throw new Error(`Oracle ${packet.proposal.oracle} is not in the allowlist`);
+		}
+		this.metrics?.transactionChecks.labels({ result: "success" }).inc();
+		return oracleTxPacketHash(packet);
+	}
+}

--- a/validator/src/consensus/verify/oracleTx/hashing.ts
+++ b/validator/src/consensus/verify/oracleTx/hashing.ts
@@ -1,0 +1,39 @@
+import { type Address, type Hex, hashTypedData } from "viem";
+import { safeTxHash } from "../safeTx/hashing.js";
+import type { OracleTransactionPacket } from "./schemas.js";
+
+export type OracleTransactionProposal = {
+	domain: OracleTransactionPacket["domain"];
+	proposal: {
+		epoch: bigint;
+		oracle: Address;
+		safeTxHash: Hex;
+	};
+};
+
+export const oracleTxProposalHash = ({ domain, proposal }: OracleTransactionProposal): Hex =>
+	hashTypedData({
+		domain: {
+			chainId: domain.chain,
+			verifyingContract: domain.consensus,
+		},
+		types: {
+			OracleTransactionProposal: [
+				{ type: "uint64", name: "epoch" },
+				{ type: "address", name: "oracle" },
+				{ type: "bytes32", name: "safeTxHash" },
+			],
+		},
+		primaryType: "OracleTransactionProposal",
+		message: proposal,
+	});
+
+export const oracleTxPacketHash = (packet: OracleTransactionPacket): Hex =>
+	oracleTxProposalHash({
+		domain: packet.domain,
+		proposal: {
+			epoch: packet.proposal.epoch,
+			oracle: packet.proposal.oracle,
+			safeTxHash: safeTxHash(packet.proposal.transaction),
+		},
+	});

--- a/validator/src/consensus/verify/oracleTx/schemas.ts
+++ b/validator/src/consensus/verify/oracleTx/schemas.ts
@@ -1,0 +1,22 @@
+import z from "zod";
+import { checkedAddressSchema } from "../../../types/schemas.js";
+import { safeTransactionSchema } from "../safeTx/schemas.js";
+
+const consensusDomainSchema = z.object({
+	chain: z.bigint().nonnegative(),
+	consensus: checkedAddressSchema,
+});
+
+const oracleTransactionProposalSchema = z.object({
+	epoch: z.bigint().nonnegative(),
+	oracle: checkedAddressSchema,
+	transaction: safeTransactionSchema,
+});
+
+export const oracleTransactionPacketSchema = z.object({
+	type: z.literal("oracle_transaction_packet"),
+	domain: consensusDomainSchema,
+	proposal: oracleTransactionProposalSchema,
+});
+
+export type OracleTransactionPacket = z.infer<typeof oracleTransactionPacketSchema>;

--- a/validator/src/frost/types.ts
+++ b/validator/src/frost/types.ts
@@ -29,3 +29,8 @@ export type ProofOfAttestationParticipation = Hex[];
 export type GroupId = Hex;
 
 export type SignatureId = Hex;
+
+export type FrostSignature = {
+	z: bigint;
+	r: FrostPoint;
+};

--- a/validator/src/machine/consensus/epochStaged.test.ts
+++ b/validator/src/machine/consensus/epochStaged.test.ts
@@ -28,6 +28,8 @@ const MACHINE_CONFIG: MachineConfig = {
 	keyGenTimeout: 20n,
 	signingTimeout: 0n,
 	blocksPerEpoch: 10n,
+	allowedOracles: [],
+	oracleTimeout: 0n,
 };
 
 const PACKET: EpochRolloverPacket = {

--- a/validator/src/machine/consensus/epochStaged.test.ts
+++ b/validator/src/machine/consensus/epochStaged.test.ts
@@ -1,36 +1,24 @@
-import { zeroHash } from "viem";
+import type { Address } from "viem";
 import { describe, expect, it, vi } from "vitest";
+import { makeMachineConfig } from "../../__tests__/data/machine.js";
 import type { SigningClient } from "../../consensus/signing/client.js";
 import type { EpochRolloverPacket } from "../../consensus/verify/rollover/schemas.js";
 import { toPoint } from "../../frost/math.js";
 import type { EpochStagedEvent } from "../transitions/types.js";
-import type { MachineConfig, MachineStates, SigningState } from "../types.js";
+import type { MachineStates, SigningState } from "../types.js";
 import { handleEpochStaged } from "./epochStaged.js";
 
 // --- Test Data ---
-const MACHINE_CONFIG: MachineConfig = {
-	account: "0x0000000000000000000000000000000000000001",
+const MACHINE_CONFIG = makeMachineConfig({
+	account: "0x0000000000000000000000000000000000000001" as Address,
 	participantsInfo: [
-		{
-			address: "0x0000000000000000000000000000000000000001",
-			activeFrom: 0n,
-		},
-		{
-			address: "0x0000000000000000000000000000000000000002",
-			activeFrom: 0n,
-		},
-		{
-			address: "0x0000000000000000000000000000000000000003",
-			activeFrom: 1n,
-		},
+		{ address: "0x0000000000000000000000000000000000000001", activeFrom: 0n },
+		{ address: "0x0000000000000000000000000000000000000002", activeFrom: 0n },
+		{ address: "0x0000000000000000000000000000000000000003", activeFrom: 1n },
 	],
-	genesisSalt: zeroHash,
 	keyGenTimeout: 20n,
-	signingTimeout: 0n,
 	blocksPerEpoch: 10n,
-	allowedOracles: [],
-	oracleTimeout: 0n,
-};
+});
 
 const PACKET: EpochRolloverPacket = {
 	type: "epoch_rollover_packet",

--- a/validator/src/machine/consensus/epochStaged.ts
+++ b/validator/src/machine/consensus/epochStaged.ts
@@ -29,7 +29,7 @@ export const handleEpochStaged = async (
 	};
 	// Check if there is a signatureId that needs to be cleaned up
 	const status = machineStates.signing[machineStates.rollover.message];
-	if (status !== undefined && status.id !== "waiting_for_request") {
+	if (status !== undefined && "signatureId" in status) {
 		consensus.signatureIdToMessage = [status.signatureId, undefined];
 	}
 	// The signing state should be cleaned up in any case, as the rollover was attested

--- a/validator/src/machine/consensus/oracleTransactionAttested.test.ts
+++ b/validator/src/machine/consensus/oracleTransactionAttested.test.ts
@@ -46,7 +46,7 @@ const PACKET: OracleTransactionPacket = {
 const MESSAGE = oracleTxPacketHash(PACKET);
 
 const INVALID_SIGNING_STATE: SigningState = {
-	id: "wait_for_oracle",
+	id: "waiting_for_oracle",
 	oracle: ORACLE_ADDRESS,
 	packet: PACKET,
 	signers: [zeroAddress],
@@ -101,7 +101,7 @@ describe("oracle transaction attested", () => {
 		const diff = await handleOracleTransactionAttested(PROTOCOL, MACHINE_STATES, EVENT);
 		expect(diff.actions).toBeUndefined();
 		expect(diff.rollover).toBeUndefined();
-		expect(diff.consensus).toStrictEqual({ signatureIdToMessage: ["0x5af35af3"] });
+		expect(diff.consensus).toStrictEqual({ signatureIdToMessage: ["0x5af35af3", undefined] });
 		expect(diff.signing).toStrictEqual([MESSAGE]);
 	});
 });

--- a/validator/src/machine/consensus/oracleTransactionAttested.test.ts
+++ b/validator/src/machine/consensus/oracleTransactionAttested.test.ts
@@ -1,0 +1,107 @@
+import { zeroAddress } from "viem";
+import { describe, expect, it } from "vitest";
+import { TEST_POINT } from "../../__tests__/data/protocol.js";
+import type { SafenetProtocol } from "../../consensus/protocol/types.js";
+import { oracleTxPacketHash } from "../../consensus/verify/oracleTx/hashing.js";
+import type { OracleTransactionPacket } from "../../consensus/verify/oracleTx/schemas.js";
+import { safeTxHash } from "../../consensus/verify/safeTx/hashing.js";
+import type { OracleTransactionAttestedEvent } from "../transitions/types.js";
+import type { MachineStates, SigningState } from "../types.js";
+import { handleOracleTransactionAttested } from "./oracleTransactionAttested.js";
+
+// --- Test Data ---
+const ORACLE_ADDRESS = "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266";
+
+const PROTOCOL = {
+	chainId: () => 42n,
+	consensus: () => "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
+} as unknown as SafenetProtocol;
+
+const PACKET: OracleTransactionPacket = {
+	type: "oracle_transaction_packet",
+	domain: {
+		chain: PROTOCOL.chainId(),
+		consensus: PROTOCOL.consensus(),
+	},
+	proposal: {
+		epoch: 10n,
+		oracle: ORACLE_ADDRESS,
+		transaction: {
+			chainId: 1n,
+			safe: zeroAddress,
+			to: zeroAddress,
+			value: 0n,
+			data: "0x",
+			operation: 0,
+			safeTxGas: 0n,
+			baseGas: 0n,
+			gasPrice: 0n,
+			gasToken: zeroAddress,
+			refundReceiver: zeroAddress,
+			nonce: 2n,
+		},
+	},
+};
+
+const MESSAGE = oracleTxPacketHash(PACKET);
+
+const INVALID_SIGNING_STATE: SigningState = {
+	id: "wait_for_oracle",
+	oracle: ORACLE_ADDRESS,
+	packet: PACKET,
+	signers: [zeroAddress],
+	deadline: 100n,
+};
+
+const SIGNING_STATE: SigningState = {
+	id: "waiting_for_attestation",
+	signatureId: "0x5af35af3",
+	deadline: 22n,
+	packet: PACKET,
+};
+
+const MACHINE_STATES: MachineStates = {
+	rollover: {
+		id: "waiting_for_genesis",
+	},
+	signing: {
+		[MESSAGE]: SIGNING_STATE,
+	},
+};
+
+const EVENT: OracleTransactionAttestedEvent = {
+	id: "event_oracle_transaction_attested",
+	block: 2n,
+	index: 0,
+	safeTxHash: safeTxHash(PACKET.proposal.transaction),
+	chainId: PACKET.proposal.transaction.chainId,
+	safe: PACKET.proposal.transaction.safe,
+	epoch: PACKET.proposal.epoch,
+	oracle: ORACLE_ADDRESS,
+	signatureId: "0x5af35af3",
+	attestation: {
+		z: 12345n,
+		r: TEST_POINT,
+	},
+};
+
+// --- Tests ---
+describe("oracle transaction attested", () => {
+	it("should not handle attestation event if in unexpected state", async () => {
+		const machineStates: MachineStates = {
+			...MACHINE_STATES,
+			signing: { [MESSAGE]: INVALID_SIGNING_STATE },
+		};
+		const diff = await handleOracleTransactionAttested(PROTOCOL, machineStates, EVENT);
+
+		expect(diff).toStrictEqual({});
+	});
+
+	it("should clean up states", async () => {
+		const diff = await handleOracleTransactionAttested(PROTOCOL, MACHINE_STATES, EVENT);
+		expect(diff.actions).toBeUndefined();
+		expect(diff.rollover).toBeUndefined();
+		expect(diff.consensus).toStrictEqual({ signatureIdToMessage: ["0x5af35af3"] });
+		expect(diff.signing).toStrictEqual([MESSAGE]);
+	});
+});

--- a/validator/src/machine/consensus/oracleTransactionAttested.ts
+++ b/validator/src/machine/consensus/oracleTransactionAttested.ts
@@ -27,7 +27,7 @@ export const handleOracleTransactionAttested = async (
 
 	return {
 		consensus: {
-			signatureIdToMessage: [status.signatureId],
+			signatureIdToMessage: [status.signatureId, undefined],
 		},
 		signing: [message],
 	};

--- a/validator/src/machine/consensus/oracleTransactionAttested.ts
+++ b/validator/src/machine/consensus/oracleTransactionAttested.ts
@@ -1,0 +1,34 @@
+import type { SafenetProtocol } from "../../consensus/protocol/types.js";
+import { oracleTxProposalHash } from "../../consensus/verify/oracleTx/hashing.js";
+import type { Logger } from "../../utils/logging.js";
+import type { OracleTransactionAttestedEvent } from "../transitions/types.js";
+import type { MachineStates, StateDiff } from "../types.js";
+
+export const handleOracleTransactionAttested = async (
+	protocol: SafenetProtocol,
+	machineStates: MachineStates,
+	event: OracleTransactionAttestedEvent,
+	logger?: Logger,
+): Promise<StateDiff> => {
+	const message = oracleTxProposalHash({
+		domain: {
+			chain: protocol.chainId(),
+			consensus: protocol.consensus(),
+		},
+		proposal: {
+			epoch: event.epoch,
+			oracle: event.oracle,
+			safeTxHash: event.safeTxHash,
+		},
+	});
+	const status = machineStates.signing[message];
+	if (status?.id !== "waiting_for_attestation") return {};
+	logger?.notice?.(`Attested oracle transaction with hash ${event.safeTxHash}`);
+
+	return {
+		consensus: {
+			signatureIdToMessage: [status.signatureId],
+		},
+		signing: [message],
+	};
+};

--- a/validator/src/machine/consensus/oracleTransactionProposed.test.ts
+++ b/validator/src/machine/consensus/oracleTransactionProposed.test.ts
@@ -3,11 +3,13 @@ import { describe, expect, it, vi } from "vitest";
 import type { SafenetProtocol } from "../../consensus/protocol/types.js";
 import type { SigningClient } from "../../consensus/signing/client.js";
 import type { VerificationEngine } from "../../consensus/verify/engine.js";
-import type { TransactionProposedEvent } from "../transitions/types.js";
+import type { OracleTransactionProposedEvent } from "../transitions/types.js";
 import type { ConsensusState, MachineConfig } from "../types.js";
-import { handleTransactionProposed } from "./transactionProposed.js";
+import { handleOracleTransactionProposed } from "./oracleTransactionProposed.js";
 
 // --- Test Data ---
+const ORACLE_ADDRESS = "0x4838B106FCe9647Bdf1E7877BF73cE8B0BAD5f97";
+
 const CONSENSUS_STATE: ConsensusState = {
 	activeEpoch: 0n,
 	groupPendingNonces: {},
@@ -20,39 +22,28 @@ const CONSENSUS_STATE: ConsensusState = {
 const MACHINE_CONFIG: MachineConfig = {
 	account: ethAddress,
 	participantsInfo: [
-		{
-			address: zeroAddress,
-			activeFrom: 0n,
-		},
-		{
-			address: zeroAddress,
-			activeFrom: 0n,
-		},
-		{
-			address: zeroAddress,
-			activeFrom: 0n,
-		},
-		{
-			address: zeroAddress,
-			activeFrom: 0n,
-		},
+		{ address: zeroAddress, activeFrom: 0n },
+		{ address: zeroAddress, activeFrom: 0n },
+		{ address: zeroAddress, activeFrom: 0n },
+		{ address: zeroAddress, activeFrom: 0n },
 	],
 	genesisSalt: zeroHash,
 	keyGenTimeout: 0n,
 	signingTimeout: 20n,
 	blocksPerEpoch: 0n,
-	allowedOracles: [],
-	oracleTimeout: 0n,
+	allowedOracles: [ORACLE_ADDRESS],
+	oracleTimeout: 30n,
 };
 
-const EVENT: TransactionProposedEvent = {
-	id: "event_transaction_proposed",
+const EVENT: OracleTransactionProposedEvent = {
+	id: "event_oracle_transaction_proposed",
 	block: 2n,
 	index: 0,
 	safeTxHash: "0x5af35af3",
 	chainId: 1n,
 	safe: "0x5afe5afe",
 	epoch: 10n,
+	oracle: ORACLE_ADDRESS,
 	transaction: {
 		chainId: 1n,
 		safe: "0x5afe5afe",
@@ -70,7 +61,7 @@ const EVENT: TransactionProposedEvent = {
 };
 
 // --- Tests ---
-describe("transaction proposed", () => {
+describe("oracle transaction proposed", () => {
 	it("should not handle proposed event if not part of signing group", async () => {
 		const protocol: SafenetProtocol = {} as unknown as SafenetProtocol;
 		const verificationEngine: VerificationEngine = {} as unknown as VerificationEngine;
@@ -78,7 +69,7 @@ describe("transaction proposed", () => {
 		const signingClient: SigningClient = {
 			hasParticipant,
 		} as unknown as SigningClient;
-		const diff = await handleTransactionProposed(
+		const diff = await handleOracleTransactionProposed(
 			MACHINE_CONFIG,
 			protocol,
 			verificationEngine,
@@ -89,6 +80,7 @@ describe("transaction proposed", () => {
 
 		expect(diff).toStrictEqual({});
 	});
+
 	it("should not handle proposed event if epoch group is unknown", async () => {
 		const protocol: SafenetProtocol = {} as unknown as SafenetProtocol;
 		const verificationEngine: VerificationEngine = {} as unknown as VerificationEngine;
@@ -100,7 +92,7 @@ describe("transaction proposed", () => {
 			...CONSENSUS_STATE,
 			epochGroups: {},
 		};
-		const diff = await handleTransactionProposed(
+		const diff = await handleOracleTransactionProposed(
 			MACHINE_CONFIG,
 			protocol,
 			verificationEngine,
@@ -129,7 +121,7 @@ describe("transaction proposed", () => {
 		const signingClient: SigningClient = {
 			hasParticipant,
 		} as unknown as SigningClient;
-		const diff = await handleTransactionProposed(
+		const diff = await handleOracleTransactionProposed(
 			MACHINE_CONFIG,
 			protocol,
 			verificationEngine,
@@ -140,19 +132,20 @@ describe("transaction proposed", () => {
 		expect(diff).toStrictEqual({});
 		expect(verify).toBeCalledTimes(1);
 		expect(verify).toBeCalledWith({
-			type: "safe_transaction_packet",
+			type: "oracle_transaction_packet",
 			domain: {
 				chain: 23n,
 				consensus: zeroAddress,
 			},
 			proposal: {
 				epoch: EVENT.epoch,
+				oracle: EVENT.oracle,
 				transaction: EVENT.transaction,
 			},
 		});
 	});
 
-	it("should transition to waiting for request after verifying transaction", async () => {
+	it("should transition to wait_for_oracle after verifying oracle transaction", async () => {
 		const protocol: SafenetProtocol = {
 			chainId: () => 23n,
 			consensus: () => zeroAddress,
@@ -167,13 +160,12 @@ describe("transaction proposed", () => {
 		} as unknown as VerificationEngine;
 		const hasParticipant = vi.fn().mockReturnValueOnce(true);
 		const participants = vi.fn();
-		// Only use a partial set of the default participants
 		participants.mockReturnValue([3n, 7n]);
 		const signingClient: SigningClient = {
 			hasParticipant,
 			participants,
 		} as unknown as SigningClient;
-		const diff = await handleTransactionProposed(
+		const diff = await handleOracleTransactionProposed(
 			MACHINE_CONFIG,
 			protocol,
 			verificationEngine,
@@ -182,13 +174,14 @@ describe("transaction proposed", () => {
 			EVENT,
 		);
 		const packet = {
-			type: "safe_transaction_packet",
+			type: "oracle_transaction_packet",
 			domain: {
 				chain: 23n,
 				consensus: zeroAddress,
 			},
 			proposal: {
 				epoch: EVENT.epoch,
+				oracle: EVENT.oracle,
 				transaction: EVENT.transaction,
 			},
 		};
@@ -198,11 +191,11 @@ describe("transaction proposed", () => {
 		expect(diff.signing).toStrictEqual([
 			"0x5af35afe",
 			{
-				id: "waiting_for_request",
-				responsible: undefined,
+				id: "wait_for_oracle",
+				oracle: ORACLE_ADDRESS,
 				packet,
 				signers: [3n, 7n],
-				deadline: 22n,
+				deadline: 32n, // block(2) + oracleTimeout(30)
 			},
 		]);
 		expect(verify).toBeCalledTimes(1);

--- a/validator/src/machine/consensus/oracleTransactionProposed.test.ts
+++ b/validator/src/machine/consensus/oracleTransactionProposed.test.ts
@@ -1,10 +1,11 @@
-import { ethAddress, zeroAddress, zeroHash } from "viem";
+import { zeroAddress } from "viem";
 import { describe, expect, it, vi } from "vitest";
+import { makeMachineConfig } from "../../__tests__/data/machine.js";
 import type { SafenetProtocol } from "../../consensus/protocol/types.js";
 import type { SigningClient } from "../../consensus/signing/client.js";
 import type { VerificationEngine } from "../../consensus/verify/engine.js";
 import type { OracleTransactionProposedEvent } from "../transitions/types.js";
-import type { ConsensusState, MachineConfig } from "../types.js";
+import type { ConsensusState } from "../types.js";
 import { handleOracleTransactionProposed } from "./oracleTransactionProposed.js";
 
 // --- Test Data ---
@@ -19,21 +20,7 @@ const CONSENSUS_STATE: ConsensusState = {
 	signatureIdToMessage: {},
 };
 
-const MACHINE_CONFIG: MachineConfig = {
-	account: ethAddress,
-	participantsInfo: [
-		{ address: zeroAddress, activeFrom: 0n },
-		{ address: zeroAddress, activeFrom: 0n },
-		{ address: zeroAddress, activeFrom: 0n },
-		{ address: zeroAddress, activeFrom: 0n },
-	],
-	genesisSalt: zeroHash,
-	keyGenTimeout: 0n,
-	signingTimeout: 20n,
-	blocksPerEpoch: 0n,
-	allowedOracles: [ORACLE_ADDRESS],
-	oracleTimeout: 30n,
-};
+const MACHINE_CONFIG = makeMachineConfig({ signingTimeout: 20n, allowedOracles: [ORACLE_ADDRESS], oracleTimeout: 30n });
 
 const EVENT: OracleTransactionProposedEvent = {
 	id: "event_oracle_transaction_proposed",
@@ -145,7 +132,7 @@ describe("oracle transaction proposed", () => {
 		});
 	});
 
-	it("should transition to wait_for_oracle after verifying oracle transaction", async () => {
+	it("should transition to waiting_for_request after verifying oracle transaction", async () => {
 		const protocol: SafenetProtocol = {
 			chainId: () => 23n,
 			consensus: () => zeroAddress,
@@ -191,11 +178,10 @@ describe("oracle transaction proposed", () => {
 		expect(diff.signing).toStrictEqual([
 			"0x5af35afe",
 			{
-				id: "wait_for_oracle",
-				oracle: ORACLE_ADDRESS,
+				id: "waiting_for_request",
 				packet,
 				signers: [3n, 7n],
-				deadline: 32n, // block(2) + oracleTimeout(30)
+				deadline: 22n, // block(2) + signingTimeout(20)
 			},
 		]);
 		expect(verify).toBeCalledTimes(1);

--- a/validator/src/machine/consensus/oracleTransactionProposed.ts
+++ b/validator/src/machine/consensus/oracleTransactionProposed.ts
@@ -1,0 +1,60 @@
+import type { SafenetProtocol } from "../../consensus/protocol/types.js";
+import type { SigningClient } from "../../consensus/signing/client.js";
+import type { VerificationEngine } from "../../consensus/verify/engine.js";
+import type { OracleTransactionPacket } from "../../consensus/verify/oracleTx/schemas.js";
+import type { Logger } from "../../utils/logging.js";
+import type { OracleTransactionProposedEvent } from "../transitions/types.js";
+import type { ConsensusState, MachineConfig, StateDiff } from "../types.js";
+
+export const handleOracleTransactionProposed = async (
+	machineConfig: MachineConfig,
+	protocol: SafenetProtocol,
+	verificationEngine: VerificationEngine,
+	signingClient: SigningClient,
+	consensusState: ConsensusState,
+	event: OracleTransactionProposedEvent,
+	logger?: Logger,
+): Promise<StateDiff> => {
+	const groupId = consensusState.epochGroups[event.epoch.toString()];
+	if (groupId === undefined) {
+		logger?.debug?.(`Unknown epoch ${event.epoch}!`);
+		return {};
+	}
+	if (!signingClient.hasParticipant(groupId, machineConfig.account)) {
+		logger?.debug?.(`Not part of signing group ${groupId}!`);
+		return {};
+	}
+	const packet: OracleTransactionPacket = {
+		type: "oracle_transaction_packet",
+		domain: {
+			chain: protocol.chainId(),
+			consensus: protocol.consensus(),
+		},
+		proposal: {
+			epoch: event.epoch,
+			oracle: event.oracle,
+			transaction: event.transaction,
+		},
+	};
+	const result = await verificationEngine.verify(packet);
+	const span = { epoch: event.epoch, safeTxHash: event.safeTxHash, oracle: event.oracle };
+	if (result.status === "invalid") {
+		logger?.info?.(`Invalid oracle transaction packet: ${result.error.message}`, span);
+		return {};
+	}
+	const message = result.packetId;
+	logger?.info?.(`Verified oracle transaction packet: ${message}`, span);
+	const signers = signingClient.participants(groupId);
+	return {
+		signing: [
+			message,
+			{
+				id: "wait_for_oracle",
+				oracle: event.oracle,
+				packet,
+				signers,
+				deadline: event.block + machineConfig.oracleTimeout,
+			},
+		],
+	};
+};

--- a/validator/src/machine/consensus/oracleTransactionProposed.ts
+++ b/validator/src/machine/consensus/oracleTransactionProposed.ts
@@ -49,11 +49,10 @@ export const handleOracleTransactionProposed = async (
 		signing: [
 			message,
 			{
-				id: "wait_for_oracle",
-				oracle: event.oracle,
+				id: "waiting_for_request",
 				packet,
 				signers,
-				deadline: event.block + machineConfig.oracleTimeout,
+				deadline: event.block + machineConfig.signingTimeout,
 			},
 		],
 	};

--- a/validator/src/machine/consensus/rollover.test.ts
+++ b/validator/src/machine/consensus/rollover.test.ts
@@ -27,6 +27,8 @@ const MACHINE_CONFIG: MachineConfig = {
 	keyGenTimeout: 20n,
 	signingTimeout: 0n,
 	blocksPerEpoch: 10n,
+	allowedOracles: [],
+	oracleTimeout: 0n,
 };
 
 const PARTICIPANTS = MACHINE_CONFIG.participantsInfo.map((i) => i.address);

--- a/validator/src/machine/consensus/rollover.test.ts
+++ b/validator/src/machine/consensus/rollover.test.ts
@@ -1,35 +1,22 @@
-import { ethAddress, zeroAddress, zeroHash } from "viem";
+import { type Address, ethAddress, zeroAddress } from "viem";
 import { describe, expect, it, vi } from "vitest";
-import { makeGroupSetup, makeKeyGenSetup } from "../../__tests__/data/machine.js";
+import { makeGroupSetup, makeKeyGenSetup, makeMachineConfig } from "../../__tests__/data/machine.js";
 import type { KeyGenClient } from "../../consensus/keyGen/client.js";
 import type { SafenetProtocol } from "../../consensus/protocol/types.js";
-import type { ConsensusState, MachineConfig, MachineStates, SigningState } from "../types.js";
+import type { ConsensusState, MachineStates, SigningState } from "../types.js";
 import { checkEpochRollover } from "./rollover.js";
 
 // --- Test Data ---
-const MACHINE_CONFIG: MachineConfig = {
-	account: "0x0000000000000000000000000000000000000001",
+const MACHINE_CONFIG = makeMachineConfig({
+	account: "0x0000000000000000000000000000000000000001" as Address,
 	participantsInfo: [
-		{
-			address: "0x0000000000000000000000000000000000000001",
-			activeFrom: 0n,
-		},
-		{
-			address: "0x0000000000000000000000000000000000000002",
-			activeFrom: 0n,
-		},
-		{
-			address: "0x0000000000000000000000000000000000000003",
-			activeFrom: 1n,
-		},
+		{ address: "0x0000000000000000000000000000000000000001", activeFrom: 0n },
+		{ address: "0x0000000000000000000000000000000000000002", activeFrom: 0n },
+		{ address: "0x0000000000000000000000000000000000000003", activeFrom: 1n },
 	],
-	genesisSalt: zeroHash,
 	keyGenTimeout: 20n,
-	signingTimeout: 0n,
 	blocksPerEpoch: 10n,
-	allowedOracles: [],
-	oracleTimeout: 0n,
-};
+});
 
 const PARTICIPANTS = MACHINE_CONFIG.participantsInfo.map((i) => i.address);
 

--- a/validator/src/machine/consensus/transactionProposed.test.ts
+++ b/validator/src/machine/consensus/transactionProposed.test.ts
@@ -1,10 +1,11 @@
-import { ethAddress, zeroAddress, zeroHash } from "viem";
+import { zeroAddress } from "viem";
 import { describe, expect, it, vi } from "vitest";
+import { makeMachineConfig } from "../../__tests__/data/machine.js";
 import type { SafenetProtocol } from "../../consensus/protocol/types.js";
 import type { SigningClient } from "../../consensus/signing/client.js";
 import type { VerificationEngine } from "../../consensus/verify/engine.js";
 import type { TransactionProposedEvent } from "../transitions/types.js";
-import type { ConsensusState, MachineConfig } from "../types.js";
+import type { ConsensusState } from "../types.js";
 import { handleTransactionProposed } from "./transactionProposed.js";
 
 // --- Test Data ---
@@ -17,33 +18,7 @@ const CONSENSUS_STATE: ConsensusState = {
 	signatureIdToMessage: {},
 };
 
-const MACHINE_CONFIG: MachineConfig = {
-	account: ethAddress,
-	participantsInfo: [
-		{
-			address: zeroAddress,
-			activeFrom: 0n,
-		},
-		{
-			address: zeroAddress,
-			activeFrom: 0n,
-		},
-		{
-			address: zeroAddress,
-			activeFrom: 0n,
-		},
-		{
-			address: zeroAddress,
-			activeFrom: 0n,
-		},
-	],
-	genesisSalt: zeroHash,
-	keyGenTimeout: 0n,
-	signingTimeout: 20n,
-	blocksPerEpoch: 0n,
-	allowedOracles: [],
-	oracleTimeout: 0n,
-};
+const MACHINE_CONFIG = makeMachineConfig({ signingTimeout: 20n });
 
 const EVENT: TransactionProposedEvent = {
 	id: "event_transaction_proposed",

--- a/validator/src/machine/keygen/committed.test.ts
+++ b/validator/src/machine/keygen/committed.test.ts
@@ -38,6 +38,8 @@ const MACHINE_CONFIG: MachineConfig = {
 	keyGenTimeout: 25n,
 	signingTimeout: 20n,
 	blocksPerEpoch: 2n,
+	allowedOracles: [],
+	oracleTimeout: 0n,
 };
 
 const EVENT: KeyGenCommittedEvent = {

--- a/validator/src/machine/keygen/committed.test.ts
+++ b/validator/src/machine/keygen/committed.test.ts
@@ -1,10 +1,10 @@
-import { ethAddress, zeroHash } from "viem";
+import { ethAddress } from "viem";
 import { entryPoint06Address, entryPoint07Address, entryPoint08Address } from "viem/account-abstraction";
 import { describe, expect, it, vi } from "vitest";
-import { TEST_POINT } from "../../__tests__/data/machine.js";
+import { makeMachineConfig, TEST_POINT } from "../../__tests__/data/machine.js";
 import type { KeyGenClient } from "../../consensus/keyGen/client.js";
 import type { KeyGenCommittedEvent } from "../transitions/types.js";
-import type { MachineConfig, MachineStates } from "../types.js";
+import type { MachineStates } from "../types.js";
 import { handleKeyGenCommitted } from "./committed.js";
 
 // --- Test Data ---
@@ -18,29 +18,17 @@ const MACHINE_STATES: MachineStates = {
 	signing: {},
 };
 
-const MACHINE_CONFIG: MachineConfig = {
+const MACHINE_CONFIG = makeMachineConfig({
 	account: entryPoint06Address,
 	participantsInfo: [
-		{
-			address: entryPoint06Address,
-			activeFrom: 0n,
-		},
-		{
-			address: entryPoint07Address,
-			activeFrom: 0n,
-		},
-		{
-			address: entryPoint08Address,
-			activeFrom: 0n,
-		},
+		{ address: entryPoint06Address, activeFrom: 0n },
+		{ address: entryPoint07Address, activeFrom: 0n },
+		{ address: entryPoint08Address, activeFrom: 0n },
 	],
-	genesisSalt: zeroHash,
 	keyGenTimeout: 25n,
 	signingTimeout: 20n,
 	blocksPerEpoch: 2n,
-	allowedOracles: [],
-	oracleTimeout: 0n,
-};
+});
 
 const EVENT: KeyGenCommittedEvent = {
 	id: "event_key_gen_committed",

--- a/validator/src/machine/keygen/complaintResponse.test.ts
+++ b/validator/src/machine/keygen/complaintResponse.test.ts
@@ -33,6 +33,8 @@ const MACHINE_CONFIG: MachineConfig = {
 	keyGenTimeout: 15n,
 	signingTimeout: 20n,
 	blocksPerEpoch: 10n,
+	allowedOracles: [],
+	oracleTimeout: 0n,
 };
 
 const EVENT: KeyGenComplaintRespondedEvent = {

--- a/validator/src/machine/keygen/complaintResponse.test.ts
+++ b/validator/src/machine/keygen/complaintResponse.test.ts
@@ -1,41 +1,26 @@
-import { ethAddress, zeroHash } from "viem";
+import { ethAddress } from "viem";
 import { entryPoint06Address, entryPoint07Address, entryPoint08Address } from "viem/account-abstraction";
 import { describe, expect, it, vi } from "vitest";
-import { makeGroupSetup, makeKeyGenSetup } from "../../__tests__/data/machine.js";
+import { makeGroupSetup, makeKeyGenSetup, makeMachineConfig } from "../../__tests__/data/machine.js";
 import type { KeyGenClient } from "../../consensus/keyGen/client.js";
 import type { SafenetProtocol } from "../../consensus/protocol/types.js";
 import type { KeyGenComplaintResponsedEvent as KeyGenComplaintRespondedEvent } from "../transitions/types.js";
-import type { MachineConfig, MachineStates } from "../types.js";
+import type { MachineStates } from "../types.js";
 import { handleComplaintResponded } from "./complaintResponse.js";
 
 // --- Test Data ---
-const MACHINE_CONFIG: MachineConfig = {
+const MACHINE_CONFIG = makeMachineConfig({
 	account: entryPoint06Address,
 	participantsInfo: [
-		{
-			address: entryPoint06Address,
-			activeFrom: 0n,
-		},
-		{
-			address: entryPoint07Address,
-			activeFrom: 0n,
-		},
-		{
-			address: entryPoint08Address,
-			activeFrom: 0n,
-		},
-		{
-			address: ethAddress,
-			activeFrom: 0n,
-		},
+		{ address: entryPoint06Address, activeFrom: 0n },
+		{ address: entryPoint07Address, activeFrom: 0n },
+		{ address: entryPoint08Address, activeFrom: 0n },
+		{ address: ethAddress, activeFrom: 0n },
 	],
-	genesisSalt: zeroHash,
 	keyGenTimeout: 15n,
 	signingTimeout: 20n,
 	blocksPerEpoch: 10n,
-	allowedOracles: [],
-	oracleTimeout: 0n,
-};
+});
 
 const EVENT: KeyGenComplaintRespondedEvent = {
 	id: "event_key_gen_complaint_responded",

--- a/validator/src/machine/keygen/complaintSubmitted.test.ts
+++ b/validator/src/machine/keygen/complaintSubmitted.test.ts
@@ -1,4 +1,4 @@
-import { ethAddress, zeroHash } from "viem";
+import { ethAddress } from "viem";
 import {
 	entryPoint06Address,
 	entryPoint07Address,
@@ -6,11 +6,11 @@ import {
 	entryPoint09Address,
 } from "viem/account-abstraction";
 import { describe, expect, it, vi } from "vitest";
-import { makeGroupSetup, makeKeyGenSetup } from "../../__tests__/data/machine.js";
+import { makeGroupSetup, makeKeyGenSetup, makeMachineConfig } from "../../__tests__/data/machine.js";
 import type { KeyGenClient } from "../../consensus/keyGen/client.js";
 import type { SafenetProtocol } from "../../consensus/protocol/types.js";
 import type { KeyGenComplaintSubmittedEvent } from "../transitions/types.js";
-import type { MachineConfig, MachineStates } from "../types.js";
+import type { MachineStates } from "../types.js";
 import { handleComplaintSubmitted } from "./complaintSubmitted.js";
 import { calcGroupContext } from "./group.js";
 
@@ -24,20 +24,17 @@ const EVENT: KeyGenComplaintSubmittedEvent = {
 	accused: entryPoint07Address,
 	compromised: false,
 };
-const MACHINE_CONFIG: MachineConfig = {
+const MACHINE_CONFIG = makeMachineConfig({
 	account: entryPoint06Address,
 	participantsInfo: [
 		{ address: entryPoint06Address, activeFrom: 0n },
 		{ address: entryPoint07Address, activeFrom: 0n },
 		{ address: entryPoint08Address, activeFrom: 0n },
 	],
-	genesisSalt: zeroHash,
 	keyGenTimeout: 10n,
 	signingTimeout: 20n,
 	blocksPerEpoch: 10n,
-	allowedOracles: [],
-	oracleTimeout: 0n,
-};
+});
 
 const makeProtocol = (): SafenetProtocol =>
 	({ consensus: vi.fn().mockReturnValue(ethAddress) }) as unknown as SafenetProtocol;

--- a/validator/src/machine/keygen/complaintSubmitted.test.ts
+++ b/validator/src/machine/keygen/complaintSubmitted.test.ts
@@ -35,6 +35,8 @@ const MACHINE_CONFIG: MachineConfig = {
 	keyGenTimeout: 10n,
 	signingTimeout: 20n,
 	blocksPerEpoch: 10n,
+	allowedOracles: [],
+	oracleTimeout: 0n,
 };
 
 const makeProtocol = (): SafenetProtocol =>

--- a/validator/src/machine/keygen/confirmed.test.ts
+++ b/validator/src/machine/keygen/confirmed.test.ts
@@ -1,7 +1,7 @@
-import { keccak256, zeroHash } from "viem";
+import { keccak256 } from "viem";
 import { entryPoint06Address, entryPoint07Address, entryPoint08Address } from "viem/account-abstraction";
 import { describe, expect, it, vi } from "vitest";
-import { TEST_POINT } from "../../__tests__/data/machine.js";
+import { makeMachineConfig, TEST_POINT } from "../../__tests__/data/machine.js";
 import type { KeyGenClient } from "../../consensus/keyGen/client.js";
 import type { SafenetProtocol } from "../../consensus/protocol/types.js";
 import type { SigningClient } from "../../consensus/signing/client.js";
@@ -9,7 +9,7 @@ import type { VerificationEngine } from "../../consensus/verify/engine.js";
 import type { EpochRolloverPacket } from "../../consensus/verify/rollover/schemas.js";
 import { jsonReplacer } from "../../utils/json.js";
 import type { KeyGenConfirmedEvent } from "../transitions/types.js";
-import type { ConsensusState, MachineConfig, MachineStates, RolloverState, SigningState } from "../types.js";
+import type { ConsensusState, MachineStates, RolloverState, SigningState } from "../types.js";
 import { handleKeyGenConfirmed } from "./confirmed.js";
 
 // --- Test Data ---
@@ -52,29 +52,17 @@ const CONSENSUS_STATE: ConsensusState = {
 	signatureIdToMessage: {},
 };
 
-const MACHINE_CONFIG: MachineConfig = {
+const MACHINE_CONFIG = makeMachineConfig({
 	account: entryPoint06Address,
 	participantsInfo: [
-		{
-			address: entryPoint06Address,
-			activeFrom: 0n,
-		},
-		{
-			address: entryPoint07Address,
-			activeFrom: 0n,
-		},
-		{
-			address: entryPoint08Address,
-			activeFrom: 0n,
-		},
+		{ address: entryPoint06Address, activeFrom: 0n },
+		{ address: entryPoint07Address, activeFrom: 0n },
+		{ address: entryPoint08Address, activeFrom: 0n },
 	],
-	genesisSalt: zeroHash,
 	keyGenTimeout: 25n,
 	signingTimeout: 20n,
 	blocksPerEpoch: 2n,
-	allowedOracles: [],
-	oracleTimeout: 0n,
-};
+});
 
 const EVENT: KeyGenConfirmedEvent = {
 	id: "event_key_gen_confirmed",

--- a/validator/src/machine/keygen/confirmed.test.ts
+++ b/validator/src/machine/keygen/confirmed.test.ts
@@ -72,6 +72,8 @@ const MACHINE_CONFIG: MachineConfig = {
 	keyGenTimeout: 25n,
 	signingTimeout: 20n,
 	blocksPerEpoch: 2n,
+	allowedOracles: [],
+	oracleTimeout: 0n,
 };
 
 const EVENT: KeyGenConfirmedEvent = {

--- a/validator/src/machine/keygen/genesis.test.ts
+++ b/validator/src/machine/keygen/genesis.test.ts
@@ -57,6 +57,8 @@ const MACHINE_CONFIG: MachineConfig = {
 	keyGenTimeout: 25n,
 	signingTimeout: 20n,
 	blocksPerEpoch: 1n,
+	allowedOracles: [],
+	oracleTimeout: 0n,
 };
 
 const EVENT: KeyGenEvent = {

--- a/validator/src/machine/keygen/genesis.test.ts
+++ b/validator/src/machine/keygen/genesis.test.ts
@@ -6,10 +6,10 @@ import {
 	entryPoint09Address,
 } from "viem/account-abstraction";
 import { describe, expect, it, vi } from "vitest";
-import { TEST_POINT } from "../../__tests__/data/machine.js";
+import { makeMachineConfig, TEST_POINT } from "../../__tests__/data/machine.js";
 import type { KeyGenClient } from "../../consensus/keyGen/client.js";
 import type { KeyGenEvent } from "../transitions/types.js";
-import type { ConsensusState, MachineConfig, MachineStates } from "../types.js";
+import type { ConsensusState, MachineStates } from "../types.js";
 import { handleGenesisKeyGen } from "./genesis.js";
 
 // --- Test Data ---
@@ -50,16 +50,13 @@ const PARTICIPANTS_INFO = [
 
 const PARTICIPANTS = PARTICIPANTS_INFO.map((i) => i.address);
 
-const MACHINE_CONFIG: MachineConfig = {
+const MACHINE_CONFIG = makeMachineConfig({
 	account: entryPoint06Address,
 	participantsInfo: PARTICIPANTS_INFO,
-	genesisSalt: zeroHash,
 	keyGenTimeout: 25n,
 	signingTimeout: 20n,
 	blocksPerEpoch: 1n,
-	allowedOracles: [],
-	oracleTimeout: 0n,
-};
+});
 
 const EVENT: KeyGenEvent = {
 	id: "event_key_gen",

--- a/validator/src/machine/keygen/secretShares.test.ts
+++ b/validator/src/machine/keygen/secretShares.test.ts
@@ -1,10 +1,9 @@
-import { zeroHash } from "viem";
 import { entryPoint06Address, entryPoint07Address, entryPoint08Address } from "viem/account-abstraction";
 import { describe, expect, it, vi } from "vitest";
-import { TEST_POINT } from "../../__tests__/data/machine.js";
+import { makeMachineConfig, TEST_POINT } from "../../__tests__/data/machine.js";
 import type { KeyGenClient } from "../../consensus/keyGen/client.js";
 import type { KeyGenSecretSharedEvent } from "../transitions/types.js";
-import type { MachineConfig, MachineStates } from "../types.js";
+import type { MachineStates } from "../types.js";
 import { handleKeyGenSecretShared } from "./secretShares.js";
 
 // --- Test Data ---
@@ -20,29 +19,17 @@ const MACHINE_STATES: MachineStates = {
 	signing: {},
 };
 
-const MACHINE_CONFIG: MachineConfig = {
+const MACHINE_CONFIG = makeMachineConfig({
 	account: entryPoint06Address,
 	participantsInfo: [
-		{
-			address: entryPoint06Address,
-			activeFrom: 0n,
-		},
-		{
-			address: entryPoint07Address,
-			activeFrom: 0n,
-		},
-		{
-			address: entryPoint08Address,
-			activeFrom: 0n,
-		},
+		{ address: entryPoint06Address, activeFrom: 0n },
+		{ address: entryPoint07Address, activeFrom: 0n },
+		{ address: entryPoint08Address, activeFrom: 0n },
 	],
-	genesisSalt: zeroHash,
 	keyGenTimeout: 25n,
 	signingTimeout: 20n,
 	blocksPerEpoch: 2n,
-	allowedOracles: [],
-	oracleTimeout: 0n,
-};
+});
 
 const EVENT: KeyGenSecretSharedEvent = {
 	id: "event_key_gen_secret_shared",

--- a/validator/src/machine/keygen/secretShares.test.ts
+++ b/validator/src/machine/keygen/secretShares.test.ts
@@ -40,6 +40,8 @@ const MACHINE_CONFIG: MachineConfig = {
 	keyGenTimeout: 25n,
 	signingTimeout: 20n,
 	blocksPerEpoch: 2n,
+	allowedOracles: [],
+	oracleTimeout: 0n,
 };
 
 const EVENT: KeyGenSecretSharedEvent = {

--- a/validator/src/machine/keygen/timeout.test.ts
+++ b/validator/src/machine/keygen/timeout.test.ts
@@ -1,40 +1,23 @@
-import { ethAddress, zeroHash } from "viem";
+import { ethAddress } from "viem";
 import { entryPoint06Address, entryPoint07Address, entryPoint08Address } from "viem/account-abstraction";
 import { describe, expect, it, vi } from "vitest";
-import { makeGroupSetup, makeKeyGenSetup } from "../../__tests__/data/machine.js";
+import { makeGroupSetup, makeKeyGenSetup, makeMachineConfig } from "../../__tests__/data/machine.js";
 import type { KeyGenClient } from "../../consensus/keyGen/client.js";
 import type { SafenetProtocol } from "../../consensus/protocol/types.js";
-import type { MachineConfig, MachineStates, RolloverState } from "../types.js";
+import type { MachineStates, RolloverState } from "../types.js";
 import { checkKeyGenTimeouts } from "./timeouts.js";
 
 // --- Test Data ---
-const MACHINE_CONFIG: MachineConfig = {
-	account: ethAddress,
+const MACHINE_CONFIG = makeMachineConfig({
 	participantsInfo: [
-		{
-			address: entryPoint06Address,
-			activeFrom: 0n,
-		},
-		{
-			address: entryPoint07Address,
-			activeFrom: 0n,
-		},
-		{
-			address: entryPoint08Address,
-			activeFrom: 0n,
-		},
-		{
-			address: ethAddress,
-			activeFrom: 0n,
-		},
+		{ address: entryPoint06Address, activeFrom: 0n },
+		{ address: entryPoint07Address, activeFrom: 0n },
+		{ address: entryPoint08Address, activeFrom: 0n },
+		{ address: ethAddress, activeFrom: 0n },
 	],
-	genesisSalt: zeroHash,
-	keyGenTimeout: 0n,
 	signingTimeout: 20n,
 	blocksPerEpoch: 10n,
-	allowedOracles: [],
-	oracleTimeout: 0n,
-};
+});
 
 // --- Tests ---
 describe("key gen timeouts", () => {

--- a/validator/src/machine/keygen/timeout.test.ts
+++ b/validator/src/machine/keygen/timeout.test.ts
@@ -32,6 +32,8 @@ const MACHINE_CONFIG: MachineConfig = {
 	keyGenTimeout: 0n,
 	signingTimeout: 20n,
 	blocksPerEpoch: 10n,
+	allowedOracles: [],
+	oracleTimeout: 0n,
 };
 
 // --- Tests ---

--- a/validator/src/machine/signing/completed.test.ts
+++ b/validator/src/machine/signing/completed.test.ts
@@ -53,6 +53,8 @@ const MACHINE_CONFIG: MachineConfig = {
 	keyGenTimeout: 0n,
 	signingTimeout: 20n,
 	blocksPerEpoch: 0n,
+	allowedOracles: [],
+	oracleTimeout: 0n,
 };
 
 const EVENT: SignedEvent = {

--- a/validator/src/machine/signing/completed.test.ts
+++ b/validator/src/machine/signing/completed.test.ts
@@ -1,8 +1,9 @@
-import { ethAddress, zeroHash } from "viem";
+import { zeroHash } from "viem";
 import { describe, expect, it } from "vitest";
+import { makeMachineConfig } from "../../__tests__/data/machine.js";
 import { toPoint } from "../../frost/math.js";
 import type { SignedEvent } from "../transitions/types.js";
-import type { ConsensusState, MachineConfig, MachineStates, SigningState } from "../types.js";
+import type { ConsensusState, MachineStates, SigningState } from "../types.js";
 import { handleSigningCompleted } from "./completed.js";
 
 // --- Test Data ---
@@ -46,16 +47,7 @@ const CONSENSUS_STATE: ConsensusState = {
 	},
 };
 
-const MACHINE_CONFIG: MachineConfig = {
-	account: ethAddress,
-	participantsInfo: [],
-	genesisSalt: zeroHash,
-	keyGenTimeout: 0n,
-	signingTimeout: 20n,
-	blocksPerEpoch: 0n,
-	allowedOracles: [],
-	oracleTimeout: 0n,
-};
+const MACHINE_CONFIG = makeMachineConfig({ participantsInfo: [], signingTimeout: 20n });
 
 const EVENT: SignedEvent = {
 	id: "event_signed",

--- a/validator/src/machine/signing/nonces.test.ts
+++ b/validator/src/machine/signing/nonces.test.ts
@@ -57,6 +57,8 @@ const MACHINE_CONFIG: MachineConfig = {
 	keyGenTimeout: 0n,
 	signingTimeout: 20n,
 	blocksPerEpoch: 8n,
+	allowedOracles: [],
+	oracleTimeout: 0n,
 };
 
 const EVENT: NonceCommitmentsEvent = {

--- a/validator/src/machine/signing/nonces.test.ts
+++ b/validator/src/machine/signing/nonces.test.ts
@@ -1,10 +1,11 @@
-import { ethAddress, zeroAddress, zeroHash } from "viem";
+import { ethAddress, zeroAddress } from "viem";
 import { describe, expect, it, vi } from "vitest";
+import { makeMachineConfig } from "../../__tests__/data/machine.js";
 import type { SigningClient } from "../../consensus/signing/client.js";
 import type { SafeTransactionPacket } from "../../consensus/verify/safeTx/schemas.js";
 import { toPoint } from "../../frost/math.js";
 import type { NonceCommitmentsEvent } from "../transitions/types.js";
-import type { ConsensusState, MachineConfig, MachineStates, SigningState } from "../types.js";
+import type { ConsensusState, MachineStates, SigningState } from "../types.js";
 import { handleRevealedNonces } from "./nonces.js";
 
 // --- Test Data ---
@@ -50,16 +51,7 @@ const CONSENSUS_STATE: ConsensusState = {
 	},
 };
 
-const MACHINE_CONFIG: MachineConfig = {
-	account: ethAddress,
-	participantsInfo: [],
-	genesisSalt: zeroHash,
-	keyGenTimeout: 0n,
-	signingTimeout: 20n,
-	blocksPerEpoch: 8n,
-	allowedOracles: [],
-	oracleTimeout: 0n,
-};
+const MACHINE_CONFIG = makeMachineConfig({ participantsInfo: [], signingTimeout: 20n, blocksPerEpoch: 8n });
 
 const EVENT: NonceCommitmentsEvent = {
 	id: "event_nonce_commitments",

--- a/validator/src/machine/signing/preprocess.test.ts
+++ b/validator/src/machine/signing/preprocess.test.ts
@@ -1,21 +1,18 @@
-import { ethAddress, zeroHash } from "viem";
+import { type Address, ethAddress } from "viem";
 import { describe, expect, it, vi } from "vitest";
+import { makeMachineConfig } from "../../__tests__/data/machine.js";
 import type { SigningClient } from "../../consensus/signing/client.js";
 import type { NonceCommitmentsHashEvent } from "../transitions/types.js";
-import type { ConsensusState, MachineConfig } from "../types.js";
+import type { ConsensusState } from "../types.js";
 import { handlePreprocess } from "./preprocess.js";
 
 // --- Test Data ---
-const MACHINE_CONFIG: MachineConfig = {
-	account: "0x0000000000000000000000000000000000005aFE",
+const MACHINE_CONFIG = makeMachineConfig({
+	account: "0x0000000000000000000000000000000000005aFE" as Address,
 	participantsInfo: [],
-	genesisSalt: zeroHash,
-	keyGenTimeout: 0n,
 	signingTimeout: 20n,
 	blocksPerEpoch: 8n,
-	allowedOracles: [],
-	oracleTimeout: 0n,
-};
+});
 const CONSENSUS_STATE: ConsensusState = {
 	activeEpoch: 0n,
 	groupPendingNonces: {

--- a/validator/src/machine/signing/preprocess.test.ts
+++ b/validator/src/machine/signing/preprocess.test.ts
@@ -13,6 +13,8 @@ const MACHINE_CONFIG: MachineConfig = {
 	keyGenTimeout: 0n,
 	signingTimeout: 20n,
 	blocksPerEpoch: 8n,
+	allowedOracles: [],
+	oracleTimeout: 0n,
 };
 const CONSENSUS_STATE: ConsensusState = {
 	activeEpoch: 0n,

--- a/validator/src/machine/signing/sign.test.ts
+++ b/validator/src/machine/signing/sign.test.ts
@@ -1,5 +1,6 @@
-import { ethAddress, zeroHash } from "viem";
+import { ethAddress, zeroAddress, zeroHash } from "viem";
 import { describe, expect, it, vi } from "vitest";
+import { makeMachineConfig } from "../../__tests__/data/machine.js";
 import type { SigningClient } from "../../consensus/signing/client.js";
 import type { VerificationEngine } from "../../consensus/verify/engine.js";
 import type { SignRequestEvent } from "../transitions/types.js";
@@ -46,16 +47,7 @@ const CONSENSUS_STATE: ConsensusState = {
 	signatureIdToMessage: {},
 };
 
-const MACHINE_CONFIG: MachineConfig = {
-	account: ethAddress,
-	participantsInfo: [],
-	genesisSalt: zeroHash,
-	keyGenTimeout: 0n,
-	signingTimeout: 20n,
-	blocksPerEpoch: 0n,
-	allowedOracles: [],
-	oracleTimeout: 0n,
-};
+const MACHINE_CONFIG = makeMachineConfig({ participantsInfo: [], signingTimeout: 20n });
 
 const EVENT: SignRequestEvent = {
 	id: "event_sign_request",
@@ -66,6 +58,40 @@ const EVENT: SignRequestEvent = {
 	message: "0x5afe5afe",
 	sid: "0x5af35af3",
 	sequence: 0n,
+};
+
+const ORACLE_ADDRESS = "0x4838B106FCe9647Bdf1E7877BF73cE8B0BAD5f97";
+
+const ORACLE_SIGNING_STATE: SigningState = {
+	id: "waiting_for_request",
+	signers: ["0x0000000000000000000000000000000000000001", "0x0000000000000000000000000000000000000002"],
+	responsible: undefined,
+	deadline: 23n,
+	packet: {
+		type: "oracle_transaction_packet",
+		domain: {
+			chain: 1n,
+			consensus: "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
+		},
+		proposal: {
+			epoch: 1n,
+			oracle: ORACLE_ADDRESS,
+			transaction: {
+				chainId: 1n,
+				safe: zeroAddress,
+				to: zeroAddress,
+				value: 0n,
+				data: "0x",
+				operation: 0,
+				safeTxGas: 0n,
+				baseGas: 0n,
+				gasPrice: 0n,
+				gasToken: zeroAddress,
+				refundReceiver: zeroAddress,
+				nonce: 0n,
+			},
+		},
+	},
 };
 
 // --- Tests ---
@@ -290,5 +316,36 @@ describe("collecting shares", () => {
 		);
 
 		expect(diff).toStrictEqual({});
+	});
+
+	it("should transition to waiting_for_oracle for oracle packets", async () => {
+		const isVerified = vi.fn().mockReturnValueOnce(true);
+		const verificationEngine = {
+			isVerified,
+		} as unknown as VerificationEngine;
+		const hasParticipant = vi.fn().mockReturnValueOnce(true);
+		const signingClient = {
+			hasParticipant,
+		} as unknown as SigningClient;
+		const machineStates: MachineStates = {
+			...MACHINE_STATES,
+			signing: { "0x5afe5afe": ORACLE_SIGNING_STATE },
+		};
+		const config: MachineConfig = { ...MACHINE_CONFIG, oracleTimeout: 50n };
+		const diff = await handleSign(config, verificationEngine, signingClient, CONSENSUS_STATE, machineStates, EVENT);
+
+		expect(diff.rollover).toBeUndefined();
+		expect(diff.consensus).toBeUndefined();
+		expect(diff.actions).toBeUndefined();
+		expect(diff.signing).toStrictEqual([
+			"0x5afe5afe",
+			{
+				id: "waiting_for_oracle",
+				oracle: ORACLE_ADDRESS,
+				signers: ORACLE_SIGNING_STATE.signers,
+				deadline: 52n, // block(2) + oracleTimeout(50)
+				packet: ORACLE_SIGNING_STATE.packet,
+			},
+		]);
 	});
 });

--- a/validator/src/machine/signing/sign.test.ts
+++ b/validator/src/machine/signing/sign.test.ts
@@ -53,6 +53,8 @@ const MACHINE_CONFIG: MachineConfig = {
 	keyGenTimeout: 0n,
 	signingTimeout: 20n,
 	blocksPerEpoch: 0n,
+	allowedOracles: [],
+	oracleTimeout: 0n,
 };
 
 const EVENT: SignRequestEvent = {

--- a/validator/src/machine/signing/sign.ts
+++ b/validator/src/machine/signing/sign.ts
@@ -40,6 +40,23 @@ export const handleSign = async (
 		return diff;
 	}
 
+	// Oracle packet: wait for oracle approval before participating in signing
+	if (status.packet.type === "oracle_transaction_packet") {
+		return {
+			...diff,
+			signing: [
+				event.message,
+				{
+					id: "waiting_for_oracle",
+					oracle: status.packet.proposal.oracle,
+					signers: status.signers,
+					deadline: event.block + machineConfig.oracleTimeout,
+					packet: status.packet,
+				},
+			],
+		};
+	}
+
 	const consensus = {
 		...diff.consensus,
 	};

--- a/validator/src/machine/signing/timeouts.test.ts
+++ b/validator/src/machine/signing/timeouts.test.ts
@@ -1,5 +1,6 @@
-import { ethAddress, zeroAddress, zeroHash } from "viem";
+import { zeroAddress } from "viem";
 import { describe, expect, it, vi } from "vitest";
+import { makeMachineConfig } from "../../__tests__/data/machine.js";
 import type { SigningClient } from "../../consensus/signing/client.js";
 import type { SafeTransactionPacket } from "../../consensus/verify/safeTx/schemas.js";
 import type { ConsensusState, MachineConfig, MachineStates, SigningState } from "../types.js";
@@ -77,20 +78,15 @@ const CONSENSUS_STATE: ConsensusState = {
 	signatureIdToMessage: {},
 };
 
-const MACHINE_CONFIG: MachineConfig = {
-	account: ethAddress,
+const MACHINE_CONFIG = makeMachineConfig({
 	participantsInfo: [
 		{ address: zeroAddress, activeFrom: 0n },
 		{ address: zeroAddress, activeFrom: 0n },
 		{ address: zeroAddress, activeFrom: 0n },
 	],
-	genesisSalt: zeroHash,
-	keyGenTimeout: 0n,
 	signingTimeout: 20n,
 	blocksPerEpoch: 8n,
-	allowedOracles: [],
-	oracleTimeout: 0n,
-};
+});
 
 // --- Tests ---
 describe("signing timeouts - base conditions", () => {

--- a/validator/src/machine/signing/timeouts.test.ts
+++ b/validator/src/machine/signing/timeouts.test.ts
@@ -88,6 +88,8 @@ const MACHINE_CONFIG: MachineConfig = {
 	keyGenTimeout: 0n,
 	signingTimeout: 20n,
 	blocksPerEpoch: 8n,
+	allowedOracles: [],
+	oracleTimeout: 0n,
 };
 
 // --- Tests ---

--- a/validator/src/machine/signing/timeouts.ts
+++ b/validator/src/machine/signing/timeouts.ts
@@ -171,7 +171,7 @@ const checkSigningRequestTimeout = (
 				],
 			};
 		}
-		case "wait_for_oracle": {
+		case "waiting_for_oracle": {
 			// Oracle did not respond in time — drop the signing request silently
 			return {
 				signing: [message, undefined],

--- a/validator/src/machine/signing/timeouts.ts
+++ b/validator/src/machine/signing/timeouts.ts
@@ -171,6 +171,12 @@ const checkSigningRequestTimeout = (
 				],
 			};
 		}
+		case "wait_for_oracle": {
+			// Oracle did not respond in time — drop the signing request silently
+			return {
+				signing: [message, undefined],
+			};
+		}
 		case "collect_nonce_commitments":
 		case "collect_signing_shares": {
 			// Remove pending request

--- a/validator/src/machine/transitions/onchain.ts
+++ b/validator/src/machine/transitions/onchain.ts
@@ -11,6 +11,8 @@ import {
 	keyGenSecretSharedEventSchema,
 	nonceCommitmentsEventSchema,
 	nonceCommitmentsHashEventSchema,
+	oracleTransactionAttestedEventSchema,
+	oracleTransactionProposedEventSchema,
 	signatureShareEventSchema,
 	signedEventSchema,
 	signRequestEventSchema,
@@ -158,6 +160,24 @@ export const logToTransition = ({
 			const args = epochProposedEventSchema.parse(eventArgs);
 			return {
 				id: "event_epoch_proposed",
+				block,
+				index,
+				...args,
+			};
+		}
+		case "OracleTransactionProposed": {
+			const args = oracleTransactionProposedEventSchema.parse(eventArgs);
+			return {
+				id: "event_oracle_transaction_proposed",
+				block,
+				index,
+				...args,
+			};
+		}
+		case "OracleTransactionAttested": {
+			const args = oracleTransactionAttestedEventSchema.parse(eventArgs);
+			return {
+				id: "event_oracle_transaction_attested",
 				block,
 				index,
 				...args,

--- a/validator/src/machine/transitions/schemas.ts
+++ b/validator/src/machine/transitions/schemas.ts
@@ -160,6 +160,25 @@ export const transactionAttestedEventSchema = z.object({
 	attestation: signatureSchema,
 });
 
+export const oracleTransactionProposedEventSchema = z.object({
+	safeTxHash: hexBytes32Schema,
+	chainId: eventBigIntSchema,
+	safe: checkedAddressSchema,
+	epoch: eventBigIntSchema,
+	oracle: checkedAddressSchema,
+	transaction: transactionSchema,
+});
+
+export const oracleTransactionAttestedEventSchema = z.object({
+	safeTxHash: hexBytes32Schema,
+	chainId: eventBigIntSchema,
+	safe: checkedAddressSchema,
+	epoch: eventBigIntSchema,
+	oracle: checkedAddressSchema,
+	signatureId: hexBytes32Schema,
+	attestation: signatureSchema,
+});
+
 const baseEventTransitionParamsSchema = z.object({
 	block: eventBigIntSchema,
 	index: z.number(),
@@ -247,6 +266,18 @@ const transactionAttestedEventTransitionSchema = baseEventTransitionParamsSchema
 		id: z.literal("event_transaction_attested"),
 	});
 
+const oracleTransactionProposedEventTransitionSchema = baseEventTransitionParamsSchema
+	.extend(oracleTransactionProposedEventSchema.shape)
+	.extend({
+		id: z.literal("event_oracle_transaction_proposed"),
+	});
+
+const oracleTransactionAttestedEventTransitionSchema = baseEventTransitionParamsSchema
+	.extend(oracleTransactionAttestedEventSchema.shape)
+	.extend({
+		id: z.literal("event_oracle_transaction_attested"),
+	});
+
 const newBlockTransition = z.object({
 	id: z.literal("block_new"),
 	block: eventBigIntSchema,
@@ -271,6 +302,8 @@ export const stateTransitionSchema = z.discriminatedUnion("id", [
 	epochStagedEventTransitionSchema,
 	transactionProposedEventTransitionSchema,
 	transactionAttestedEventTransitionSchema,
+	oracleTransactionProposedEventTransitionSchema,
+	oracleTransactionAttestedEventTransitionSchema,
 	// Consensus Clock
 	newBlockTransition,
 ]);

--- a/validator/src/machine/transitions/types.ts
+++ b/validator/src/machine/transitions/types.ts
@@ -178,6 +178,34 @@ export type TransactionAttestedEvent = {
 	};
 };
 
+export type OracleTransactionProposedEvent = {
+	id: "event_oracle_transaction_proposed";
+	block: bigint;
+	index: number;
+	safeTxHash: Hex;
+	chainId: bigint;
+	safe: Address;
+	epoch: bigint;
+	oracle: Address;
+	transaction: SafeTransaction;
+};
+
+export type OracleTransactionAttestedEvent = {
+	id: "event_oracle_transaction_attested";
+	block: bigint;
+	index: number;
+	safeTxHash: Hex;
+	chainId: bigint;
+	safe: Address;
+	epoch: bigint;
+	oracle: Address;
+	signatureId: SignatureId;
+	attestation: {
+		z: bigint;
+		r: FrostPoint;
+	};
+};
+
 export type EventTransition =
 	| KeyGenEvent
 	| KeyGenCommittedEvent
@@ -193,6 +221,8 @@ export type EventTransition =
 	| EpochProposedEvent
 	| EpochStagedEvent
 	| TransactionProposedEvent
-	| TransactionAttestedEvent;
+	| TransactionAttestedEvent
+	| OracleTransactionProposedEvent
+	| OracleTransactionAttestedEvent;
 
 export type StateTransition = NewBlock | EventTransition;

--- a/validator/src/machine/transitions/types.ts
+++ b/validator/src/machine/transitions/types.ts
@@ -1,6 +1,6 @@
 import type { Address, Hex } from "viem";
 import type { SafeTransaction } from "../../consensus/verify/safeTx/schemas.js";
-import type { FrostPoint, GroupId, ProofOfKnowledge, SignatureId } from "../../frost/types.js";
+import type { FrostPoint, FrostSignature, GroupId, ProofOfKnowledge, SignatureId } from "../../frost/types.js";
 
 export type NewBlock = {
 	id: "block_new";
@@ -119,10 +119,7 @@ export type SignedEvent = {
 	index: number;
 	sid: SignatureId;
 	selectionRoot: Hex;
-	signature: {
-		z: bigint;
-		r: FrostPoint;
-	};
+	signature: FrostSignature;
 };
 
 export type EpochProposedEvent = {
@@ -146,10 +143,7 @@ export type EpochStagedEvent = {
 	groupId: GroupId;
 	groupKey: FrostPoint;
 	signatureId: SignatureId;
-	attestation: {
-		z: bigint;
-		r: FrostPoint;
-	};
+	attestation: FrostSignature;
 };
 
 export type TransactionProposedEvent = {
@@ -172,10 +166,7 @@ export type TransactionAttestedEvent = {
 	safe: Address;
 	epoch: bigint;
 	signatureId: SignatureId;
-	attestation: {
-		z: bigint;
-		r: FrostPoint;
-	};
+	attestation: FrostSignature;
 };
 
 export type OracleTransactionProposedEvent = {
@@ -200,10 +191,7 @@ export type OracleTransactionAttestedEvent = {
 	epoch: bigint;
 	oracle: Address;
 	signatureId: SignatureId;
-	attestation: {
-		z: bigint;
-		r: FrostPoint;
-	};
+	attestation: FrostSignature;
 };
 
 export type EventTransition =

--- a/validator/src/machine/types.ts
+++ b/validator/src/machine/types.ts
@@ -1,5 +1,6 @@
 import type { Address, Hex } from "viem";
 import type { ProtocolAction } from "../consensus/protocol/types.js";
+import type { OracleTransactionPacket } from "../consensus/verify/oracleTx/schemas.js";
 import type { EpochRolloverPacket } from "../consensus/verify/rollover/schemas.js";
 import type { SafeTransactionPacket } from "../consensus/verify/safeTx/schemas.js";
 import type { GroupId, SignatureId } from "../frost/types.js";
@@ -63,7 +64,7 @@ export type RolloverState = Readonly<
 >;
 
 export type BaseSigningState = {
-	packet: SafeTransactionPacket | EpochRolloverPacket;
+	packet: SafeTransactionPacket | EpochRolloverPacket | OracleTransactionPacket;
 };
 
 export type SigningState = Readonly<
@@ -92,6 +93,12 @@ export type SigningState = Readonly<
 					id: "waiting_for_attestation";
 					signatureId: SignatureId;
 					responsible?: Address;
+					deadline: bigint;
+			  }
+			| {
+					id: "wait_for_oracle";
+					oracle: Address;
+					signers: readonly Address[];
 					deadline: bigint;
 			  }
 		)
@@ -146,4 +153,6 @@ export type MachineConfig = {
 	keyGenTimeout: bigint;
 	signingTimeout: bigint;
 	blocksPerEpoch: bigint;
+	allowedOracles: readonly Address[];
+	oracleTimeout: bigint;
 };

--- a/validator/src/machine/types.ts
+++ b/validator/src/machine/types.ts
@@ -96,7 +96,7 @@ export type SigningState = Readonly<
 					deadline: bigint;
 			  }
 			| {
-					id: "wait_for_oracle";
+					id: "waiting_for_oracle";
 					oracle: Address;
 					signers: readonly Address[];
 					deadline: bigint;

--- a/validator/src/service/machine.ts
+++ b/validator/src/service/machine.ts
@@ -4,6 +4,8 @@ import type { ProtocolAction, SafenetProtocol } from "../consensus/protocol/type
 import type { SigningClient } from "../consensus/signing/client.js";
 import type { VerificationEngine } from "../consensus/verify/engine.js";
 import { handleEpochStaged } from "../machine/consensus/epochStaged.js";
+import { handleOracleTransactionAttested } from "../machine/consensus/oracleTransactionAttested.js";
+import { handleOracleTransactionProposed } from "../machine/consensus/oracleTransactionProposed.js";
 import { checkEpochRollover } from "../machine/consensus/rollover.js";
 import { handleTransactionAttested } from "../machine/consensus/transactionAttested.js";
 import { handleTransactionProposed } from "../machine/consensus/transactionProposed.js";
@@ -64,6 +66,8 @@ export class SafenetStateMachine {
 		blocksPerEpoch,
 		keyGenTimeout,
 		signingTimeout,
+		allowedOracles,
+		oracleTimeout,
 		storage,
 	}: {
 		account: Address;
@@ -78,6 +82,8 @@ export class SafenetStateMachine {
 		blocksPerEpoch?: bigint;
 		keyGenTimeout?: bigint;
 		signingTimeout?: bigint;
+		allowedOracles?: readonly Address[];
+		oracleTimeout?: bigint;
 		storage: StateStorage;
 	}) {
 		this.#machineConfig = {
@@ -87,6 +93,8 @@ export class SafenetStateMachine {
 			blocksPerEpoch: blocksPerEpoch ?? BLOCKS_PER_EPOCH,
 			keyGenTimeout: keyGenTimeout ?? DEFAULT_TIMEOUT,
 			signingTimeout: signingTimeout ?? DEFAULT_TIMEOUT,
+			allowedOracles: allowedOracles ?? [],
+			oracleTimeout: oracleTimeout ?? DEFAULT_TIMEOUT,
 		};
 		this.#protocol = protocol;
 		this.#keyGenClient = keyGenClient;
@@ -361,6 +369,20 @@ export class SafenetStateMachine {
 			}
 			case "event_transaction_attested": {
 				return await handleTransactionAttested(this.#protocol, machineStates, transition, this.#logger);
+			}
+			case "event_oracle_transaction_proposed": {
+				return await handleOracleTransactionProposed(
+					this.#machineConfig,
+					this.#protocol,
+					this.#verificationEngine,
+					this.#signingClient,
+					consensusState,
+					transition,
+					this.#logger,
+				);
+			}
+			case "event_oracle_transaction_attested": {
+				return await handleOracleTransactionAttested(this.#protocol, machineStates, transition, this.#logger);
 			}
 		}
 	}

--- a/validator/src/service/service.ts
+++ b/validator/src/service/service.ts
@@ -16,6 +16,7 @@ import { SqliteActionQueue, SqliteTxStorage } from "../consensus/protocol/sqlite
 import { SigningClient } from "../consensus/signing/client.js";
 import { SqliteClientStorage } from "../consensus/storage/sqlite.js";
 import { type PacketHandler, type Typed, VerificationEngine } from "../consensus/verify/engine.js";
+import { OracleTransactionHandler } from "../consensus/verify/oracleTx/handler.js";
 import { EpochRolloverHandler } from "../consensus/verify/rollover/handler.js";
 import { SafeTransactionHandler } from "../consensus/verify/safeTx/handler.js";
 import { SqliteStateStorage } from "../machine/storage/sqlite.js";
@@ -69,6 +70,7 @@ export class ValidatorService {
 		const check = buildSafeTransactionCheck();
 		verificationHandlers.set("safe_transaction_packet", new SafeTransactionHandler(check, metrics));
 		verificationHandlers.set("epoch_rollover_packet", new EpochRolloverHandler());
+		verificationHandlers.set("oracle_transaction_packet", new OracleTransactionHandler([], metrics));
 		const verificationEngine = new VerificationEngine(verificationHandlers);
 		const actionStorage = new SqliteActionQueue(database);
 		const txStorage = new SqliteTxStorage(database);

--- a/validator/src/service/service.ts
+++ b/validator/src/service/service.ts
@@ -70,7 +70,10 @@ export class ValidatorService {
 		const check = buildSafeTransactionCheck();
 		verificationHandlers.set("safe_transaction_packet", new SafeTransactionHandler(check, metrics));
 		verificationHandlers.set("epoch_rollover_packet", new EpochRolloverHandler());
-		verificationHandlers.set("oracle_transaction_packet", new OracleTransactionHandler([], metrics));
+		verificationHandlers.set(
+			"oracle_transaction_packet",
+			new OracleTransactionHandler(config.allowedOracles ?? [], metrics),
+		);
 		const verificationEngine = new VerificationEngine(verificationHandlers);
 		const actionStorage = new SqliteActionQueue(database);
 		const txStorage = new SqliteTxStorage(database);

--- a/validator/src/types/abis.ts
+++ b/validator/src/types/abis.ts
@@ -8,6 +8,14 @@ export const CONSENSUS_TRANSACTION_PROPOSED_EVENT = parseAbiItem(
 	"event TransactionProposed(bytes32 indexed safeTxHash, uint256 indexed chainId, address indexed safe, uint64 epoch, (uint256 chainId, address safe, address to, uint256 value, bytes data, uint8 operation, uint256 safeTxGas, uint256 baseGas, uint256 gasPrice, address gasToken, address refundReceiver, uint256 nonce) transaction)",
 );
 
+export const CONSENSUS_ORACLE_TRANSACTION_PROPOSED_EVENT = parseAbiItem(
+	"event OracleTransactionProposed(bytes32 indexed safeTxHash, uint256 indexed chainId, address indexed safe, uint64 epoch, address oracle, (uint256 chainId, address safe, address to, uint256 value, bytes data, uint8 operation, uint256 safeTxGas, uint256 baseGas, uint256 gasPrice, address gasToken, address refundReceiver, uint256 nonce) transaction)",
+);
+
+export const CONSENSUS_ORACLE_TRANSACTION_ATTESTED_EVENT = parseAbiItem(
+	"event OracleTransactionAttested(bytes32 indexed safeTxHash, uint256 indexed chainId, address indexed safe, uint64 epoch, address oracle, bytes32 signatureId, ((uint256 x, uint256 y) r, uint256 z) attestation)",
+);
+
 export const CONSENSUS_OTHER_EVENTS = parseAbi([
 	"event EpochProposed(uint64 indexed activeEpoch, uint64 indexed proposedEpoch, uint64 rolloverBlock, bytes32 groupId, (uint256 x, uint256 y) groupKey)",
 	"event TransactionAttested(bytes32 indexed safeTxHash, uint256 indexed chainId, address indexed safe, uint64 epoch, bytes32 signatureId, ((uint256 x, uint256 y) r, uint256 z) attestation)",
@@ -16,6 +24,8 @@ export const CONSENSUS_OTHER_EVENTS = parseAbi([
 export const CONSENSUS_EVENTS = [
 	CONSENSUS_EPOCH_STAGED_EVENT,
 	CONSENSUS_TRANSACTION_PROPOSED_EVENT,
+	CONSENSUS_ORACLE_TRANSACTION_PROPOSED_EVENT,
+	CONSENSUS_ORACLE_TRANSACTION_ATTESTED_EVENT,
 	...CONSENSUS_OTHER_EVENTS,
 ] as const;
 

--- a/validator/src/types/interfaces.ts
+++ b/validator/src/types/interfaces.ts
@@ -18,6 +18,7 @@ export interface ProtocolConfig {
 	keyGenTimeout?: bigint;
 	signingTimeout?: bigint;
 	blocksBeforeResubmit?: bigint;
+	allowedOracles?: readonly Address[];
 }
 
 export type AbiPoint = { x: bigint; y: bigint };


### PR DESCRIPTION
## Summary
This PR adds support for oracle-initiated transaction proposals and attestations to the Safenet consensus state machine. Oracles can now propose transactions that are verified, signed by the consensus group, and attested on-chain.

## Key Changes

- **Oracle Transaction Events**: Added two new event types to the state machine:
  - `OracleTransactionProposedEvent`: Triggered when an oracle proposes a transaction
  - `OracleTransactionAttestedEvent`: Triggered when an oracle attests to a signed transaction

- **Event Handlers**: Implemented handlers for oracle transaction events:
  - `handleOracleTransactionProposed`: Verifies oracle transactions and initiates signing with a `wait_for_oracle` state
  - `handleOracleTransactionAttested`: Cleans up signing state after oracle attestation

- **Verification**: Added oracle transaction verification infrastructure:
  - `OracleTransactionHandler`: Validates oracle addresses against an allowlist
  - `oracleTxPacketHash`: EIP-712 hashing for oracle transaction packets
  - `OracleTransactionPacket` schema: Type-safe packet structure

- **Configuration**: Extended `MachineConfig` with:
  - `allowedOracles`: List of authorized oracle addresses
  - `oracleTimeout`: Deadline for oracle responses (in blocks)

- **State Management**: 
  - Added `wait_for_oracle` signing state for pending oracle attestations
  - Integrated oracle transaction packets into the signing state union type
  - Added timeout handling for oracle signing requests

- **Event Parsing**: Updated on-chain event parsing to handle `OracleTransactionProposed` and `OracleTransactionAttested` events

## Implementation Details

- Oracle transactions follow the same verification and signing flow as regular transactions but with oracle-specific validation
- The oracle allowlist is checked during packet verification to ensure only authorized oracles can propose transactions
- Oracle response deadlines are calculated as `event.block + oracleTimeout`
- Timeout handling silently drops oracle signing requests that exceed the deadline

https://claude.ai/code/session_01PqYGQdURoiXstksLkGyrau