### PR TITLE
Add oracle-checked transaction approval mechanism

### DIFF
--- a/contracts/src/AlwaysApproveOracle.sol
+++ b/contracts/src/AlwaysApproveOracle.sol
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: GPL-3.0-only
+pragma solidity ^0.8.30;
+
+import {IOracle} from "@/interfaces/IOracle.sol";
+
+/**
+ * @title Always Approve Oracle
+ * @notice A proof-of-concept oracle that immediately approves every request.
+ * @dev Emits OracleResult with approved=true synchronously inside postRequest. Useful for integration
+ *      testing and demonstrating the end-to-end oracle flow without manual interaction.
+ */
+contract AlwaysApproveOracle is IOracle {
+    /**
+     * @inheritdoc IOracle
+     */
+    function postRequest(bytes32 requestId) external {
+        emit OracleResult(requestId, msg.sender, "", true);
+    }
+}

--- a/contracts/src/Consensus.sol
+++ b/contracts/src/Consensus.sol
@@ -5,6 +5,7 @@ import {IERC165} from "@oz/utils/introspection/IERC165.sol";
 import {FROSTCoordinator} from "@/FROSTCoordinator.sol";
 import {IConsensus} from "@/interfaces/IConsensus.sol";
 import {IFROSTCoordinatorCallback} from "@/interfaces/IFROSTCoordinatorCallback.sol";
+import {IOracle} from "@/interfaces/IOracle.sol";
 import {ConsensusMessages} from "@/libraries/ConsensusMessages.sol";
 import {FROST} from "@/libraries/FROST.sol";
 import {FROSTGroupId} from "@/libraries/FROSTGroupId.sol";
@@ -343,6 +344,24 @@ contract Consensus is IConsensus, IERC165, IFROSTCoordinatorCallback {
     /**
      * @inheritdoc IConsensus
      */
+    function proposeOracleTransaction(address oracle, SafeTransaction.T memory transaction)
+        public
+        returns (bytes32 safeTxHash)
+    {
+        Epochs memory epochs = _processRollover();
+        safeTxHash = transaction.hash();
+        bytes32 message = domainSeparator().oracleTransactionProposal(epochs.active, oracle, safeTxHash);
+        require($attestations[message].isZero(), AlreadyAttested());
+        emit OracleTransactionProposed(
+            safeTxHash, transaction.chainId, transaction.safe, epochs.active, oracle, transaction
+        );
+        _COORDINATOR.sign($groups[epochs.active], message);
+        IOracle(oracle).postRequest(message);
+    }
+
+    /**
+     * @inheritdoc IConsensus
+     */
     function attestTransaction(
         uint64 epoch,
         uint256 chainId,
@@ -362,6 +381,37 @@ contract Consensus is IConsensus, IERC165, IFROSTCoordinatorCallback {
         FROST.Signature memory attestation = _COORDINATOR.signatureVerify(signatureId, $groups[epoch], message);
         $attestations[message] = signatureId;
         emit TransactionAttested(safeTxHash, chainId, safe, epoch, signatureId, attestation);
+    }
+
+    /**
+     * @inheritdoc IConsensus
+     */
+    function attestOracleTransaction(
+        uint64 epoch,
+        address oracle,
+        uint256 chainId,
+        address safe,
+        bytes32 safeTxStructHash,
+        FROSTSignatureId.T signatureId
+    ) public {
+        bytes32 safeTxHash = SafeTransaction.partialHash(chainId, safe, safeTxStructHash);
+        bytes32 message = domainSeparator().oracleTransactionProposal(epoch, oracle, safeTxHash);
+        require($attestations[message].isZero(), AlreadyAttested());
+        FROST.Signature memory attestation = _COORDINATOR.signatureVerify(signatureId, $groups[epoch], message);
+        $attestations[message] = signatureId;
+        emit OracleTransactionAttested(safeTxHash, chainId, safe, epoch, oracle, signatureId, attestation);
+    }
+
+    /**
+     * @inheritdoc IConsensus
+     */
+    function getOracleTransactionAttestationByHash(uint64 epoch, address oracle, bytes32 safeTxHash)
+        public
+        view
+        returns (FROST.Signature memory signature)
+    {
+        bytes32 message = domainSeparator().oracleTransactionProposal(epoch, oracle, safeTxHash);
+        return _COORDINATOR.signatureValue($attestations[message]);
     }
 
     // ============================================================
@@ -402,6 +452,10 @@ contract Consensus is IConsensus, IERC165, IFROSTCoordinatorCallback {
             (uint64 epoch, uint256 chainId, address safe, bytes32 safeTxStructHash) =
                 abi.decode(context[4:], (uint64, uint256, address, bytes32));
             attestTransaction(epoch, chainId, safe, safeTxStructHash, signatureId);
+        } else if (selector == this.attestOracleTransaction.selector) {
+            (uint64 epoch, address oracle, uint256 chainId, address safe, bytes32 safeTxStructHash) =
+                abi.decode(context[4:], (uint64, address, uint256, address, bytes32));
+            attestOracleTransaction(epoch, oracle, chainId, safe, safeTxStructHash, signatureId);
         } else {
             revert UnknownSignatureSelector();
         }

--- a/contracts/src/SimpleOracle.sol
+++ b/contracts/src/SimpleOracle.sol
@@ -37,6 +37,11 @@ contract SimpleOracle is IOracle {
     error NotApprover();
 
     /**
+     * @notice Thrown when postRequest is called for a request that is already pending.
+     */
+    error RequestAlreadyPending();
+
+    /**
      * @notice Thrown when approve or reject is called for a request that has not been posted.
      */
     error RequestNotPending();
@@ -61,6 +66,7 @@ contract SimpleOracle is IOracle {
      * @inheritdoc IOracle
      */
     function postRequest(bytes32 requestId) external {
+        require($proposers[requestId] == address(0), RequestAlreadyPending());
         $proposers[requestId] = msg.sender;
     }
 

--- a/contracts/src/SimpleOracle.sol
+++ b/contracts/src/SimpleOracle.sol
@@ -1,0 +1,94 @@
+// SPDX-License-Identifier: GPL-3.0-only
+pragma solidity ^0.8.30;
+
+import {IOracle} from "@/interfaces/IOracle.sol";
+
+/**
+ * @title Simple Oracle
+ * @notice A proof-of-concept oracle where a designated approver manually approves or rejects requests.
+ * @dev postRequest records the caller (typically the Consensus contract) as the proposer. The approver
+ *      must then call approve() or reject() to emit the OracleResult. This is suitable for testing and
+ *      for use cases that require explicit human review of each transaction.
+ */
+contract SimpleOracle is IOracle {
+    // ============================================================
+    // STORAGE VARIABLES
+    // ============================================================
+
+    /**
+     * @notice The address authorised to approve or reject oracle requests.
+     */
+    address public immutable APPROVER;
+
+    /**
+     * @notice Mapping from request ID to the proposer address that posted the request.
+     * @dev A non-zero value indicates the request is pending approval.
+     */
+    // forge-lint: disable-next-line(mixed-case-variable)
+    mapping(bytes32 requestId => address proposer) private $proposers;
+
+    // ============================================================
+    // ERRORS
+    // ============================================================
+
+    /**
+     * @notice Thrown when a function restricted to the approver is called by another address.
+     */
+    error NotApprover();
+
+    /**
+     * @notice Thrown when approve or reject is called for a request that has not been posted.
+     */
+    error RequestNotPending();
+
+    // ============================================================
+    // CONSTRUCTOR
+    // ============================================================
+
+    /**
+     * @notice Constructs the SimpleOracle with a designated approver.
+     * @param approver The address authorised to approve or reject oracle requests.
+     */
+    constructor(address approver) {
+        APPROVER = approver;
+    }
+
+    // ============================================================
+    // IOracle IMPLEMENTATION
+    // ============================================================
+
+    /**
+     * @inheritdoc IOracle
+     */
+    function postRequest(bytes32 requestId) external {
+        $proposers[requestId] = msg.sender;
+    }
+
+    // ============================================================
+    // EXTERNAL FUNCTIONS
+    // ============================================================
+
+    /**
+     * @notice Approves a pending oracle request, emitting OracleResult with approved=true.
+     * @param requestId The EIP-712 hash of the OracleTransactionProposal message.
+     */
+    function approve(bytes32 requestId) external {
+        require(msg.sender == APPROVER, NotApprover());
+        address proposer = $proposers[requestId];
+        require(proposer != address(0), RequestNotPending());
+        delete $proposers[requestId];
+        emit OracleResult(requestId, proposer, "", true);
+    }
+
+    /**
+     * @notice Rejects a pending oracle request, emitting OracleResult with approved=false.
+     * @param requestId The EIP-712 hash of the OracleTransactionProposal message.
+     */
+    function reject(bytes32 requestId) external {
+        require(msg.sender == APPROVER, NotApprover());
+        address proposer = $proposers[requestId];
+        require(proposer != address(0), RequestNotPending());
+        delete $proposers[requestId];
+        emit OracleResult(requestId, proposer, "", false);
+    }
+}

--- a/contracts/src/interfaces/IConsensus.sol
+++ b/contracts/src/interfaces/IConsensus.sol
@@ -98,6 +98,44 @@ interface IConsensus {
         FROST.Signature attestation
     );
 
+    /**
+     * @notice Emitted when a transaction is proposed for oracle-checked validator approval.
+     * @param safeTxHash The hash of the proposed Safe transaction.
+     * @param chainId The chain ID of the Safe account.
+     * @param safe The address of the Safe.
+     * @param epoch The epoch in which the transaction is proposed.
+     * @param oracle The address of the oracle contract used for evaluation.
+     * @param transaction The proposed Safe transaction.
+     */
+    event OracleTransactionProposed(
+        bytes32 indexed safeTxHash,
+        uint256 indexed chainId,
+        address indexed safe,
+        uint64 epoch,
+        address oracle,
+        SafeTransaction.T transaction
+    );
+
+    /**
+     * @notice Emitted when an oracle-checked transaction is attested by the validator set.
+     * @param safeTxHash The hash of the attested Safe transaction.
+     * @param chainId The chain ID of the Safe account.
+     * @param safe The address of the Safe account.
+     * @param epoch The epoch in which the attested transaction was proposed.
+     * @param oracle The address of the oracle contract used for evaluation.
+     * @param signatureId The FROST signature identifier corresponding to the attestation.
+     * @param attestation The attestation to the oracle-checked Safe transaction.
+     */
+    event OracleTransactionAttested(
+        bytes32 indexed safeTxHash,
+        uint256 indexed chainId,
+        address indexed safe,
+        uint64 epoch,
+        address oracle,
+        FROSTSignatureId.T signatureId,
+        FROST.Signature attestation
+    );
+
     // ============================================================
     // CONFIGURATION
     // ============================================================
@@ -259,4 +297,45 @@ interface IConsensus {
         bytes32 safeTxStructHash,
         FROSTSignatureId.T signatureId
     ) external;
+
+    /**
+     * @notice Proposes a transaction for oracle-checked validator approval.
+     * @param oracle Address of the oracle contract to use for evaluation.
+     * @param transaction The Safe transaction to propose.
+     * @return safeTxHash The Safe transaction hash.
+     */
+    function proposeOracleTransaction(address oracle, SafeTransaction.T memory transaction)
+        external
+        returns (bytes32 safeTxHash);
+
+    /**
+     * @notice Attests to an oracle-checked transaction.
+     * @param epoch The epoch in which the transaction was proposed.
+     * @param oracle The address of the oracle contract used for evaluation.
+     * @param chainId The chain ID of the Safe account.
+     * @param safe The address of the Safe account.
+     * @param safeTxStructHash The EIP-712 struct hash of the Safe transaction data.
+     * @param signatureId The FROST signature identifier attesting to the transaction.
+     * @dev Called internally via the onSignCompleted callback. No explicit time limit is imposed.
+     */
+    function attestOracleTransaction(
+        uint64 epoch,
+        address oracle,
+        uint256 chainId,
+        address safe,
+        bytes32 safeTxStructHash,
+        FROSTSignatureId.T signatureId
+    ) external;
+
+    /**
+     * @notice Gets an oracle transaction attestation by transaction hash.
+     * @param epoch The epoch in which the transaction was proposed.
+     * @param oracle The address of the oracle contract used for evaluation.
+     * @param safeTxHash The Safe transaction hash to query the attestation for.
+     * @return signature The FROST signature attesting to the oracle-checked transaction.
+     */
+    function getOracleTransactionAttestationByHash(uint64 epoch, address oracle, bytes32 safeTxHash)
+        external
+        view
+        returns (FROST.Signature memory signature);
 }

--- a/contracts/src/interfaces/IOracle.sol
+++ b/contracts/src/interfaces/IOracle.sol
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: GPL-3.0-only
+pragma solidity ^0.8.30;
+
+/**
+ * @title Oracle Interface
+ * @notice Interface for oracle contracts that participate in oracle-checked transaction approval.
+ */
+interface IOracle {
+    // ============================================================
+    // EVENTS
+    // ============================================================
+
+    /**
+     * @notice Emitted when an oracle produces a result for a request.
+     * @param requestId The EIP-712 hash of the OracleTransactionProposal message.
+     * @param proposer The address that posted the request (typically the Consensus contract).
+     * @param result Arbitrary result data (oracle-specific encoding).
+     * @param approved Whether the oracle approves the transaction.
+     */
+    event OracleResult(bytes32 indexed requestId, address indexed proposer, bytes result, bool approved);
+
+    // ============================================================
+    // EXTERNAL FUNCTIONS
+    // ============================================================
+
+    /**
+     * @notice Post a signing request to the oracle for evaluation.
+     * @param requestId The EIP-712 hash of the OracleTransactionProposal message.
+     * @dev The oracle records msg.sender as the proposer in OracleResult, allowing oracles to
+     *      differentiate requests from the Consensus contract versus other callers.
+     *      Transaction data is not passed here; the oracle is expected to fetch it independently
+     *      from the OracleTransactionProposed event.
+     */
+    function postRequest(bytes32 requestId) external;
+}

--- a/contracts/src/libraries/ConsensusMessages.sol
+++ b/contracts/src/libraries/ConsensusMessages.sol
@@ -29,6 +29,12 @@ library ConsensusMessages {
     bytes32 internal constant TRANSACTION_PROPOSAL_TYPEHASH =
         hex"0791f9d2a47e59f417d6c5d2ac1c700ccf949a66461ac7842e6d104c1a92b152";
 
+    /**
+     * @custom:precomputed keccak256("OracleTransactionProposal(uint64 epoch,address oracle,bytes32 safeTxHash)")
+     */
+    bytes32 internal constant ORACLE_TRANSACTION_PROPOSAL_TYPEHASH =
+        hex"30673a82bcf1a0fa66d1c97cbe53999fc6c0b3e987742353c9aaecb3890205e9";
+
     // ============================================================
     // INTERNAL FUNCTIONS
     // ============================================================
@@ -97,6 +103,32 @@ library ConsensusMessages {
             mstore(add(ptr, 0x20), epoch)
             mstore(add(ptr, 0x40), transactionHash)
             mstore(add(ptr, 0x22), keccak256(ptr, 0x60))
+            mstore(ptr, hex"1901")
+            mstore(add(ptr, 0x02), domainSeparator)
+            result := keccak256(ptr, 0x42)
+        }
+    }
+
+    /**
+     * @notice Computes the oracle transaction proposal message that must be attested to by validators.
+     * @param domainSeparator The EIP-712 domain separator.
+     * @param epoch The epoch for the oracle transaction proposal.
+     * @param oracle The address of the oracle contract used for evaluation.
+     * @param safeTxHash The hash of the Safe transaction.
+     * @return result The oracle transaction proposal message hash, used as the oracle requestId.
+     */
+    function oracleTransactionProposal(bytes32 domainSeparator, uint64 epoch, address oracle, bytes32 safeTxHash)
+        internal
+        pure
+        returns (bytes32 result)
+    {
+        assembly ("memory-safe") {
+            let ptr := mload(0x40)
+            mstore(ptr, ORACLE_TRANSACTION_PROPOSAL_TYPEHASH)
+            mstore(add(ptr, 0x20), epoch)
+            mstore(add(ptr, 0x40), oracle)
+            mstore(add(ptr, 0x60), safeTxHash)
+            mstore(add(ptr, 0x22), keccak256(ptr, 0x80))
             mstore(ptr, hex"1901")
             mstore(add(ptr, 0x02), domainSeparator)
             result := keccak256(ptr, 0x42)

--- a/contracts/test/AlwaysApproveOracle.t.sol
+++ b/contracts/test/AlwaysApproveOracle.t.sol
@@ -1,0 +1,54 @@
+// SPDX-License-Identifier: GPL-3.0-only
+pragma solidity ^0.8.30;
+
+import {Test, Vm} from "@forge-std/Test.sol";
+import {IOracle} from "@/interfaces/IOracle.sol";
+import {AlwaysApproveOracle} from "@/AlwaysApproveOracle.sol";
+
+contract AlwaysApproveOracleTest is Test {
+    AlwaysApproveOracle public oracle;
+    address public requester;
+
+    bytes32 constant REQUEST_ID = keccak256("requestId");
+
+    function setUp() public {
+        requester = vm.createWallet("requester").addr;
+        oracle = new AlwaysApproveOracle();
+    }
+
+    function test_PostRequest_EmitsOracleResult_Immediately() public {
+        vm.expectEmit(true, true, false, true);
+        emit IOracle.OracleResult(REQUEST_ID, requester, "", true);
+
+        vm.prank(requester);
+        oracle.postRequest(REQUEST_ID);
+    }
+
+    function test_PostRequest_EmitsApprovedTrue() public {
+        vm.recordLogs();
+
+        vm.prank(requester);
+        oracle.postRequest(REQUEST_ID);
+
+        Vm.Log[] memory logs = vm.getRecordedLogs();
+        assertEq(logs.length, 1);
+
+        // topic[0] = event selector, topic[1] = requestId, topic[2] = proposer
+        assertEq(logs[0].topics[1], REQUEST_ID);
+        assertEq(logs[0].topics[2], bytes32(uint256(uint160(requester))));
+
+        // data = abi.encode(result, approved) — last word is the bool
+        (, bool approved) = abi.decode(logs[0].data, (bytes, bool));
+        assertTrue(approved);
+    }
+
+    function test_PostRequest_ProposerIsCallerAddress() public {
+        address anotherCaller = vm.createWallet("other").addr;
+
+        vm.expectEmit(true, true, false, true);
+        emit IOracle.OracleResult(REQUEST_ID, anotherCaller, "", true);
+
+        vm.prank(anotherCaller);
+        oracle.postRequest(REQUEST_ID);
+    }
+}

--- a/contracts/test/Consensus.t.sol
+++ b/contracts/test/Consensus.t.sol
@@ -19,7 +19,7 @@ contract ConsensusTest is Test {
 
     FROSTGroupId.T immutable GENESIS_GROUP = FROSTGroupId.T.wrap(keccak256("genesisGroup"));
 
-    address constant SAFE = address(0x5afe5afe5afe5afe5afe5afe5afe5afe5afe5afe);
+    address constant SAFE = address(0x5afe5afE5afE5afE5afE5aFe5aFe5Afe5Afe5AfE);
 
     Vm.Wallet public group;
 

--- a/contracts/test/Consensus.t.sol
+++ b/contracts/test/Consensus.t.sol
@@ -4,13 +4,22 @@ pragma solidity ^0.8.30;
 import {Test, Vm} from "@forge-std/Test.sol";
 import {MockCoordinator} from "@test/util/MockCoordinator.sol";
 import {Consensus, IConsensus} from "@/Consensus.sol";
+import {FROST} from "@/libraries/FROST.sol";
 import {FROSTGroupId} from "@/libraries/FROSTGroupId.sol";
 import {FROSTSignatureId} from "@/libraries/FROSTSignatureId.sol";
+import {SafeTransaction} from "@/libraries/SafeTransaction.sol";
+
+contract MockOracle {
+    function postRequest(bytes32) external {}
+}
 
 contract ConsensusTest is Test {
     using FROSTGroupId for FROSTGroupId.T;
+    using SafeTransaction for SafeTransaction.T;
 
     FROSTGroupId.T immutable GENESIS_GROUP = FROSTGroupId.T.wrap(keccak256("genesisGroup"));
+
+    address constant SAFE = address(0x5afe5afe5afe5afe5afe5afe5afe5afe5afe5afe);
 
     Vm.Wallet public group;
 
@@ -96,5 +105,105 @@ contract ConsensusTest is Test {
 
         (address staker) = consensus.getValidatorStaker(validator);
         assertEq(staker, newStaker);
+    }
+
+    // ============================================================
+    // ORACLE TRANSACTION TESTS
+    // ============================================================
+
+    // keccak256("SafeTx(address to,uint256 value,bytes data,uint8 operation,uint256 safeTxGas,uint256 baseGas,uint256 gasPrice,address gasToken,address refundReceiver,uint256 nonce)")
+    bytes32 private constant SAFE_TX_TYPEHASH = hex"bb8310d486368db6bd6f849402fdd73ad53d316b5a4b2644ad6efe0f941286d8";
+
+    function _makeTransaction() internal view returns (SafeTransaction.T memory) {
+        return SafeTransaction.T({
+            chainId: block.chainid,
+            safe: SAFE,
+            to: address(0xBEEF),
+            value: 0,
+            data: "",
+            operation: SafeTransaction.Operation.CALL,
+            safeTxGas: 0,
+            baseGas: 0,
+            gasPrice: 0,
+            gasToken: address(0),
+            refundReceiver: address(0),
+            nonce: 1
+        });
+    }
+
+    function _transactionStructHash(SafeTransaction.T memory transaction) internal pure returns (bytes32 structHash) {
+        assembly ("memory-safe") {
+            let ptr := mload(0x40)
+            mstore(ptr, SAFE_TX_TYPEHASH)
+            mcopy(add(ptr, 0x20), add(transaction, 0x40), 0x140)
+            let data := mload(add(transaction, 0x80))
+            mstore(add(ptr, 0x60), keccak256(add(data, 0x20), mload(data)))
+            structHash := keccak256(ptr, 0x160)
+        }
+    }
+
+    function test_ProposeOracleTransaction_EmitsEvent() public {
+        MockOracle oracle = new MockOracle();
+        SafeTransaction.T memory transaction = _makeTransaction();
+        bytes32 safeTxHash = transaction.hash();
+
+        vm.expectEmit(true, true, true, true);
+        emit IConsensus.OracleTransactionProposed(safeTxHash, block.chainid, SAFE, 0, address(oracle), transaction);
+
+        consensus.proposeOracleTransaction(address(oracle), transaction);
+    }
+
+    function test_ProposeOracleTransaction_AlreadyAttested_Reverts() public {
+        MockOracle oracle = new MockOracle();
+        SafeTransaction.T memory transaction = _makeTransaction();
+        bytes32 safeTxStructHash = _transactionStructHash(transaction);
+        FROSTSignatureId.T signatureId = FROSTSignatureId.T.wrap(keccak256("testSig"));
+
+        // Attest the transaction so the message slot is occupied.
+        consensus.attestOracleTransaction(0, address(oracle), block.chainid, SAFE, safeTxStructHash, signatureId);
+
+        // Proposing the same (oracle, transaction) should now revert since it is already attested.
+        vm.expectRevert(Consensus.AlreadyAttested.selector);
+        consensus.proposeOracleTransaction(address(oracle), transaction);
+    }
+
+    function test_AttestOracleTransaction_StoresAndEmits() public {
+        MockOracle oracle = new MockOracle();
+        bytes32 safeTxStructHash = bytes32(uint256(0xdeadbeef));
+        bytes32 safeTxHash = SafeTransaction.partialHash(block.chainid, SAFE, safeTxStructHash);
+        FROSTSignatureId.T signatureId = FROSTSignatureId.T.wrap(keccak256("testSig"));
+
+        FROST.Signature memory emptySig = coordinator.signatureValue(signatureId);
+
+        vm.expectEmit(true, true, true, true);
+        emit IConsensus.OracleTransactionAttested(
+            safeTxHash, block.chainid, SAFE, 0, address(oracle), signatureId, emptySig
+        );
+
+        consensus.attestOracleTransaction(0, address(oracle), block.chainid, SAFE, safeTxStructHash, signatureId);
+    }
+
+    function test_AttestOracleTransaction_DoubleAttest_Reverts() public {
+        MockOracle oracle = new MockOracle();
+        bytes32 safeTxStructHash = bytes32(uint256(0xdeadbeef));
+        FROSTSignatureId.T signatureId = FROSTSignatureId.T.wrap(keccak256("testSig"));
+
+        consensus.attestOracleTransaction(0, address(oracle), block.chainid, SAFE, safeTxStructHash, signatureId);
+
+        vm.expectRevert(Consensus.AlreadyAttested.selector);
+        consensus.attestOracleTransaction(0, address(oracle), block.chainid, SAFE, safeTxStructHash, signatureId);
+    }
+
+    function test_GetOracleTransactionAttestationByHash() public {
+        MockOracle oracle = new MockOracle();
+        bytes32 safeTxStructHash = bytes32(uint256(0xdeadbeef));
+        bytes32 safeTxHash = SafeTransaction.partialHash(block.chainid, SAFE, safeTxStructHash);
+        FROSTSignatureId.T signatureId = FROSTSignatureId.T.wrap(keccak256("testSig"));
+
+        consensus.attestOracleTransaction(0, address(oracle), block.chainid, SAFE, safeTxStructHash, signatureId);
+
+        FROST.Signature memory sig = consensus.getOracleTransactionAttestationByHash(0, address(oracle), safeTxHash);
+        // MockCoordinator returns an empty signature — we verify the call succeeds.
+        assertEq(sig.r.x, 0);
     }
 }

--- a/contracts/test/SimpleOracle.t.sol
+++ b/contracts/test/SimpleOracle.t.sol
@@ -1,0 +1,105 @@
+// SPDX-License-Identifier: GPL-3.0-only
+pragma solidity ^0.8.30;
+
+import {Test} from "@forge-std/Test.sol";
+import {IOracle} from "@/interfaces/IOracle.sol";
+import {SimpleOracle} from "@/SimpleOracle.sol";
+
+contract SimpleOracleTest is Test {
+    SimpleOracle public oracle;
+    address public approver;
+    address public requester;
+
+    bytes32 constant REQUEST_ID = keccak256("requestId");
+
+    function setUp() public {
+        approver = vm.createWallet("approver").addr;
+        requester = vm.createWallet("requester").addr;
+        oracle = new SimpleOracle(approver);
+    }
+
+    function test_PostRequest_RecordsRequester() public {
+        vm.prank(requester);
+        oracle.postRequest(REQUEST_ID);
+
+        // Verify by successfully approving — would revert with RequestNotPending if not recorded.
+        vm.prank(approver);
+        oracle.approve(REQUEST_ID);
+    }
+
+    function test_Approve_EmitsOracleResult_True() public {
+        vm.prank(requester);
+        oracle.postRequest(REQUEST_ID);
+
+        vm.expectEmit(true, true, false, true);
+        emit IOracle.OracleResult(REQUEST_ID, requester, "", true);
+
+        vm.prank(approver);
+        oracle.approve(REQUEST_ID);
+    }
+
+    function test_Reject_EmitsOracleResult_False() public {
+        vm.prank(requester);
+        oracle.postRequest(REQUEST_ID);
+
+        vm.expectEmit(true, true, false, true);
+        emit IOracle.OracleResult(REQUEST_ID, requester, "", false);
+
+        vm.prank(approver);
+        oracle.reject(REQUEST_ID);
+    }
+
+    function test_Approve_NotApprover_Reverts() public {
+        vm.prank(requester);
+        oracle.postRequest(REQUEST_ID);
+
+        vm.expectRevert(SimpleOracle.NotApprover.selector);
+        oracle.approve(REQUEST_ID);
+    }
+
+    function test_Reject_NotApprover_Reverts() public {
+        vm.prank(requester);
+        oracle.postRequest(REQUEST_ID);
+
+        vm.expectRevert(SimpleOracle.NotApprover.selector);
+        oracle.reject(REQUEST_ID);
+    }
+
+    function test_Approve_RequestNotPending_Reverts() public {
+        vm.expectRevert(SimpleOracle.RequestNotPending.selector);
+        vm.prank(approver);
+        oracle.approve(REQUEST_ID);
+    }
+
+    function test_Reject_RequestNotPending_Reverts() public {
+        vm.expectRevert(SimpleOracle.RequestNotPending.selector);
+        vm.prank(approver);
+        oracle.reject(REQUEST_ID);
+    }
+
+    function test_Approve_ClearsRequest() public {
+        vm.prank(requester);
+        oracle.postRequest(REQUEST_ID);
+
+        vm.prank(approver);
+        oracle.approve(REQUEST_ID);
+
+        // Second approval should revert because the request was cleared.
+        vm.expectRevert(SimpleOracle.RequestNotPending.selector);
+        vm.prank(approver);
+        oracle.approve(REQUEST_ID);
+    }
+
+    function test_Reject_ClearsRequest() public {
+        vm.prank(requester);
+        oracle.postRequest(REQUEST_ID);
+
+        vm.prank(approver);
+        oracle.reject(REQUEST_ID);
+
+        // Second rejection should revert because the request was cleared.
+        vm.expectRevert(SimpleOracle.RequestNotPending.selector);
+        vm.prank(approver);
+        oracle.reject(REQUEST_ID);
+    }
+}

--- a/contracts/test/SimpleOracle.t.sol
+++ b/contracts/test/SimpleOracle.t.sol
@@ -27,6 +27,15 @@ contract SimpleOracleTest is Test {
         oracle.approve(REQUEST_ID);
     }
 
+    function test_PostRequest_AlreadyPending_Reverts() public {
+        vm.prank(requester);
+        oracle.postRequest(REQUEST_ID);
+
+        vm.expectRevert(SimpleOracle.RequestAlreadyPending.selector);
+        vm.prank(requester);
+        oracle.postRequest(REQUEST_ID);
+    }
+
     function test_Approve_EmitsOracleResult_True() public {
         vm.prank(requester);
         oracle.postRequest(REQUEST_ID);

--- a/contracts/test/libraries/ConsensusMessages.t.sol
+++ b/contracts/test/libraries/ConsensusMessages.t.sol
@@ -22,4 +22,18 @@ contract ConsensusMessagesTest is Test {
 
         assertEq(message, hex"c1e4d484d6c376741c904290cc043f4afb4618f9d567dcdd0edcbf22abae57f7");
     }
+
+    function test_OracleTransactionProposalTypehash() public pure {
+        assertEq(
+            ConsensusMessages.ORACLE_TRANSACTION_PROPOSAL_TYPEHASH,
+            keccak256("OracleTransactionProposal(uint64 epoch,address oracle,bytes32 safeTxHash)")
+        );
+    }
+
+    function test_OracleTransactionProposal() public pure {
+        bytes32 message = ConsensusMessages.domain(23, 0x4838B106FCe9647Bdf1E7877BF73cE8B0BAD5f97)
+            .oracleTransactionProposal(1, 0x1234567890123456789012345678901234567890, bytes32(uint256(42)));
+
+        assertEq(message, hex"8c14cc0ff2766f091808488a64caf93c17362432d9384fd7ee3d9c6975dea85f");
+    }
 }

--- a/contracts/test/util/MockCoordinator.sol
+++ b/contracts/test/util/MockCoordinator.sol
@@ -17,9 +17,13 @@ contract MockCoordinator {
         return groupKeys[group];
     }
 
+    function sign(FROSTGroupId.T, bytes32) external pure returns (FROSTSignatureId.T sid) {}
+
     function signatureVerify(FROSTSignatureId.T, FROSTGroupId.T, bytes32)
         external
-        view
+        pure
         returns (FROST.Signature memory signature)
     {}
+
+    function signatureValue(FROSTSignatureId.T) external pure returns (FROST.Signature memory) {}
 }


### PR DESCRIPTION
## Summary
This PR introduces an oracle-checked transaction approval system that allows validators to attest to Safe transactions through an oracle intermediary. The system enables flexible transaction validation workflows where an oracle can evaluate transactions before validator attestation.

## Key Changes

### Core Oracle Infrastructure
- **New `IOracle` interface**: Defines the standard for oracle contracts with a `postRequest()` function and `OracleResult` event
- **`SimpleOracle` implementation**: A proof-of-concept oracle where a designated approver manually approves or rejects requests
- **`AlwaysApproveOracle` implementation**: A test oracle that immediately approves all requests synchronously

### Consensus Contract Extensions
- **`proposeOracleTransaction()`**: Proposes a Safe transaction for oracle-checked validator approval, emits `OracleTransactionProposed` event, and posts the request to the oracle
- **`attestOracleTransaction()`**: Allows validators to attest to oracle-checked transactions with signature verification
- **`getOracleTransactionAttestationByHash()`**: Retrieves stored attestations by transaction hash
- **`onSignCompleted()` callback support**: Added routing for `attestOracleTransaction` selector to handle signature completion callbacks

### Message and Cryptography Updates
- **New `ORACLE_TRANSACTION_PROPOSAL_TYPEHASH`**: EIP-712 type hash for oracle transaction proposals
- **`oracleTransactionProposal()` helper**: Computes the oracle transaction proposal message hash used as the oracle request ID
- **`SafeTransaction.partialHash()`**: Utility to compute Safe transaction hashes from struct hash and metadata

### Event Definitions
- **`OracleTransactionProposed`**: Emitted when a transaction is proposed for oracle evaluation
- **`OracleTransactionAttested`**: Emitted when validators attest to an oracle-checked transaction

### Testing
- Comprehensive test suites for both oracle implementations
- Oracle transaction proposal and attestation tests in `ConsensusTest`
- Message hash computation verification tests

## Notable Implementation Details
- Oracle requests use the EIP-712 message hash as the request ID, enabling oracles to independently verify transaction authenticity
- The `AlwaysApproveOracle` emits results synchronously, while `SimpleOracle` requires explicit approver action
- Attestations are stored by message hash to prevent double-attestation
- The system integrates with existing FROST signature verification and coordinator callbacks

https://claude.ai/code/session_01H4Eokiyqq2xv6T9Szni5jD