### PR TITLE
Guard A and naming convention

### DIFF
--- a/contracts/src/guard/SafenetGuardA.sol
+++ b/contracts/src/guard/SafenetGuardA.sol
@@ -10,7 +10,7 @@ import {BaseTransactionGuard} from "@safe/base/GuardManager.sol";
 import {ISafe} from "@safe/interfaces/ISafe.sol";
 
 /**
- * @title SafenetGuard
+ * @title SafenetGuardA
  * @notice Safe Transaction Guard that gates every Safe transaction behind Safenet
  *         threshold-signature attestation.
  *
@@ -19,9 +19,9 @@ import {ISafe} from "@safe/interfaces/ISafe.sol";
  *      The Safenet Consensus contract lives exclusively on Gnosis Chain. Because cross-chain
  *      calls are not feasible, this guard maintains its own local consensus state.
  *
- *      **Epoch history.** Group keys are stored in `_epochGroupKeys`, a mapping from epoch number
+ *      **Epoch history.** Group keys are stored in `$epochGroupKeys`, a mapping from epoch number
  *      to FROST group public key. Each `updateEpoch` call adds the new epoch's key to the mapping,
- *      so all historic keys remain available for signature verification. `_activeEpoch` tracks the
+ *      so all historic keys remain available for signature verification. `$activeEpoch` tracks the
  *      current epoch number; keys for all past epochs remain resolvable via `_resolveGroupKey`.
  *
  *      **Inline attestation.** FROST attestations are passed as a trailer appended to Safe's
@@ -36,7 +36,7 @@ import {ISafe} from "@safe/interfaces/ISafe.sol";
  *      rather than a Safenet attestation. `DELEGATECALL` to the guard is never auto-allowed:
  *      it would execute guard functions in the Safe's storage context.
  */
-contract SafenetGuard is BaseTransactionGuard {
+contract SafenetGuardA is BaseTransactionGuard {
     // ============================================================
     // STORAGE VARIABLES
     // ============================================================
@@ -61,7 +61,8 @@ contract SafenetGuard is BaseTransactionGuard {
      * @notice The currently active epoch number.
      * @dev Set at construction and advanced on every `updateEpoch` call.
      */
-    uint64 private _activeEpoch;
+    // forge-lint: disable-next-line(mixed-case-variable)
+    uint64 private $activeEpoch;
 
     /**
      * @notice Maps each epoch number to its FROST group public key.
@@ -72,7 +73,8 @@ contract SafenetGuard is BaseTransactionGuard {
      *      All stored keys are guaranteed non-zero because both the constructor and `updateEpoch`
      *      call `Secp256k1.requireNonZero` before writing.
      */
-    mapping(uint64 epoch => Secp256k1.Point groupKey) private _epochGroupKeys;
+    // forge-lint: disable-next-line(mixed-case-variable)
+    mapping(uint64 epoch => Secp256k1.Point groupKey) private $epochGroupKeys;
 
     /**
      * @notice Time-delayed execution allowances for the escape hatch, keyed by Safe address.
@@ -81,7 +83,8 @@ contract SafenetGuard is BaseTransactionGuard {
      *      deleted on use by `checkTransaction`, and deleted early by `cancelAllowTransaction`.
      *      Keying by `msg.sender` (the Safe) ensures no Safe can interfere with another's allowances.
      */
-    mapping(address safe => mapping(bytes32 safeTxHash => uint256 executableAt)) private _allowedTransactions;
+    // forge-lint: disable-next-line(mixed-case-variable)
+    mapping(address safe => mapping(bytes32 safeTxHash => uint256 executableAt)) private $allowedTransactions;
 
     // ============================================================
     // EVENTS
@@ -129,7 +132,7 @@ contract SafenetGuard is BaseTransactionGuard {
 
     /**
      * @notice Thrown by `_resolveGroupKey` when the requested epoch has no group key stored in
-     *         `_epochGroupKeys` — i.e., the epoch was never activated via `updateEpoch` or set
+     *         `$epochGroupKeys` — i.e., the epoch was never activated via `updateEpoch` or set
      *         as the initial epoch in the constructor.
      */
     error InvalidEpoch();
@@ -198,8 +201,8 @@ contract SafenetGuard is BaseTransactionGuard {
         Secp256k1.requireNonZero(initialGroupKey);
         _CONSENSUS_DOMAIN_SEPARATOR = ConsensusMessages.domain(consensusChainId, consensusAddress);
         _ALLOW_TX_DELAY = allowTransactionDelay;
-        _activeEpoch = initialEpoch;
-        _epochGroupKeys[initialEpoch] = initialGroupKey;
+        $activeEpoch = initialEpoch;
+        $epochGroupKeys[initialEpoch] = initialGroupKey;
         emit EpochUpdated(0, initialEpoch, initialGroupKey);
     }
 
@@ -217,8 +220,8 @@ contract SafenetGuard is BaseTransactionGuard {
      *      MultiSendCallOnly.
      *      `rolloverBlock` is a Gnosis Chain block number embedded in the signed message; no check
      *      against `block.number` is performed because the local chain's block number is unrelated.
-     *      The new epoch's group key is written to `_epochGroupKeys[proposedEpoch]` and
-     *      `_activeEpoch` is advanced. All previously stored keys remain in the mapping.
+     *      The new epoch's group key is written to `$epochGroupKeys[proposedEpoch]` and
+     *      `$activeEpoch` is advanced. All previously stored keys remain in the mapping.
      * @param proposedEpoch  New epoch number. Must be strictly greater than the active epoch;
      *                       equal or lower values revert with `EpochNotAdvancing`.
      * @param rolloverBlock  Gnosis Chain block number from the epoch rollover message. Required
@@ -234,15 +237,15 @@ contract SafenetGuard is BaseTransactionGuard {
         Secp256k1.Point calldata newGroupKey,
         FROST.Signature calldata signature
     ) external {
-        require(proposedEpoch > _activeEpoch, EpochNotAdvancing());
+        require(proposedEpoch > $activeEpoch, EpochNotAdvancing());
         Secp256k1.requireNonZero(newGroupKey);
         bytes32 message = ConsensusMessages.epochRollover(
-            _CONSENSUS_DOMAIN_SEPARATOR, _activeEpoch, proposedEpoch, rolloverBlock, newGroupKey
+            _CONSENSUS_DOMAIN_SEPARATOR, $activeEpoch, proposedEpoch, rolloverBlock, newGroupKey
         );
-        FROST.verify(_epochGroupKeys[_activeEpoch], signature, message);
-        uint64 prevEpoch = _activeEpoch;
-        _activeEpoch = proposedEpoch;
-        _epochGroupKeys[proposedEpoch] = newGroupKey;
+        FROST.verify($epochGroupKeys[$activeEpoch], signature, message);
+        uint64 prevEpoch = $activeEpoch;
+        $activeEpoch = proposedEpoch;
+        $epochGroupKeys[proposedEpoch] = newGroupKey;
         emit EpochUpdated(prevEpoch, proposedEpoch, newGroupKey);
     }
 
@@ -261,9 +264,9 @@ contract SafenetGuard is BaseTransactionGuard {
      *                   if an allowance is already pending for this Safe and hash.
      */
     function allowTransaction(bytes32 safeTxHash) external {
-        require(_allowedTransactions[msg.sender][safeTxHash] == 0, TransactionAlreadyAllowed());
+        require($allowedTransactions[msg.sender][safeTxHash] == 0, TransactionAlreadyAllowed());
         uint256 executableAt = block.timestamp + _ALLOW_TX_DELAY;
-        _allowedTransactions[msg.sender][safeTxHash] = executableAt;
+        $allowedTransactions[msg.sender][safeTxHash] = executableAt;
         emit TransactionAllowed(msg.sender, safeTxHash, executableAt);
     }
 
@@ -276,8 +279,8 @@ contract SafenetGuard is BaseTransactionGuard {
      *                   no allowance exists for this Safe and hash.
      */
     function cancelAllowTransaction(bytes32 safeTxHash) external {
-        require(_allowedTransactions[msg.sender][safeTxHash] != 0, AllowanceNotFound());
-        delete _allowedTransactions[msg.sender][safeTxHash];
+        require($allowedTransactions[msg.sender][safeTxHash] != 0, AllowanceNotFound());
+        delete $allowedTransactions[msg.sender][safeTxHash];
         emit AllowanceCancelled(msg.sender, safeTxHash);
     }
 
@@ -342,9 +345,9 @@ contract SafenetGuard is BaseTransactionGuard {
             return;
         }
 
-        uint256 executableAt = _allowedTransactions[msg.sender][safeTxHash];
+        uint256 executableAt = $allowedTransactions[msg.sender][safeTxHash];
         if (executableAt != 0 && block.timestamp >= executableAt) {
-            delete _allowedTransactions[msg.sender][safeTxHash];
+            delete $allowedTransactions[msg.sender][safeTxHash];
             emit TransactionExecutedViaAllowance(msg.sender, safeTxHash);
             return;
         }
@@ -390,7 +393,7 @@ contract SafenetGuard is BaseTransactionGuard {
      * @notice Returns the epoch number of the current active epoch.
      */
     function activeEpoch() external view returns (uint64) {
-        return _activeEpoch;
+        return $activeEpoch;
     }
 
     /**
@@ -412,7 +415,7 @@ contract SafenetGuard is BaseTransactionGuard {
      *         or zero if no allowance exists for the given Safe and hash.
      */
     function getAllowedTxTimestamp(address safe, bytes32 safeTxHash) external view returns (uint256 executableAt) {
-        return _allowedTransactions[safe][safeTxHash];
+        return $allowedTransactions[safe][safeTxHash];
     }
 
     // ============================================================
@@ -420,13 +423,13 @@ contract SafenetGuard is BaseTransactionGuard {
     // ============================================================
 
     /**
-     * @dev Returns the group key for `epoch` from `_epochGroupKeys`.
+     * @dev Returns the group key for `epoch` from `$epochGroupKeys`.
      *      Reverts `InvalidEpoch` if no key was ever stored for this epoch.
      *      A zero point is treated as "not stored" — guaranteed safe because the constructor
      *      and `updateEpoch` both call `Secp256k1.requireNonZero` before writing.
      */
     function _resolveGroupKey(uint64 epoch) private view returns (Secp256k1.Point memory key) {
-        key = _epochGroupKeys[epoch];
+        key = $epochGroupKeys[epoch];
         if (key.x == 0 && key.y == 0) revert InvalidEpoch();
     }
 
@@ -448,8 +451,7 @@ contract SafenetGuard is BaseTransactionGuard {
         if (operation != Enum.Operation.Call) return false;
         // forge-lint: disable-next-line(unsafe-typecast)
         bytes4 selector = bytes4(data);
-        return
-            selector == SafenetGuard.allowTransaction.selector
-                || selector == SafenetGuard.cancelAllowTransaction.selector;
+        return selector == SafenetGuardA.allowTransaction.selector
+            || selector == SafenetGuardA.cancelAllowTransaction.selector;
     }
 }

--- a/contracts/test/SafenetGuardA.t.sol
+++ b/contracts/test/SafenetGuardA.t.sol
@@ -11,14 +11,14 @@ import {ISafe} from "@safe/interfaces/ISafe.sol";
 import {IGuardManager} from "@safe/interfaces/IGuardManager.sol";
 import {Safe} from "@safe/Safe.sol";
 import {SafeProxyFactory} from "@safe/proxies/SafeProxyFactory.sol";
-import {SafenetGuard} from "@/guard/SafenetGuardA.sol";
+import {SafenetGuardA} from "@/guard/SafenetGuardA.sol";
 import {ForgeSecp256k1} from "@test/util/ForgeSecp256k1.sol";
 import {MockERC1271} from "@test/util/MockERC1271.sol";
 
 contract SafenetGuardTest is Test {
     using ForgeSecp256k1 for ForgeSecp256k1.P;
 
-    SafenetGuard public guard;
+    SafenetGuardA public guard;
 
     // ============================================================
     // CONSTANTS — DEPLOYMENT
@@ -81,7 +81,7 @@ contract SafenetGuardTest is Test {
 
         // Deploy guard
         Secp256k1.Point memory groupKey = ForgeSecp256k1.g(GROUP_SK).toPoint();
-        guard = new SafenetGuard(CONSENSUS_CHAIN_ID, CONSENSUS_ADDR, INITIAL_EPOCH, groupKey, ALLOW_TX_DELAY_SECONDS);
+        guard = new SafenetGuardA(CONSENSUS_CHAIN_ID, CONSENSUS_ADDR, INITIAL_EPOCH, groupKey, ALLOW_TX_DELAY_SECONDS);
 
         // Install transaction guard (no guard active yet — executes directly)
         _execSafeTx(
@@ -194,7 +194,7 @@ contract SafenetGuardTest is Test {
     ///      Callers that need to reference the subsequent tx hash should compute it at nonce + 1.
     function _allowTransaction(bytes32 safeTxHash) internal {
         uint256 nonce = safe.nonce();
-        bytes memory data = abi.encodeCall(SafenetGuard.allowTransaction, (safeTxHash));
+        bytes memory data = abi.encodeCall(SafenetGuardA.allowTransaction, (safeTxHash));
         _execSafeTxWithNonce(address(guard), 0, data, Enum.Operation.Call, nonce);
     }
 
@@ -204,21 +204,21 @@ contract SafenetGuardTest is Test {
 
     function test_constructor_revertsOnZeroConsensusAddress() public {
         Secp256k1.Point memory key = ForgeSecp256k1.g(GROUP_SK).toPoint();
-        vm.expectRevert(SafenetGuard.InvalidAddress.selector);
-        new SafenetGuard(CONSENSUS_CHAIN_ID, address(0), INITIAL_EPOCH, key, ALLOW_TX_DELAY_SECONDS);
+        vm.expectRevert(SafenetGuardA.InvalidAddress.selector);
+        new SafenetGuardA(CONSENSUS_CHAIN_ID, address(0), INITIAL_EPOCH, key, ALLOW_TX_DELAY_SECONDS);
     }
 
     function test_constructor_revertsOnInvalidGroupKey() public {
         vm.expectRevert(Secp256k1.NotOnCurve.selector);
-        new SafenetGuard(
+        new SafenetGuardA(
             CONSENSUS_CHAIN_ID, CONSENSUS_ADDR, INITIAL_EPOCH, Secp256k1.Point({x: 0, y: 0}), ALLOW_TX_DELAY_SECONDS
         );
     }
 
     function test_constructor_revertsOnZeroAllowTxDelay() public {
         Secp256k1.Point memory key = ForgeSecp256k1.g(GROUP_SK).toPoint();
-        vm.expectRevert(SafenetGuard.InvalidParameter.selector);
-        new SafenetGuard(CONSENSUS_CHAIN_ID, CONSENSUS_ADDR, INITIAL_EPOCH, key, 0);
+        vm.expectRevert(SafenetGuardA.InvalidParameter.selector);
+        new SafenetGuardA(CONSENSUS_CHAIN_ID, CONSENSUS_ADDR, INITIAL_EPOCH, key, 0);
     }
 
     function test_constructor_setsState() public view {
@@ -232,8 +232,8 @@ contract SafenetGuardTest is Test {
     function test_constructor_emitsEpochUpdated() public {
         Secp256k1.Point memory key = ForgeSecp256k1.g(GROUP_SK).toPoint();
         vm.expectEmit(true, true, false, true);
-        emit SafenetGuard.EpochUpdated(0, INITIAL_EPOCH, key);
-        new SafenetGuard(CONSENSUS_CHAIN_ID, CONSENSUS_ADDR, INITIAL_EPOCH, key, ALLOW_TX_DELAY_SECONDS);
+        emit SafenetGuardA.EpochUpdated(0, INITIAL_EPOCH, key);
+        new SafenetGuardA(CONSENSUS_CHAIN_ID, CONSENSUS_ADDR, INITIAL_EPOCH, key, ALLOW_TX_DELAY_SECONDS);
     }
 
     // ============================================================
@@ -258,7 +258,7 @@ contract SafenetGuardTest is Test {
 
     function test_checkTransaction_revertsWhenNoAttestation() public {
         uint256 nonce = safe.nonce();
-        vm.expectRevert(SafenetGuard.AttestationNotFound.selector);
+        vm.expectRevert(SafenetGuardA.AttestationNotFound.selector);
         _execSafeTxWithNonce(TX_TO, TX_VALUE, TX_DATA, TX_OP, nonce);
     }
 
@@ -274,7 +274,7 @@ contract SafenetGuardTest is Test {
         bytes memory attestation = abi.encode(uint64(99), sig);
         bytes memory combined =
             bytes.concat(_signSafeTx(txHash), abi.encodePacked(attestation, bytes32(attestation.length)));
-        vm.expectRevert(SafenetGuard.InvalidEpoch.selector);
+        vm.expectRevert(SafenetGuardA.InvalidEpoch.selector);
         safe.execTransaction(TX_TO, TX_VALUE, TX_DATA, TX_OP, 0, 0, 0, address(0), payable(address(0)), combined);
     }
 
@@ -282,7 +282,7 @@ contract SafenetGuardTest is Test {
         // to=guard, value=0, data=allowTransaction(hash), op=Call — no attestation needed
         bytes32 anyHash = keccak256("any");
         assertEq(guard.getAllowedTxTimestamp(address(safe), anyHash), 0);
-        bytes memory data = abi.encodeCall(SafenetGuard.allowTransaction, (anyHash));
+        bytes memory data = abi.encodeCall(SafenetGuardA.allowTransaction, (anyHash));
         _execSafeTx(address(guard), 0, data, Enum.Operation.Call, ExecMode.Direct); // auto-allowed
         // The allowTransaction body ran with msg.sender == safe — allowance must be registered
         assertGt(guard.getAllowedTxTimestamp(address(safe), anyHash), 0);
@@ -292,36 +292,36 @@ contract SafenetGuardTest is Test {
         // Pre-register an allowance so cancelAllowTransaction's inner call succeeds
         bytes32 anyHash = keccak256("any");
         _allowTransaction(anyHash);
-        bytes memory data = abi.encodeCall(SafenetGuard.cancelAllowTransaction, (anyHash));
+        bytes memory data = abi.encodeCall(SafenetGuardA.cancelAllowTransaction, (anyHash));
         _execSafeTx(address(guard), 0, data, Enum.Operation.Call, ExecMode.Direct); // auto-allowed
     }
 
     function test_checkTransaction_doesNotAutoAllowDelegatecall() public {
         bytes32 anyHash = keccak256("any");
-        bytes memory data = abi.encodeCall(SafenetGuard.allowTransaction, (anyHash));
+        bytes memory data = abi.encodeCall(SafenetGuardA.allowTransaction, (anyHash));
         uint256 nonce = safe.nonce();
-        vm.expectRevert(SafenetGuard.AttestationNotFound.selector);
+        vm.expectRevert(SafenetGuardA.AttestationNotFound.selector);
         _execSafeTxWithNonce(address(guard), 0, data, Enum.Operation.DelegateCall, nonce);
     }
 
     function test_checkTransaction_doesNotAutoAllowNonZeroValue() public {
-        bytes memory data = abi.encodeCall(SafenetGuard.allowTransaction, (keccak256("any")));
+        bytes memory data = abi.encodeCall(SafenetGuardA.allowTransaction, (keccak256("any")));
         uint256 nonce = safe.nonce();
-        vm.expectRevert(SafenetGuard.AttestationNotFound.selector);
+        vm.expectRevert(SafenetGuardA.AttestationNotFound.selector);
         _execSafeTxWithNonce(address(guard), 1, data, Enum.Operation.Call, nonce);
     }
 
     function test_checkTransaction_doesNotAutoAllowShortData() public {
         uint256 nonce = safe.nonce();
-        vm.expectRevert(SafenetGuard.AttestationNotFound.selector);
+        vm.expectRevert(SafenetGuardA.AttestationNotFound.selector);
         _execSafeTxWithNonce(address(guard), 0, hex"aabbcc", Enum.Operation.Call, nonce); // 3 bytes < 4
     }
 
     function test_checkTransaction_doesNotAutoAllowOtherSelectors() public {
         // updateEpoch selector is not auto-allowed
-        bytes memory data = abi.encodeWithSelector(SafenetGuard.updateEpoch.selector, uint64(0), uint64(0));
+        bytes memory data = abi.encodeWithSelector(SafenetGuardA.updateEpoch.selector, uint64(0), uint64(0));
         uint256 nonce = safe.nonce();
-        vm.expectRevert(SafenetGuard.AttestationNotFound.selector);
+        vm.expectRevert(SafenetGuardA.AttestationNotFound.selector);
         _execSafeTxWithNonce(address(guard), 0, data, Enum.Operation.Call, nonce);
     }
 
@@ -337,7 +337,7 @@ contract SafenetGuardTest is Test {
         bytes32 safeTxHash = _safeTxHash(TX_TO, TX_VALUE, TX_DATA, TX_OP, nonce);
         _allowTransaction(safeTxHash);
         vm.warp(block.timestamp + ALLOW_TX_DELAY_SECONDS - 1);
-        vm.expectRevert(SafenetGuard.AttestationNotFound.selector);
+        vm.expectRevert(SafenetGuardA.AttestationNotFound.selector);
         _execSafeTxWithNonce(TX_TO, TX_VALUE, TX_DATA, TX_OP, nonce);
     }
 
@@ -355,7 +355,7 @@ contract SafenetGuardTest is Test {
         _allowTransaction(safeTxHash);
         vm.warp(block.timestamp + ALLOW_TX_DELAY_SECONDS);
         vm.expectEmit(true, true, false, false);
-        emit SafenetGuard.TransactionExecutedViaAllowance(address(safe), safeTxHash);
+        emit SafenetGuardA.TransactionExecutedViaAllowance(address(safe), safeTxHash);
         _execSafeTx(TX_TO, TX_VALUE, TX_DATA, TX_OP, ExecMode.Direct);
     }
 
@@ -374,8 +374,8 @@ contract SafenetGuardTest is Test {
         bytes32 safeTxHash = keccak256("tx");
         _allowTransaction(safeTxHash);
         uint256 nonce = safe.nonce();
-        bytes memory data = abi.encodeCall(SafenetGuard.allowTransaction, (safeTxHash));
-        vm.expectRevert(SafenetGuard.TransactionAlreadyAllowed.selector);
+        bytes memory data = abi.encodeCall(SafenetGuardA.allowTransaction, (safeTxHash));
+        vm.expectRevert(SafenetGuardA.TransactionAlreadyAllowed.selector);
         _execSafeTxWithNonce(address(guard), 0, data, Enum.Operation.Call, nonce);
     }
 
@@ -383,7 +383,7 @@ contract SafenetGuardTest is Test {
         bytes32 safeTxHash = keccak256("tx");
         uint256 expectedAt = block.timestamp + ALLOW_TX_DELAY_SECONDS;
         vm.expectEmit(true, true, false, true);
-        emit SafenetGuard.TransactionAllowed(address(safe), safeTxHash, expectedAt);
+        emit SafenetGuardA.TransactionAllowed(address(safe), safeTxHash, expectedAt);
         _allowTransaction(safeTxHash);
     }
 
@@ -394,7 +394,7 @@ contract SafenetGuardTest is Test {
     function test_cancelAllowTransaction_differentCallerCannotCancel() public {
         bytes32 safeTxHash = keccak256("tx");
         _allowTransaction(safeTxHash); // registers under address(safe)
-        vm.expectRevert(SafenetGuard.AllowanceNotFound.selector);
+        vm.expectRevert(SafenetGuardA.AllowanceNotFound.selector);
         vm.prank(other);
         guard.cancelAllowTransaction(safeTxHash);
         // Safe's allowance is unchanged
@@ -411,7 +411,7 @@ contract SafenetGuardTest is Test {
 
     function test_cancelAllowTransaction_revertsIfNotPending() public {
         bytes32 safeTxHash = keccak256("tx");
-        vm.expectRevert(SafenetGuard.AllowanceNotFound.selector);
+        vm.expectRevert(SafenetGuardA.AllowanceNotFound.selector);
         vm.prank(address(safe));
         guard.cancelAllowTransaction(safeTxHash);
     }
@@ -420,7 +420,7 @@ contract SafenetGuardTest is Test {
         bytes32 safeTxHash = keccak256("tx");
         _allowTransaction(safeTxHash);
         vm.expectEmit(true, true, false, false);
-        emit SafenetGuard.AllowanceCancelled(address(safe), safeTxHash);
+        emit SafenetGuardA.AllowanceCancelled(address(safe), safeTxHash);
         vm.prank(address(safe));
         guard.cancelAllowTransaction(safeTxHash);
     }
@@ -435,7 +435,7 @@ contract SafenetGuardTest is Test {
             guard.consensusDomainSeparator(), INITIAL_EPOCH, INITIAL_EPOCH, 100, newKey
         );
         FROST.Signature memory sig = _frostSign(GROUP_SK, GROUP_NK, message);
-        vm.expectRevert(SafenetGuard.EpochNotAdvancing.selector);
+        vm.expectRevert(SafenetGuardA.EpochNotAdvancing.selector);
         guard.updateEpoch(INITIAL_EPOCH, 100, newKey, sig);
     }
 
@@ -495,7 +495,7 @@ contract SafenetGuardTest is Test {
         bytes memory attestation = abi.encode(uint64(INITIAL_EPOCH + 1), sig);
         bytes memory combined =
             bytes.concat(_signSafeTx(txHash), abi.encodePacked(attestation, bytes32(attestation.length)));
-        vm.expectRevert(SafenetGuard.InvalidEpoch.selector);
+        vm.expectRevert(SafenetGuardA.InvalidEpoch.selector);
         safe.execTransaction(TX_TO, TX_VALUE, TX_DATA, TX_OP, 0, 0, 0, address(0), payable(address(0)), combined);
     }
 
@@ -507,7 +507,7 @@ contract SafenetGuardTest is Test {
         FROST.Signature memory sig = _frostSign(GROUP_SK, GROUP_NK, message);
 
         vm.expectEmit(true, true, false, true);
-        emit SafenetGuard.EpochUpdated(INITIAL_EPOCH, newEpoch, newKey);
+        emit SafenetGuardA.EpochUpdated(INITIAL_EPOCH, newEpoch, newKey);
         guard.updateEpoch(newEpoch, 100, newKey, sig);
     }
 
@@ -568,7 +568,7 @@ contract SafenetGuardTest is Test {
         _allowTransaction(safeTxHash);
 
         // Before delay: guard reverts → Safe propagates revert, nonce unchanged
-        vm.expectRevert(SafenetGuard.AttestationNotFound.selector);
+        vm.expectRevert(SafenetGuardA.AttestationNotFound.selector);
         _execSafeTxWithNonce(TX_TO, TX_VALUE, TX_DATA, TX_OP, nonce);
 
         // After delay: passes and consumes allowance, nonce increments
@@ -578,7 +578,7 @@ contract SafenetGuardTest is Test {
 
         // Second call: allowance gone, nonce has incremented → different hash → fails
         uint256 nonce2 = safe.nonce();
-        vm.expectRevert(SafenetGuard.AttestationNotFound.selector);
+        vm.expectRevert(SafenetGuardA.AttestationNotFound.selector);
         _execSafeTxWithNonce(TX_TO, TX_VALUE, TX_DATA, TX_OP, nonce2);
     }
 
@@ -665,7 +665,7 @@ contract SafenetGuardTest is Test {
         uint256 nonce = safe.nonce();
         bytes32 txHash = _safeTxHash(TX_TO, TX_VALUE, TX_DATA, TX_OP, nonce);
         bytes memory combined = abi.encodePacked(_signSafeTx(txHash), bytes32(0));
-        vm.expectRevert(SafenetGuard.AttestationNotFound.selector);
+        vm.expectRevert(SafenetGuardA.AttestationNotFound.selector);
         safe.execTransaction(TX_TO, TX_VALUE, TX_DATA, TX_OP, 0, 0, 0, address(0), payable(address(0)), combined);
     }
 
@@ -674,7 +674,7 @@ contract SafenetGuardTest is Test {
         uint256 nonce = safe.nonce();
         bytes32 txHash = _safeTxHash(TX_TO, TX_VALUE, TX_DATA, TX_OP, nonce);
         bytes memory combined = abi.encodePacked(_signSafeTx(txHash), bytes32(uint256(66)));
-        vm.expectRevert(SafenetGuard.AttestationNotFound.selector);
+        vm.expectRevert(SafenetGuardA.AttestationNotFound.selector);
         safe.execTransaction(TX_TO, TX_VALUE, TX_DATA, TX_OP, 0, 0, 0, address(0), payable(address(0)), combined);
     }
 


### PR DESCRIPTION
This renames the first guard's test file as well as changes the private variable naming for consistency.

Based on the comment: https://github.com/safe-research/safenet/pull/348#discussion_r3147281263

No functional change to the contract, only naming and moving-based changes.