### PR TITLE
Fix Foundry version in CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,11 @@ jobs:
           cache: "npm"
 
       - uses: foundry-rs/foundry-toolchain@v1
+        with:
+          # We fix the foundry version because of a formatting bug introduced
+          # in version 1.7.0.
+          # See <https://github.com/foundry-rs/foundry/issues/13362>
+          version: v1.5.1
 
       - run: npm ci
       - run: npm run check


### PR DESCRIPTION
Fix foundry version to the last stable release, as v1.7.0 was released with a formatting bug that affects our code.

See https://github.com/foundry-rs/foundry/issues/13362