### PR TITLE
Safenet Cosigner

### DIFF
--- a/contracts/src/cosigner/README.md
+++ b/contracts/src/cosigner/README.md
@@ -1,0 +1,52 @@
+# Safenet Cosigner
+
+This directory contains an EIP-1271 contract signer implementation for Safenet. Unlike the guard variants, which intercept every transaction as a Safe Guard module, the cosigner participates as a Safe owner and gates transactions through Safe's standard EIP-1271 signature verification flow.
+
+---
+
+## SafenetCosigner
+
+**File:** `SafenetCosigner.sol`
+
+SafenetCosigner is an EIP-1271 contract signer that gates Safe transactions behind FROST threshold-signature attestation produced by the Safenet validator network. It is deployed once and added as an owner of a Safe alongside the human key holders.
+
+### How it works
+
+**EIP-1271 integration.** Safe calls `isValidSignature(safeTxHash, contractSignature)` on any owner that is a contract. The cosigner implements this interface and returns `0x1626ba7e` when it approves the transaction. The FROST attestation travels as dynamic contract signature data inside Safe's existing `signatures` bytes — no custom trailer encoding is required.
+
+**Signature construction.** Safe requires `signatures` entries sorted ascending by owner address. For the cosigner entry, include a contract signature slot (`v = 0`) and append the FROST attestation as dynamic data:
+
+```
+Static slot (65 bytes):
+  r (bytes32) = address(cosigner) left-padded with zeros
+  s (bytes32) = byte offset of the dynamic data = (total static entries) * 65
+  v (uint8)   = 0x00
+
+Dynamic data (appended after all static entries):
+  uint256                             : byte length of the encoded attestation
+  abi.encode(uint64, FROST.Signature) : epoch and FROST signature
+```
+
+To use the escape hatch instead, set the dynamic data to an empty byte sequence (length = 0, no following bytes).
+
+**Replay protection.** The Safe nonce is embedded in `safeTxHash`, making every attested message unique. No separate spent-signature registry is needed.
+
+**Epoch state.** Only the two most recent epochs are retained: `$currentEpoch` and `$previousEpoch`. On each `updateEpoch` call the current epoch shifts to previous and the new epoch becomes current. The sliding window allows in-flight transactions to complete across epoch boundaries while preventing unbounded storage growth. `updateEpoch` is permissionless — any party holding the FROST-signed rollover message can advance the epoch.
+
+**Escape hatch.** Owners can register a specific transaction for time-delayed execution via `allowTransaction`. The call must go through the Safe's own `execTransaction`, so the Safe's owner-signature threshold is required to register an allowance — including the cosigner's approval if the human owners alone cannot reach it. After a configurable delay, passing empty bytes as the dynamic contract signature data causes the cosigner to approve via the matured allowance. Allowances are not deleted on use because `isValidSignature` is `view`; replay is prevented by Safe's nonce advancing after execution.
+
+### Pros
+
+- Uses Safe's standard EIP-1271 contract-signature mechanism — no custom trailer encoding required.
+- Replay protection is inherited from the Safe nonce — no additional registry.
+- Only two epoch keys are retained, bounding storage growth regardless of how many rollovers occur.
+- `updateEpoch` is permissionless, improving liveness during validator set changes.
+- Fully self-contained: no cross-chain calls at execution time.
+- Escape hatch provides a liveness guarantee if Safenet is unavailable.
+
+### Cons
+
+- Only the two most recent epoch keys are valid. An in-flight transaction attested under an older epoch will be rejected once two subsequent rollovers have occurred.
+- Registering an escape-hatch allowance requires the cosigner's approval at registration time, so it must be done proactively while Safenet is still available.
+- Cancelling an allowance goes through `execTransaction` and requires the Safe's owner-signature threshold. If the remaining human owners can reach that threshold without the cosigner, cancellation is still possible even when Safenet is unavailable.
+- Escape-hatch UX requires owners to proactively register a transaction hash and wait out the full delay, which may be operationally burdensome in time-sensitive situations.

--- a/contracts/src/cosigner/README.md
+++ b/contracts/src/cosigner/README.md
@@ -47,7 +47,7 @@ The registered hash is nonce-bound to the Safe's nonce at registration time. If 
 - `updateEpoch` is permissionless, improving liveness during validator set changes.
 - Fully self-contained: no cross-chain calls at execution time.
 - Escape hatch can be registered by any single Safe owner without Safenet availability, providing a liveness guarantee if Safenet is unavailable.
-- Relay-compatible escape hatch registration via EIP-712 (`allowEscapeHatchWithSig`), supporting both EOA and contract owners.
+- Relay-compatible escape hatch registration via `allowEscapeHatchWithSig`, using Safe's own `checkNSignatures` for signature verification — supports ECDSA, EIP-1271 contract signatures, and pre-approved hashes without any custom signature logic.
 
 ### Cons
 

--- a/contracts/src/cosigner/README.md
+++ b/contracts/src/cosigner/README.md
@@ -33,7 +33,11 @@ To use the escape hatch instead, set the dynamic data to an empty byte sequence 
 
 **Epoch state.** Only the two most recent epochs are retained: `$currentEpoch` and `$previousEpoch`. On each `updateEpoch` call the current epoch shifts to previous and the new epoch becomes current. The sliding window allows in-flight transactions to complete across epoch boundaries while preventing unbounded storage growth. `updateEpoch` is permissionless — any party holding the FROST-signed rollover message can advance the epoch.
 
-**Escape hatch.** Owners can register a specific transaction for time-delayed execution via `allowTransaction`. The call must go through the Safe's own `execTransaction`, so the Safe's owner-signature threshold is required to register an allowance — including the cosigner's approval if the human owners alone cannot reach it. After a configurable delay, passing empty bytes as the dynamic contract signature data causes the cosigner to approve via the matured allowance. Allowances are not deleted on use because `isValidSignature` is `view`; replay is prevented by Safe's nonce advancing after execution.
+**Escape hatch.** Any single Safe owner can register a time-delayed `removeOwner` call that removes the cosigner from the Safe by calling `allowEscapeHatch` directly, or `allowEscapeHatchWithSig` when submitting via a relay service. Registration does not require a Safenet attestation, making it available even when the Safenet network is unavailable. Both functions accept an `EscapeHatchRequest` struct that captures the target Safe address (`safe`), the `removeOwner` parameters (`prevOwner`, `threshold`), and the Safe transaction gas parameters (`safeTxGas`, `baseGas`, `gasPrice`, `gasToken`, `refundReceiver`).
+
+After the configured delay, the Safe owners execute the pre-registered `removeOwner` transaction by passing empty bytes as the cosigner's dynamic signature data; the cosigner approves it via the empty-signature path in `isValidSignature`. Registrations are not deleted on use because `isValidSignature` is `view`; replay is prevented by Safe's nonce advancing after execution.
+
+The registered hash is nonce-bound to the Safe's nonce at registration time. If other transactions advance the nonce before execution, the registration becomes stale and must be repeated. To invalidate a pending registration, `threshold` owners can execute a dummy transaction to advance the Safe nonce.
 
 ### Pros
 
@@ -42,11 +46,12 @@ To use the escape hatch instead, set the dynamic data to an empty byte sequence 
 - Only two epoch keys are retained, bounding storage growth regardless of how many rollovers occur.
 - `updateEpoch` is permissionless, improving liveness during validator set changes.
 - Fully self-contained: no cross-chain calls at execution time.
-- Escape hatch provides a liveness guarantee if Safenet is unavailable.
+- Escape hatch can be registered by any single Safe owner without Safenet availability, providing a liveness guarantee if Safenet is unavailable.
+- Relay-compatible escape hatch registration via EIP-712 (`allowEscapeHatchWithSig`), supporting both EOA and contract owners.
 
 ### Cons
 
 - Only the two most recent epoch keys are valid. An in-flight transaction attested under an older epoch will be rejected once two subsequent rollovers have occurred.
-- Registering an escape-hatch allowance requires the cosigner's approval at registration time, so it must be done proactively while Safenet is still available.
-- Cancelling an allowance goes through `execTransaction` and requires the Safe's owner-signature threshold. If the remaining human owners can reach that threshold without the cosigner, cancellation is still possible even when Safenet is unavailable.
-- Escape-hatch UX requires owners to proactively register a transaction hash and wait out the full delay, which may be operationally burdensome in time-sensitive situations.
+- Escape-hatch UX requires owners to proactively register the `removeOwner` hash and wait out the full delay, which may be operationally burdensome in time-sensitive situations.
+- The registered hash is nonce-bound; if the Safe nonce advances before execution (e.g. due to another transaction), the registration must be repeated. Though, this is by design.
+- Invalidating a pending escape-hatch registration requires `threshold` owners to execute a dummy transaction without the cosigner's approval, which is only possible if the human owners can independently reach the Safe threshold.

--- a/contracts/src/cosigner/README.md
+++ b/contracts/src/cosigner/README.md
@@ -33,7 +33,21 @@ To use the pre-approved transaction path instead, set the dynamic data to an emp
 
 **Epoch state.** Only the two most recent epochs are retained: `$currentEpoch` and `$previousEpoch`. On each `updateEpoch` call the current epoch shifts to previous and the new epoch becomes current. The sliding window allows in-flight transactions to complete across epoch boundaries while preventing unbounded storage growth. `updateEpoch` is permissionless — any party holding the FROST-signed rollover message can advance the epoch.
 
-**Pre-approved transactions.** Safe owners can register any Safe transaction for time-delayed execution by calling `allowTransaction`. Registration requires signatures from `max(threshold - 1, 1)` Safe owners over `SafeTransaction.hash` — the same hash Safe owners sign for normal `execTransaction` — and does not require a Safenet attestation, making it available even when Safenet is unavailable. `allowTransaction` accepts a `SafeTransaction.T` struct covering all Safe transaction parameters (`safe`, `to`, `value`, `data`, `operation`, `safeTxGas`, `baseGas`, `gasPrice`, `gasToken`, `refundReceiver`, `nonce`) along with a `chainId` used to domain-separate the hash.
+**Pre-approved transactions.** Safe owners can register any Safe transaction for time-delayed execution by calling `allowTransaction(safe, safeTxHash, signatures)`. The caller supplies the Safe address, the precomputed `safeTxHash`, and `max(threshold - 1, 1)` owner signatures over the EIP-712 typed message `AllowTransaction(bytes32 safeTxHash)` under the cosigner's own domain. No Safenet attestation is required, making this available even when Safenet is unavailable.
+
+The EIP-712 domain used for `allowTransaction` signatures is:
+```
+EIP712Domain(uint256 chainId, address verifyingContract)
+  chainId           = deployment chain id
+  verifyingContract = address(cosigner)
+```
+
+The struct type is:
+```
+AllowTransaction(bytes32 safeTxHash)
+```
+
+Owners compute `safeTxHash` off-chain using `SafeTransaction.hash(safeTx)` — the same hash they sign for normal `execTransaction` — and sign the `AllowTransaction` EIP-712 message over it. The cosigner's `allowTransactionDomainSeparator()` view function returns the domain separator for off-chain message construction.
 
 After the configured delay, the Safe owners execute the pre-registered transaction by passing empty bytes as the cosigner's dynamic signature data; the cosigner approves it via the empty-signature path in `isValidSignature`. Registrations are not deleted on use because `isValidSignature` is `view`; replay is prevented by Safe's nonce advancing after execution.
 
@@ -47,7 +61,7 @@ The registered hash is nonce-bound to the Safe's nonce at registration time. If 
 - `updateEpoch` is permissionless, improving liveness during validator set changes.
 - Fully self-contained: no cross-chain calls at execution time.
 - Pre-approved transactions require no Safenet attestation, providing a liveness guarantee if Safenet is unavailable.
-- `allowTransaction` uses `SafeTransaction.hash` — the same hash owners sign for normal execution — so no additional signing infrastructure is needed on the client side.
+- `allowTransaction` signatures use a dedicated EIP-712 typed message (`AllowTransaction`), domain-separated by the cosigner contract address — preventing cross-contract replay.
 - Registration requires `max(threshold - 1, 1)` owner signatures, matching the number of human signatures needed to execute the transaction, preventing unilateral registration by a single owner.
 - Any Safe transaction can be pre-approved, not just cosigner removal — `removeOwner` is the typical escape hatch but the mechanism is general.
 

--- a/contracts/src/cosigner/README.md
+++ b/contracts/src/cosigner/README.md
@@ -33,7 +33,7 @@ To use the escape hatch instead, set the dynamic data to an empty byte sequence 
 
 **Epoch state.** Only the two most recent epochs are retained: `$currentEpoch` and `$previousEpoch`. On each `updateEpoch` call the current epoch shifts to previous and the new epoch becomes current. The sliding window allows in-flight transactions to complete across epoch boundaries while preventing unbounded storage growth. `updateEpoch` is permissionless — any party holding the FROST-signed rollover message can advance the epoch.
 
-**Escape hatch.** Any single Safe owner can register a time-delayed `removeOwner` call that removes the cosigner from the Safe by calling `allowEscapeHatch` directly, or `allowEscapeHatchWithSig` when submitting via a relay service. Registration does not require a Safenet attestation, making it available even when the Safenet network is unavailable. Both functions accept an `EscapeHatchRequest` struct that captures the target Safe address (`safe`), the `removeOwner` parameters (`prevOwner`, `threshold`), and the Safe transaction gas parameters (`safeTxGas`, `baseGas`, `gasPrice`, `gasToken`, `refundReceiver`).
+**Escape hatch.** Safe owners can register a time-delayed `removeOwner` call that removes the cosigner from the Safe by calling `allowEscapeHatch`. Registration requires signatures from `max(threshold - 1, 1)` Safe owners over the EIP-712 hash of the `EscapeHatchRequest` — no Safenet attestation is required, making it available even when the Safenet network is unavailable. The function accepts any Safe-compatible signature format (packed ECDSA, EIP-1271 contract signature, or pre-approved hash) via `ISafe.checkNSignatures`, and is relay-compatible so `msg.sender` need not be a Safe owner. `allowEscapeHatch` accepts an `EscapeHatchRequest` struct that captures the target Safe address (`safe`), the `removeOwner` parameters (`prevOwner`, `threshold`), the Safe transaction gas parameters (`safeTxGas`, `baseGas`, `gasPrice`, `gasToken`, `refundReceiver`), and the Safe's current nonce at registration time (`nonce`).
 
 After the configured delay, the Safe owners execute the pre-registered `removeOwner` transaction by passing empty bytes as the cosigner's dynamic signature data; the cosigner approves it via the empty-signature path in `isValidSignature`. Registrations are not deleted on use because `isValidSignature` is `view`; replay is prevented by Safe's nonce advancing after execution.
 
@@ -46,8 +46,9 @@ The registered hash is nonce-bound to the Safe's nonce at registration time. If 
 - Only two epoch keys are retained, bounding storage growth regardless of how many rollovers occur.
 - `updateEpoch` is permissionless, improving liveness during validator set changes.
 - Fully self-contained: no cross-chain calls at execution time.
-- Escape hatch can be registered by any single Safe owner without Safenet availability, providing a liveness guarantee if Safenet is unavailable.
-- Relay-compatible escape hatch registration via `allowEscapeHatchWithSig`, using Safe's own `checkNSignatures` for signature verification — supports ECDSA, EIP-1271 contract signatures, and pre-approved hashes without any custom signature logic.
+- Escape hatch requires no Safenet attestation, providing a liveness guarantee if Safenet is unavailable.
+- Relay-compatible escape hatch registration via `allowEscapeHatch`, using Safe's own `checkNSignatures` for signature verification — supports ECDSA, EIP-1271 contract signatures, and pre-approved hashes without any custom signature logic.
+- Registration requires `max(threshold - 1, 1)` owner signatures, matching the number of human signatures needed to execute the escape hatch, preventing unilateral removal by a single owner.
 
 ### Cons
 

--- a/contracts/src/cosigner/README.md
+++ b/contracts/src/cosigner/README.md
@@ -27,15 +27,15 @@ Dynamic data (appended after all static entries):
   abi.encode(uint64, FROST.Signature) : epoch and FROST signature
 ```
 
-To use the escape hatch instead, set the dynamic data to an empty byte sequence (length = 0, no following bytes).
+To use the pre-approved transaction path instead, set the dynamic data to an empty byte sequence (length = 0, no following bytes).
 
 **Replay protection.** The Safe nonce is embedded in `safeTxHash`, making every attested message unique. No separate spent-signature registry is needed.
 
 **Epoch state.** Only the two most recent epochs are retained: `$currentEpoch` and `$previousEpoch`. On each `updateEpoch` call the current epoch shifts to previous and the new epoch becomes current. The sliding window allows in-flight transactions to complete across epoch boundaries while preventing unbounded storage growth. `updateEpoch` is permissionless — any party holding the FROST-signed rollover message can advance the epoch.
 
-**Escape hatch.** Safe owners can register a time-delayed `removeOwner` call that removes the cosigner from the Safe by calling `allowEscapeHatch`. Registration requires signatures from `max(threshold - 1, 1)` Safe owners over the EIP-712 hash of the `EscapeHatchRequest` — no Safenet attestation is required, making it available even when the Safenet network is unavailable. The function accepts any Safe-compatible signature format (packed ECDSA, EIP-1271 contract signature, or pre-approved hash) via `ISafe.checkNSignatures`, and is relay-compatible so `msg.sender` need not be a Safe owner. `allowEscapeHatch` accepts an `EscapeHatchRequest` struct that captures the target Safe address (`safe`), the `removeOwner` parameters (`prevOwner`, `threshold`), the Safe transaction gas parameters (`safeTxGas`, `baseGas`, `gasPrice`, `gasToken`, `refundReceiver`), and the Safe's current nonce at registration time (`nonce`).
+**Pre-approved transactions.** Safe owners can register any Safe transaction for time-delayed execution by calling `allowTransaction`. Registration requires signatures from `max(threshold - 1, 1)` Safe owners over `SafeTransaction.hash` — the same hash Safe owners sign for normal `execTransaction` — and does not require a Safenet attestation, making it available even when Safenet is unavailable. `allowTransaction` accepts a `SafeTransaction.T` struct covering all Safe transaction parameters (`safe`, `to`, `value`, `data`, `operation`, `safeTxGas`, `baseGas`, `gasPrice`, `gasToken`, `refundReceiver`, `nonce`) along with a `chainId` used to domain-separate the hash.
 
-After the configured delay, the Safe owners execute the pre-registered `removeOwner` transaction by passing empty bytes as the cosigner's dynamic signature data; the cosigner approves it via the empty-signature path in `isValidSignature`. Registrations are not deleted on use because `isValidSignature` is `view`; replay is prevented by Safe's nonce advancing after execution.
+After the configured delay, the Safe owners execute the pre-registered transaction by passing empty bytes as the cosigner's dynamic signature data; the cosigner approves it via the empty-signature path in `isValidSignature`. Registrations are not deleted on use because `isValidSignature` is `view`; replay is prevented by Safe's nonce advancing after execution.
 
 The registered hash is nonce-bound to the Safe's nonce at registration time. If other transactions advance the nonce before execution, the registration becomes stale and must be repeated. To invalidate a pending registration, `threshold` owners can execute a dummy transaction to advance the Safe nonce.
 
@@ -46,13 +46,14 @@ The registered hash is nonce-bound to the Safe's nonce at registration time. If 
 - Only two epoch keys are retained, bounding storage growth regardless of how many rollovers occur.
 - `updateEpoch` is permissionless, improving liveness during validator set changes.
 - Fully self-contained: no cross-chain calls at execution time.
-- Escape hatch requires no Safenet attestation, providing a liveness guarantee if Safenet is unavailable.
-- Relay-compatible escape hatch registration via `allowEscapeHatch`, using Safe's own `checkNSignatures` for signature verification — supports ECDSA, EIP-1271 contract signatures, and pre-approved hashes without any custom signature logic.
-- Registration requires `max(threshold - 1, 1)` owner signatures, matching the number of human signatures needed to execute the escape hatch, preventing unilateral removal by a single owner.
+- Pre-approved transactions require no Safenet attestation, providing a liveness guarantee if Safenet is unavailable.
+- `allowTransaction` uses `SafeTransaction.hash` — the same hash owners sign for normal execution — so no additional signing infrastructure is needed on the client side.
+- Registration requires `max(threshold - 1, 1)` owner signatures, matching the number of human signatures needed to execute the transaction, preventing unilateral registration by a single owner.
+- Any Safe transaction can be pre-approved, not just cosigner removal — `removeOwner` is the typical escape hatch but the mechanism is general.
 
 ### Cons
 
 - Only the two most recent epoch keys are valid. An in-flight transaction attested under an older epoch will be rejected once two subsequent rollovers have occurred.
-- Escape-hatch UX requires owners to proactively register the `removeOwner` hash and wait out the full delay, which may be operationally burdensome in time-sensitive situations.
+- Pre-approved transaction UX requires owners to coordinate `max(threshold - 1, 1)` signatures, register the transaction hash, and wait out the full delay, which may be operationally burdensome in time-sensitive situations.
 - The registered hash is nonce-bound; if the Safe nonce advances before execution (e.g. due to another transaction), the registration must be repeated. Though, this is by design.
-- Invalidating a pending escape-hatch registration requires `threshold` owners to execute a dummy transaction without the cosigner's approval, which is only possible if the human owners can independently reach the Safe threshold.
+- Invalidating a pending registration requires `threshold` owners to execute a dummy transaction without the cosigner's approval, which is only possible if the human owners can independently reach the Safe threshold.

--- a/contracts/src/cosigner/SafenetCosigner.sol
+++ b/contracts/src/cosigner/SafenetCosigner.sol
@@ -54,19 +54,11 @@ contract SafenetCosigner is ISignatureValidator {
     EpochState private $currentEpoch;
 
     /**
-     * @dev Only valid when `$hasPreviousEpoch` is true (after the first `updateEpoch` call).
+     * @dev Only valid after the first `updateEpoch` call. Callers must validate the returned key
+     *      with `Secp256k1.requireNonZero` before use.
      */
     // forge-lint: disable-next-line(mixed-case-variable)
     EpochState private $previousEpoch;
-
-    /**
-     * @notice True once the first `updateEpoch` call has populated `$previousEpoch`.
-     * @dev Guards `_resolveGroupKey` against treating the zero-initialised `$previousEpoch`
-     *      slot as a valid epoch entry before any rollover has occurred. Without this flag,
-     *      `_resolveGroupKey(0)` would return a zero group key — trivially forgeable via FROST.
-     */
-    // forge-lint: disable-next-line(mixed-case-variable)
-    bool private $hasPreviousEpoch;
 
     // forge-lint: disable-next-line(mixed-case-variable)
     mapping(address safe => mapping(bytes32 safeTxHash => uint256 executableAt)) private $allowedTransactions;
@@ -84,8 +76,6 @@ contract SafenetCosigner is ISignatureValidator {
     // ============================================================
     // ERRORS
     // ============================================================
-
-    error AttestationNotFound();
 
     error InvalidEpoch();
 
@@ -141,7 +131,6 @@ contract SafenetCosigner is ISignatureValidator {
         FROST.verify($currentEpoch.groupKey, signature, message);
         uint64 prevEpoch = $currentEpoch.epoch;
         $previousEpoch = $currentEpoch;
-        $hasPreviousEpoch = true;
         $currentEpoch = EpochState({epoch: proposedEpoch, groupKey: newGroupKey});
         emit EpochUpdated(prevEpoch, proposedEpoch, newGroupKey);
     }
@@ -161,16 +150,19 @@ contract SafenetCosigner is ISignatureValidator {
      */
     function isValidSignature(bytes32 _hash, bytes memory _signature) external view override returns (bytes4) {
         if (_signature.length > 0) {
+            if (_signature.length != 128) return bytes4(0);
             (uint64 epoch, FROST.Signature memory sig) = abi.decode(_signature, (uint64, FROST.Signature));
             bytes32 message = ConsensusMessages.transactionProposal(_CONSENSUS_DOMAIN_SEPARATOR, epoch, _hash);
-            FROST.verify(_resolveGroupKey(epoch), sig, message);
+            Secp256k1.Point memory groupKey = _resolveGroupKey(epoch);
+            Secp256k1.requireNonZero(groupKey);
+            FROST.verify(groupKey, sig, message);
             return EIP1271_MAGIC_VALUE;
         }
 
         uint256 executableAt = $allowedTransactions[msg.sender][_hash];
         if (executableAt != 0 && block.timestamp >= executableAt) return EIP1271_MAGIC_VALUE;
 
-        revert AttestationNotFound();
+        return bytes4(0);
     }
 
     // ============================================================
@@ -211,7 +203,7 @@ contract SafenetCosigner is ISignatureValidator {
     }
 
     function previousEpoch() external view returns (uint64) {
-        if (!$hasPreviousEpoch) revert InvalidEpoch();
+        if ($previousEpoch.groupKey.x | $previousEpoch.groupKey.y == 0) revert InvalidEpoch();
         return $previousEpoch.epoch;
     }
 
@@ -233,7 +225,7 @@ contract SafenetCosigner is ISignatureValidator {
 
     function _resolveGroupKey(uint64 epoch) private view returns (Secp256k1.Point memory) {
         if ($currentEpoch.epoch == epoch) return $currentEpoch.groupKey;
-        if ($hasPreviousEpoch && $previousEpoch.epoch == epoch) return $previousEpoch.groupKey;
+        if ($previousEpoch.epoch == epoch) return $previousEpoch.groupKey;
         revert InvalidEpoch();
     }
 }

--- a/contracts/src/cosigner/SafenetCosigner.sol
+++ b/contracts/src/cosigner/SafenetCosigner.sol
@@ -1,0 +1,239 @@
+// SPDX-License-Identifier: GPL-3.0-only
+pragma solidity ^0.8.30;
+
+import {ConsensusMessages} from "@/libraries/ConsensusMessages.sol";
+import {FROST} from "@/libraries/FROST.sol";
+import {Secp256k1} from "@/libraries/Secp256k1.sol";
+import {ISignatureValidator} from "@safe/interfaces/ISignatureValidator.sol";
+
+/**
+ * @title SafenetCosigner
+ * @notice EIP-1271 contract signer that gates Safe transactions behind Safenet
+ *         threshold-signature attestation. Deploy once and add as a Safe owner.
+ *
+ * @dev **Signature construction.**
+ *      Safe requires `signatures` entries sorted ascending by owner address. For the
+ *      cosigner entry, include a contract signature slot (`v = 0`) and append the FROST
+ *      attestation as dynamic data:
+ *
+ *      Static slot (65 bytes):
+ *        r (bytes32) = address(cosigner) left-padded with zeros
+ *        s (bytes32) = byte offset of the dynamic data = (total static entries) * 65
+ *        v (uint8)   = 0x00
+ *
+ *      Dynamic data (appended after all static entries):
+ *        uint256                    : byte length of the encoded attestation
+ *        abi.encode(uint64, FROST.Signature) : epoch and FROST signature
+ *
+ *      Safe calls `isValidSignature(safeTxHash, abi.encode(epoch, sig))` on this contract.
+ *      To use the escape hatch instead, set the dynamic data to an empty byte sequence
+ *      (length = 0, no following bytes) and ensure a matured allowance exists for this Safe.
+ *      Allowances are registered by calling `allowTransaction` on this contract via the Safe's
+ *      own `execTransaction` — requiring the full owner-signature threshold including the
+ *      cosigner's approval. This prevents any subset of owners from bypassing the threshold.
+ */
+contract SafenetCosigner is ISignatureValidator {
+    // ============================================================
+    // TYPES
+    // ============================================================
+
+    struct EpochState {
+        uint64 epoch;
+        Secp256k1.Point groupKey;
+    }
+
+    // ============================================================
+    // STORAGE VARIABLES
+    // ============================================================
+
+    bytes32 private immutable _CONSENSUS_DOMAIN_SEPARATOR;
+
+    uint256 private immutable _ALLOW_TX_DELAY;
+
+    // forge-lint: disable-next-line(mixed-case-variable)
+    EpochState private $currentEpoch;
+
+    /**
+     * @dev Only valid when `$hasPreviousEpoch` is true (after the first `updateEpoch` call).
+     */
+    // forge-lint: disable-next-line(mixed-case-variable)
+    EpochState private $previousEpoch;
+
+    /**
+     * @notice True once the first `updateEpoch` call has populated `$previousEpoch`.
+     * @dev Guards `_resolveGroupKey` against treating the zero-initialised `$previousEpoch`
+     *      slot as a valid epoch entry before any rollover has occurred. Without this flag,
+     *      `_resolveGroupKey(0)` would return a zero group key — trivially forgeable via FROST.
+     */
+    // forge-lint: disable-next-line(mixed-case-variable)
+    bool private $hasPreviousEpoch;
+
+    // forge-lint: disable-next-line(mixed-case-variable)
+    mapping(address safe => mapping(bytes32 safeTxHash => uint256 executableAt)) private $allowedTransactions;
+
+    // ============================================================
+    // EVENTS
+    // ============================================================
+
+    event EpochUpdated(uint64 indexed previousEpoch, uint64 indexed activeEpoch, Secp256k1.Point activeGroupKey);
+
+    event TransactionAllowed(address indexed safe, bytes32 indexed safeTxHash, uint256 executableAt);
+
+    event AllowanceCancelled(address indexed safe, bytes32 indexed safeTxHash);
+
+    // ============================================================
+    // ERRORS
+    // ============================================================
+
+    error AttestationNotFound();
+
+    error InvalidEpoch();
+
+    error EpochNotAdvancing();
+
+    error TransactionAlreadyAllowed();
+
+    error AllowanceNotFound();
+
+    error InvalidAddress();
+
+    error InvalidParameter();
+
+    // ============================================================
+    // CONSTRUCTOR
+    // ============================================================
+
+    constructor(
+        uint256 consensusChainId,
+        address consensusAddress,
+        uint64 initialEpoch,
+        Secp256k1.Point memory initialGroupKey,
+        uint256 allowTransactionDelay
+    ) {
+        require(consensusAddress != address(0), InvalidAddress());
+        require(allowTransactionDelay != 0, InvalidParameter());
+        Secp256k1.requireNonZero(initialGroupKey);
+        _CONSENSUS_DOMAIN_SEPARATOR = ConsensusMessages.domain(consensusChainId, consensusAddress);
+        _ALLOW_TX_DELAY = allowTransactionDelay;
+        $currentEpoch = EpochState({epoch: initialEpoch, groupKey: initialGroupKey});
+        emit EpochUpdated(0, initialEpoch, initialGroupKey);
+    }
+
+    // ============================================================
+    // EPOCH MANAGEMENT
+    // ============================================================
+
+    /**
+     * @dev `$currentEpoch` shifts to `$previousEpoch` and the new epoch becomes `$currentEpoch`.
+     *      Only the two most recent epochs are retained; older keys are discarded on each rollover.
+     */
+    function updateEpoch(
+        uint64 proposedEpoch,
+        uint64 rolloverBlock,
+        Secp256k1.Point calldata newGroupKey,
+        FROST.Signature calldata signature
+    ) external {
+        require(proposedEpoch > $currentEpoch.epoch, EpochNotAdvancing());
+        Secp256k1.requireNonZero(newGroupKey);
+        bytes32 message = ConsensusMessages.epochRollover(
+            _CONSENSUS_DOMAIN_SEPARATOR, $currentEpoch.epoch, proposedEpoch, rolloverBlock, newGroupKey
+        );
+        FROST.verify($currentEpoch.groupKey, signature, message);
+        uint64 prevEpoch = $currentEpoch.epoch;
+        $previousEpoch = $currentEpoch;
+        $hasPreviousEpoch = true;
+        $currentEpoch = EpochState({epoch: proposedEpoch, groupKey: newGroupKey});
+        emit EpochUpdated(prevEpoch, proposedEpoch, newGroupKey);
+    }
+
+    // ============================================================
+    // EIP-1271
+    // ============================================================
+
+    /**
+     * @dev Called by Safe during `execTransaction`. `msg.sender` is the Safe.
+     *      Two execution paths:
+     *      1. FROST attestation: `_signature` = `abi.encode(uint64 epoch, FROST.Signature sig)`.
+     *         Verifies the FROST sig against `_hash` under the resolved group key.
+     *      2. Escape hatch: `_signature` is empty. Approves if a matured allowance exists for
+     *         `(msg.sender, _hash)`. Allowances are not deleted on use because this function is
+     *         `view` — replay is prevented by Safe's own nonce advancing after execution.
+     */
+    function isValidSignature(bytes32 _hash, bytes memory _signature) external view override returns (bytes4) {
+        if (_signature.length > 0) {
+            (uint64 epoch, FROST.Signature memory sig) = abi.decode(_signature, (uint64, FROST.Signature));
+            bytes32 message = ConsensusMessages.transactionProposal(_CONSENSUS_DOMAIN_SEPARATOR, epoch, _hash);
+            FROST.verify(_resolveGroupKey(epoch), sig, message);
+            return EIP1271_MAGIC_VALUE;
+        }
+
+        uint256 executableAt = $allowedTransactions[msg.sender][_hash];
+        if (executableAt != 0 && block.timestamp >= executableAt) return EIP1271_MAGIC_VALUE;
+
+        revert AttestationNotFound();
+    }
+
+    // ============================================================
+    // ALLOWANCE (ESCAPE HATCH)
+    // ============================================================
+
+    /**
+     * @dev Registers a time-delayed allowance for `safeTxHash`. Must be called by the Safe
+     *      itself via `execTransaction`, so the full owner-signature threshold is required.
+     *      After `_ALLOW_TX_DELAY` seconds the cosigner approves the hash via the escape-hatch
+     *      path in `isValidSignature` (pass empty bytes as the dynamic contract signature data).
+     */
+    function allowTransaction(bytes32 safeTxHash) external {
+        require($allowedTransactions[msg.sender][safeTxHash] == 0, TransactionAlreadyAllowed());
+        uint256 executableAt = block.timestamp + _ALLOW_TX_DELAY;
+        $allowedTransactions[msg.sender][safeTxHash] = executableAt;
+        emit TransactionAllowed(msg.sender, safeTxHash, executableAt);
+    }
+
+    /**
+     * @dev Cancels a pending allowance. Must be called by the Safe itself via `execTransaction`.
+     *      Cancellation requires the Safe's owner-signature threshold — if the remaining human
+     *      owners can reach that threshold without the cosigner, cancellation remains possible
+     *      even when Safenet is unavailable.
+     */
+    function cancelAllowTransaction(bytes32 safeTxHash) external {
+        require($allowedTransactions[msg.sender][safeTxHash] != 0, AllowanceNotFound());
+        delete $allowedTransactions[msg.sender][safeTxHash];
+        emit AllowanceCancelled(msg.sender, safeTxHash);
+    }
+
+    // ============================================================
+    // VIEW FUNCTIONS
+    // ============================================================
+
+    function activeEpoch() external view returns (uint64) {
+        return $currentEpoch.epoch;
+    }
+
+    function previousEpoch() external view returns (uint64) {
+        if (!$hasPreviousEpoch) revert InvalidEpoch();
+        return $previousEpoch.epoch;
+    }
+
+    function allowTxDelay() external view returns (uint256) {
+        return _ALLOW_TX_DELAY;
+    }
+
+    function consensusDomainSeparator() external view returns (bytes32) {
+        return _CONSENSUS_DOMAIN_SEPARATOR;
+    }
+
+    function getAllowedTxTimestamp(address safe, bytes32 safeTxHash) external view returns (uint256 executableAt) {
+        return $allowedTransactions[safe][safeTxHash];
+    }
+
+    // ============================================================
+    // PRIVATE HELPERS
+    // ============================================================
+
+    function _resolveGroupKey(uint64 epoch) private view returns (Secp256k1.Point memory) {
+        if ($currentEpoch.epoch == epoch) return $currentEpoch.groupKey;
+        if ($hasPreviousEpoch && $previousEpoch.epoch == epoch) return $previousEpoch.groupKey;
+        revert InvalidEpoch();
+    }
+}

--- a/contracts/src/cosigner/SafenetCosigner.sol
+++ b/contracts/src/cosigner/SafenetCosigner.sol
@@ -32,9 +32,10 @@ import {ISignatureValidator} from "@safe/interfaces/ISignatureValidator.sol";
  *      (length = 0, no following bytes) and ensure a matured escape hatch registration exists.
  *
  *      **Escape hatch.**
- *      Any Safe owner can register a time-delayed `removeOwner` call targeting the cosigner
- *      itself by calling `allowEscapeHatch` directly, or `allowEscapeHatchWithSig` when
- *      submitting via a relay service. Registration does not require a Safenet attestation.
+ *      Safe owners can register a time-delayed `removeOwner` call targeting the cosigner
+ *      itself by calling `allowEscapeHatch`. Registration requires signatures from
+ *      `max(threshold - 1, 1)` Safe owners and does not require a Safenet attestation,
+ *      making the escape hatch available even when Safenet is unavailable.
  *      After `_ALLOW_TX_DELAY` seconds, the Safe owners can execute the pre-registered
  *      `removeOwner` transaction by passing empty bytes as the cosigner's dynamic signature
  *      data; the cosigner approves it via the empty-signature path in `isValidSignature`.
@@ -134,8 +135,6 @@ contract SafenetCosigner is ISignatureValidator {
 
     error InvalidParameter();
 
-    error NotSafeOwner();
-
     error InvalidThreshold();
 
     error InvalidNonce();
@@ -229,26 +228,22 @@ contract SafenetCosigner is ISignatureValidator {
 
     /**
      * @dev Registers a time-delayed `removeOwner` call that removes this cosigner from `request.safe`.
-     *      Any single Safe owner may call this directly — no Safenet attestation is required,
-     *      making the escape hatch available even when Safenet is unavailable.
+     *      Requires signatures from `max(threshold - 1, 1)` Safe owners over the EIP-712 hash of
+     *      the `EscapeHatchRequest`. Accepts any Safe-compatible signature format (packed ECDSA,
+     *      EIP-1271 contract signature, or pre-approved hash); verification is delegated to
+     *      `ISafe.checkNSignatures`. No Safenet attestation is required, making the escape hatch
+     *      available even when Safenet is unavailable.
      *      `request.threshold` must equal the Safe's current threshold or current threshold minus one.
      *      The registered hash is nonce-bound to the Safe's current nonce at registration time;
      *      if other transactions advance the nonce before execution, re-registration is required.
      *      To invalidate a pending registration, advance the Safe nonce with a dummy transaction.
      */
-    function allowEscapeHatch(EscapeHatchRequest calldata request) external {
-        require(ISafe(payable(request.safe)).isOwner(msg.sender), NotSafeOwner());
-        _registerEscapeHatch(request);
-    }
-
-    /**
-     * @dev Relay-compatible variant of `allowEscapeHatch`. Accepts a Safe-compatible signature
-     *      (packed ECDSA, EIP-1271 contract signature, or pre-approved hash) from a Safe owner
-     *      over the EIP-712 hash of the `EscapeHatchRequest`, allowing submission via a relay
-     *      service where `msg.sender` is not the Safe owner. Signature verification and owner
-     *      membership check are both delegated to `ISafe.checkNSignatures`.
-     */
-    function allowEscapeHatchWithSig(EscapeHatchRequest calldata request, bytes calldata signature) external {
+    function allowEscapeHatch(EscapeHatchRequest calldata request, bytes calldata signature) external {
+        ISafe safeContract = ISafe(payable(request.safe));
+        require(request.nonce == safeContract.nonce(), InvalidNonce());
+        uint256 currentThreshold = safeContract.getThreshold();
+        require(request.threshold == currentThreshold || request.threshold == currentThreshold - 1, InvalidThreshold());
+        uint256 requiredSignatures = currentThreshold > 1 ? currentThreshold - 1 : 1;
         // forge-lint: disable-next-item(asm-keccak256)
         bytes32 structHash = keccak256(
             abi.encode(
@@ -266,8 +261,12 @@ contract SafenetCosigner is ISignatureValidator {
         );
         // forge-lint: disable-next-item(asm-keccak256)
         bytes32 messageHash = keccak256(abi.encodePacked("\x19\x01", _domainSeparator(), structHash));
-        ISafe(payable(request.safe)).checkNSignatures(address(0), messageHash, signature, 1);
-        _registerEscapeHatch(request);
+        safeContract.checkNSignatures(address(0), messageHash, signature, requiredSignatures);
+        bytes32 safeTxHash = _escapeHatchTxHash(request);
+        require($allowedTransactions[request.safe][safeTxHash] == 0, TransactionAlreadyAllowed());
+        uint256 executableAt = block.timestamp + _ALLOW_TX_DELAY;
+        $allowedTransactions[request.safe][safeTxHash] = executableAt;
+        emit TransactionAllowed(request.safe, safeTxHash, executableAt);
     }
 
     // ============================================================
@@ -298,18 +297,6 @@ contract SafenetCosigner is ISignatureValidator {
     // ============================================================
     // PRIVATE HELPERS
     // ============================================================
-
-    function _registerEscapeHatch(EscapeHatchRequest calldata request) private {
-        ISafe safeContract = ISafe(payable(request.safe));
-        require(request.nonce == safeContract.nonce(), InvalidNonce());
-        uint256 currentThreshold = safeContract.getThreshold();
-        require(request.threshold == currentThreshold || request.threshold == currentThreshold - 1, InvalidThreshold());
-        bytes32 safeTxHash = _escapeHatchTxHash(request);
-        require($allowedTransactions[request.safe][safeTxHash] == 0, TransactionAlreadyAllowed());
-        uint256 executableAt = block.timestamp + _ALLOW_TX_DELAY;
-        $allowedTransactions[request.safe][safeTxHash] = executableAt;
-        emit TransactionAllowed(request.safe, safeTxHash, executableAt);
-    }
 
     function _escapeHatchTxHash(EscapeHatchRequest calldata request) private view returns (bytes32) {
         return SafeTransaction.hash(

--- a/contracts/src/cosigner/SafenetCosigner.sol
+++ b/contracts/src/cosigner/SafenetCosigner.sol
@@ -64,6 +64,9 @@ contract SafenetCosigner is ISignatureValidator {
      * @custom:param gasPrice Gas price used for the refund calculation.
      * @custom:param gasToken Token used for gas payment; `address(0)` for the native token.
      * @custom:param refundReceiver Recipient of the gas refund; `address(0)` for `tx.origin`.
+     * @custom:param nonce The Safe's current nonce at registration time. Binds the registration to a
+     *              specific Safe nonce, preventing replay of a signed `EscapeHatchRequest` across
+     *              future nonce values.
      */
     struct EscapeHatchRequest {
         address safe;
@@ -74,6 +77,7 @@ contract SafenetCosigner is ISignatureValidator {
         uint256 gasPrice;
         address gasToken;
         address refundReceiver;
+        uint256 nonce;
     }
 
     // ============================================================
@@ -81,7 +85,7 @@ contract SafenetCosigner is ISignatureValidator {
     // ============================================================
 
     bytes32 private constant _ESCAPE_HATCH_TYPEHASH = keccak256(
-        "EscapeHatchRequest(address safe,address prevOwner,uint256 threshold,uint256 safeTxGas,uint256 baseGas,uint256 gasPrice,address gasToken,address refundReceiver)"
+        "EscapeHatchRequest(address safe,address prevOwner,uint256 threshold,uint256 safeTxGas,uint256 baseGas,uint256 gasPrice,address gasToken,address refundReceiver,uint256 nonce)"
     );
 
     // ============================================================
@@ -132,6 +136,8 @@ contract SafenetCosigner is ISignatureValidator {
     error NotSafeOwner();
 
     error InvalidThreshold();
+
+    error InvalidNonce();
 
     error InvalidSignature();
 
@@ -258,7 +264,8 @@ contract SafenetCosigner is ISignatureValidator {
                 request.baseGas,
                 request.gasPrice,
                 request.gasToken,
-                request.refundReceiver
+                request.refundReceiver,
+                request.nonce
             )
         );
         // forge-lint: disable-next-item(asm-keccak256)
@@ -298,20 +305,19 @@ contract SafenetCosigner is ISignatureValidator {
 
     function _registerEscapeHatch(EscapeHatchRequest calldata request) private {
         ISafe safeContract = ISafe(payable(request.safe));
+        require(request.nonce == safeContract.nonce(), InvalidNonce());
         uint256 currentThreshold = safeContract.getThreshold();
-        require(request.threshold == currentThreshold || request.threshold == currentThreshold - 1, InvalidThreshold());
-        bytes32 safeTxHash = _escapeHatchTxHash(safeContract, request);
+        require(
+            request.threshold == currentThreshold || request.threshold == currentThreshold - 1, InvalidThreshold()
+        );
+        bytes32 safeTxHash = _escapeHatchTxHash(request);
         require($allowedTransactions[request.safe][safeTxHash] == 0, TransactionAlreadyAllowed());
         uint256 executableAt = block.timestamp + _ALLOW_TX_DELAY;
         $allowedTransactions[request.safe][safeTxHash] = executableAt;
         emit TransactionAllowed(request.safe, safeTxHash, executableAt);
     }
 
-    function _escapeHatchTxHash(ISafe safeContract, EscapeHatchRequest calldata request)
-        private
-        view
-        returns (bytes32)
-    {
+    function _escapeHatchTxHash(EscapeHatchRequest calldata request) private view returns (bytes32) {
         return SafeTransaction.hash(
             SafeTransaction.T({
                 chainId: block.chainid,
@@ -325,7 +331,7 @@ contract SafenetCosigner is ISignatureValidator {
                 gasPrice: request.gasPrice,
                 gasToken: request.gasToken,
                 refundReceiver: request.refundReceiver,
-                nonce: safeContract.nonce()
+                nonce: request.nonce
             })
         );
     }

--- a/contracts/src/cosigner/SafenetCosigner.sol
+++ b/contracts/src/cosigner/SafenetCosigner.sol
@@ -3,8 +3,11 @@ pragma solidity ^0.8.30;
 
 import {ConsensusMessages} from "@/libraries/ConsensusMessages.sol";
 import {FROST} from "@/libraries/FROST.sol";
+import {SafeTransaction} from "@/libraries/SafeTransaction.sol";
 import {Secp256k1} from "@/libraries/Secp256k1.sol";
+import {ISafe, IOwnerManager} from "@safe/interfaces/ISafe.sol";
 import {ISignatureValidator} from "@safe/interfaces/ISignatureValidator.sol";
+import {IERC1271} from "@oz/interfaces/IERC1271.sol";
 
 /**
  * @title SafenetCosigner
@@ -22,15 +25,23 @@ import {ISignatureValidator} from "@safe/interfaces/ISignatureValidator.sol";
  *        v (uint8)   = 0x00
  *
  *      Dynamic data (appended after all static entries):
- *        uint256                    : byte length of the encoded attestation
+ *        uint256                             : byte length of the encoded attestation
  *        abi.encode(uint64, FROST.Signature) : epoch and FROST signature
  *
  *      Safe calls `isValidSignature(safeTxHash, abi.encode(epoch, sig))` on this contract.
  *      To use the escape hatch instead, set the dynamic data to an empty byte sequence
- *      (length = 0, no following bytes) and ensure a matured allowance exists for this Safe.
- *      Allowances are registered by calling `allowTransaction` on this contract via the Safe's
- *      own `execTransaction` — requiring the full owner-signature threshold including the
- *      cosigner's approval. This prevents any subset of owners from bypassing the threshold.
+ *      (length = 0, no following bytes) and ensure a matured escape hatch registration exists.
+ *
+ *      **Escape hatch.**
+ *      Any Safe owner can register a time-delayed `removeOwner` call targeting the cosigner
+ *      itself by calling `allowEscapeHatch` directly, or `allowEscapeHatchWithSig` when
+ *      submitting via a relay service. Registration does not require a Safenet attestation.
+ *      After `_ALLOW_TX_DELAY` seconds, the Safe owners can execute the pre-registered
+ *      `removeOwner` transaction by passing empty bytes as the cosigner's dynamic signature
+ *      data; the cosigner approves it via the empty-signature path in `isValidSignature`.
+ *      The registered hash is nonce-bound: if other transactions advance the Safe nonce before
+ *      execution, the registration becomes stale and must be repeated. To invalidate a pending
+ *      registration, `threshold` owners can execute a dummy transaction to advance the Safe nonce.
  */
 contract SafenetCosigner is ISignatureValidator {
     // ============================================================
@@ -42,6 +53,37 @@ contract SafenetCosigner is ISignatureValidator {
         Secp256k1.Point groupKey;
     }
 
+    /**
+     * @notice Parameters for an escape-hatch registration.
+     * @custom:param safe The Safe account from which this cosigner should be removed.
+     * @custom:param prevOwner Owner address preceding this cosigner in the Safe's owner linked list.
+     * @custom:param threshold Threshold to set after removal; must equal the Safe's current threshold
+     *              or current threshold minus one.
+     * @custom:param safeTxGas Gas forwarded to the Safe transaction's inner call.
+     * @custom:param baseGas Base gas cost charged to the Safe for the transaction.
+     * @custom:param gasPrice Gas price used for the refund calculation.
+     * @custom:param gasToken Token used for gas payment; `address(0)` for the native token.
+     * @custom:param refundReceiver Recipient of the gas refund; `address(0)` for `tx.origin`.
+     */
+    struct EscapeHatchRequest {
+        address safe;
+        address prevOwner;
+        uint256 threshold;
+        uint256 safeTxGas;
+        uint256 baseGas;
+        uint256 gasPrice;
+        address gasToken;
+        address refundReceiver;
+    }
+
+    // ============================================================
+    // CONSTANTS
+    // ============================================================
+
+    bytes32 private constant _ESCAPE_HATCH_TYPEHASH = keccak256(
+        "EscapeHatchRequest(address safe,address prevOwner,uint256 threshold,uint256 safeTxGas,uint256 baseGas,uint256 gasPrice,address gasToken,address refundReceiver)"
+    );
+
     // ============================================================
     // STORAGE VARIABLES
     // ============================================================
@@ -49,6 +91,8 @@ contract SafenetCosigner is ISignatureValidator {
     bytes32 private immutable _CONSENSUS_DOMAIN_SEPARATOR;
 
     uint256 private immutable _ALLOW_TX_DELAY;
+
+    bytes32 private immutable _DOMAIN_SEPARATOR;
 
     // forge-lint: disable-next-line(mixed-case-variable)
     EpochState private $currentEpoch;
@@ -71,8 +115,6 @@ contract SafenetCosigner is ISignatureValidator {
 
     event TransactionAllowed(address indexed safe, bytes32 indexed safeTxHash, uint256 executableAt);
 
-    event AllowanceCancelled(address indexed safe, bytes32 indexed safeTxHash);
-
     // ============================================================
     // ERRORS
     // ============================================================
@@ -83,11 +125,15 @@ contract SafenetCosigner is ISignatureValidator {
 
     error TransactionAlreadyAllowed();
 
-    error AllowanceNotFound();
-
     error InvalidAddress();
 
     error InvalidParameter();
+
+    error NotSafeOwner();
+
+    error InvalidThreshold();
+
+    error InvalidSignature();
 
     // ============================================================
     // CONSTRUCTOR
@@ -105,6 +151,16 @@ contract SafenetCosigner is ISignatureValidator {
         Secp256k1.requireNonZero(initialGroupKey);
         _CONSENSUS_DOMAIN_SEPARATOR = ConsensusMessages.domain(consensusChainId, consensusAddress);
         _ALLOW_TX_DELAY = allowTransactionDelay;
+        // forge-lint: disable-next-item(asm-keccak256)
+        _DOMAIN_SEPARATOR = keccak256(
+            abi.encode(
+                keccak256("EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)"),
+                keccak256("SafenetCosigner"),
+                keccak256("1"),
+                block.chainid,
+                address(this)
+            )
+        );
         $currentEpoch = EpochState({epoch: initialEpoch, groupKey: initialGroupKey});
         emit EpochUpdated(0, initialEpoch, initialGroupKey);
     }
@@ -144,9 +200,9 @@ contract SafenetCosigner is ISignatureValidator {
      *      Two execution paths:
      *      1. FROST attestation: `_signature` = `abi.encode(uint64 epoch, FROST.Signature sig)`.
      *         Verifies the FROST sig against `_hash` under the resolved group key.
-     *      2. Escape hatch: `_signature` is empty. Approves if a matured allowance exists for
-     *         `(msg.sender, _hash)`. Allowances are not deleted on use because this function is
-     *         `view` — replay is prevented by Safe's own nonce advancing after execution.
+     *      2. Escape hatch: `_signature` is empty. Approves if a matured escape hatch registration
+     *         exists for `(msg.sender, _hash)`. Registrations are not deleted on use because this
+     *         function is `view` — replay is prevented by Safe's own nonce advancing after execution.
      */
     function isValidSignature(bytes32 _hash, bytes memory _signature) external view override returns (bytes4) {
         if (_signature.length > 0) {
@@ -166,32 +222,53 @@ contract SafenetCosigner is ISignatureValidator {
     }
 
     // ============================================================
-    // ALLOWANCE (ESCAPE HATCH)
+    // ESCAPE HATCH
     // ============================================================
 
     /**
-     * @dev Registers a time-delayed allowance for `safeTxHash`. Must be called by the Safe
-     *      itself via `execTransaction`, so the full owner-signature threshold is required.
-     *      After `_ALLOW_TX_DELAY` seconds the cosigner approves the hash via the escape-hatch
-     *      path in `isValidSignature` (pass empty bytes as the dynamic contract signature data).
+     * @dev Registers a time-delayed `removeOwner` call that removes this cosigner from `request.safe`.
+     *      Any single Safe owner may call this directly — no Safenet attestation is required,
+     *      making the escape hatch available even when Safenet is unavailable.
+     *      `request.threshold` must equal the Safe's current threshold or current threshold minus one.
+     *      The registered hash is nonce-bound to the Safe's current nonce at registration time;
+     *      if other transactions advance the nonce before execution, re-registration is required.
+     *      To invalidate a pending registration, advance the Safe nonce with a dummy transaction.
      */
-    function allowTransaction(bytes32 safeTxHash) external {
-        require($allowedTransactions[msg.sender][safeTxHash] == 0, TransactionAlreadyAllowed());
-        uint256 executableAt = block.timestamp + _ALLOW_TX_DELAY;
-        $allowedTransactions[msg.sender][safeTxHash] = executableAt;
-        emit TransactionAllowed(msg.sender, safeTxHash, executableAt);
+    function allowEscapeHatch(EscapeHatchRequest calldata request) external {
+        require(ISafe(payable(request.safe)).isOwner(msg.sender), NotSafeOwner());
+        _registerEscapeHatch(request);
     }
 
     /**
-     * @dev Cancels a pending allowance. Must be called by the Safe itself via `execTransaction`.
-     *      Cancellation requires the Safe's owner-signature threshold — if the remaining human
-     *      owners can reach that threshold without the cosigner, cancellation remains possible
-     *      even when Safenet is unavailable.
+     * @dev Relay-compatible variant of `allowEscapeHatch`. Accepts an EIP-712 signature from
+     *      `signer` over `EscapeHatchRequest(address safe,address prevOwner,uint256 threshold,
+     *      uint256 safeTxGas,uint256 baseGas,uint256 gasPrice,address gasToken,address refundReceiver)`,
+     *      allowing submission via a relay service where `msg.sender` is not the Safe owner.
+     *      Supports both ECDSA (EOA) and EIP-1271 (contract) owners. The signature must be
+     *      produced with `eth_signTypedData` over this contract's EIP-712 domain.
      */
-    function cancelAllowTransaction(bytes32 safeTxHash) external {
-        require($allowedTransactions[msg.sender][safeTxHash] != 0, AllowanceNotFound());
-        delete $allowedTransactions[msg.sender][safeTxHash];
-        emit AllowanceCancelled(msg.sender, safeTxHash);
+    function allowEscapeHatchWithSig(EscapeHatchRequest calldata request, address signer, bytes calldata signature)
+        external
+    {
+        require(ISafe(payable(request.safe)).isOwner(signer), NotSafeOwner());
+        // forge-lint: disable-next-item(asm-keccak256)
+        bytes32 structHash = keccak256(
+            abi.encode(
+                _ESCAPE_HATCH_TYPEHASH,
+                request.safe,
+                request.prevOwner,
+                request.threshold,
+                request.safeTxGas,
+                request.baseGas,
+                request.gasPrice,
+                request.gasToken,
+                request.refundReceiver
+            )
+        );
+        // forge-lint: disable-next-item(asm-keccak256)
+        bytes32 messageHash = keccak256(abi.encodePacked("\x19\x01", _DOMAIN_SEPARATOR, structHash));
+        _verifySignature(signer, messageHash, signature);
+        _registerEscapeHatch(request);
     }
 
     // ============================================================
@@ -203,7 +280,7 @@ contract SafenetCosigner is ISignatureValidator {
     }
 
     function previousEpoch() external view returns (uint64) {
-        if ($previousEpoch.groupKey.x | $previousEpoch.groupKey.y == 0) revert InvalidEpoch();
+        Secp256k1.requireNonZero($previousEpoch.groupKey);
         return $previousEpoch.epoch;
     }
 
@@ -222,6 +299,60 @@ contract SafenetCosigner is ISignatureValidator {
     // ============================================================
     // PRIVATE HELPERS
     // ============================================================
+
+    function _registerEscapeHatch(EscapeHatchRequest calldata request) private {
+        ISafe safeContract = ISafe(payable(request.safe));
+        uint256 currentThreshold = safeContract.getThreshold();
+        require(
+            request.threshold == currentThreshold || request.threshold == currentThreshold - 1, InvalidThreshold()
+        );
+        bytes32 safeTxHash = _escapeHatchTxHash(safeContract, request);
+        require($allowedTransactions[request.safe][safeTxHash] == 0, TransactionAlreadyAllowed());
+        uint256 executableAt = block.timestamp + _ALLOW_TX_DELAY;
+        $allowedTransactions[request.safe][safeTxHash] = executableAt;
+        emit TransactionAllowed(request.safe, safeTxHash, executableAt);
+    }
+
+    function _escapeHatchTxHash(ISafe safeContract, EscapeHatchRequest calldata request)
+        private
+        view
+        returns (bytes32)
+    {
+        return SafeTransaction.hash(
+            SafeTransaction.T({
+                chainId: block.chainid,
+                safe: request.safe,
+                to: request.safe,
+                value: 0,
+                data: abi.encodeCall(IOwnerManager.removeOwner, (request.prevOwner, address(this), request.threshold)),
+                operation: SafeTransaction.Operation.CALL,
+                safeTxGas: request.safeTxGas,
+                baseGas: request.baseGas,
+                gasPrice: request.gasPrice,
+                gasToken: request.gasToken,
+                refundReceiver: request.refundReceiver,
+                nonce: safeContract.nonce()
+            })
+        );
+    }
+
+    function _verifySignature(address signer, bytes32 hash, bytes calldata signature) private view {
+        if (signer.code.length > 0) {
+            require(IERC1271(signer).isValidSignature(hash, signature) == EIP1271_MAGIC_VALUE, InvalidSignature());
+        } else {
+            require(signature.length == 65, InvalidSignature());
+            bytes32 r;
+            bytes32 s;
+            uint8 v;
+            bytes memory sig = signature;
+            assembly ("memory-safe") {
+                r := mload(add(sig, 0x20))
+                s := mload(add(sig, 0x40))
+                v := byte(0, mload(add(sig, 0x60)))
+            }
+            require(ecrecover(hash, v, r, s) == signer, InvalidSignature());
+        }
+    }
 
     function _resolveGroupKey(uint64 epoch) private view returns (Secp256k1.Point memory) {
         if ($currentEpoch.epoch == epoch) return $currentEpoch.groupKey;

--- a/contracts/src/cosigner/SafenetCosigner.sol
+++ b/contracts/src/cosigner/SafenetCosigner.sol
@@ -95,7 +95,9 @@ contract SafenetCosigner is ISignatureValidator {
 
     uint256 private immutable _ALLOW_TX_DELAY;
 
-    bytes32 private immutable _DOMAIN_SEPARATOR;
+    bytes32 private immutable _CACHED_DOMAIN_SEPARATOR;
+
+    uint256 private immutable _CACHED_CHAIN_ID;
 
     // forge-lint: disable-next-line(mixed-case-variable)
     EpochState private $currentEpoch;
@@ -154,8 +156,9 @@ contract SafenetCosigner is ISignatureValidator {
         Secp256k1.requireNonZero(initialGroupKey);
         _CONSENSUS_DOMAIN_SEPARATOR = ConsensusMessages.domain(consensusChainId, consensusAddress);
         _ALLOW_TX_DELAY = allowTransactionDelay;
+        _CACHED_CHAIN_ID = block.chainid;
         // forge-lint: disable-next-item(asm-keccak256)
-        _DOMAIN_SEPARATOR = keccak256(
+        _CACHED_DOMAIN_SEPARATOR = keccak256(
             abi.encode(
                 keccak256("EIP712Domain(uint256 chainId,address verifyingContract)"), block.chainid, address(this)
             )
@@ -262,7 +265,7 @@ contract SafenetCosigner is ISignatureValidator {
             )
         );
         // forge-lint: disable-next-item(asm-keccak256)
-        bytes32 messageHash = keccak256(abi.encodePacked("\x19\x01", _DOMAIN_SEPARATOR, structHash));
+        bytes32 messageHash = keccak256(abi.encodePacked("\x19\x01", _domainSeparator(), structHash));
         ISafe(payable(request.safe)).checkNSignatures(address(0), messageHash, signature, 1);
         _registerEscapeHatch(request);
     }
@@ -324,6 +327,16 @@ contract SafenetCosigner is ISignatureValidator {
                 refundReceiver: request.refundReceiver,
                 nonce: request.nonce
             })
+        );
+    }
+
+    function _domainSeparator() private view returns (bytes32) {
+        if (block.chainid == _CACHED_CHAIN_ID) return _CACHED_DOMAIN_SEPARATOR;
+        // forge-lint: disable-next-item(asm-keccak256)
+        return keccak256(
+            abi.encode(
+                keccak256("EIP712Domain(uint256 chainId,address verifyingContract)"), block.chainid, address(this)
+            )
         );
     }
 

--- a/contracts/src/cosigner/SafenetCosigner.sol
+++ b/contracts/src/cosigner/SafenetCosigner.sol
@@ -160,18 +160,18 @@ contract SafenetCosigner is ISignatureValidator {
      *         because this function is `view` — replay is prevented by Safe's own nonce advancing
      *         after execution.
      */
-    function isValidSignature(bytes32 _hash, bytes memory _signature) external view override returns (bytes4) {
-        if (_signature.length > 0) {
-            if (_signature.length != 128) return bytes4(0);
-            (uint64 epoch, FROST.Signature memory sig) = abi.decode(_signature, (uint64, FROST.Signature));
-            bytes32 message = ConsensusMessages.transactionProposal(_CONSENSUS_DOMAIN_SEPARATOR, epoch, _hash);
+    function isValidSignature(bytes32 hash, bytes memory signature) external view override returns (bytes4) {
+        if (signature.length > 0) {
+            if (signature.length != 128) return bytes4(0);
+            (uint64 epoch, FROST.Signature memory sig) = abi.decode(signature, (uint64, FROST.Signature));
+            bytes32 message = ConsensusMessages.transactionProposal(_CONSENSUS_DOMAIN_SEPARATOR, epoch, hash);
             Secp256k1.Point memory groupKey = _resolveGroupKey(epoch);
             Secp256k1.requireNonZero(groupKey);
             FROST.verify(groupKey, sig, message);
             return EIP1271_MAGIC_VALUE;
         }
 
-        uint256 executableAt = $allowedTransactions[msg.sender][_hash];
+        uint256 executableAt = $allowedTransactions[msg.sender][hash];
         if (executableAt != 0 && block.timestamp >= executableAt) return EIP1271_MAGIC_VALUE;
 
         return bytes4(0);
@@ -194,7 +194,6 @@ contract SafenetCosigner is ISignatureValidator {
      *      To invalidate a pending registration, advance the Safe nonce with a dummy transaction.
      */
     function allowTransaction(SafeTransaction.T calldata safeTx, bytes calldata signature) external {
-        require(safeTx.chainId == block.chainid, InvalidParameter());
         ISafe safeContract = ISafe(payable(safeTx.safe));
         require(safeTx.nonce == safeContract.nonce(), InvalidNonce());
         uint256 currentThreshold = safeContract.getThreshold();

--- a/contracts/src/cosigner/SafenetCosigner.sol
+++ b/contracts/src/cosigner/SafenetCosigner.sol
@@ -154,9 +154,7 @@ contract SafenetCosigner is ISignatureValidator {
         // forge-lint: disable-next-item(asm-keccak256)
         _DOMAIN_SEPARATOR = keccak256(
             abi.encode(
-                keccak256("EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)"),
-                keccak256("SafenetCosigner"),
-                keccak256("1"),
+                keccak256("EIP712Domain(uint256 chainId,address verifyingContract)"),
                 block.chainid,
                 address(this)
             )

--- a/contracts/src/cosigner/SafenetCosigner.sol
+++ b/contracts/src/cosigner/SafenetCosigner.sol
@@ -5,7 +5,7 @@ import {ConsensusMessages} from "@/libraries/ConsensusMessages.sol";
 import {FROST} from "@/libraries/FROST.sol";
 import {SafeTransaction} from "@/libraries/SafeTransaction.sol";
 import {Secp256k1} from "@/libraries/Secp256k1.sol";
-import {ISafe, IOwnerManager} from "@safe/interfaces/ISafe.sol";
+import {ISafe} from "@safe/interfaces/ISafe.sol";
 import {ISignatureValidator} from "@safe/interfaces/ISignatureValidator.sol";
 
 /**
@@ -28,17 +28,19 @@ import {ISignatureValidator} from "@safe/interfaces/ISignatureValidator.sol";
  *        abi.encode(uint64, FROST.Signature) : epoch and FROST signature
  *
  *      Safe calls `isValidSignature(safeTxHash, abi.encode(epoch, sig))` on this contract.
- *      To use the escape hatch instead, set the dynamic data to an empty byte sequence
- *      (length = 0, no following bytes) and ensure a matured escape hatch registration exists.
+ *      To use the pre-approved transaction path instead, set the dynamic data to an empty byte
+ *      sequence (length = 0, no following bytes) and ensure a matured `allowTransaction`
+ *      registration exists.
  *
- *      **Escape hatch.**
- *      Safe owners can register a time-delayed `removeOwner` call targeting the cosigner
- *      itself by calling `allowEscapeHatch`. Registration requires signatures from
- *      `max(threshold - 1, 1)` Safe owners and does not require a Safenet attestation,
- *      making the escape hatch available even when Safenet is unavailable.
- *      After `_ALLOW_TX_DELAY` seconds, the Safe owners can execute the pre-registered
- *      `removeOwner` transaction by passing empty bytes as the cosigner's dynamic signature
- *      data; the cosigner approves it via the empty-signature path in `isValidSignature`.
+ *      **Pre-approved transactions.**
+ *      Safe owners can register any Safe transaction for time-delayed execution by calling
+ *      `allowTransaction`. Registration requires signatures from `max(threshold - 1, 1)` Safe
+ *      owners over `SafeTransaction.hash` — the same hash Safe owners sign for normal
+ *      `execTransaction` — and does not require a Safenet attestation, making it available even
+ *      when Safenet is unavailable.
+ *      After `_ALLOW_TX_DELAY` seconds, the Safe owners can execute the pre-registered transaction
+ *      by passing empty bytes as the cosigner's dynamic signature data; the cosigner approves it
+ *      via the empty-signature path in `isValidSignature`.
  *      The registered hash is nonce-bound: if other transactions advance the Safe nonce before
  *      execution, the registration becomes stale and must be repeated. To invalidate a pending
  *      registration, `threshold` owners can execute a dummy transaction to advance the Safe nonce.
@@ -53,44 +55,6 @@ contract SafenetCosigner is ISignatureValidator {
         Secp256k1.Point groupKey;
     }
 
-    /**
-     * @notice Parameters for an escape-hatch registration.
-     * @custom:param safe The Safe account from which this cosigner should be removed.
-     * @custom:param prevOwner Owner address preceding this cosigner in the Safe's owner linked list.
-     * @custom:param threshold Threshold to set after removal; must equal the Safe's current threshold
-     *              or current threshold minus one.
-     * @custom:param safeTxGas Gas forwarded to the Safe transaction's inner call.
-     * @custom:param baseGas Base gas cost charged to the Safe for the transaction.
-     * @custom:param gasPrice Gas price used for the refund calculation.
-     * @custom:param gasToken Token used for gas payment; `address(0)` for the native token.
-     * @custom:param refundReceiver Recipient of the gas refund; `address(0)` for `tx.origin`.
-     * @custom:param nonce The Safe's current nonce at registration time. Binds the registration to a
-     *              specific Safe nonce, preventing replay of a signed `EscapeHatchRequest` across
-     *              future nonce values.
-     */
-    struct EscapeHatchRequest {
-        address safe;
-        address prevOwner;
-        uint256 threshold;
-        uint256 safeTxGas;
-        uint256 baseGas;
-        uint256 gasPrice;
-        address gasToken;
-        address refundReceiver;
-        uint256 nonce;
-    }
-
-    // ============================================================
-    // CONSTANTS
-    // ============================================================
-
-    bytes32 private constant _ESCAPE_HATCH_TYPEHASH = keccak256(
-        "EscapeHatchRequest(address safe,address prevOwner,uint256 threshold,uint256 safeTxGas,uint256 baseGas,uint256 gasPrice,address gasToken,address refundReceiver,uint256 nonce)"
-    );
-
-    bytes32 private constant _EIP712_DOMAIN_TYPEHASH =
-        keccak256("EIP712Domain(uint256 chainId,address verifyingContract)");
-
     // ============================================================
     // STORAGE VARIABLES
     // ============================================================
@@ -98,10 +62,6 @@ contract SafenetCosigner is ISignatureValidator {
     bytes32 private immutable _CONSENSUS_DOMAIN_SEPARATOR;
 
     uint256 private immutable _ALLOW_TX_DELAY;
-
-    bytes32 private immutable _CACHED_DOMAIN_SEPARATOR;
-
-    uint256 private immutable _CACHED_CHAIN_ID;
 
     // forge-lint: disable-next-line(mixed-case-variable)
     EpochState private $currentEpoch;
@@ -138,8 +98,6 @@ contract SafenetCosigner is ISignatureValidator {
 
     error InvalidParameter();
 
-    error InvalidThreshold();
-
     error InvalidNonce();
 
     // ============================================================
@@ -158,9 +116,6 @@ contract SafenetCosigner is ISignatureValidator {
         Secp256k1.requireNonZero(initialGroupKey);
         _CONSENSUS_DOMAIN_SEPARATOR = ConsensusMessages.domain(consensusChainId, consensusAddress);
         _ALLOW_TX_DELAY = allowTransactionDelay;
-        _CACHED_CHAIN_ID = block.chainid;
-        // forge-lint: disable-next-item(asm-keccak256)
-        _CACHED_DOMAIN_SEPARATOR = keccak256(abi.encode(_EIP712_DOMAIN_TYPEHASH, block.chainid, address(this)));
         $currentEpoch = EpochState({epoch: initialEpoch, groupKey: initialGroupKey});
         emit EpochUpdated(0, initialEpoch, initialGroupKey);
     }
@@ -200,9 +155,10 @@ contract SafenetCosigner is ISignatureValidator {
      *      Two execution paths:
      *      1. FROST attestation: `_signature` = `abi.encode(uint64 epoch, FROST.Signature sig)`.
      *         Verifies the FROST sig against `_hash` under the resolved group key.
-     *      2. Escape hatch: `_signature` is empty. Approves if a matured escape hatch registration
-     *         exists for `(msg.sender, _hash)`. Registrations are not deleted on use because this
-     *         function is `view` — replay is prevented by Safe's own nonce advancing after execution.
+     *      2. Pre-approved transaction: `_signature` is empty. Approves if a matured `allowTransaction`
+     *         registration exists for `(msg.sender, _hash)`. Registrations are not deleted on use
+     *         because this function is `view` — replay is prevented by Safe's own nonce advancing
+     *         after execution.
      */
     function isValidSignature(bytes32 _hash, bytes memory _signature) external view override returns (bytes4) {
         if (_signature.length > 0) {
@@ -222,50 +178,33 @@ contract SafenetCosigner is ISignatureValidator {
     }
 
     // ============================================================
-    // ESCAPE HATCH
+    // TRANSACTION ALLOWLIST
     // ============================================================
 
     /**
-     * @dev Registers a time-delayed `removeOwner` call that removes this cosigner from `request.safe`.
-     *      Requires signatures from `max(threshold - 1, 1)` Safe owners over the EIP-712 hash of
-     *      the `EscapeHatchRequest`. Accepts any Safe-compatible signature format (packed ECDSA,
+     * @dev Registers any Safe transaction for time-delayed execution without Safenet attestation.
+     *      Requires signatures from `max(threshold - 1, 1)` Safe owners over
+     *      `SafeTransaction.hash(safeTx)` — the same hash Safe owners sign for normal
+     *      `execTransaction`. Accepts any Safe-compatible signature format (packed ECDSA,
      *      EIP-1271 contract signature, or pre-approved hash); verification is delegated to
-     *      `ISafe.checkNSignatures`. No Safenet attestation is required, making the escape hatch
-     *      available even when Safenet is unavailable.
-     *      `request.threshold` must equal the Safe's current threshold or current threshold minus one.
-     *      The registered hash is nonce-bound to the Safe's current nonce at registration time;
-     *      if other transactions advance the nonce before execution, re-registration is required.
+     *      `ISafe.checkNSignatures`. No Safenet attestation is required, making this available
+     *      even when Safenet is unavailable.
+     *      `safeTx.nonce` must equal the Safe's current nonce at registration time; if other
+     *      transactions advance the nonce before execution, re-registration is required.
      *      To invalidate a pending registration, advance the Safe nonce with a dummy transaction.
      */
-    function allowEscapeHatch(EscapeHatchRequest calldata request, bytes calldata signature) external {
-        ISafe safeContract = ISafe(payable(request.safe));
-        require(request.nonce == safeContract.nonce(), InvalidNonce());
+    function allowTransaction(SafeTransaction.T calldata safeTx, bytes calldata signature) external {
+        require(safeTx.chainId == block.chainid, InvalidParameter());
+        ISafe safeContract = ISafe(payable(safeTx.safe));
+        require(safeTx.nonce == safeContract.nonce(), InvalidNonce());
         uint256 currentThreshold = safeContract.getThreshold();
-        require(request.threshold == currentThreshold || request.threshold == currentThreshold - 1, InvalidThreshold());
         uint256 requiredSignatures = currentThreshold > 1 ? currentThreshold - 1 : 1;
-        // forge-lint: disable-next-item(asm-keccak256)
-        bytes32 structHash = keccak256(
-            abi.encode(
-                _ESCAPE_HATCH_TYPEHASH,
-                request.safe,
-                request.prevOwner,
-                request.threshold,
-                request.safeTxGas,
-                request.baseGas,
-                request.gasPrice,
-                request.gasToken,
-                request.refundReceiver,
-                request.nonce
-            )
-        );
-        // forge-lint: disable-next-item(asm-keccak256)
-        bytes32 messageHash = keccak256(abi.encodePacked("\x19\x01", _domainSeparator(), structHash));
-        safeContract.checkNSignatures(address(0), messageHash, signature, requiredSignatures);
-        bytes32 safeTxHash = _escapeHatchTxHash(request);
-        require($allowedTransactions[request.safe][safeTxHash] == 0, TransactionAlreadyAllowed());
+        bytes32 safeTxHash = SafeTransaction.hash(safeTx);
+        safeContract.checkNSignatures(address(0), safeTxHash, signature, requiredSignatures);
+        require($allowedTransactions[safeTx.safe][safeTxHash] == 0, TransactionAlreadyAllowed());
         uint256 executableAt = block.timestamp + _ALLOW_TX_DELAY;
-        $allowedTransactions[request.safe][safeTxHash] = executableAt;
-        emit TransactionAllowed(request.safe, safeTxHash, executableAt);
+        $allowedTransactions[safeTx.safe][safeTxHash] = executableAt;
+        emit TransactionAllowed(safeTx.safe, safeTxHash, executableAt);
     }
 
     // ============================================================
@@ -296,31 +235,6 @@ contract SafenetCosigner is ISignatureValidator {
     // ============================================================
     // PRIVATE HELPERS
     // ============================================================
-
-    function _escapeHatchTxHash(EscapeHatchRequest calldata request) private view returns (bytes32) {
-        return SafeTransaction.hash(
-            SafeTransaction.T({
-                chainId: block.chainid,
-                safe: request.safe,
-                to: request.safe,
-                value: 0,
-                data: abi.encodeCall(IOwnerManager.removeOwner, (request.prevOwner, address(this), request.threshold)),
-                operation: SafeTransaction.Operation.CALL,
-                safeTxGas: request.safeTxGas,
-                baseGas: request.baseGas,
-                gasPrice: request.gasPrice,
-                gasToken: request.gasToken,
-                refundReceiver: request.refundReceiver,
-                nonce: request.nonce
-            })
-        );
-    }
-
-    function _domainSeparator() private view returns (bytes32) {
-        if (block.chainid == _CACHED_CHAIN_ID) return _CACHED_DOMAIN_SEPARATOR;
-        // forge-lint: disable-next-item(asm-keccak256)
-        return keccak256(abi.encode(_EIP712_DOMAIN_TYPEHASH, block.chainid, address(this)));
-    }
 
     function _resolveGroupKey(uint64 epoch) private view returns (Secp256k1.Point memory) {
         if ($currentEpoch.epoch == epoch) return $currentEpoch.groupKey;

--- a/contracts/src/cosigner/SafenetCosigner.sol
+++ b/contracts/src/cosigner/SafenetCosigner.sol
@@ -7,7 +7,6 @@ import {SafeTransaction} from "@/libraries/SafeTransaction.sol";
 import {Secp256k1} from "@/libraries/Secp256k1.sol";
 import {ISafe, IOwnerManager} from "@safe/interfaces/ISafe.sol";
 import {ISignatureValidator} from "@safe/interfaces/ISignatureValidator.sol";
-import {IERC1271} from "@oz/interfaces/IERC1271.sol";
 
 /**
  * @title SafenetCosigner
@@ -139,8 +138,6 @@ contract SafenetCosigner is ISignatureValidator {
 
     error InvalidNonce();
 
-    error InvalidSignature();
-
     // ============================================================
     // CONSTRUCTOR
     // ============================================================
@@ -242,17 +239,13 @@ contract SafenetCosigner is ISignatureValidator {
     }
 
     /**
-     * @dev Relay-compatible variant of `allowEscapeHatch`. Accepts an EIP-712 signature from
-     *      `signer` over `EscapeHatchRequest(address safe,address prevOwner,uint256 threshold,
-     *      uint256 safeTxGas,uint256 baseGas,uint256 gasPrice,address gasToken,address refundReceiver)`,
-     *      allowing submission via a relay service where `msg.sender` is not the Safe owner.
-     *      Supports both ECDSA (EOA) and EIP-1271 (contract) owners. The signature must be
-     *      produced with `eth_signTypedData` over this contract's EIP-712 domain.
+     * @dev Relay-compatible variant of `allowEscapeHatch`. Accepts a Safe-compatible signature
+     *      (packed ECDSA, EIP-1271 contract signature, or pre-approved hash) from a Safe owner
+     *      over the EIP-712 hash of the `EscapeHatchRequest`, allowing submission via a relay
+     *      service where `msg.sender` is not the Safe owner. Signature verification and owner
+     *      membership check are both delegated to `ISafe.checkNSignatures`.
      */
-    function allowEscapeHatchWithSig(EscapeHatchRequest calldata request, address signer, bytes calldata signature)
-        external
-    {
-        require(ISafe(payable(request.safe)).isOwner(signer), NotSafeOwner());
+    function allowEscapeHatchWithSig(EscapeHatchRequest calldata request, bytes calldata signature) external {
         // forge-lint: disable-next-item(asm-keccak256)
         bytes32 structHash = keccak256(
             abi.encode(
@@ -270,7 +263,7 @@ contract SafenetCosigner is ISignatureValidator {
         );
         // forge-lint: disable-next-item(asm-keccak256)
         bytes32 messageHash = keccak256(abi.encodePacked("\x19\x01", _DOMAIN_SEPARATOR, structHash));
-        _verifySignature(signer, messageHash, signature);
+        ISafe(payable(request.safe)).checkNSignatures(address(0), messageHash, signature, 1);
         _registerEscapeHatch(request);
     }
 
@@ -334,24 +327,6 @@ contract SafenetCosigner is ISignatureValidator {
                 nonce: request.nonce
             })
         );
-    }
-
-    function _verifySignature(address signer, bytes32 hash, bytes calldata signature) private view {
-        if (signer.code.length > 0) {
-            require(IERC1271(signer).isValidSignature(hash, signature) == EIP1271_MAGIC_VALUE, InvalidSignature());
-        } else {
-            require(signature.length == 65, InvalidSignature());
-            bytes32 r;
-            bytes32 s;
-            uint8 v;
-            bytes memory sig = signature;
-            assembly ("memory-safe") {
-                r := mload(add(sig, 0x20))
-                s := mload(add(sig, 0x40))
-                v := byte(0, mload(add(sig, 0x60)))
-            }
-            require(ecrecover(hash, v, r, s) == signer, InvalidSignature());
-        }
     }
 
     function _resolveGroupKey(uint64 epoch) private view returns (Secp256k1.Point memory) {

--- a/contracts/src/cosigner/SafenetCosigner.sol
+++ b/contracts/src/cosigner/SafenetCosigner.sol
@@ -154,9 +154,7 @@ contract SafenetCosigner is ISignatureValidator {
         // forge-lint: disable-next-item(asm-keccak256)
         _DOMAIN_SEPARATOR = keccak256(
             abi.encode(
-                keccak256("EIP712Domain(uint256 chainId,address verifyingContract)"),
-                block.chainid,
-                address(this)
+                keccak256("EIP712Domain(uint256 chainId,address verifyingContract)"), block.chainid, address(this)
             )
         );
         $currentEpoch = EpochState({epoch: initialEpoch, groupKey: initialGroupKey});

--- a/contracts/src/cosigner/SafenetCosigner.sol
+++ b/contracts/src/cosigner/SafenetCosigner.sol
@@ -205,6 +205,11 @@ contract SafenetCosigner is ISignatureValidator {
      *      `safeTxHash` must embed the Safe's current nonce; if other transactions advance the
      *      nonce before execution, re-registration is required.
      *      To invalidate a pending registration, advance the Safe nonce with a dummy transaction.
+     *      The `max(threshold - 1, 1)` requirement rests on the assumption that Safenet will never
+     *      sign a `TransactionProposal` for a `safeTxHash` that has an `AllowTransaction` preimage.
+     *      Such a signature could satisfy the cosigner's own EIP-1271 check within `checkNSignatures`,
+     *      reducing the effective human-owner signature requirement from `threshold - 1` to
+     *      `threshold - 2`.
      */
     function allowTransaction(address safe, bytes32 safeTxHash, bytes calldata signature) external {
         ISafe safeContract = ISafe(payable(safe));

--- a/contracts/src/cosigner/SafenetCosigner.sol
+++ b/contracts/src/cosigner/SafenetCosigner.sol
@@ -213,7 +213,7 @@ contract SafenetCosigner is ISignatureValidator {
      *      Currently, this is not directly supported by the Safe Transaction Service for the owners,
      *      but currently it is acceptable under the assumption that Safenet allows to disable Safenet
      *      (so the escape hatch is really only required if Safenet is down).
-     * 
+     *
      */
     function allowTransaction(address safe, bytes32 safeTxHash, bytes calldata signature) external {
         ISafe safeContract = ISafe(payable(safe));

--- a/contracts/src/cosigner/SafenetCosigner.sol
+++ b/contracts/src/cosigner/SafenetCosigner.sol
@@ -303,9 +303,7 @@ contract SafenetCosigner is ISignatureValidator {
     function _registerEscapeHatch(EscapeHatchRequest calldata request) private {
         ISafe safeContract = ISafe(payable(request.safe));
         uint256 currentThreshold = safeContract.getThreshold();
-        require(
-            request.threshold == currentThreshold || request.threshold == currentThreshold - 1, InvalidThreshold()
-        );
+        require(request.threshold == currentThreshold || request.threshold == currentThreshold - 1, InvalidThreshold());
         bytes32 safeTxHash = _escapeHatchTxHash(safeContract, request);
         require($allowedTransactions[request.safe][safeTxHash] == 0, TransactionAlreadyAllowed());
         uint256 executableAt = block.timestamp + _ALLOW_TX_DELAY;

--- a/contracts/src/cosigner/SafenetCosigner.sol
+++ b/contracts/src/cosigner/SafenetCosigner.sol
@@ -3,7 +3,6 @@ pragma solidity ^0.8.30;
 
 import {ConsensusMessages} from "@/libraries/ConsensusMessages.sol";
 import {FROST} from "@/libraries/FROST.sol";
-import {SafeTransaction} from "@/libraries/SafeTransaction.sol";
 import {Secp256k1} from "@/libraries/Secp256k1.sol";
 import {ISafe} from "@safe/interfaces/ISafe.sol";
 import {ISignatureValidator} from "@safe/interfaces/ISignatureValidator.sol";
@@ -34,16 +33,16 @@ import {ISignatureValidator} from "@safe/interfaces/ISignatureValidator.sol";
  *
  *      **Pre-approved transactions.**
  *      Safe owners can register any Safe transaction for time-delayed execution by calling
- *      `allowTransaction`. Registration requires signatures from `max(threshold - 1, 1)` Safe
- *      owners over `SafeTransaction.hash` — the same hash Safe owners sign for normal
- *      `execTransaction` — and does not require a Safenet attestation, making it available even
- *      when Safenet is unavailable.
+ *      `allowTransaction(safe, safeTxHash, signatures)`. Registration requires signatures from
+ *      `max(threshold - 1, 1)` Safe owners over the EIP-712 typed message
+ *      `AllowTransaction(bytes32 safeTxHash)` under this contract's domain, and does not require
+ *      a Safenet attestation, making it available even when Safenet is unavailable.
  *      After `_ALLOW_TX_DELAY` seconds, the Safe owners can execute the pre-registered transaction
  *      by passing empty bytes as the cosigner's dynamic signature data; the cosigner approves it
  *      via the empty-signature path in `isValidSignature`.
- *      The registered hash is nonce-bound: if other transactions advance the Safe nonce before
- *      execution, the registration becomes stale and must be repeated. To invalidate a pending
- *      registration, `threshold` owners can execute a dummy transaction to advance the Safe nonce.
+ *      The `safeTxHash` is nonce-bound: if other transactions advance the Safe nonce before
+ *      execution, the registration becomes stale. To invalidate a pending registration,
+ *      `threshold` owners can execute a dummy transaction to advance the Safe nonce.
  */
 contract SafenetCosigner is ISignatureValidator {
     // ============================================================
@@ -56,12 +55,27 @@ contract SafenetCosigner is ISignatureValidator {
     }
 
     // ============================================================
+    // CONSTANTS
+    // ============================================================
+
+    // forge-lint: disable-next-item(asm-keccak256)
+    bytes32 private constant _EIP712_DOMAIN_TYPEHASH =
+        keccak256("EIP712Domain(uint256 chainId,address verifyingContract)");
+
+    // forge-lint: disable-next-item(asm-keccak256)
+    bytes32 private constant _ALLOW_TRANSACTION_TYPEHASH = keccak256("AllowTransaction(bytes32 safeTxHash)");
+
+    // ============================================================
     // STORAGE VARIABLES
     // ============================================================
 
     bytes32 private immutable _CONSENSUS_DOMAIN_SEPARATOR;
 
     uint256 private immutable _ALLOW_TX_DELAY;
+
+    uint256 private immutable _CACHED_CHAIN_ID;
+
+    bytes32 private immutable _CACHED_DOMAIN_SEPARATOR;
 
     // forge-lint: disable-next-line(mixed-case-variable)
     EpochState private $currentEpoch;
@@ -98,8 +112,6 @@ contract SafenetCosigner is ISignatureValidator {
 
     error InvalidParameter();
 
-    error InvalidNonce();
-
     // ============================================================
     // CONSTRUCTOR
     // ============================================================
@@ -116,6 +128,8 @@ contract SafenetCosigner is ISignatureValidator {
         Secp256k1.requireNonZero(initialGroupKey);
         _CONSENSUS_DOMAIN_SEPARATOR = ConsensusMessages.domain(consensusChainId, consensusAddress);
         _ALLOW_TX_DELAY = allowTransactionDelay;
+        _CACHED_CHAIN_ID = block.chainid;
+        _CACHED_DOMAIN_SEPARATOR = keccak256(abi.encode(_EIP712_DOMAIN_TYPEHASH, block.chainid, address(this)));
         $currentEpoch = EpochState({epoch: initialEpoch, groupKey: initialGroupKey});
         emit EpochUpdated(0, initialEpoch, initialGroupKey);
     }
@@ -153,10 +167,10 @@ contract SafenetCosigner is ISignatureValidator {
     /**
      * @dev Called by Safe during `execTransaction`. `msg.sender` is the Safe.
      *      Two execution paths:
-     *      1. FROST attestation: `_signature` = `abi.encode(uint64 epoch, FROST.Signature sig)`.
-     *         Verifies the FROST sig against `_hash` under the resolved group key.
-     *      2. Pre-approved transaction: `_signature` is empty. Approves if a matured `allowTransaction`
-     *         registration exists for `(msg.sender, _hash)`. Registrations are not deleted on use
+     *      1. FROST attestation: `signature` = `abi.encode(uint64 epoch, FROST.Signature sig)`.
+     *         Verifies the FROST sig against `hash` under the resolved group key.
+     *      2. Pre-approved transaction: `signature` is empty. Approves if a matured `allowTransaction`
+     *         registration exists for `(msg.sender, hash)`. Registrations are not deleted on use
      *         because this function is `view` — replay is prevented by Safe's own nonce advancing
      *         after execution.
      */
@@ -183,27 +197,28 @@ contract SafenetCosigner is ISignatureValidator {
 
     /**
      * @dev Registers any Safe transaction for time-delayed execution without Safenet attestation.
-     *      Requires signatures from `max(threshold - 1, 1)` Safe owners over
-     *      `SafeTransaction.hash(safeTx)` — the same hash Safe owners sign for normal
-     *      `execTransaction`. Accepts any Safe-compatible signature format (packed ECDSA,
-     *      EIP-1271 contract signature, or pre-approved hash); verification is delegated to
-     *      `ISafe.checkNSignatures`. No Safenet attestation is required, making this available
-     *      even when Safenet is unavailable.
-     *      `safeTx.nonce` must equal the Safe's current nonce at registration time; if other
-     *      transactions advance the nonce before execution, re-registration is required.
+     *      Requires signatures from `max(threshold - 1, 1)` Safe owners over the EIP-712 typed
+     *      message `AllowTransaction(bytes32 safeTxHash)` under this contract's domain. Accepts
+     *      any Safe-compatible signature format (packed ECDSA, EIP-1271 contract signature, or
+     *      pre-approved hash); verification is delegated to `ISafe.checkNSignatures`. No Safenet
+     *      attestation is required, making this available even when Safenet is unavailable.
+     *      `safeTxHash` must embed the Safe's current nonce; if other transactions advance the
+     *      nonce before execution, re-registration is required.
      *      To invalidate a pending registration, advance the Safe nonce with a dummy transaction.
      */
-    function allowTransaction(SafeTransaction.T calldata safeTx, bytes calldata signature) external {
-        ISafe safeContract = ISafe(payable(safeTx.safe));
-        require(safeTx.nonce == safeContract.nonce(), InvalidNonce());
+    function allowTransaction(address safe, bytes32 safeTxHash, bytes calldata signature) external {
+        ISafe safeContract = ISafe(payable(safe));
         uint256 currentThreshold = safeContract.getThreshold();
         uint256 requiredSignatures = currentThreshold > 1 ? currentThreshold - 1 : 1;
-        bytes32 safeTxHash = SafeTransaction.hash(safeTx);
-        safeContract.checkNSignatures(address(0), safeTxHash, signature, requiredSignatures);
-        require($allowedTransactions[safeTx.safe][safeTxHash] == 0, TransactionAlreadyAllowed());
+        // forge-lint: disable-next-line(asm-keccak256)
+        bytes32 structHash = keccak256(abi.encode(_ALLOW_TRANSACTION_TYPEHASH, safeTxHash));
+        // forge-lint: disable-next-line(asm-keccak256)
+        bytes32 messageHash = keccak256(abi.encodePacked("\x19\x01", _domainSeparator(), structHash));
+        safeContract.checkNSignatures(address(0), messageHash, signature, requiredSignatures);
+        require($allowedTransactions[safe][safeTxHash] == 0, TransactionAlreadyAllowed());
         uint256 executableAt = block.timestamp + _ALLOW_TX_DELAY;
-        $allowedTransactions[safeTx.safe][safeTxHash] = executableAt;
-        emit TransactionAllowed(safeTx.safe, safeTxHash, executableAt);
+        $allowedTransactions[safe][safeTxHash] = executableAt;
+        emit TransactionAllowed(safe, safeTxHash, executableAt);
     }
 
     // ============================================================
@@ -227,6 +242,10 @@ contract SafenetCosigner is ISignatureValidator {
         return _CONSENSUS_DOMAIN_SEPARATOR;
     }
 
+    function allowTransactionDomainSeparator() external view returns (bytes32) {
+        return _domainSeparator();
+    }
+
     function getAllowedTxTimestamp(address safe, bytes32 safeTxHash) external view returns (uint256 executableAt) {
         return $allowedTransactions[safe][safeTxHash];
     }
@@ -239,5 +258,11 @@ contract SafenetCosigner is ISignatureValidator {
         if ($currentEpoch.epoch == epoch) return $currentEpoch.groupKey;
         if ($previousEpoch.epoch == epoch) return $previousEpoch.groupKey;
         revert InvalidEpoch();
+    }
+
+    function _domainSeparator() private view returns (bytes32) {
+        if (block.chainid == _CACHED_CHAIN_ID) return _CACHED_DOMAIN_SEPARATOR;
+        // forge-lint: disable-next-line(asm-keccak256)
+        return keccak256(abi.encode(_EIP712_DOMAIN_TYPEHASH, block.chainid, address(this)));
     }
 }

--- a/contracts/src/cosigner/SafenetCosigner.sol
+++ b/contracts/src/cosigner/SafenetCosigner.sol
@@ -300,9 +300,7 @@ contract SafenetCosigner is ISignatureValidator {
         ISafe safeContract = ISafe(payable(request.safe));
         require(request.nonce == safeContract.nonce(), InvalidNonce());
         uint256 currentThreshold = safeContract.getThreshold();
-        require(
-            request.threshold == currentThreshold || request.threshold == currentThreshold - 1, InvalidThreshold()
-        );
+        require(request.threshold == currentThreshold || request.threshold == currentThreshold - 1, InvalidThreshold());
         bytes32 safeTxHash = _escapeHatchTxHash(request);
         require($allowedTransactions[request.safe][safeTxHash] == 0, TransactionAlreadyAllowed());
         uint256 executableAt = block.timestamp + _ALLOW_TX_DELAY;

--- a/contracts/src/cosigner/SafenetCosigner.sol
+++ b/contracts/src/cosigner/SafenetCosigner.sol
@@ -88,6 +88,9 @@ contract SafenetCosigner is ISignatureValidator {
         "EscapeHatchRequest(address safe,address prevOwner,uint256 threshold,uint256 safeTxGas,uint256 baseGas,uint256 gasPrice,address gasToken,address refundReceiver,uint256 nonce)"
     );
 
+    bytes32 private constant _EIP712_DOMAIN_TYPEHASH =
+        keccak256("EIP712Domain(uint256 chainId,address verifyingContract)");
+
     // ============================================================
     // STORAGE VARIABLES
     // ============================================================
@@ -157,11 +160,7 @@ contract SafenetCosigner is ISignatureValidator {
         _ALLOW_TX_DELAY = allowTransactionDelay;
         _CACHED_CHAIN_ID = block.chainid;
         // forge-lint: disable-next-item(asm-keccak256)
-        _CACHED_DOMAIN_SEPARATOR = keccak256(
-            abi.encode(
-                keccak256("EIP712Domain(uint256 chainId,address verifyingContract)"), block.chainid, address(this)
-            )
-        );
+        _CACHED_DOMAIN_SEPARATOR = keccak256(abi.encode(_EIP712_DOMAIN_TYPEHASH, block.chainid, address(this)));
         $currentEpoch = EpochState({epoch: initialEpoch, groupKey: initialGroupKey});
         emit EpochUpdated(0, initialEpoch, initialGroupKey);
     }
@@ -320,11 +319,7 @@ contract SafenetCosigner is ISignatureValidator {
     function _domainSeparator() private view returns (bytes32) {
         if (block.chainid == _CACHED_CHAIN_ID) return _CACHED_DOMAIN_SEPARATOR;
         // forge-lint: disable-next-item(asm-keccak256)
-        return keccak256(
-            abi.encode(
-                keccak256("EIP712Domain(uint256 chainId,address verifyingContract)"), block.chainid, address(this)
-            )
-        );
+        return keccak256(abi.encode(_EIP712_DOMAIN_TYPEHASH, block.chainid, address(this)));
     }
 
     function _resolveGroupKey(uint64 epoch) private view returns (Secp256k1.Point memory) {

--- a/contracts/src/cosigner/SafenetCosigner.sol
+++ b/contracts/src/cosigner/SafenetCosigner.sol
@@ -210,6 +210,10 @@ contract SafenetCosigner is ISignatureValidator {
      *      Such a signature could satisfy the cosigner's own EIP-1271 check within `checkNSignatures`,
      *      reducing the effective human-owner signature requirement from `threshold - 1` to
      *      `threshold - 2`.
+     *      Currently, this is not directly supported by the Safe Transaction Service for the owners,
+     *      but currently it is acceptable under the assumption that Safenet allows to disable Safenet
+     *      (so the escape hatch is really only required if Safenet is down).
+     * 
      */
     function allowTransaction(address safe, bytes32 safeTxHash, bytes calldata signature) external {
         ISafe safeContract = ISafe(payable(safe));


### PR DESCRIPTION
This is a different approach to Safenet Guard. Technically, it's not a guard, but a cosigner.

This also shares some features of the guard, like:
- Only 2 epochs stored
- Verification of the hash based on the FROST signature

Here, the escape hatch must be created differently from the other two guards, since the transaction must go through `execTransaction(...)`. The escape hatch is developed, where any Arbitrary transaction can be executed with `max(threshold - 1, 1)` owner signatures. The threshold count is set this way for safety, where the setup is 1 of n (which ideally should not be configured that way with Safenet Cosigner). In this way, the threshold owner schedules the removal of `SafenetCosigner` (similar to how the Guard removal is scheduled using `allowTransaction`) and then executes the removal once the timestamp passes. The first tx signs with the `safeTxHash`, and the second tx executes the tx that results in the `safeTxHash` that was allowed in the first. There is a time delay built in between these two transactions.

Initially, the approach was to allow any owner to call `removeOwner(...)` with hardcoded values to remove the owner (`address(this)`) and reduce the threshold count by 1, or leave it unchanged. The aim was to allow the removal of the `SafenetCosigner` from the owner list if Safenet is down. But based on our recent discussion, we understand that we should not grant any owner unilateral authority to initiate this process, even though it is only allowed for the removal of `SafenetCosigner`.

Later, it was updated so that the `threshold-1` owners can sign an arbitrary transaction once and wait for the timestamp to be reached before allowing it in `SafenetCosigner`. Once the timestamp has passed, the same signature used by the owners can be used for execution (since `SafenetCosigner.isValidSignature(...)` will now be allowed). With Guards, the threshold owners had to sign twice (once to queue the tx and once to execute it), but with Cosigner in the current design, the threshold owner only needs to sign once to remove Cosigner. As the intention is the same (to remove the Cosigner) and it is already approved by the threshold count of owners, the need for another threshold count of owners to sign for execution seems redundant. If the intention changes (i.e., decided not to remove the owner), the threshold count of owners could execute a dummy transaction anyway to increase the nonce, thereby invalidating the cosigner removal transaction. But the shortcomings were noted here: https://github.com/safe-research/safenet/pull/354#discussion_r3218757818

More details are added in the README.