### PR TITLE
Add Check for PR Markdown Comments

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,4 +1,4 @@
-name: PR
+name: pr
 
 on:
   pull_request:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,0 +1,31 @@
+name: PR
+
+on:
+  pull_request:
+    types:
+      - opened
+      - edited
+      - reopened
+      - synchronize
+      - ready_for_review
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  markdown:
+    name: markdown
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check PR markdown has no comments
+        run: |
+          body=$(jq -r '.pull_request.body // ""' "${{ github.event_path }}")
+
+          if [[ "$body" != *"<!--"* ]]; then
+            exit 0
+          fi
+
+          echo "PR markdown must not contain HTML comments. Remove template guidance before marking the PR ready for review." >&2
+          exit 1


### PR DESCRIPTION
Add check to ensure guidance comments from PR template are removed.

### Context and Motivation

I noticed when experimenting with PRs, that Markdown (i.e. HTML) comments that are included in PR descriptions are preserved in the Git commit message. Since we don't want the PR guidance comments included in the PR template to appear in our Git history, this PR adds a new CI workflow that ensures that the guidance comments are removed from the PR description.

### Decisions and Tradeoffs

For now, I only check for the "start comment tag". This is not perfect, but a good enough approximation. I also did not make this check mandatory in case the PR description deliberately includes a Markdown comment.

### Testing

I left a comment in this PR description to make sure it is caught and it worked. Removing the comment made the check pass:

<img width="1303" height="475" alt="image" src="https://github.com/user-attachments/assets/bfafb720-4470-4bed-9f11-13030786d25d" />

