### PR TITLE
Use Stricter Tool Versions

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+engine-strict = true

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,6 +42,8 @@ The steps for project setup are documented in the root [README.md](./README.md#p
 
 Always use `npm ci` instead of `npm install` / `npm i`. `npm ci` installs exactly what is in `package-lock.json` and never modifies it, keeping the lock file stable.
 
+Make sure you have the correct tool versions (NodeJS 24, NPM 11, Foundry 1.5.1). Use `npm run foundryup` to set up the correct Foundry version.
+
 ### Commands
 
 All commands are specified in the root [package.json](./package.json). Workspace specific commands can be found in the `package.json` of each corresponding workspace.

--- a/README.md
+++ b/README.md
@@ -10,6 +10,18 @@ This is a work-in-progress. Don't use it yet!
 
 ## Developing
 
+### Requirements
+
+Developing on the project requires a few tools:
+
+- NodeJS v24 (LTS)
+- NPM v11
+- Foundry v1.5.1
+
+### Foundry Setup
+
+Stable Foundry has a known [formatting bug](https://github.com/foundry-rs/foundry/issues/13362) that affects this repository. With `foundryup` installed, the correct Foundry version can be set up with `npm run foundryup`.
+
 ### Project Setup
 
 Clone the repository and all its submodules with:

--- a/contracts/package.json
+++ b/contracts/package.json
@@ -4,7 +4,7 @@
 	"scripts": {
 		"build": "forge build --force",
 		"check": "npm run check:foundry && forge fmt --check && forge lint --deny notes",
-		"check:foundry": "sh -c 'test \"$(forge --version | head -1)\" = \"forge Version: 1.5.1-v1.5.1\"'",
+		"check:foundry": "test \"$(forge --version | head -1)\" = \"forge Version: 1.5.1-v1.5.1\"",
 		"cmd:deploy": "forge script DeployScript",
 		"cmd:genesis": "forge script GenesisScript",
 		"cmd:propose": "forge script ProposeScript",

--- a/contracts/package.json
+++ b/contracts/package.json
@@ -3,7 +3,8 @@
 	"private": true,
 	"scripts": {
 		"build": "forge build --force",
-		"check": "forge fmt --check && forge lint --deny notes",
+		"check": "npm run check:foundry && forge fmt --check && forge lint --deny notes",
+		"check:foundry": "sh -c 'test \"$(forge --version | head -1)\" = \"forge Version: 1.5.1-v1.5.1\"'",
 		"cmd:deploy": "forge script DeployScript",
 		"cmd:genesis": "forge script GenesisScript",
 		"cmd:propose": "forge script ProposeScript",

--- a/package.json
+++ b/package.json
@@ -6,11 +6,16 @@
 		"explorer",
 		"validator"
 	],
+	"engines": {
+		"node": "24",
+		"npm": "11"
+	},
 	"scripts": {
 		"build": "npm run build --workspaces",
 		"check": "biome check && npm run check --workspaces",
 		"devnet": "./scripts/run_devnet.sh",
 		"fix": "biome check --write && npm run fix --workspaces",
+		"foundryup": "foundryup --install v1.5.1",
 		"test": "npm run test --workspaces",
 		"test:integration": "./scripts/run_integration_test.sh",
 		"coverage": "npm run coverage --workspaces"


### PR DESCRIPTION
This PR changes our monorepo to enforce stricter policies on tools.

### Context and Motivation

We had some confusion about which tool versions should be used. We changed our monorepo, so that we will get `npm` errors if using a different version of NodeJS and NPM. We also added some ad-hoc protection against using the incorrect Foundry version, and a custom script for installing the correct one.

### Decisions and Tradeoffs

The Foundry tool integration is very ad-hoc at the moment. This was done to avoid relying on additional third party tools. Additionally, the installation of the Foundry tool is not done as an `install` script - I don't think the security risk of running an installer that pulls a binary from the internet automatically with `npm ci` worth the inconvenience of manually running `npm run foundryup` periodically.

### Testing

```
$ node --version
v26.1.0
$ npm ci
npm error code EBADENGINE
npm error engine Unsupported engine
npm error engine Not compatible with your version of node/npm: undefined
npm error notsup Not compatible with your version of node/npm: undefined
npm error notsup Required: {"node":"24","npm":"11"}
npm error notsup Actual:   {"node":"v26.1.0","npm":"11.13.0"}
npm error A complete log of this run can be found in: /home/nlordell/.npm/_logs/2026-05-12T12_18_13_232Z-debug-0.log
```

```
$ forge --version
forge Version: 1.7.1
Commit SHA: 4072e48705af9d93e3c0f6e29e93b5e9a40caed8
Build Timestamp: 2026-05-08T07:50:55.527285345Z (1778226655)
Build Profile: dist
$ npm run -w contracts check

> check
> npm run check:foundry && forge fmt --check && forge lint --deny notes


> check:foundry
> sh -c 'test "$(forge --version | head -1)" = "forge Version: 1.5.1-v1.5.1"'

npm error Lifecycle script `check:foundry` failed with error:
npm error code 1
npm error path /workspace/safe-research/safenet/contracts
npm error workspace @safenet/contracts
npm error location /workspace/safe-research/safenet/contracts
npm error command failed
npm error command sh -c sh -c 'test "$(forge --version | head -1)" = "forge Version: 1.5.1-v1.5.1"'
npm error Lifecycle script `check` failed with error:
npm error code 1
npm error path /workspace/safe-research/safenet/contracts
npm error workspace @safenet/contracts
npm error location /workspace/safe-research/safenet/contracts
npm error command failed
npm error command sh -c npm run check:foundry && forge fmt --check && forge lint --deny notes
```
