### PR TITLE
Support Nodes With No Uncled Block Logs

### DIFF
--- a/validator/src/watcher/blocks.test.ts
+++ b/validator/src/watcher/blocks.test.ts
@@ -355,7 +355,7 @@ describe("BlockWatcher", () => {
 			expect(await blocks.next()).toEqual(newBlockUpdate({ number: 999n }));
 
 			// Revalidate block 999, as the block 1000 is still queued from startup.
-			mocks.getBlock.mockResolvedValueOnce(block({ number: 1000n, hash: keccak256(toHex("new999")) }));
+			mocks.getBlock.mockResolvedValueOnce(block({ number: 999n, hash: keccak256(toHex("new999")) }));
 			const uncle = await blocks.revalidateLastBlock();
 			expect(uncle).not.toBeNull();
 

--- a/validator/src/watcher/blocks.test.ts
+++ b/validator/src/watcher/blocks.test.ts
@@ -76,6 +76,7 @@ const setupNext = async (config: { latestBlock: bigint; startTime: number; maxRe
 	});
 
 	return {
+		blocks,
 		next() {
 			return blocks.next();
 		},
@@ -282,6 +283,83 @@ describe("BlockWatcher", () => {
 				newBlockUpdate({ number: 998n, hash: keccak256(toHex("reorg998")) }),
 				newBlockUpdate({ number: 999n, hash: keccak256(toHex("reorg999")) }),
 			]);
+		});
+	});
+
+	describe("revalidate", () => {
+		it("returns null when the block is still canonical", async () => {
+			const { blocks, mocks } = await setupNext({ latestBlock: 1000n, startTime: 2000100 });
+
+			mocks.getBlock.mockResolvedValueOnce(block({ number: 1000n }));
+
+			const uncle = await blocks.revalidateLastBlock();
+
+			expect(uncle).toBe(null);
+			expect(mocks.getBlock.mock.calls).toEqual([[{ blockNumber: 1000n }]]);
+		});
+
+		it("returns a uncle update when the block was reorged out", async () => {
+			const { blocks, next, mocks } = await setupNext({ latestBlock: 1000n, startTime: 2000100 });
+
+			// The RPC now reports a different hash at block 1000 — the block we tracked has
+			// been reorged out from under us.
+			mocks.getBlock.mockResolvedValueOnce(block({ number: 1000n, hash: keccak256(toHex("new1000")) }));
+
+			const uncle = await blocks.revalidateLastBlock();
+
+			expect(uncle).toEqual({
+				type: "watcher_update_uncle_block",
+				blockNumber: 1000n,
+				blockHash: numberToHex(1000n, { size: 32 }),
+			});
+			expect(mocks.getBlock.mock.calls).toEqual([[{ blockNumber: 1000n }]]);
+
+			// After the revalidation, the next `next()` call should return the same
+			// pending uncle block update. It does make additional queries.
+			mocks.getBlock.mockClear();
+			const update = await next();
+			expect(mocks.getBlock.mock.calls).toEqual([]);
+			expect(update).toEqual({ type: "watcher_update_uncle_block", blockNumber: 1000n });
+		});
+
+		it("returns true when the block is no longer available on the RPC", async () => {
+			const { blocks, mocks } = await setupNext({ latestBlock: 1000n, startTime: 2000100 });
+
+			mocks.getBlock.mockRejectedValueOnce(new BlockNotFoundError({ blockNumber: 1000n }));
+
+			const reorged = await blocks.revalidateLastBlock();
+
+			expect(reorged).not.toBeNull();
+		});
+
+		it("propagates non-`BlockNotFoundError` errors", async () => {
+			const { blocks, mocks } = await setupNext({ latestBlock: 1000n, startTime: 2000100 });
+
+			mocks.getBlock.mockRejectedValueOnce(new Error("rpc unavailable"));
+
+			await expect(blocks.revalidateLastBlock()).rejects.toThrow("rpc unavailable");
+		});
+
+		it("purges queued descendant updates when an older tracked block is reorged", async () => {
+			// Initialize with `maxReorgDepth: 3` and three tracked blocks (998..1000). Their
+			// `new_block` updates remain queued from initialization — we don't drain them so we
+			// can observe that `revalidate` removes the descendants of the reorged block.
+			const { create, mocks } = setupCreate({ lastIndexedBlock: null, maxReorgDepth: 3 });
+
+			mocks.getBlock.mockResolvedValueOnce(block({ number: 1000n }));
+			mocks.getBlock.mockResolvedValueOnce(block({ number: 998n }));
+			mocks.getBlock.mockResolvedValueOnce(block({ number: 999n }));
+
+			const blocks = await create();
+			expect(await blocks.next()).toEqual(newBlockUpdate({ number: 998n }));
+			expect(await blocks.next()).toEqual(newBlockUpdate({ number: 999n }));
+
+			// Revalidate block 999, as the block 1000 is still queued from startup.
+			mocks.getBlock.mockResolvedValueOnce(block({ number: 1000n, hash: keccak256(toHex("new999")) }));
+			const uncle = await blocks.revalidateLastBlock();
+			expect(uncle).not.toBeNull();
+
+			expect(blocks.queued()).toStrictEqual([{ type: "watcher_update_uncle_block", blockNumber: 999n }]);
 		});
 	});
 });

--- a/validator/src/watcher/blocks.ts
+++ b/validator/src/watcher/blocks.ts
@@ -51,6 +51,11 @@ export type BlockUpdate =
 	| { type: "watcher_update_uncle_block"; blockNumber: bigint }
 	| { type: "watcher_update_new_block"; blockNumber: bigint; blockHash: Hex; logsBloom: Hex };
 
+/**
+ * A Block that was removed from the cannonical chain on revalidation.
+ */
+export type InvalidatedBlockUpdate = Extract<BlockUpdate, { type: "watcher_update_uncle_block" }> & { blockHash: Hex };
+
 type Config = Settings & Options;
 type Block = ViemBlock<bigint, false, "latest">;
 type PendingBlock = {
@@ -252,6 +257,68 @@ export class BlockWatcher {
 			blockHash: block.hash,
 			logsBloom: block.logsBloom,
 		};
+	}
+
+	/**
+	 * Revalidate that the last seen block is still canonical on the connected RPC
+	 * node. If the block is no longer canonical (either the node now reports a
+	 * different hash at the same height, or it cannot find the block at all)
+	 * invalidate the watcher's pending state so the following `next()` calls
+	 * re-fetch the canonical replacement.
+	 *
+	 * This is used to recover from RPC nodes that briefly observe a block, expose
+	 * its hash, and then lose the ability to serve logs for that hash (most
+	 * notably Reth around uncled blocks).
+	 */
+	public async revalidateLastBlock(): Promise<InvalidatedBlockUpdate | null> {
+		const nextQueued = this.#queue.at(0);
+		if (nextQueued !== undefined && nextQueued.type !== "watcher_update_new_block") {
+			// Revalidating a block while warping is not possible, as it is beyond
+			// the max reorg depth for the watcher.
+			return null;
+		}
+
+		// Get the last block that block that was emitted as a block update. This
+		// ensures that calls to `revalidate` work in the unlikely case of a reorg
+		// on startup.
+		const lastBlockIndex = this.#blocks.findLastIndex(
+			(block) => nextQueued === undefined || block.number < nextQueued.blockNumber,
+		);
+		if (lastBlockIndex < 0) {
+			// We are trying to re-canonicalize past the max reorg depth, so there is
+			// nothing to do.
+			return null;
+		}
+		const lastBlock = this.#blocks[lastBlockIndex];
+
+		let block: Block | null;
+		try {
+			block = await this.#client.getBlock({ blockNumber: lastBlock.number });
+		} catch (err) {
+			if (!(err instanceof BlockNotFoundError)) {
+				throw err;
+			}
+			block = null;
+		}
+
+		if (lastBlock.hash === block?.hash) {
+			return null;
+		}
+
+		// We remove all blocks that are no longer canonical.
+		this.#blocks.length = lastBlockIndex;
+		// Update the pending block to be the one that was just uncled, which is
+		// the last block we had previously seen.
+		this.#pending = {
+			number: lastBlock.number,
+			timestampMs: lastBlock.timestamp * 1000n,
+		};
+
+		// Clear the update queue and insert the uncle block update.
+		const uncle = { type: "watcher_update_uncle_block", blockNumber: lastBlock.number } as const;
+		this.#queue.splice(0, this.#queue.length, uncle);
+
+		return { ...uncle, blockHash: lastBlock.hash };
 	}
 
 	/**

--- a/validator/src/watcher/blocks.ts
+++ b/validator/src/watcher/blocks.ts
@@ -305,7 +305,8 @@ export class BlockWatcher {
 			return null;
 		}
 
-		// We remove all blocks that are no longer canonical.
+		// We remove all blocks that are no longer canonical, that is the last block
+		// and all of its children.
 		this.#blocks.length = lastBlockIndex;
 		// Update the pending block to be the one that was just uncled, which is
 		// the last block we had previously seen.

--- a/validator/src/watcher/blocks.ts
+++ b/validator/src/watcher/blocks.ts
@@ -52,7 +52,7 @@ export type BlockUpdate =
 	| { type: "watcher_update_new_block"; blockNumber: bigint; blockHash: Hex; logsBloom: Hex };
 
 /**
- * A Block that was removed from the cannonical chain on revalidation.
+ * A Block that was removed from the canonical chain on revalidation.
  */
 export type InvalidatedBlockUpdate = Extract<BlockUpdate, { type: "watcher_update_uncle_block" }> & { blockHash: Hex };
 

--- a/validator/src/watcher/events.test.ts
+++ b/validator/src/watcher/events.test.ts
@@ -162,6 +162,54 @@ describe("EventWatcher", () => {
 		});
 	});
 
+	describe("onBlockInvalidated", () => {
+		it("returns to idle when invalidating the in-progress block", async () => {
+			const { events, mocks } = setup();
+
+			events.onBlockUpdate({
+				type: "watcher_update_new_block",
+				blockNumber: 1337n,
+				blockHash: keccak256(toHex("1337")),
+				logsBloom: BLOOM_ALL,
+			});
+
+			// Drive at least one failed log fetch so the event watcher is mid-block when the
+			// invalidation arrives — this matches the scenario the watcher loop creates after a
+			// `ResourceNotFoundRpcError` is escalated through `revalidateLastBlock`.
+			mocks.getLogs.mockRejectedValueOnce(new Error("logs unavailable"));
+			await expect(events.next()).rejects.toThrow();
+
+			events.onBlockInvalidated({ blockHash: keccak256(toHex("1337")) });
+
+			// After invalidation, the event watcher must be idle and not attempt any more
+			// log queries for the abandoned block hash.
+			mocks.getLogs.mockClear();
+			await expect(events.next()).resolves.toBeNull();
+			expect(mocks.getLogs).toBeCalledTimes(0);
+		});
+
+		it("throws when not in a block step", () => {
+			const { events } = setup();
+			expect(() => events.onBlockInvalidated({ blockHash: keccak256(toHex("1337")) })).toThrow();
+
+			events.onBlockUpdate({ type: "watcher_update_warp_to_block", fromBlock: 123n, toBlock: 130n });
+			expect(() => events.onBlockInvalidated({ blockHash: keccak256(toHex("1337")) })).toThrow();
+		});
+
+		it("throws when the block hash does not match the in-progress block", () => {
+			const { events } = setup();
+
+			events.onBlockUpdate({
+				type: "watcher_update_new_block",
+				blockNumber: 1337n,
+				blockHash: keccak256(toHex("1337")),
+				logsBloom: BLOOM_ALL,
+			});
+
+			expect(() => events.onBlockInvalidated({ blockHash: keccak256(toHex("other")) })).toThrow();
+		});
+	});
+
 	describe("warping", () => {
 		it("should fetch logs in pages", async () => {
 			const { events, mocks } = setup();

--- a/validator/src/watcher/events.ts
+++ b/validator/src/watcher/events.ts
@@ -18,7 +18,7 @@ import { computeLogsBloom, isInBloom } from "../utils/bloom.js";
 import { withDefaults } from "../utils/config.js";
 import type { Logger } from "../utils/logging.js";
 import { BackoffError } from "./backoff.js";
-import type { BlockUpdate } from "./blocks.js";
+import type { BlockUpdate, InvalidatedBlockUpdate } from "./blocks.js";
 
 export type Client = Pick<PublicClient, "getLogs">;
 export type Events = readonly AbiEvent[];
@@ -305,6 +305,16 @@ export class EventWatcher<E extends Events> {
 		// ensures all possible values for `type` are handled. If we would forget to handle a case,
 		// we would get a compiler error that `step` is possibly uninitialized.
 		this.#step = step;
+	}
+
+	onBlockInvalidated({ blockHash }: Pick<InvalidatedBlockUpdate, "blockHash">) {
+		if (this.#step.type !== "block" || this.#step.blockHash !== blockHash) {
+			throw new Error("unexpected block invalidation");
+		}
+
+		// The block we were trying to get logs for is no longer in the canonical
+		// chain. Go back to to `idle`.
+		this.#step = { type: "idle" };
 	}
 
 	async next(): Promise<Log<E>[] | null> {

--- a/validator/src/watcher/index.ts
+++ b/validator/src/watcher/index.ts
@@ -2,7 +2,7 @@
  * Watching for blocks and on-chain events.
  */
 
-import type { Prettify } from "viem";
+import { type Prettify, ResourceNotFoundRpcError } from "viem";
 import { formatError } from "../utils/errors.js";
 import type { Logger } from "../utils/logging.js";
 import { Backoff, type Config as BackoffConfig } from "./backoff.js";
@@ -57,9 +57,28 @@ export class Watcher<E extends Events> {
 		this.#running = false;
 	}
 
+	async #nextLogs() {
+		try {
+			return await this.#events.next();
+		} catch (error) {
+			if (error instanceof ResourceNotFoundRpcError) {
+				// Some RPC nodes will see an uncled block but not support querying logs
+				// for it (for example, Reth). Ask the `BlockWatcher` to revalidate the
+				// last block it produced and make sure it is still canonical.
+				const uncle = await this.#blocks.revalidateLastBlock();
+				if (uncle !== null) {
+					this.#events.onBlockInvalidated(uncle);
+					return null;
+				}
+			}
+
+			throw error;
+		}
+	}
+
 	async #next() {
 		while (true /* logs !== null */) {
-			const logs = await this.#events.next();
+			const logs = await this.#nextLogs();
 			if (logs === null) {
 				break;
 			}

--- a/validator/src/watcher/index.ts
+++ b/validator/src/watcher/index.ts
@@ -5,7 +5,7 @@
 import { type Prettify, ResourceNotFoundRpcError } from "viem";
 import { formatError } from "../utils/errors.js";
 import type { Logger } from "../utils/logging.js";
-import { Backoff, type Config as BackoffConfig } from "./backoff.js";
+import { Backoff, type Config as BackoffConfig, BackoffError } from "./backoff.js";
 import {
 	type Client as BlockClient,
 	type BlockUpdate,
@@ -66,10 +66,16 @@ export class Watcher<E extends Events> {
 				// for it (for example, Reth). Ask the `BlockWatcher` to revalidate the
 				// last block it produced and make sure it is still canonical.
 				const uncle = await this.#blocks.revalidateLastBlock();
-				if (uncle !== null) {
-					this.#events.onBlockInvalidated(uncle);
-					return null;
+				if (uncle === null) {
+					// The block is still canonical, but the logs for it are still not
+					// available to the node. Lets backoff to wait for syncing.
+					throw new BackoffError("Missing logs for latest block");
 				}
+
+				// The block we were fetching logs for was uncled. Let the event fetcher
+				// know and return that there are no more logs to fetch.
+				this.#events.onBlockInvalidated(uncle);
+				return null;
 			}
 
 			throw error;


### PR DESCRIPTION
Add support for nodes where querying logs for uncled blocks returns an error.

### Context and Motivation

Previously, the watcher would assume that if a node would return a block with number and hash, that it would also be able to return logs for those blocks. Typically, nodes satisfy this assumption (Geth and Nethermind). However, some nodes do not always behave this way if a block is detected as being uncled between the `eth_getBlock` and `eth_getLogs` query, and will instead return an RPC error (such as Reth).

### Decisions and Tradeoffs

The solution to the issue is to, under certain RPC errors, trigger a re-evaluation of the cannonical chain to determine if we are trying to fetch logs for a block that has been uncled, and instead proceed with reorg handling in that case.

### Testing

Added some unit tests to check the new block watching logic changes.
