### PR TITLE
fix: add legacy EIP-1271 interface support to SafenetCosigner

### DIFF
--- a/contracts/src/cosigner/SafenetCosigner.sol
+++ b/contracts/src/cosigner/SafenetCosigner.sol
@@ -58,6 +58,8 @@ contract SafenetCosigner is ISignatureValidator {
     // CONSTANTS
     // ============================================================
 
+    bytes4 private constant LEGACY_EIP1271_MAGIC_VALUE = bytes4(0x20c13b0b);
+
     // forge-lint: disable-next-item(asm-keccak256)
     bytes32 private constant _EIP712_DOMAIN_TYPEHASH =
         keccak256("EIP712Domain(uint256 chainId,address verifyingContract)");
@@ -175,19 +177,19 @@ contract SafenetCosigner is ISignatureValidator {
      *         after execution.
      */
     function isValidSignature(bytes32 hash, bytes memory signature) external view override returns (bytes4) {
-        if (signature.length > 0) {
-            if (signature.length != 128) return bytes4(0);
-            (uint64 epoch, FROST.Signature memory sig) = abi.decode(signature, (uint64, FROST.Signature));
-            bytes32 message = ConsensusMessages.transactionProposal(_CONSENSUS_DOMAIN_SEPARATOR, epoch, hash);
-            Secp256k1.Point memory groupKey = _resolveGroupKey(epoch);
-            Secp256k1.requireNonZero(groupKey);
-            FROST.verify(groupKey, sig, message);
-            return EIP1271_MAGIC_VALUE;
-        }
+        if (_isVerified(hash, signature)) return EIP1271_MAGIC_VALUE;
+        return bytes4(0);
+    }
 
-        uint256 executableAt = $allowedTransactions[msg.sender][hash];
-        if (executableAt != 0 && block.timestamp >= executableAt) return EIP1271_MAGIC_VALUE;
-
+    /**
+     * @dev Legacy EIP-1271 callback for Safe versions compiled with the old `ISignatureValidator`
+     *      interface (selector `0x20c13b0b`). Called by Safe 1.4.1 during `execTransaction`.
+     *      `_data` is the raw EIP-712 encoding `\x19\x01 || domainSeparator || structHash`
+     *      (66 bytes); its keccak256 equals the `safeTxHash`. `_signature` is the same
+     *      128-byte FROST attestation accepted by the modern interface.
+     */
+    function isValidSignature(bytes calldata _data, bytes calldata _signature) external view returns (bytes4) {
+        if (_isVerified(keccak256(_data), _signature)) return LEGACY_EIP1271_MAGIC_VALUE;
         return bytes4(0);
     }
 
@@ -262,6 +264,20 @@ contract SafenetCosigner is ISignatureValidator {
     // ============================================================
     // PRIVATE HELPERS
     // ============================================================
+
+    function _isVerified(bytes32 hash, bytes memory signature) private view returns (bool) {
+        if (signature.length > 0) {
+            if (signature.length != 128) return false;
+            (uint64 epoch, FROST.Signature memory sig) = abi.decode(signature, (uint64, FROST.Signature));
+            bytes32 message = ConsensusMessages.transactionProposal(_CONSENSUS_DOMAIN_SEPARATOR, epoch, hash);
+            Secp256k1.Point memory groupKey = _resolveGroupKey(epoch);
+            Secp256k1.requireNonZero(groupKey);
+            FROST.verify(groupKey, sig, message);
+            return true;
+        }
+        uint256 executableAt = $allowedTransactions[msg.sender][hash];
+        return executableAt != 0 && block.timestamp >= executableAt;
+    }
 
     function _resolveGroupKey(uint64 epoch) private view returns (Secp256k1.Point memory) {
         if ($currentEpoch.epoch == epoch) return $currentEpoch.groupKey;

--- a/contracts/src/cosigner/SafenetCosigner.sol
+++ b/contracts/src/cosigner/SafenetCosigner.sol
@@ -58,7 +58,7 @@ contract SafenetCosigner is ISignatureValidator {
     // CONSTANTS
     // ============================================================
 
-    bytes4 private constant LEGACY_EIP1271_MAGIC_VALUE = bytes4(0x20c13b0b);
+    bytes4 private constant _LEGACY_EIP1271_MAGIC_VALUE = bytes4(0x20c13b0b);
 
     // forge-lint: disable-next-item(asm-keccak256)
     bytes32 private constant _EIP712_DOMAIN_TYPEHASH =
@@ -189,7 +189,7 @@ contract SafenetCosigner is ISignatureValidator {
      *      128-byte FROST attestation accepted by the modern interface.
      */
     function isValidSignature(bytes calldata _data, bytes calldata _signature) external view returns (bytes4) {
-        if (_isVerified(keccak256(_data), _signature)) return LEGACY_EIP1271_MAGIC_VALUE;
+        if (_isVerified(keccak256(_data), _signature)) return _LEGACY_EIP1271_MAGIC_VALUE;
         return bytes4(0);
     }
 


### PR DESCRIPTION
Add legacy EIP-1271 interface overload to `SafenetCosigner` to support Safe 1.4.1.

### Context and Motivation

Safe 1.4.1 (and other older Safe versions) was compiled against the original `ISignatureValidator` interface, which defines `isValidSignature(bytes,bytes)` with selector `0x20c13b0b`. The modern EIP-1271 standard uses `isValidSignature(bytes32,bytes)` with selector `0x1626ba7e`. `SafenetCosigner` only implemented the modern interface, so when `execTransaction` on a Safe 1.4.1 instance called the cosigner for signature validation, it received no magic value back and rejected the signature — causing a bare revert with no error data.

This PR adds the legacy overload so the cosigner works across both Safe versions. The `_data` argument in the legacy interface is the raw EIP-712 encoding (`\x19\x01 || domainSeparator || structHash`, 66 bytes), whose `keccak256` equals the `safeTxHash` — so verification logic is identical; only the input hashing step differs.

### Decisions and Tradeoffs

- The verification logic shared between both overloads was extracted into a `_isVerified(bytes32, bytes)` private helper to avoid duplication and keep both public functions thin.
- The legacy overload returns `bytes4(0x20c13b0b)` on success (not the `EIP1271_MAGIC_VALUE` constant `0x1626ba7e`), because Safe 1.4.1 checks for the old selector. Returning the wrong magic value would silently fail validation.
