### PR TITLE
Safenet Cosigner Deployment

### DIFF
--- a/contracts/.env.sample
+++ b/contracts/.env.sample
@@ -4,6 +4,18 @@
 # 2 = Canonical Deterministic Deployment Factory
 FACTORY=1
 
+# SafenetCosigner Deployment Config
+# Chain ID of the Consensus contract (100 = Gnosis Chain)
+CONSENSUS_CHAIN_ID=100
+# Address of the Consensus contract on the consensus chain
+CONSENSUS_ADDRESS=0x223624cBF099e5a8f8cD5aF22aFa424a1d1acEE9
+# Initial epoch and FROST group key — obtain by calling activeEpoch() on the Consensus contract
+INITIAL_EPOCH=
+INITIAL_GROUP_KEY_X=
+INITIAL_GROUP_KEY_Y=
+# Delay in seconds before a pre-approved transaction can be executed (default: 60)
+ALLOW_TX_DELAY=60
+
 # Staking Contract Deployment Config
 # Initial owner of the staking contract, can be set to any address
 STAKING_INITIAL_OWNER=0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266 # Anvil #1 Default Address

--- a/contracts/package.json
+++ b/contracts/package.json
@@ -9,6 +9,7 @@
 		"cmd:genesis": "forge script GenesisScript",
 		"cmd:propose": "forge script ProposeScript",
 		"cmd:deploy:testing-erc20": "forge script DeployERC20Script",
+		"cmd:deploy:cosigner": "forge script DeployCosignerScript",
 		"cmd:deploy:staking": "forge script DeployStakingScript",
 		"cmd:proposeValidators": "forge script ProposeValidatorsScript",
 		"cmd:acceptValidators": "forge script AcceptValidatorsScript",

--- a/contracts/script/DeployCosigner.s.sol
+++ b/contracts/script/DeployCosigner.s.sol
@@ -14,7 +14,10 @@ contract DeployCosignerScript is Script {
         // Required script arguments:
         uint256 consensusChainId = vm.envUint("CONSENSUS_CHAIN_ID");
         address consensusAddress = vm.envAddress("CONSENSUS_ADDRESS");
-        uint64 initialEpoch = uint64(vm.envUint("INITIAL_EPOCH"));
+        uint256 rawEpoch = vm.envUint("INITIAL_EPOCH");
+        require(rawEpoch <= type(uint64).max, "INITIAL_EPOCH overflow: value exceeds uint64");
+        // forge-lint: disable-next-line(unsafe-typecast)
+        uint64 initialEpoch = uint64(rawEpoch);
         uint256 groupKeyX = vm.envUint("INITIAL_GROUP_KEY_X");
         uint256 groupKeyY = vm.envUint("INITIAL_GROUP_KEY_Y");
 

--- a/contracts/script/DeployCosigner.s.sol
+++ b/contracts/script/DeployCosigner.s.sol
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: GPL-3.0-only
+pragma solidity ^0.8.30;
+
+import {Script, console} from "@forge-std/Script.sol";
+import {SafenetCosigner} from "@/cosigner/SafenetCosigner.sol";
+import {Secp256k1} from "@/libraries/Secp256k1.sol";
+import {DeterministicDeployment} from "@script/util/DeterministicDeployment.sol";
+import {getFactory} from "@script/util/GetFactory.sol";
+
+contract DeployCosignerScript is Script {
+    using DeterministicDeployment for DeterministicDeployment.Factory;
+
+    function run() public returns (address cosigner) {
+        // Required script arguments:
+        uint256 consensusChainId = vm.envUint("CONSENSUS_CHAIN_ID");
+        address consensusAddress = vm.envAddress("CONSENSUS_ADDRESS");
+        uint64 initialEpoch = uint64(vm.envUint("INITIAL_EPOCH"));
+        uint256 groupKeyX = vm.envUint("INITIAL_GROUP_KEY_X");
+        uint256 groupKeyY = vm.envUint("INITIAL_GROUP_KEY_Y");
+
+        // Optional script arguments:
+        uint256 allowTxDelay = vm.envOr("ALLOW_TX_DELAY", uint256(60));
+        DeterministicDeployment.Factory factory = getFactory(vm);
+
+        Secp256k1.Point memory initialGroupKey = Secp256k1.Point({x: groupKeyX, y: groupKeyY});
+
+        vm.startBroadcast();
+
+        cosigner = factory.deployWithArgs(
+            bytes32(0),
+            type(SafenetCosigner).creationCode,
+            abi.encode(consensusChainId, consensusAddress, initialEpoch, initialGroupKey, allowTxDelay)
+        );
+
+        vm.stopBroadcast();
+
+        console.log("SafenetCosigner deployed at:", cosigner);
+    }
+}

--- a/contracts/script/README.md
+++ b/contracts/script/README.md
@@ -176,3 +176,25 @@ npm run cmd:initiateWithdraw -w @safenet/contracts -- --rpc-url http://127.0.0.1
 ```
 npm run cmd:claimWithdraw -w @safenet/contracts -- --rpc-url http://127.0.0.1:8545 --broadcast --sender 0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266 --account sender-keystore-account
 ```
+
+## SafenetCosigner
+
+Deploys a `SafenetCosigner` contract bound to a specific Consensus contract and epoch. The cosigner is deployed deterministically via CREATE2, so the address is fixed given the same constructor arguments and salt.
+
+Note: Make sure you have filled the `.env` file with the correct values. SafenetCosigner deployment requires:
+- `CONSENSUS_CHAIN_ID` — chain ID of the Consensus contract (e.g. `100` for Gnosis Chain)
+- `CONSENSUS_ADDRESS` — address of the Consensus contract on the consensus chain
+- `INITIAL_EPOCH` — epoch number to initialise the cosigner with (obtain via `activeEpoch()` on the Consensus contract)
+- `INITIAL_GROUP_KEY_X`, `INITIAL_GROUP_KEY_Y` — coordinates of the FROST group public key for that epoch
+
+Optional:
+- `ALLOW_TX_DELAY` — delay in seconds before a pre-approved transaction can be executed (default: `60`)
+- `FACTORY` — `1` for Safe Singleton Factory (default), `2` for Canonical Factory
+
+### Command
+
+```
+npm run cmd:deploy:cosigner -w @safenet/contracts -- --rpc-url http://127.0.0.1:8545 --broadcast --sender 0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266 --account sender-keystore-account
+```
+
+---

--- a/contracts/script/README.md
+++ b/contracts/script/README.md
@@ -184,8 +184,8 @@ Deploys a `SafenetCosigner` contract bound to a specific Consensus contract and 
 Note: Make sure you have filled the `.env` file with the correct values. SafenetCosigner deployment requires:
 - `CONSENSUS_CHAIN_ID` — chain ID of the Consensus contract (e.g. `100` for Gnosis Chain)
 - `CONSENSUS_ADDRESS` — address of the Consensus contract on the consensus chain
-- `INITIAL_EPOCH` — epoch number to initialise the cosigner with (obtain via `activeEpoch()` on the Consensus contract)
-- `INITIAL_GROUP_KEY_X`, `INITIAL_GROUP_KEY_Y` — coordinates of the FROST group public key for that epoch
+- `INITIAL_EPOCH` — epoch number to initialise the cosigner with (obtain via `getActiveEpoch()` on the Consensus contract)
+- `INITIAL_GROUP_KEY_X`, `INITIAL_GROUP_KEY_Y` — x and y coordinates of the FROST group public key for that epoch (call `getCoordinator()` on the Consensus contract to get the `FROSTCoordinator` address, then call `groupKey(groupId)` with the group ID returned by `getActiveEpoch()`)
 
 Optional:
 - `ALLOW_TX_DELAY` — delay in seconds before a pre-approved transaction can be executed (default: `60`)


### PR DESCRIPTION
Add a Forge deployment script for `SafenetCosigner`, following the same deterministic CREATE2 pattern used by the existing staking deployment scripts.

### Context and Motivation

- `SafenetCosigner` was test deployed via the TypeScript integration test script (`examples/test-cosigner-hypernative.ts`) created in #372. A standalone Forge script makes it deployable independently, useful for production deployments.
- The script mirrors the pattern in `DeployStakingScript`: reads constructor args from env vars, deploys via the configured `DeterministicDeployment` factory (Safe Singleton Factory by default), and logs the deployed address.

### Decisions and Tradeoffs

- `INITIAL_EPOCH` and `INITIAL_GROUP_KEY_X/Y` are required env vars rather than being fetched on-chain. A cross-chain read (Gnosis Chain → target chain) is not straightforward in Forge, and requiring the caller to supply the current epoch values keeps the script simple and explicit.
- The CREATE2 salt is hardcoded to `bytes32(0)`, consistent with `DeployStakingScript`.

### Testing

- Dry-run (`npm run cmd:deploy:cosigner -w @safenet/contracts`) prints the deterministic address without broadcasting.
- Re-running with the same args is a no-op, `deployWithArgs` skips deployment if code is already present at the computed address.
