### PR TITLE
SentinelOracle - Phase 3: Add transitions and handlers

### DIFF
--- a/validator/src/sentinel/abis.ts
+++ b/validator/src/sentinel/abis.ts
@@ -5,10 +5,6 @@ export const SENTINEL_NEW_REQUEST_EVENT = parseAbiItem(
 	"event NewRequest(bytes32 indexed requestId, address indexed proposer, uint256 fee, uint256 bondTarget, uint256 deadline)",
 );
 
-export const SENTINEL_DISPUTE_RESOLVED_EVENT = parseAbiItem(
-	"event DisputeResolved(bytes32 indexed requestId, uint8 outcome, uint256 slashed)",
-);
-
 export const SENTINEL_CLAIMED_EVENT = parseAbiItem(
 	"event Claimed(bytes32 indexed requestId, address indexed sentinel, uint256 bondReturn, uint256 feeReward)",
 );
@@ -17,13 +13,7 @@ export const SENTINEL_COMMITTED_EVENT = parseAbiItem(
 	"event Committed(bytes32 indexed requestId, address indexed sentinel, bool approved, uint256 bondAmount, uint256 position)",
 );
 
-export const SENTINEL_EVENTS = [
-	SENTINEL_NEW_REQUEST_EVENT,
-	ORACLE_RESULT_EVENT,
-	SENTINEL_DISPUTE_RESOLVED_EVENT,
-	SENTINEL_COMMITTED_EVENT,
-	SENTINEL_CLAIMED_EVENT,
-] as const;
+export const SENTINEL_EVENTS = [SENTINEL_NEW_REQUEST_EVENT, ORACLE_RESULT_EVENT, SENTINEL_COMMITTED_EVENT] as const;
 
 export const SENTINEL_ORACLE_FUNCTIONS = parseAbi([
 	"function commitApprove(bytes32 requestId, uint256 bondAmount) external",

--- a/validator/src/sentinel/detector.ts
+++ b/validator/src/sentinel/detector.ts
@@ -1,0 +1,8 @@
+import { type Address, type Hex, isAddressEqual } from "viem";
+
+export type TransactionPayload = { to: Address; value: bigint; data: Hex };
+export type Detector = (payload: TransactionPayload) => boolean;
+
+export function createDetector(blocklist: readonly Address[] = []): Detector {
+	return (payload) => !blocklist.some((blocked) => isAddressEqual(blocked, payload.to));
+}

--- a/validator/src/sentinel/detector.ts
+++ b/validator/src/sentinel/detector.ts
@@ -1,6 +1,6 @@
-import { type Address, type Hex, isAddressEqual } from "viem";
+import { type Address, isAddressEqual } from "viem";
+import type { TransactionPayload } from "./types.js";
 
-export type TransactionPayload = { to: Address; value: bigint; data: Hex };
 export type Detector = (payload: TransactionPayload) => boolean;
 
 export function createDetector(blocklist: readonly Address[] = []): Detector {

--- a/validator/src/sentinel/handlers.ts
+++ b/validator/src/sentinel/handlers.ts
@@ -1,12 +1,11 @@
 import type { Hex } from "viem";
-import { isAddressEqual } from "viem";
+import { decodeAbiParameters, isAddressEqual } from "viem";
 import { oracleTxProposalHash } from "../consensus/verify/oracleTx/hashing.js";
 import type { OracleTransactionProposedEvent } from "../machine/transitions/types.js";
 import type { Logger } from "../utils/logging.js";
 import type { Detector } from "./detector.js";
 import type {
 	SentinelCommittedTransition,
-	SentinelDisputeResolvedTransition,
 	SentinelNewRequestTransition,
 	SentinelOracleResultTransition,
 } from "./transitions.js";
@@ -37,17 +36,17 @@ export function handleNewRequest(
 	logger: Logger,
 ): SentinelStateDiff {
 	const existing = requests.get(transition.requestId);
-	if (existing !== undefined && existing.status !== "preparing") return {};
-	const approve = existing?.approve ?? true;
+	if (existing === undefined || existing.status !== "preparing") return {};
+	const approve = existing.approve;
 	logger.info("SentinelService: committing vote", {
 		requestId: transition.requestId,
 		approve,
 		hasTxPayload: existing !== undefined,
 	});
 	return {
-		request: [transition.requestId, { deadline: transition.deadline, status: "pending" }],
+		request: [transition.requestId, { deadline: transition.deadline, status: "pending", approve }],
 		actions: [
-			{ id: "sentinel_approve_token", bondTarget: transition.bondTarget },
+			{ id: "sentinel_approve_token", bondAmount: transition.bondTarget },
 			approve
 				? { id: "sentinel_commit_approve", requestId: transition.requestId, bondAmount: config.bondAmount }
 				: { id: "sentinel_commit_deny", requestId: transition.requestId, bondAmount: config.bondAmount },
@@ -64,39 +63,50 @@ export function handleCommitted(
 	const existing = requests.get(transition.requestId);
 	if (existing === undefined || existing.status !== "pending") return {};
 	return {
-		request: [transition.requestId, { deadline: existing.deadline, status: "committed" }],
+		request: [transition.requestId, { deadline: existing.deadline, status: "committed", approve: existing.approve }],
 	};
 }
 
 export function handleResolved(
 	requests: ReadonlyMap<Hex, SentinelRequestState>,
-	transition: SentinelOracleResultTransition | SentinelDisputeResolvedTransition,
+	transition: SentinelOracleResultTransition,
 ): SentinelStateDiff {
-	if (!requests.has(transition.requestId)) return {};
+	const existing = requests.get(transition.requestId);
+	if (existing === undefined) return {};
+	// Only claim if we committed on-chain; drop silently otherwise (e.g. commit tx never confirmed).
+	if (existing.status !== "committed" && existing.status !== "finalized") {
+		return { request: [transition.requestId, undefined] };
+	}
+	// result encodes SentinelOracleRequest.ResolveReason (uint8): TIMEOUT = 2.
+	// On timeout every participant gets their bond back regardless of how they voted.
+	const [reason] = decodeAbiParameters([{ type: "uint8" }], transition.result);
+	const voteWon = reason === 2 || transition.approved === existing.approve;
 	return {
 		request: [transition.requestId, undefined],
-		actions: [{ id: "sentinel_claim", requestId: transition.requestId }],
+		actions: voteWon ? [{ id: "sentinel_claim", requestId: transition.requestId }] : undefined,
 	};
 }
 
 export function handleBlockAdvance(
 	requests: ReadonlyMap<Hex, SentinelRequestState>,
 	blockNumber: bigint,
+	config: SentinelConfig,
 ): SentinelStateDiff[] {
 	const diffs: SentinelStateDiff[] = [];
-	for (const [requestId, { deadline, status }] of requests) {
-		if (blockNumber <= deadline) continue;
-		if (status === "committed") {
-			// Transition to finalized + queue the finalize action (emitted at most once)
+	for (const [requestId, state] of requests) {
+		if (blockNumber <= state.deadline) continue;
+		if (state.status === "committed") {
+			// Transition to finalized; deadline is reset to give time for OracleResult
 			diffs.push({
-				request: [requestId, { deadline, status: "finalized" }],
+				request: [
+					requestId,
+					{ status: "finalized", deadline: blockNumber + config.votingWindow, approve: state.approve },
+				],
 				actions: [{ id: "sentinel_finalize", requestId }],
 			});
-		} else if (status === "pending" || status === "preparing") {
-			// Drop requests where the voting window passed or no matching NewRequest arrived
+		} else if (state.status === "pending" || state.status === "preparing" || state.status === "finalized") {
 			diffs.push({ request: [requestId, undefined] });
 		}
-		// "finalized" status: waiting for OracleResult — no action needed
 	}
 	return diffs;
 }

--- a/validator/src/sentinel/handlers.ts
+++ b/validator/src/sentinel/handlers.ts
@@ -1,0 +1,102 @@
+import type { Hex } from "viem";
+import { isAddressEqual } from "viem";
+import { oracleTxProposalHash } from "../consensus/verify/oracleTx/hashing.js";
+import type { OracleTransactionProposedEvent } from "../machine/transitions/types.js";
+import type { Logger } from "../utils/logging.js";
+import type { Detector } from "./detector.js";
+import type {
+	SentinelCommittedTransition,
+	SentinelDisputeResolvedTransition,
+	SentinelNewRequestTransition,
+	SentinelOracleResultTransition,
+} from "./transitions.js";
+import type { SentinelConfig, SentinelRequestState, SentinelStateDiff } from "./types.js";
+
+export function handleOracleTransactionProposed(
+	transition: OracleTransactionProposedEvent,
+	config: SentinelConfig,
+	detector: Detector,
+): SentinelStateDiff {
+	// Only handle requests from the configured oracle
+	if (!isAddressEqual(transition.oracle, config.oracle)) return {};
+
+	const requestId = oracleTxProposalHash({
+		domain: { chain: config.chainId, consensus: config.consensus },
+		proposal: { epoch: transition.epoch, oracle: transition.oracle, safeTxHash: transition.safeTxHash },
+	});
+	const approve = detector(transition.transaction);
+	return {
+		request: [requestId, { deadline: transition.block + config.votingWindow, status: "preparing", approve }],
+	};
+}
+
+export function handleNewRequest(
+	requests: ReadonlyMap<Hex, SentinelRequestState>,
+	transition: SentinelNewRequestTransition,
+	config: SentinelConfig,
+	logger: Logger,
+): SentinelStateDiff {
+	const existing = requests.get(transition.requestId);
+	if (existing !== undefined && existing.status !== "preparing") return {};
+	const approve = existing?.approve ?? true;
+	logger.info("SentinelService: committing vote", {
+		requestId: transition.requestId,
+		approve,
+		hasTxPayload: existing !== undefined,
+	});
+	return {
+		request: [transition.requestId, { deadline: transition.deadline, status: "pending" }],
+		actions: [
+			{ id: "sentinel_approve_token", bondTarget: transition.bondTarget },
+			approve
+				? { id: "sentinel_commit_approve", requestId: transition.requestId, bondAmount: config.bondAmount }
+				: { id: "sentinel_commit_deny", requestId: transition.requestId, bondAmount: config.bondAmount },
+		],
+	};
+}
+
+export function handleCommitted(
+	requests: ReadonlyMap<Hex, SentinelRequestState>,
+	transition: SentinelCommittedTransition,
+	config: SentinelConfig,
+): SentinelStateDiff {
+	if (!isAddressEqual(config.account, transition.sentinel)) return {};
+	const existing = requests.get(transition.requestId);
+	if (existing === undefined || existing.status !== "pending") return {};
+	return {
+		request: [transition.requestId, { deadline: existing.deadline, status: "committed" }],
+	};
+}
+
+export function handleResolved(
+	requests: ReadonlyMap<Hex, SentinelRequestState>,
+	transition: SentinelOracleResultTransition | SentinelDisputeResolvedTransition,
+): SentinelStateDiff {
+	if (!requests.has(transition.requestId)) return {};
+	return {
+		request: [transition.requestId, undefined],
+		actions: [{ id: "sentinel_claim", requestId: transition.requestId }],
+	};
+}
+
+export function handleBlockAdvance(
+	requests: ReadonlyMap<Hex, SentinelRequestState>,
+	blockNumber: bigint,
+): SentinelStateDiff[] {
+	const diffs: SentinelStateDiff[] = [];
+	for (const [requestId, { deadline, status }] of requests) {
+		if (blockNumber <= deadline) continue;
+		if (status === "committed") {
+			// Transition to finalized + queue the finalize action (emitted at most once)
+			diffs.push({
+				request: [requestId, { deadline, status: "finalized" }],
+				actions: [{ id: "sentinel_finalize", requestId }],
+			});
+		} else if (status === "pending" || status === "preparing") {
+			// Drop requests where the voting window passed or no matching NewRequest arrived
+			diffs.push({ request: [requestId, undefined] });
+		}
+		// "finalized" status: waiting for OracleResult — no action needed
+	}
+	return diffs;
+}

--- a/validator/src/sentinel/transitions.ts
+++ b/validator/src/sentinel/transitions.ts
@@ -1,0 +1,118 @@
+import type { Address, Hex } from "viem";
+import { z } from "zod";
+import { oracleTransactionProposedEventSchema } from "../machine/transitions/schemas.js";
+import type { OracleTransactionProposedEvent } from "../machine/transitions/types.js";
+import { CONSENSUS_ORACLE_TRANSACTION_PROPOSED_EVENT } from "../types/abis.js";
+import { checkedAddressSchema, hexBytes32Schema, hexDataSchema } from "../types/schemas.js";
+import type { Log } from "../watcher/events.js";
+import { SENTINEL_EVENTS } from "./abis.js";
+
+export const SENTINEL_ALL_EVENTS = [...SENTINEL_EVENTS, CONSENSUS_ORACLE_TRANSACTION_PROPOSED_EVENT] as const;
+
+const eventBigIntSchema = z.coerce.bigint().nonnegative();
+
+const newRequestArgsSchema = z.object({
+	requestId: hexBytes32Schema,
+	proposer: checkedAddressSchema,
+	fee: eventBigIntSchema,
+	bondTarget: eventBigIntSchema,
+	deadline: eventBigIntSchema,
+});
+
+const committedArgsSchema = z.object({
+	requestId: hexBytes32Schema,
+	sentinel: checkedAddressSchema,
+	approved: z.boolean(),
+	bondAmount: eventBigIntSchema,
+	position: eventBigIntSchema,
+});
+
+const oracleResultArgsSchema = z.object({
+	requestId: hexBytes32Schema,
+	proposer: checkedAddressSchema,
+	result: hexDataSchema,
+	approved: z.boolean(),
+});
+
+const disputeResolvedArgsSchema = z.object({
+	requestId: hexBytes32Schema,
+	outcome: z.number(),
+	slashed: eventBigIntSchema,
+});
+
+export type SentinelNewRequestTransition = {
+	id: "sentinel_event_new_request";
+	requestId: Hex;
+	proposer: Address;
+	fee: bigint;
+	bondTarget: bigint;
+	deadline: bigint;
+};
+
+export type SentinelCommittedTransition = {
+	id: "sentinel_event_committed";
+	requestId: Hex;
+	sentinel: Address;
+	approved: boolean;
+	bondAmount: bigint;
+	position: bigint;
+};
+
+export type SentinelOracleResultTransition = {
+	id: "sentinel_event_oracle_result";
+	requestId: Hex;
+	proposer: Address;
+	result: Hex;
+	approved: boolean;
+};
+
+export type SentinelDisputeResolvedTransition = {
+	id: "sentinel_event_dispute_resolved";
+	requestId: Hex;
+	outcome: number;
+	slashed: bigint;
+};
+
+export type SentinelOracleTransition =
+	| SentinelNewRequestTransition
+	| SentinelCommittedTransition
+	| SentinelOracleResultTransition
+	| SentinelDisputeResolvedTransition
+	| OracleTransactionProposedEvent;
+
+export type SentinelLog = Log<typeof SENTINEL_ALL_EVENTS>;
+
+export const logToTransition = ({
+	eventName,
+	args: eventArgs,
+	blockNumber,
+	logIndex,
+}: SentinelLog): SentinelOracleTransition => {
+	switch (eventName) {
+		case "NewRequest": {
+			const args = newRequestArgsSchema.parse(eventArgs);
+			return { id: "sentinel_event_new_request", ...args };
+		}
+		case "Committed": {
+			const args = committedArgsSchema.parse(eventArgs);
+			return { id: "sentinel_event_committed", ...args };
+		}
+		case "OracleResult": {
+			const args = oracleResultArgsSchema.parse(eventArgs);
+			return { id: "sentinel_event_oracle_result", ...args };
+		}
+		case "DisputeResolved": {
+			const args = disputeResolvedArgsSchema.parse(eventArgs);
+			return { id: "sentinel_event_dispute_resolved", ...args };
+		}
+		case "OracleTransactionProposed": {
+			const args = oracleTransactionProposedEventSchema.parse(eventArgs);
+			return {
+				id: "event_oracle_transaction_proposed",
+				block: blockNumber,
+				index: logIndex,
+				...args,
+			};
+		}
+	}
+};

--- a/validator/src/sentinel/transitions.ts
+++ b/validator/src/sentinel/transitions.ts
@@ -34,12 +34,6 @@ const oracleResultArgsSchema = z.object({
 	approved: z.boolean(),
 });
 
-const disputeResolvedArgsSchema = z.object({
-	requestId: hexBytes32Schema,
-	outcome: z.number(),
-	slashed: eventBigIntSchema,
-});
-
 export type SentinelNewRequestTransition = {
 	id: "sentinel_event_new_request";
 	requestId: Hex;
@@ -66,18 +60,10 @@ export type SentinelOracleResultTransition = {
 	approved: boolean;
 };
 
-export type SentinelDisputeResolvedTransition = {
-	id: "sentinel_event_dispute_resolved";
-	requestId: Hex;
-	outcome: number;
-	slashed: bigint;
-};
-
 export type SentinelOracleTransition =
 	| SentinelNewRequestTransition
 	| SentinelCommittedTransition
 	| SentinelOracleResultTransition
-	| SentinelDisputeResolvedTransition
 	| OracleTransactionProposedEvent;
 
 export type SentinelLog = Log<typeof SENTINEL_ALL_EVENTS>;
@@ -100,10 +86,6 @@ export const logToTransition = ({
 		case "OracleResult": {
 			const args = oracleResultArgsSchema.parse(eventArgs);
 			return { id: "sentinel_event_oracle_result", ...args };
-		}
-		case "DisputeResolved": {
-			const args = disputeResolvedArgsSchema.parse(eventArgs);
-			return { id: "sentinel_event_dispute_resolved", ...args };
 		}
 		case "OracleTransactionProposed": {
 			const args = oracleTransactionProposedEventSchema.parse(eventArgs);

--- a/validator/src/sentinel/types.ts
+++ b/validator/src/sentinel/types.ts
@@ -31,13 +31,14 @@ export type SentinelAction = CommitApprove | CommitDeny | SentinelFinalize | Sen
 
 export type SentinelActionWithTimeout = SentinelAction & { validUntil: number };
 
-export type SentinelRequestStatus = "preparing" | "pending" | "committed" | "finalized";
+type RequestBase = { deadline: bigint; approve: boolean };
 
-export type SentinelRequestState = {
-	deadline: bigint;
-	status: SentinelRequestStatus;
-	approve?: boolean;
-};
+export type PreparingRequest = RequestBase & { status: "preparing" };
+export type PendingRequest = RequestBase & { status: "pending" };
+export type CommittedRequest = RequestBase & { status: "committed" };
+export type FinalizedRequest = RequestBase & { status: "finalized" };
+
+export type SentinelRequestState = PreparingRequest | PendingRequest | CommittedRequest | FinalizedRequest;
 
 export type TransactionPayload = { to: Address; value: bigint; data: Hex };
 

--- a/validator/src/sentinel/types.ts
+++ b/validator/src/sentinel/types.ts
@@ -1,4 +1,4 @@
-import type { Hex } from "viem";
+import type { Address, Hex } from "viem";
 
 export type CommitApprove = {
 	id: "sentinel_commit_approve";
@@ -31,11 +31,24 @@ export type SentinelAction = CommitApprove | CommitDeny | SentinelFinalize | Sen
 
 export type SentinelActionWithTimeout = SentinelAction & { validUntil: number };
 
-export type SentinelRequestStatus = "pending" | "committed" | "finalized";
+export type SentinelRequestStatus = "preparing" | "pending" | "committed" | "finalized";
 
 export type SentinelRequestState = {
 	deadline: bigint;
 	status: SentinelRequestStatus;
+	approve?: boolean;
+};
+
+export type TransactionPayload = { to: Address; value: bigint; data: Hex };
+
+export type SentinelConfig = {
+	readonly account: Address;
+	readonly bondAmount: bigint;
+	readonly consensus: Address;
+	readonly oracle: Address;
+	readonly chainId: bigint;
+	// Voting window in blocks, used as TTL for the preparing state cleanup.
+	readonly votingWindow: bigint;
 };
 
 export type SentinelStateDiff = {

--- a/validator/src/types/schemas.ts
+++ b/validator/src/types/schemas.ts
@@ -90,6 +90,8 @@ export const sentinelConfigSchema = z.object({
 	SENTINEL_ORACLE_ADDRESS: checkedAddressSchema,
 	SENTINEL_BOND_AMOUNT: z.coerce.bigint().positive(),
 	SENTINEL_BLOCKLIST: emptyToDefault(jsonStringToValue(z.array(checkedAddressSchema)).optional(), []),
+	// Voting window in blocks. Controls the TTL for the preparing state and when finalize becomes eligible.
+	SENTINEL_VOTING_WINDOW: emptyToDefault(z.coerce.bigint().positive(), 12n),
 	STORAGE_FILE: emptyToDefault(z.string().optional()),
 });
 


### PR DESCRIPTION
### Context and Motivation

Task in Phase 3 of the Sentinel Oracle ([Feature Spec](https://github.com/safe-research/safenet/blob/main/features/2026_05_05_transaction_checker_oracle_v1.md#phase-3--checker-node-service-pr-3-can-be-parallelized-with-phase-2)). Complete list of tasks can be found in the [milestone](https://github.com/safe-research/safenet/milestone/1)

Types for the different transitions are added and a handler that update the state based on these transitions (this required some type updates).

To avoid passing too many parameters to the handle functions a SentinelConfig has been added.