### PR TITLE
SentinelOracle - Phase 3: Add sentinel storage

### DIFF
--- a/validator/src/sentinel/storage.ts
+++ b/validator/src/sentinel/storage.ts
@@ -1,4 +1,4 @@
-import type { Database } from "better-sqlite3";
+import type { Database, Statement } from "better-sqlite3";
 import type { Hex } from "viem";
 import { z } from "zod";
 import { hexBytes32Schema } from "../types/schemas.js";
@@ -15,12 +15,14 @@ const requestQueryResultSchema = z.array(
 const sentinelRequestStateSchema = z.object({
 	deadline: z.coerce.bigint().nonnegative(),
 	status: z.enum(["preparing", "pending", "committed", "finalized"]),
-	approve: z.boolean().optional(),
+	approve: z.boolean(),
 });
 
 export class SentinelStateStorage {
 	#db: Database;
 	#requests: Map<Hex, SentinelRequestState>;
+	#insertStmt: Statement;
+	#deleteStmt: Statement;
 
 	constructor(database: Database) {
 		this.#db = database;
@@ -30,6 +32,13 @@ export class SentinelStateStorage {
 				stateJson TEXT NOT NULL
 			);
 		`);
+		this.#insertStmt = this.#db.prepare(`
+			INSERT INTO sentinel_requests (id, stateJson)
+			VALUES (?, ?)
+			ON CONFLICT(id) DO UPDATE SET
+				stateJson = excluded.stateJson
+		`);
+		this.#deleteStmt = this.#db.prepare("DELETE FROM sentinel_requests WHERE id = ?");
 		this.#requests = this.#load();
 	}
 
@@ -51,18 +60,11 @@ export class SentinelStateStorage {
 		if (diff.request) {
 			const [id, state] = diff.request;
 			if (state === undefined) {
-				this.#db.prepare("DELETE FROM sentinel_requests WHERE id = ?").run(id);
+				this.#deleteStmt.run(id);
 				this.#requests.delete(id);
 			} else {
 				const stateJson = JSON.stringify(state, jsonReplacer);
-				this.#db
-					.prepare(`
-						INSERT INTO sentinel_requests (id, stateJson)
-						VALUES (?, ?)
-						ON CONFLICT(id) DO UPDATE SET
-							stateJson = excluded.stateJson
-					`)
-					.run(id, stateJson);
+				this.#insertStmt.run(id, stateJson);
 				this.#requests.set(id, state);
 			}
 		}

--- a/validator/src/sentinel/storage.ts
+++ b/validator/src/sentinel/storage.ts
@@ -20,7 +20,7 @@ const sentinelRequestStateSchema = z.object({
 
 export class SentinelStateStorage {
 	#db: Database;
-	#requests: Map<Hex, SentinelRequestState>;
+	#requests: Record<Hex, SentinelRequestState>;
 	#insertStmt: Statement;
 	#deleteStmt: Statement;
 
@@ -42,17 +42,17 @@ export class SentinelStateStorage {
 		this.#requests = this.#load();
 	}
 
-	#load(): Map<Hex, SentinelRequestState> {
+	#load(): Record<Hex, SentinelRequestState> {
 		const rows = requestQueryResultSchema.parse(this.#db.prepare("SELECT id, stateJson FROM sentinel_requests").all());
-		const map = new Map<Hex, SentinelRequestState>();
+		const requests: Record<Hex, SentinelRequestState> = {};
 		for (const row of rows) {
 			const data = JSON.parse(row.stateJson);
-			map.set(row.id, sentinelRequestStateSchema.parse(data));
+			requests[row.id] = sentinelRequestStateSchema.parse(data);
 		}
-		return map;
+		return requests;
 	}
 
-	requests(): ReadonlyMap<Hex, SentinelRequestState> {
+	requests(): Readonly<Record<Hex, SentinelRequestState>> {
 		return this.#requests;
 	}
 
@@ -61,11 +61,11 @@ export class SentinelStateStorage {
 			const [id, state] = diff.request;
 			if (state === undefined) {
 				this.#deleteStmt.run(id);
-				this.#requests.delete(id);
+				delete this.#requests[id];
 			} else {
 				const stateJson = JSON.stringify(state, jsonReplacer);
 				this.#insertStmt.run(id, stateJson);
-				this.#requests.set(id, state);
+				this.#requests[id] = state;
 			}
 		}
 		return diff.actions ?? [];

--- a/validator/src/sentinel/storage.ts
+++ b/validator/src/sentinel/storage.ts
@@ -1,0 +1,71 @@
+import type { Database } from "better-sqlite3";
+import type { Hex } from "viem";
+import { z } from "zod";
+import { hexBytes32Schema } from "../types/schemas.js";
+import { jsonReplacer } from "../utils/json.js";
+import type { SentinelAction, SentinelRequestState, SentinelStateDiff } from "./types.js";
+
+const requestQueryResultSchema = z.array(
+	z.object({
+		id: hexBytes32Schema,
+		stateJson: z.string(),
+	}),
+);
+
+const sentinelRequestStateSchema = z.object({
+	deadline: z.coerce.bigint().nonnegative(),
+	status: z.enum(["preparing", "pending", "committed", "finalized"]),
+	approve: z.boolean().optional(),
+});
+
+export class SentinelStateStorage {
+	#db: Database;
+	#requests: Map<Hex, SentinelRequestState>;
+
+	constructor(database: Database) {
+		this.#db = database;
+		this.#db.exec(`
+			CREATE TABLE IF NOT EXISTS sentinel_requests (
+				id TEXT PRIMARY KEY,
+				stateJson TEXT NOT NULL
+			);
+		`);
+		this.#requests = this.#load();
+	}
+
+	#load(): Map<Hex, SentinelRequestState> {
+		const rows = requestQueryResultSchema.parse(this.#db.prepare("SELECT id, stateJson FROM sentinel_requests").all());
+		const map = new Map<Hex, SentinelRequestState>();
+		for (const row of rows) {
+			const data = JSON.parse(row.stateJson);
+			map.set(row.id, sentinelRequestStateSchema.parse(data));
+		}
+		return map;
+	}
+
+	requests(): ReadonlyMap<Hex, SentinelRequestState> {
+		return this.#requests;
+	}
+
+	applyDiff(diff: SentinelStateDiff): SentinelAction[] {
+		if (diff.request) {
+			const [id, state] = diff.request;
+			if (state === undefined) {
+				this.#db.prepare("DELETE FROM sentinel_requests WHERE id = ?").run(id);
+				this.#requests.delete(id);
+			} else {
+				const stateJson = JSON.stringify(state, jsonReplacer);
+				this.#db
+					.prepare(`
+						INSERT INTO sentinel_requests (id, stateJson)
+						VALUES (?, ?)
+						ON CONFLICT(id) DO UPDATE SET
+							stateJson = excluded.stateJson
+					`)
+					.run(id, stateJson);
+				this.#requests.set(id, state);
+			}
+		}
+		return diff.actions ?? [];
+	}
+}


### PR DESCRIPTION
### Context and Motivation

Task in Phase 3 of the Sentinel Oracle ([Feature Spec](https://github.com/safe-research/safenet/blob/main/features/2026_05_05_transaction_checker_oracle_v1.md#phase-3--checker-node-service-pr-3-can-be-parallelized-with-phase-2)). Complete list of tasks can be found in the [milestone](https://github.com/safe-research/safenet/milestone/1)

Add a storage with persitency for sentinal requests. It follows the same pattern as the signing request storage.