### PR TITLE
SentinelOracle - Phase 3: Add sentinel node

### DIFF
--- a/validator/package.json
+++ b/validator/package.json
@@ -6,7 +6,7 @@
 		"build": "rimraf dist && tsc --project tsconfig.dist.json",
 		"check": "biome check && tsc",
 		"dev": "tsx src/validator.ts",
-		"dev:sentinel": "tsx src/sentinel-node.ts",
+		"dev:sentinel": "tsx src/sentinel.ts",
 		"cmd:derive-genesis": "tsx src/cmd/derive-genesis.ts",
 		"cmd:logs-reliability": "tsx src/cmd/logs-reliability.ts",
 		"cmd:trigger-genesis": "tsx src/cmd/trigger-genesis.ts",

--- a/validator/package.json
+++ b/validator/package.json
@@ -6,6 +6,7 @@
 		"build": "rimraf dist && tsc --project tsconfig.dist.json",
 		"check": "biome check && tsc",
 		"dev": "tsx src/validator.ts",
+		"dev:sentinel": "tsx src/sentinel-node.ts",
 		"cmd:derive-genesis": "tsx src/cmd/derive-genesis.ts",
 		"cmd:logs-reliability": "tsx src/cmd/logs-reliability.ts",
 		"cmd:trigger-genesis": "tsx src/cmd/trigger-genesis.ts",

--- a/validator/src/sentinel-node.ts
+++ b/validator/src/sentinel-node.ts
@@ -1,0 +1,125 @@
+import Sqlite3 from "better-sqlite3";
+import dotenv from "dotenv";
+import { type ChainFees, createPublicClient, extractChain, http, webSocket } from "viem";
+import { createNonceManager, privateKeyToAccount } from "viem/accounts";
+import { jsonRpc } from "viem/nonce";
+import { z } from "zod";
+import type { WatcherConfig } from "./machine/transitions/watcher.js";
+import { createDetector } from "./sentinel/detector.js";
+import { SentinelService } from "./sentinel/service.js";
+import { supportedChains } from "./types/chains.js";
+import {
+	checkedAddressSchema,
+	hexBytes32Schema,
+	metricsConfigSchema,
+	sentinelConfigSchema,
+	submissionConfigSchema,
+	supportedChainsSchema,
+	watcherConfigSchema,
+} from "./types/schemas.js";
+import { formatError } from "./utils/errors.js";
+import { createLogger } from "./utils/logging.js";
+import { createMetricsService } from "./utils/metrics.js";
+import { withTracing } from "./utils/transport.js";
+import { COMMIT_SHA } from "./version.js";
+
+dotenv.config({ quiet: true });
+
+const sentinelNodeConfigSchema = z.object({
+	...metricsConfigSchema.shape,
+	...watcherConfigSchema.shape,
+	...submissionConfigSchema.shape,
+	...sentinelConfigSchema.shape,
+	RPC_URL: z.url(),
+	CHAIN_ID: supportedChainsSchema,
+	PRIVATE_KEY: hexBytes32Schema,
+	CONSENSUS_ADDRESS: checkedAddressSchema,
+});
+
+const result = sentinelNodeConfigSchema.safeParse(process.env);
+if (!result.success) {
+	console.error("Invalid environment variable configuration:", z.treeifyError(result.error));
+	process.exit(1);
+}
+
+const cfg = result.data;
+
+const logger = createLogger({
+	level: cfg.LOG_LEVEL,
+	pretty: process.stdout.isTTY,
+});
+
+const account = privateKeyToAccount(cfg.PRIVATE_KEY, {
+	nonceManager: createNonceManager({ source: jsonRpc() }),
+});
+logger.notice(`Using sentinel account ${account.address}`);
+
+const metrics = createMetricsService({
+	logger,
+	host: cfg.METRICS_HOST,
+	port: cfg.METRICS_PORT,
+	commit: COMMIT_SHA,
+});
+
+const transport = withTracing(cfg.RPC_URL.startsWith("wss") ? webSocket(cfg.RPC_URL) : http(cfg.RPC_URL), {
+	logger,
+	metrics: metrics.metrics,
+});
+
+const fees: ChainFees = {
+	baseFeeMultiplier: cfg.BASE_FEE_MULTIPLIER ?? 2,
+	maxPriorityFeePerGas: cfg.PRIORITY_FEE_PER_GAS,
+};
+
+const chain = {
+	...extractChain({ chains: supportedChains, id: cfg.CHAIN_ID }),
+	fees,
+};
+
+const publicClient = createPublicClient({ chain, transport });
+
+const watcherConfig: WatcherConfig = {
+	blockTimeOverride: cfg.BLOCK_TIME_OVERRIDE,
+	maxReorgDepth: cfg.MAX_REORG_DEPTH ?? 5,
+	blockPageSize: cfg.BLOCK_PAGE_SIZE,
+	blockAllLogsQueryRetryCount: cfg.BLOCK_ALL_LOGS_QUERY_RETRY_COUNT,
+	blockSingleQueryRetryCount: cfg.BLOCK_SINGLE_QUERY_RETRY_COUNT,
+	maxLogsPerQuery: cfg.MAX_LOGS_PER_QUERY,
+};
+
+const db = new Sqlite3(cfg.STORAGE_FILE ?? ":memory:");
+
+const sentinelConfig = {
+	account: account.address,
+	oracle: cfg.SENTINEL_ORACLE_ADDRESS,
+	feeToken: cfg.SENTINEL_FEE_TOKEN,
+	consensus: cfg.CONSENSUS_ADDRESS,
+	bondAmount: cfg.SENTINEL_BOND_AMOUNT,
+	chainId: BigInt(cfg.CHAIN_ID),
+	votingWindow: cfg.SENTINEL_VOTING_WINDOW,
+} as const;
+
+const service = new SentinelService({
+	account,
+	publicClient,
+	config: sentinelConfig,
+	detector: createDetector(cfg.SENTINEL_BLOCKLIST),
+	logger,
+	watcherConfig,
+	database: db,
+});
+
+const shutdown = async () => {
+	logger.notice("Shutting down sentinel service...");
+	await Promise.all([service.stop(), metrics.stop()]);
+	process.exit(0);
+};
+process.on("SIGINT", shutdown);
+process.on("SIGTERM", shutdown);
+
+Promise.all([service.start(), metrics.start()]).catch((error: unknown) => {
+	logger.error("Sentinel service failed to start.", { error: formatError(error) });
+	process.exit(1);
+});
+
+export default {};

--- a/validator/src/sentinel-node.ts
+++ b/validator/src/sentinel-node.ts
@@ -4,19 +4,12 @@ import { type ChainFees, createPublicClient, extractChain, http, webSocket } fro
 import { createNonceManager, privateKeyToAccount } from "viem/accounts";
 import { jsonRpc } from "viem/nonce";
 import { z } from "zod";
-import type { WatcherConfig } from "./machine/transitions/watcher.js";
 import { createDetector } from "./sentinel/detector.js";
 import { SentinelService } from "./sentinel/service.js";
+import type { SentinelConfig } from "./sentinel/types.js";
+import type { WatcherConfig } from "./shared/watcher.js";
 import { supportedChains } from "./types/chains.js";
-import {
-	checkedAddressSchema,
-	hexBytes32Schema,
-	metricsConfigSchema,
-	sentinelConfigSchema,
-	submissionConfigSchema,
-	supportedChainsSchema,
-	watcherConfigSchema,
-} from "./types/schemas.js";
+import { sentinelConfigSchema } from "./types/schemas.js";
 import { formatError } from "./utils/errors.js";
 import { createLogger } from "./utils/logging.js";
 import { createMetricsService } from "./utils/metrics.js";
@@ -25,18 +18,7 @@ import { COMMIT_SHA } from "./version.js";
 
 dotenv.config({ quiet: true });
 
-const sentinelNodeConfigSchema = z.object({
-	...metricsConfigSchema.shape,
-	...watcherConfigSchema.shape,
-	...submissionConfigSchema.shape,
-	...sentinelConfigSchema.shape,
-	RPC_URL: z.url(),
-	CHAIN_ID: supportedChainsSchema,
-	PRIVATE_KEY: hexBytes32Schema,
-	CONSENSUS_ADDRESS: checkedAddressSchema,
-});
-
-const result = sentinelNodeConfigSchema.safeParse(process.env);
+const result = sentinelConfigSchema.safeParse(process.env);
 if (!result.success) {
 	console.error("Invalid environment variable configuration:", z.treeifyError(result.error));
 	process.exit(1);
@@ -89,15 +71,14 @@ const watcherConfig: WatcherConfig = {
 
 const db = new Sqlite3(cfg.STORAGE_FILE ?? ":memory:");
 
-const sentinelConfig = {
+const sentinelConfig: SentinelConfig = {
 	account: account.address,
 	oracle: cfg.SENTINEL_ORACLE_ADDRESS,
-	feeToken: cfg.SENTINEL_FEE_TOKEN,
+	feeToken: cfg.SENTINEL_ORACLE_FEE_TOKEN,
 	consensus: cfg.CONSENSUS_ADDRESS,
-	bondAmount: cfg.SENTINEL_BOND_AMOUNT,
 	chainId: BigInt(cfg.CHAIN_ID),
 	votingWindow: cfg.SENTINEL_VOTING_WINDOW,
-} as const;
+};
 
 const service = new SentinelService({
 	account,
@@ -107,6 +88,7 @@ const service = new SentinelService({
 	logger,
 	watcherConfig,
 	database: db,
+	metrics: metrics.metrics,
 });
 
 const shutdown = async () => {

--- a/validator/src/sentinel.ts
+++ b/validator/src/sentinel.ts
@@ -91,9 +91,17 @@ const service = new SentinelService({
 	metrics: metrics.metrics,
 });
 
+let shuttingDown = false;
 const shutdown = async () => {
+	if (shuttingDown) return;
+	shuttingDown = true;
 	logger.notice("Shutting down sentinel service...");
-	await Promise.all([service.stop(), metrics.stop()]);
+	try {
+		await Promise.all([service.stop(), metrics.stop()]);
+		db.close();
+	} catch (error: unknown) {
+		logger.error("Error during shutdown.", { error: formatError(error) });
+	}
 	process.exit(0);
 };
 process.on("SIGINT", shutdown);

--- a/validator/src/sentinel/service.ts
+++ b/validator/src/sentinel/service.ts
@@ -4,7 +4,6 @@ import { SqliteTxStorage } from "../consensus/protocol/sqlite.js";
 import { GasFeeEstimator, TransactionManager } from "../consensus/protocol/transaction.js";
 import type { WatcherConfig } from "../shared/watcher.js";
 import type { ValidatorAccount } from "../types/account.js";
-import { formatError } from "../utils/errors.js";
 import type { Logger } from "../utils/logging.js";
 import type { Metrics } from "../utils/metrics.js";
 import type { Detector } from "./detector.js";
@@ -28,7 +27,6 @@ export class SentinelService {
 	#storage: SentinelStateStorage;
 	#protocol: SentinelProtocol;
 	#watcher: SentinelTransitionWatcher;
-	#handlerChain: Promise<unknown> = Promise.resolve();
 
 	constructor({
 		account,
@@ -77,13 +75,9 @@ export class SentinelService {
 				if (transition.id === "block_new") {
 					gasFeeEstimator.invalidate();
 					txManager.triggerPendingCheck(transition.block);
-					this.#handlerChain = this.#handlerChain
-						.then(() => this.#processBlock(transition.block))
-						.catch((err) => this.#logger.error("SentinelService: error processing block", { error: formatError(err) }));
+					this.#processBlock(transition.block);
 				} else {
-					this.#handlerChain = this.#handlerChain
-						.then(() => this.#processLog(transition))
-						.catch((err) => this.#logger.error("SentinelService: error processing log", { error: formatError(err) }));
+					this.#processLog(transition);
 				}
 			},
 		});

--- a/validator/src/types/schemas.ts
+++ b/validator/src/types/schemas.ts
@@ -88,11 +88,19 @@ export const submissionConfigSchema = z.object({
 });
 
 export const sentinelConfigSchema = z.object({
+	...metricsConfigSchema.shape,
+	...watcherConfigSchema.shape,
+	...submissionConfigSchema.shape,
 	SENTINEL_ORACLE_ADDRESS: checkedAddressSchema,
+	SENTINEL_ORACLE_FEE_TOKEN: checkedAddressSchema,
 	SENTINEL_BLOCKLIST: emptyToDefault(jsonStringToValue(z.array(checkedAddressSchema)).optional(), []),
 	// Voting window in blocks. Controls the TTL for the preparing state and when finalize becomes eligible.
 	SENTINEL_VOTING_WINDOW: emptyToDefault(z.coerce.bigint().positive(), 12n),
 	STORAGE_FILE: emptyToDefault(z.string().optional()),
+	RPC_URL: z.url(),
+	PRIVATE_KEY: hexBytes32Schema,
+	CONSENSUS_ADDRESS: checkedAddressSchema,
+	CHAIN_ID: supportedChainsSchema,
 });
 
 export const validatorConfigSchema = z.object({

--- a/validator/tsconfig.dist.json
+++ b/validator/tsconfig.dist.json
@@ -4,5 +4,5 @@
 		"noEmit": false,
 		"outDir": "./dist"
 	},
-	"include": ["src/validator.ts"]
+	"include": ["src/validator.ts", "src/sentinel.ts"]
 }


### PR DESCRIPTION
### Context and Motivation

Task in Phase 3 of the Sentinel Oracle ([Feature Spec](https://github.com/safe-research/safenet/blob/main/features/2026_05_05_transaction_checker_oracle_v1.md#phase-3--checker-node-service-pr-3-can-be-parallelized-with-phase-2)). Complete list of tasks can be found in the [milestone](https://github.com/safe-research/safenet/milestone/1)

Add the logic to setup, start and stop the sentinel service. The service can be started via the `dev:sentinel` script.

Note: additionally two smaller refactorings have been included (see PR comments).