### PR TITLE
Explicit Tx Rejection Spec

### DIFF
--- a/features/2026_05_19_explicit_transaction_rejection.md
+++ b/features/2026_05_19_explicit_transaction_rejection.md
@@ -1,0 +1,409 @@
+# Feature Proposal: Explicit Transaction Rejection Response
+Component: `all`
+
+---
+
+## Overview
+
+Currently, when a validator determines a transaction is invalid, it silently drops it. The FROST signing ceremony times out with no on-chain record. From the user's and operator's perspective, "rejected" and "error/timeout" are indistinguishable.
+
+This feature adds an explicit on-chain rejection mechanism: a validator that determines a transaction is invalid submits a `rejectTransaction` (or `rejectOracleTransaction`) call to `Consensus.sol`, storing the rejection reason on-chain. The explorer surfaces this as a distinct "Rejected" status with the specific reason code.
+
+**Phases (separate PRs):**
+1. **Contracts** — Add `rejectTransaction`, `rejectOracleTransaction`, `getTransactionRejection`, `getOracleTransactionRejection`, `TransactionRejected`, `OracleTransactionRejected` events, and `RejectionReason` enum.
+2. **Validator** — Emit `consensus_reject_transaction` / `consensus_reject_oracle_transaction` action on invalid transactions instead of silently returning.
+3. **Explorer** — Query `TransactionRejected` / `OracleTransactionRejected` events and display rejection status with reason.
+
+Phases 2 and 3 can be developed in parallel once Phase 1 is merged.
+
+---
+
+## Architecture Decision
+
+### On-chain rejection over off-chain signaling
+
+Rejection is recorded on-chain via new `rejectTransaction` / `rejectOracleTransaction` functions rather than via off-chain storage or P2P messages. This is consistent with the existing architecture where all protocol communication happens through contract events, and it ensures transparency and verifiability.
+
+### Rejection is advisory — attestation is never blocked
+
+A rejection event provides fast feedback and observability, but **does not prevent a subsequent attestation**. `attestTransaction` is not modified. If an attestation is recorded for a previously rejected proposal, the explorer shows `ATTESTED` (attestation takes precedence).
+
+**Why**: The allowed-modules, allowed-guards, and allowed-fallback-handler lists are hardcoded per validator binary version (see `checks/config/modules.ts`, `guards.ts`, `fallback.ts`). During a rolling upgrade where some validators run a newer version with an expanded allowlist, a validator on the old version could reject a transaction that the majority considers valid. Making rejection block attestation would give a single outdated validator the power to permanently deny any transaction in that epoch, with no override mechanism. Keeping rejection advisory eliminates this DoS vector entirely.
+
+### First validator wins (race-to-reject)
+
+The first validator to call `rejectTransaction` establishes the on-chain record; subsequent calls revert with `AlreadyRejected`. This keeps storage and gas costs to a single slot and a single tx per proposal.
+
+`rejectTransaction` still guards against rejecting an already-attested proposal (`require($attestations[message].isZero(), AlreadyAttested())`) to avoid emitting misleading rejection events after a successful attestation.
+
+### Access control: FROST group participants only
+
+`rejectTransaction` calls `_COORDINATOR.participantKey($groups[epoch], msg.sender)`, which reverts with `InvalidParticipant` (from `FROSTParticipantMap.getKey`) if the caller is not a member of the epoch's signing group. This revert propagates and serves as the access control guard. No return-value check is needed.
+
+### Error codes as a `uint8` enum
+
+Rejection reasons are stored on-chain as a `uint8` enum (`RejectionReason`), matching the current set of `TransactionCheckErrorCode` values in the validator. Adding new codes requires a contract upgrade.
+
+### Oracle transaction parity
+
+`proposeOracleTransaction` has a parallel lifecycle with a different message derivation (includes oracle address). This feature adds `rejectOracleTransaction` to provide the same rejection visibility for oracle-checked proposals.
+
+### Alternatives Considered
+
+**Off-chain validator database**: Validators could write rejections to a shared or local DB for the explorer to query. Rejected because it breaks the transparency guarantee and requires additional infrastructure.
+
+**Threshold-based rejection**: Require M-of-N validators to reject before marking as rejected. Would handle version-mismatch cases more gracefully, but adds significant complexity (per-validator storage, threshold parameter). Advisory rejection achieves the same safety with less complexity.
+
+**Mutual exclusivity (rejection blocks attestation)**: Initially considered for a cleaner state machine. Rejected because the hardcoded allowlists mean validators on different versions can disagree. A single old-version validator could permanently block a valid transaction in an epoch with no recovery path. See "Rejection is advisory" above.
+
+**bytes32 string instead of enum**: Stores the human-readable reason code (e.g. `"no_delegatecall"`) directly. More flexible for adding new codes without an upgrade but costs slightly more gas and has weaker type safety.
+
+---
+
+## User Flow
+
+### Rejected transaction in explorer
+
+```
+Transaction page
+─────────────────────────────────────────────────────
+Transaction Proposals
+
+  Proposal #1
+  ┌─────────────────────────────────────────────────┐
+  │ Status:    [ REJECTED ]                         │
+  │ Proposed:  Block 12345  (Explorer Tx)           │
+  │ Rejected:  Block 12347  (Explorer Tx)           │
+  │ Reason:    No delegatecall                      │
+  └─────────────────────────────────────────────────┘
+```
+
+The "Reason" field displays a human-readable label for the `RejectionReason` enum value. The rejection block and tx link provide auditability.
+
+If a proposal has both a rejection and an attestation, `ATTESTED` is displayed (attestation takes precedence). This state indicates a validator version mismatch during the rejection and is an operational signal, not an error.
+
+---
+
+## Tech Specs
+
+### Contracts
+
+#### New: `RejectionReason` enum (in `IConsensus.sol`)
+
+```solidity
+enum RejectionReason {
+    NotRejected,                // 0 — default storage value; returned by view functions when no rejection exists
+    Unknown,                    // 1
+    NoDelegatecall,             // 2
+    UnsupportedModule,          // 3
+    UnsupportedModuleGuard,     // 4
+    UnsupportedGuard,           // 5
+    UnsupportedFallbackHandler, // 6
+    InvalidSelfCall,            // 7
+    InvalidMultisend,           // 8
+    InvalidMigration,           // 9
+    InvalidSignMessage,         // 10
+    InvalidCreateCall           // 11
+}
+```
+
+#### New storage in `Consensus.sol`
+
+```solidity
+struct RejectionInfo {
+    address validator;       // 20 bytes — non-zero acts as "is rejected" sentinel
+    RejectionReason reason;  // 1 byte
+}
+mapping(bytes32 message => RejectionInfo) private $rejections;
+```
+
+#### New events in `IConsensus.sol`
+
+```solidity
+event TransactionRejected(
+    bytes32 indexed safeTxHash,
+    uint256 indexed chainId,
+    address indexed safe,
+    uint64 epoch,
+    address validator,
+    RejectionReason reason
+);
+
+event OracleTransactionRejected(
+    bytes32 indexed safeTxHash,
+    uint256 indexed chainId,
+    address indexed safe,
+    uint64 epoch,
+    address oracle,
+    address validator,
+    RejectionReason reason
+);
+```
+
+#### New errors in `Consensus.sol`
+
+```solidity
+error AlreadyRejected();
+```
+
+#### New function `rejectTransaction` in `IConsensus.sol` / `Consensus.sol`
+
+```solidity
+function rejectTransaction(
+    uint64 epoch,
+    uint256 chainId,
+    address safe,
+    bytes32 safeTxStructHash,
+    RejectionReason reason
+) external;
+```
+
+Implementation:
+1. Reconstruct `safeTxHash` via `SafeTransaction.partialHash(chainId, safe, safeTxStructHash)`.
+2. Reconstruct `message` via `domainSeparator().transactionProposal(epoch, safeTxHash)`.
+3. Call `_COORDINATOR.participantKey($groups[epoch], msg.sender)` — reverts with `InvalidParticipant` for non-members, acting as access control.
+4. `require($attestations[message].isZero(), AlreadyAttested())` — don't reject what's already attested.
+5. `require($rejections[message].validator == address(0), AlreadyRejected())` — first validator wins.
+6. Store `$rejections[message] = RejectionInfo(msg.sender, reason)`.
+7. Emit `TransactionRejected(safeTxHash, chainId, safe, epoch, msg.sender, reason)`.
+
+#### New function `rejectOracleTransaction` in `IConsensus.sol` / `Consensus.sol`
+
+```solidity
+function rejectOracleTransaction(
+    uint64 epoch,
+    address oracle,
+    uint256 chainId,
+    address safe,
+    bytes32 safeTxStructHash,
+    RejectionReason reason
+) external;
+```
+
+Implementation mirrors `rejectTransaction` but uses `domainSeparator().oracleTransactionProposal(epoch, oracle, safeTxHash)` as the message key and checks `$attestations` via the oracle message key.
+
+#### New view functions in `IConsensus.sol` / `Consensus.sol`
+
+```solidity
+function getTransactionRejection(uint64 epoch, bytes32 safeTxHash)
+    external view returns (address validator, RejectionReason reason);
+
+function getOracleTransactionRejection(uint64 epoch, address oracle, bytes32 safeTxHash)
+    external view returns (address validator, RejectionReason reason);
+```
+
+Both return `(address(0), RejectionReason.NotRejected)` when not rejected.
+
+#### `attestTransaction` — no change
+
+`attestTransaction` is **not** modified. Rejection is advisory and does not block attestation.
+
+#### Test cases
+
+- Valid tx: can be attested; can also be rejected after attestation — second call reverts with `AlreadyAttested`.
+- Invalid tx: can be rejected; attestation can still proceed after rejection (advisory).
+- Double rejection: second call reverts with `AlreadyRejected`.
+- Non-participant rejection: reverts with `InvalidParticipant` (from coordinator).
+- All `RejectionReason` values round-trip through event and view.
+- Oracle variants: same cases for `rejectOracleTransaction`.
+
+---
+
+### Validator
+
+#### New protocol action types (`types.ts`)
+
+```typescript
+export type RejectTransaction = {
+    id: "consensus_reject_transaction";
+    epoch: bigint;
+    chainId: bigint;
+    safe: Address;
+    safeTxStructHash: Hex;
+    reason: TransactionCheckErrorCode;
+};
+
+export type RejectOracleTransaction = {
+    id: "consensus_reject_oracle_transaction";
+    epoch: bigint;
+    oracle: Address;
+    chainId: bigint;
+    safe: Address;
+    safeTxStructHash: Hex;
+    reason: TransactionCheckErrorCode;
+};
+```
+
+Add both to the `ConsensusAction` union.
+
+#### Mapping `TransactionCheckErrorCode` → `RejectionReason` (new helper)
+
+```typescript
+const REJECTION_REASON: Record<TransactionCheckErrorCode, number> = {
+    unknown: 1,
+    no_delegatecall: 2,
+    unsupported_module: 3,
+    unsupported_module_guard: 4,
+    unsupported_guard: 5,
+    unsupported_fallback_handler: 6,
+    invalid_self_call: 7,
+    invalid_multisend: 8,
+    invalid_migration: 9,
+    invalid_sign_message: 10,
+    invalid_create_call: 11,
+};
+```
+
+#### Updated `handleTransactionProposed` (`transactionProposed.ts`)
+
+When `result.status === "invalid"`, instead of `return {}`:
+
+```typescript
+return {
+    actions: [{
+        id: "consensus_reject_transaction",
+        epoch: event.epoch,
+        chainId: protocol.chainId(),
+        safe: event.transaction.safe,
+        safeTxStructHash: event.transaction.structHash,
+        reason: result.error.code,
+    }],
+};
+```
+
+The oracle transaction handler (`handleOracleTransactionProposed`) is updated analogously, using `"consensus_reject_oracle_transaction"` and including the `oracle` address.
+
+#### Updated `BaseProtocol` (`base.ts`)
+
+- Add `case "consensus_reject_transaction"` and `case "consensus_reject_oracle_transaction"` to `performAction`.
+- Add abstract methods `rejectTransaction` and `rejectOracleTransaction`.
+
+#### Updated `OnchainProtocol` (`onchain.ts`)
+
+Implement both methods by calling the corresponding contract functions.
+
+#### `AlreadyRejected` handling (Issues 3 & 6)
+
+When `rejectTransaction` reverts with `AlreadyRejected`, it means another validator submitted the rejection first — the goal is already achieved. The validator must:
+- **Not retry**: detect the `AlreadyRejected` error in `onchain.ts` and return a successful `SubmittedAction` (or throw a dedicated terminal error that `BaseProtocol` recognises as non-retryable).
+- **Log at `info` level**, not `warn` — this is an expected race outcome, not a failure.
+
+The same handling applies to `AlreadyAttested` reverts from `rejectTransaction` (the tx was attested before rejection was submitted — also a terminal, non-error outcome).
+
+#### Test cases
+
+- Invalid tx produces a `consensus_reject_transaction` action with correct reason code.
+- `AlreadyRejected` revert is treated as success (no retry, info log).
+- `AlreadyAttested` revert from `rejectTransaction` is treated as success (no retry, info log).
+- All error codes map to the correct `RejectionReason` uint8.
+- Oracle variants of the above.
+
+---
+
+### Explorer
+
+#### Updated `ProposalStatus` (`transactions.ts`)
+
+```typescript
+export type ProposalStatus = "ATTESTED" | "PROPOSED" | "TIMED_OUT" | "REJECTED";
+```
+
+Status precedence (highest wins): `ATTESTED` > `REJECTED` > `TIMED_OUT` > `PROPOSED`.
+
+#### Updated `TransactionProposal` type
+
+```typescript
+export type RejectionInfo = {
+    validator: Address;
+    reason: string;  // human-readable label
+    block: bigint;
+    tx: Hex;
+};
+
+export type TransactionProposal = {
+    // ...existing fields...
+    rejectedAt: RejectionInfo | null;
+};
+```
+
+#### Updated `loadTransactionProposals` (`transactions.ts`)
+
+Include `TransactionRejected` (and `OracleTransactionRejected` for oracle proposals) in the `eth_getLogs` topic filter alongside `TransactionProposed` and `TransactionAttested`. Build a `rejections` map keyed by `safeTxHash:epoch` and apply precedence: if both `rejectedAt` and `attestedAt` are present, status is `ATTESTED`.
+
+#### Updated ABI (`abi.ts`)
+
+Add `TransactionRejected` and `OracleTransactionRejected` events to `consensusAbi` and their selectors to `transactionEventSelectors`.
+
+#### Updated `SafeTxProposals.tsx`
+
+- Show `rejectedAt` block + tx link (similar to `attestedAt`).
+- Show "Reason: \<human-readable label\>" when rejected.
+- `StatusBadge` gets a red/error color for `"REJECTED"`.
+
+#### Human-readable reason labels
+
+```typescript
+const REJECTION_REASON_LABELS: Record<number, string> = {
+    1: "Unknown",
+    2: "No delegatecall",
+    3: "Unsupported module",
+    4: "Unsupported module guard",
+    5: "Unsupported guard",
+    6: "Unsupported fallback handler",
+    7: "Invalid self call",
+    8: "Invalid multisend",
+    9: "Invalid migration",
+    10: "Invalid sign message",
+    11: "Invalid create call",
+};
+```
+
+#### Test cases
+
+- Proposal with `TransactionRejected` event: `status: "REJECTED"` with correct `rejectedAt`.
+- Proposal with both `TransactionRejected` and `TransactionAttested`: `status: "ATTESTED"` (attestation wins).
+- Proposal with attestation only: `status: "ATTESTED"`.
+- Proposal past timeout with no rejection: `status: "TIMED_OUT"`.
+- Oracle proposal variants of the above.
+
+---
+
+## Implementation Phases
+
+### Phase 1 — Contracts (PR 1)
+**Can start immediately.**
+
+Files:
+- `contracts/src/interfaces/IConsensus.sol` — `RejectionReason` enum, `TransactionRejected` and `OracleTransactionRejected` events, `AlreadyRejected` error, `rejectTransaction`, `rejectOracleTransaction`, `getTransactionRejection`, `getOracleTransactionRejection` signatures.
+- `contracts/src/Consensus.sol` — `RejectionInfo` struct, `$rejections` storage, all four function implementations. No change to `attestTransaction` or `attestOracleTransaction`.
+- `contracts/test/` — Unit tests for rejection flow (regular and oracle variants).
+
+### Phase 2a — Validator (PR 2)
+**Can start after Phase 1 is merged (or in parallel using a local ABI draft).**
+
+Files:
+- `validator/src/consensus/protocol/types.ts` — `RejectTransaction`, `RejectOracleTransaction` types, updated `ConsensusAction`.
+- `validator/src/machine/consensus/transactionProposed.ts` — Return `actions` diff for invalid tx.
+- `validator/src/machine/consensus/oracleTransactionProposed.ts` (or equivalent) — Same for oracle proposals.
+- `validator/src/consensus/protocol/base.ts` — New cases in `performAction`, abstract methods.
+- `validator/src/consensus/protocol/onchain.ts` — Implement on-chain calls with `AlreadyRejected` / `AlreadyAttested` terminal handling.
+- `validator/src/machine/consensus/transactionProposed.test.ts` — Tests.
+
+### Phase 2b — Explorer (PR 3)
+**Can start after Phase 1 is merged, in parallel with Phase 2a.**
+
+Files:
+- `explorer/src/lib/consensus/abi.ts` — Add `TransactionRejected`, `OracleTransactionRejected` events + selectors.
+- `explorer/src/lib/consensus/transactions.ts` — `RejectionInfo` type, updated `TransactionProposal`, updated `loadTransactionProposals` with precedence logic.
+- `explorer/src/components/transaction/SafeTxProposals.tsx` — Show rejection info.
+- `explorer/src/components/common/StatusBadge.tsx` — Add `REJECTED` color.
+- `explorer/src/lib/consensus/transactions.test.ts` — Tests.
+
+---
+
+## Open Questions / Assumptions
+
+- **`safeTxStructHash` availability**: The validator must compute the EIP-712 struct hash from `event.transaction` when constructing the reject action. This follows the same pattern used for `attestTransaction`.
+- **`participantKey` access control**: `FROSTParticipantMap.getKey` reverts with `InvalidParticipant` for non-members (confirmed by reading the implementation). The key is only set after DKG completes, so only participants in a fully-formed group can call `rejectTransaction`. This is the desired behaviour.
+- **Rejection + attestation coexistence**: Because rejection is advisory, it is theoretically possible for both `TransactionRejected` and `TransactionAttested` to exist for the same proposal. This indicates a validator version mismatch at the time of rejection. The explorer shows `ATTESTED` in this case and the co-existence of both events is an operational signal for the team.
+- **Devnet deployment**: After all three phases are merged, a devnet redeployment is required to pick up the new contract interface.

--- a/features/2026_05_19_explicit_transaction_rejection.md
+++ b/features/2026_05_19_explicit_transaction_rejection.md
@@ -11,10 +11,10 @@ This feature adds an explicit **decline** to the signing ceremony: a validator t
 
 **Phases (separate PRs):**
 1. **FROSTCoordinator** — Add `signDecline`, threshold stopping logic, and `SignDeclined`/`SignRejected` events. No callback yet.
-2. **Consensus callback** — Add `signDeclineWithCallback` to `FROSTCoordinator`, add `onSignRejected` to `IFROSTCoordinatorCallback`, implement on `Consensus`, emit `TransactionRejected`/`OracleTransactionRejected`. Completes the on-chain rejection story.
-3. **Validator** — Add `"waiting_to_decline"` state and `sign_decline_with_callback` action. Can be developed in parallel with Phase 2, requires it before merging.
-4. **Explorer: rejection status** — Add `REJECTED` to `ProposalStatus`, derive from `TransactionRejected` events on Consensus.
-5. **Explorer: declined breakdown** — Add `declined` to `AttestationStatus`, query `SignDeclined` events on coordinator, add "Declined" row to UI. Can be developed in parallel with Phase 4, can start after Phase 1.
+2. **Consensus callback** — Add `signDeclineWithCallback` to `FROSTCoordinator`, add `onSignRejected` to `IFROSTCoordinatorCallback`, implement on `Consensus`, emit `TransactionRejected`/`OracleTransactionRejected`.
+3. **Validator** — Add `"waiting_to_decline"` state and `sign_decline_with_callback` action. Can be developed and merged in parallel with Phase 2; both depend only on Phase 1.
+4. **Explorer: rejection status** — Add `REJECTED` to `ProposalStatus`, derive from `TransactionRejected` events on Consensus. Requires Phase 2.
+5. **Explorer: declined breakdown** — Add `declined` to `AttestationStatus`, query `SignDeclined` events on coordinator, add "Declined" row to UI. Can be developed in parallel with Phases 2–4, can start after Phase 1.
 
 ---
 
@@ -599,9 +599,9 @@ Files:
 - `contracts/test/` — Tests for the full rejection callback chain (`signDeclineWithCallback` → `onSignRejected` → `rejectTransaction` → event emitted).
 
 ### Phase 3 — Validator (PR 3)
-**Can start after Phase 1 is merged; requires Phase 2 before merging (for the Consensus ABI entries used in the callback context).**
+**Can start and merge after Phase 1 is merged. Independent of Phase 2.**
 
-Can be developed in parallel with Phase 2 using local ABI drafts.
+Develop using local ABI drafts for `signDeclineWithCallback` (coordinator, Phase 2) and `rejectTransaction`/`rejectOracleTransaction` (Consensus, Phase 2); update to the real ABI before merging.
 
 Files:
 - `validator/src/machine/types.ts` — Add `"waiting_to_decline"` to `SigningState`.
@@ -645,17 +645,11 @@ Files:
 
 ### Dependency graph
 
-```
-PR 1 (FROSTCoordinator)
-  │
-  ├──▶ PR 2 (Consensus Callback)
-  │         │
-  │         ├──▶ PR 3 (Validator)  ──▶ (merge after PR 2)
-  │         │
-  │         └──▶ PR 4 (Explorer: Rejection Status)
-  │                   │
-  └──▶ PR 5 (Explorer: Declined Breakdown)  ──▶ (merge after PR 4)
-```
+- **PR 1** — no dependencies
+- **PR 2** — depends on PR 1
+- **PR 3** — depends on PR 1 (independent of PR 2)
+- **PR 4** — depends on PR 2
+- **PR 5** — depends on PR 1; merge after PR 4 for UX coherence
 
 ### Merge sequence
 
@@ -663,13 +657,13 @@ PR 1 (FROSTCoordinator)
 |----|-------------|-------------------|
 | PR 1 | — | immediately |
 | PR 2 | PR 1 | PR 1 |
-| PR 3 | PR 2 | PR 1 (use local ABI drafts for PR 2's Consensus additions) |
+| PR 3 | PR 1 | PR 1 (use local ABI drafts for PR 2's `signDeclineWithCallback` and Consensus additions) |
 | PR 4 | PR 2 | PR 2 |
 | PR 5 | PR 4 | PR 1 (use local ABI drafts; merge after PR 4 for UX) |
 
-**Parallel tracks**: PRs 2 and 3 can be developed in parallel. PRs 4 and 5 can be developed in parallel with each other and with PR 3.
+**Parallel tracks**: PRs 2 and 3 are fully independent of each other — both branch from PR 1. PRs 4 and 5 can be developed in parallel with each other and with PR 3.
 
-**Note on local ABI drafts**: PR 3 needs `signDeclineWithCallback` (coordinator, PR 1) and `rejectTransaction`/`rejectOracleTransaction` (Consensus, PR 2) for the callback context encoding. PR 5 needs `SignDeclined` (coordinator, PR 1). When developing ahead of the upstream PR being merged, stub the relevant ABI entries locally and update to the real ABI before merging.
+**Note on local ABI drafts**: PR 3 needs `signDeclineWithCallback` (added to coordinator in PR 2) and `rejectTransaction`/`rejectOracleTransaction` (Consensus, PR 2) for the callback context encoding. PR 5 needs `SignDeclined` (coordinator, PR 1). When developing ahead of the upstream PR, stub the relevant ABI entries locally and update to the real ABI before merging.
 
 ---
 

--- a/features/2026_05_19_explicit_transaction_rejection.md
+++ b/features/2026_05_19_explicit_transaction_rejection.md
@@ -200,7 +200,7 @@ Both return `(address(0), RejectionReason.NotRejected)` when not rejected.
 
 #### Test cases
 
-- Valid tx: can be attested; can also be rejected after attestation — second call reverts with `AlreadyAttested`.
+- Valid tx: can be attested; attempting to reject it after attestation reverts with `AlreadyAttested`.
 - Invalid tx: can be rejected; attestation can still proceed after rejection (advisory).
 - Double rejection: second call reverts with `AlreadyRejected`.
 - Non-participant rejection: reverts with `InvalidParticipant` (from coordinator).
@@ -282,7 +282,7 @@ The oracle transaction handler (`handleOracleTransactionProposed`) is updated an
 
 Implement both methods by calling the corresponding contract functions.
 
-#### `AlreadyRejected` handling (Issues 3 & 6)
+#### `AlreadyRejected` handling
 
 When `rejectTransaction` reverts with `AlreadyRejected`, it means another validator submitted the rejection first — the goal is already achieved. The validator must:
 - **Not retry**: detect the `AlreadyRejected` error in `onchain.ts` and return a successful `SubmittedAction` (or throw a dedicated terminal error that `BaseProtocol` recognises as non-retryable).

--- a/features/2026_05_19_explicit_transaction_rejection.md
+++ b/features/2026_05_19_explicit_transaction_rejection.md
@@ -7,12 +7,12 @@ Component: `all`
 
 Currently, when a validator determines a transaction is invalid, it silently drops it. The FROST signing ceremony times out with no on-chain record. From the user's and operator's perspective, "rejected" and "error/timeout" are indistinguishable.
 
-This feature adds an explicit on-chain rejection mechanism: a validator that determines a transaction is invalid submits a `rejectTransaction` (or `rejectOracleTransaction`) call to `Consensus.sol`, storing the rejection reason on-chain. The explorer surfaces this as a distinct "Rejected" status with the specific reason code.
+This feature adds an explicit on-chain rejection mechanism: a validator that determines a transaction is invalid submits a `rejectTransaction` (or `rejectOracleTransaction`) call to `Consensus.sol`. Each validator's rejection is recorded individually. The explorer surfaces this as a distinct "Rejected" status.
 
 **Phases (separate PRs):**
-1. **Contracts** — Add `rejectTransaction`, `rejectOracleTransaction`, `getTransactionRejection`, `getOracleTransactionRejection`, `TransactionRejected`, `OracleTransactionRejected` events, and `RejectionReason` enum.
+1. **Contracts** — Add `rejectTransaction`, `rejectOracleTransaction`, `getTransactionRejection`, `getOracleTransactionRejection`, `TransactionRejected`, and `OracleTransactionRejected` events.
 2. **Validator** — Emit `consensus_reject_transaction` / `consensus_reject_oracle_transaction` action on invalid transactions instead of silently returning.
-3. **Explorer** — Query `TransactionRejected` / `OracleTransactionRejected` events and display rejection status with reason.
+3. **Explorer** — Query `TransactionRejected` / `OracleTransactionRejected` events and display rejection status.
 
 Phases 2 and 3 can be developed in parallel once Phase 1 is merged.
 
@@ -30,19 +30,24 @@ A rejection event provides fast feedback and observability, but **does not preve
 
 **Why**: The allowed-modules, allowed-guards, and allowed-fallback-handler lists are hardcoded per validator binary version (see `checks/config/modules.ts`, `guards.ts`, `fallback.ts`). During a rolling upgrade where some validators run a newer version with an expanded allowlist, a validator on the old version could reject a transaction that the majority considers valid. Making rejection block attestation would give a single outdated validator the power to permanently deny any transaction in that epoch, with no override mechanism. Keeping rejection advisory eliminates this DoS vector entirely.
 
-### First validator wins (race-to-reject)
+### Per-validator tracking
 
-The first validator to call `rejectTransaction` establishes the on-chain record; subsequent calls revert with `AlreadyRejected`. This keeps storage and gas costs to a single slot and a single tx per proposal.
+Each validator's rejection is stored as an individual flag. This means:
+- Multiple `TransactionRejected` events can be emitted for the same proposal, one per rejecting validator.
+- Rejection and attestation coexist naturally — no "first wins" special-casing needed.
+- The explorer can show which validators rejected, providing richer observability.
 
-`rejectTransaction` still guards against rejecting an already-attested proposal (`require($attestations[message].isZero(), AlreadyAttested())`) to avoid emitting misleading rejection events after a successful attestation.
+### Rejection stored on `Consensus`, not `FROSTCoordinator`
+
+Rejection is a consensus-layer concern (is this Safe transaction valid per the network's rules?) and belongs alongside attestation in `Consensus.sol`. The `FROSTCoordinator` manages low-level FROST signing mechanics and has no knowledge of Safe transactions or validator validity rules. Placing rejection there would introduce a semantic mismatch and couple the signing infrastructure to application-layer policy. Keeping both attestation and rejection in `Consensus` also maintains a consistent and complete picture of a proposal's lifecycle in one contract.
+
+### Rejection is a flag — no reason code
+
+Only a boolean flag per (message, validator) is stored. A reason code would improve user-facing messages but requires maintaining a `RejectionReason` enum in sync across the contract and validator, and adds a contract upgrade path when new checks are introduced. The flag alone is sufficient for the primary goals of fast feedback and observability.
 
 ### Access control: FROST group participants only
 
 `rejectTransaction` calls `_COORDINATOR.participantKey($groups[epoch], msg.sender)`, which reverts with `InvalidParticipant` (from `FROSTParticipantMap.getKey`) if the caller is not a member of the epoch's signing group. This revert propagates and serves as the access control guard. No return-value check is needed.
-
-### Error codes as a `uint8` enum
-
-Rejection reasons are stored on-chain as a `uint8` enum (`RejectionReason`), matching the current set of `TransactionCheckErrorCode` values in the validator. Adding new codes requires a contract upgrade.
 
 ### Oracle transaction parity
 
@@ -56,7 +61,7 @@ Rejection reasons are stored on-chain as a `uint8` enum (`RejectionReason`), mat
 
 **Mutual exclusivity (rejection blocks attestation)**: Initially considered for a cleaner state machine. Rejected because the hardcoded allowlists mean validators on different versions can disagree. A single old-version validator could permanently block a valid transaction in an epoch with no recovery path. See "Rejection is advisory" above.
 
-**bytes32 string instead of enum**: Stores the human-readable reason code (e.g. `"no_delegatecall"`) directly. More flexible for adding new codes without an upgrade but costs slightly more gas and has weaker type safety.
+**Reason codes**: Storing a `RejectionReason` enum alongside the flag would improve user-facing messages. Dropped in favour of the simpler flag to avoid keeping TS and Solidity enums in sync and to avoid contract upgrades when new checks are added.
 
 ---
 
@@ -74,13 +79,11 @@ Transaction Proposals
   │ Status:    [ REJECTED ]                         │
   │ Proposed:  Block 12345  (Explorer Tx)           │
   │ Rejected:  Block 12347  (Explorer Tx)           │
-  │ Reason:    No delegatecall                      │
+  │            Block 12348  (Explorer Tx)           │
   └─────────────────────────────────────────────────┘
 ```
 
-The "Reason" field displays a human-readable label for the `RejectionReason` enum value. The rejection block and tx link provide auditability.
-
-If a proposal has both a rejection and an attestation, `ATTESTED` is displayed (attestation takes precedence). This state indicates a validator version mismatch during the rejection and is an operational signal, not an error.
+Each rejection event is shown as a separate row. If a proposal has both rejections and an attestation, `ATTESTED` is displayed (attestation takes precedence). This state indicates a validator version mismatch during the rejection and is an operational signal, not an error.
 
 ---
 
@@ -88,33 +91,10 @@ If a proposal has both a rejection and an attestation, `ATTESTED` is displayed (
 
 ### Contracts
 
-#### New: `RejectionReason` enum (in `IConsensus.sol`)
-
-```solidity
-enum RejectionReason {
-    NotRejected,                // 0 — default storage value; returned by view functions when no rejection exists
-    Unknown,                    // 1
-    NoDelegatecall,             // 2
-    UnsupportedModule,          // 3
-    UnsupportedModuleGuard,     // 4
-    UnsupportedGuard,           // 5
-    UnsupportedFallbackHandler, // 6
-    InvalidSelfCall,            // 7
-    InvalidMultisend,           // 8
-    InvalidMigration,           // 9
-    InvalidSignMessage,         // 10
-    InvalidCreateCall           // 11
-}
-```
-
 #### New storage in `Consensus.sol`
 
 ```solidity
-struct RejectionInfo {
-    address validator;       // 20 bytes — non-zero acts as "is rejected" sentinel
-    RejectionReason reason;  // 1 byte
-}
-mapping(bytes32 message => RejectionInfo) private $rejections;
+mapping(bytes32 message => mapping(address validator => bool)) private $rejections;
 ```
 
 #### New events in `IConsensus.sol`
@@ -125,8 +105,7 @@ event TransactionRejected(
     uint256 indexed chainId,
     address indexed safe,
     uint64 epoch,
-    address validator,
-    RejectionReason reason
+    address validator
 );
 
 event OracleTransactionRejected(
@@ -135,8 +114,7 @@ event OracleTransactionRejected(
     address indexed safe,
     uint64 epoch,
     address oracle,
-    address validator,
-    RejectionReason reason
+    address validator
 );
 ```
 
@@ -153,8 +131,7 @@ function rejectTransaction(
     uint64 epoch,
     uint256 chainId,
     address safe,
-    bytes32 safeTxStructHash,
-    RejectionReason reason
+    bytes32 safeTxStructHash
 ) external;
 ```
 
@@ -163,9 +140,9 @@ Implementation:
 2. Reconstruct `message` via `domainSeparator().transactionProposal(epoch, safeTxHash)`.
 3. Call `_COORDINATOR.participantKey($groups[epoch], msg.sender)` — reverts with `InvalidParticipant` for non-members, acting as access control.
 4. `require($attestations[message].isZero(), AlreadyAttested())` — don't reject what's already attested.
-5. `require($rejections[message].validator == address(0), AlreadyRejected())` — first validator wins.
-6. Store `$rejections[message] = RejectionInfo(msg.sender, reason)`.
-7. Emit `TransactionRejected(safeTxHash, chainId, safe, epoch, msg.sender, reason)`.
+5. `require(!$rejections[message][msg.sender], AlreadyRejected())` — prevent double rejection by the same validator.
+6. Set `$rejections[message][msg.sender] = true`.
+7. Emit `TransactionRejected(safeTxHash, chainId, safe, epoch, msg.sender)`.
 
 #### New function `rejectOracleTransaction` in `IConsensus.sol` / `Consensus.sol`
 
@@ -175,24 +152,21 @@ function rejectOracleTransaction(
     address oracle,
     uint256 chainId,
     address safe,
-    bytes32 safeTxStructHash,
-    RejectionReason reason
+    bytes32 safeTxStructHash
 ) external;
 ```
 
-Implementation mirrors `rejectTransaction` but uses `domainSeparator().oracleTransactionProposal(epoch, oracle, safeTxHash)` as the message key and checks `$attestations` via the oracle message key.
+Implementation mirrors `rejectTransaction` but uses `domainSeparator().oracleTransactionProposal(epoch, oracle, safeTxHash)` as the message key.
 
 #### New view functions in `IConsensus.sol` / `Consensus.sol`
 
 ```solidity
-function getTransactionRejection(uint64 epoch, bytes32 safeTxHash)
-    external view returns (address validator, RejectionReason reason);
+function getTransactionRejection(uint64 epoch, bytes32 safeTxHash, address validator)
+    external view returns (bool rejected);
 
-function getOracleTransactionRejection(uint64 epoch, address oracle, bytes32 safeTxHash)
-    external view returns (address validator, RejectionReason reason);
+function getOracleTransactionRejection(uint64 epoch, address oracle, bytes32 safeTxHash, address validator)
+    external view returns (bool rejected);
 ```
-
-Both return `(address(0), RejectionReason.NotRejected)` when not rejected.
 
 #### `attestTransaction` — no change
 
@@ -201,10 +175,10 @@ Both return `(address(0), RejectionReason.NotRejected)` when not rejected.
 #### Test cases
 
 - Valid tx: can be attested; attempting to reject it after attestation reverts with `AlreadyAttested`.
-- Invalid tx: can be rejected; attestation can still proceed after rejection (advisory).
-- Double rejection: second call reverts with `AlreadyRejected`.
+- Invalid tx: can be rejected by multiple validators independently; attestation can still proceed after rejection (advisory).
+- Double rejection by the same validator: second call reverts with `AlreadyRejected`.
+- Two different validators rejecting the same proposal: both succeed, two events emitted.
 - Non-participant rejection: reverts with `InvalidParticipant` (from coordinator).
-- All `RejectionReason` values round-trip through event and view.
 - Oracle variants: same cases for `rejectOracleTransaction`.
 
 ---
@@ -220,7 +194,6 @@ export type RejectTransaction = {
     chainId: bigint;
     safe: Address;
     safeTxStructHash: Hex;
-    reason: TransactionCheckErrorCode;
 };
 
 export type RejectOracleTransaction = {
@@ -230,29 +203,10 @@ export type RejectOracleTransaction = {
     chainId: bigint;
     safe: Address;
     safeTxStructHash: Hex;
-    reason: TransactionCheckErrorCode;
 };
 ```
 
 Add both to the `ConsensusAction` union.
-
-#### Mapping `TransactionCheckErrorCode` → `RejectionReason` (new helper)
-
-```typescript
-const REJECTION_REASON: Record<TransactionCheckErrorCode, number> = {
-    unknown: 1,
-    no_delegatecall: 2,
-    unsupported_module: 3,
-    unsupported_module_guard: 4,
-    unsupported_guard: 5,
-    unsupported_fallback_handler: 6,
-    invalid_self_call: 7,
-    invalid_multisend: 8,
-    invalid_migration: 9,
-    invalid_sign_message: 10,
-    invalid_create_call: 11,
-};
-```
 
 #### Updated `handleTransactionProposed` (`transactionProposed.ts`)
 
@@ -266,7 +220,6 @@ return {
         chainId: protocol.chainId(),
         safe: event.transaction.safe,
         safeTxStructHash: event.transaction.structHash,
-        reason: result.error.code,
     }],
 };
 ```
@@ -284,19 +237,14 @@ Implement both methods by calling the corresponding contract functions.
 
 #### `AlreadyRejected` handling
 
-When `rejectTransaction` reverts with `AlreadyRejected`, it means another validator submitted the rejection first — the goal is already achieved. The validator must:
-- **Not retry**: detect the `AlreadyRejected` error in `onchain.ts` and return a successful `SubmittedAction` (or throw a dedicated terminal error that `BaseProtocol` recognises as non-retryable).
-- **Log at `info` level**, not `warn` — this is an expected race outcome, not a failure.
-
-The same handling applies to `AlreadyAttested` reverts from `rejectTransaction` (the tx was attested before rejection was submitted — also a terminal, non-error outcome).
+When `rejectTransaction` reverts with `AlreadyRejected`, the same validator somehow submitted the rejection twice — treat it as a terminal, non-retryable outcome. When it reverts with `AlreadyAttested`, the tx was attested before rejection was submitted — also terminal. Both are caught in `onchain.ts`, resolved as completed actions, and logged at `info` rather than `warn`.
 
 #### Test cases
 
-- Invalid tx produces a `consensus_reject_transaction` action with correct reason code.
-- `AlreadyRejected` revert is treated as success (no retry, info log).
-- `AlreadyAttested` revert from `rejectTransaction` is treated as success (no retry, info log).
-- All error codes map to the correct `RejectionReason` uint8.
-- Oracle variants of the above.
+- Invalid tx produces a `consensus_reject_transaction` action.
+- `AlreadyRejected` revert resolves without retry and logs at info level.
+- `AlreadyAttested` revert from `rejectTransaction` resolves without retry.
+- Oracle transaction variants of the above.
 
 ---
 
@@ -313,22 +261,21 @@ Status precedence (highest wins): `ATTESTED` > `REJECTED` > `TIMED_OUT` > `PROPO
 #### Updated `TransactionProposal` type
 
 ```typescript
-export type RejectionInfo = {
+export type RejectionEvent = {
     validator: Address;
-    reason: string;  // human-readable label
     block: bigint;
     tx: Hex;
 };
 
 export type TransactionProposal = {
     // ...existing fields...
-    rejectedAt: RejectionInfo | null;
+    rejections: RejectionEvent[];  // one entry per rejecting validator
 };
 ```
 
 #### Updated `loadTransactionProposals` (`transactions.ts`)
 
-Include `TransactionRejected` (and `OracleTransactionRejected` for oracle proposals) in the `eth_getLogs` topic filter alongside `TransactionProposed` and `TransactionAttested`. Build a `rejections` map keyed by `safeTxHash:epoch` and apply precedence: if both `rejectedAt` and `attestedAt` are present, status is `ATTESTED`.
+Include `TransactionRejected` (and `OracleTransactionRejected` for oracle proposals) in the `eth_getLogs` topic filter alongside `TransactionProposed` and `TransactionAttested`. Collect all rejection events per `safeTxHash:epoch` into the `rejections` array. Status is `REJECTED` if `rejections` is non-empty and no attestation exists.
 
 #### Updated ABI (`abi.ts`)
 
@@ -336,33 +283,14 @@ Add `TransactionRejected` and `OracleTransactionRejected` events to `consensusAb
 
 #### Updated `SafeTxProposals.tsx`
 
-- Show `rejectedAt` block + tx link (similar to `attestedAt`).
-- Show "Reason: \<human-readable label\>" when rejected.
-- `StatusBadge` gets a red/error color for `"REJECTED"`.
-
-#### Human-readable reason labels
-
-```typescript
-const REJECTION_REASON_LABELS: Record<number, string> = {
-    1: "Unknown",
-    2: "No delegatecall",
-    3: "Unsupported module",
-    4: "Unsupported module guard",
-    5: "Unsupported guard",
-    6: "Unsupported fallback handler",
-    7: "Invalid self call",
-    8: "Invalid multisend",
-    9: "Invalid migration",
-    10: "Invalid sign message",
-    11: "Invalid create call",
-};
-```
+- Show each entry in `rejections` as a row with block number and tx link (similar to `attestedAt`).
+- `StatusBadge` gets a red/error colour for `"REJECTED"`.
 
 #### Test cases
 
-- Proposal with `TransactionRejected` event: `status: "REJECTED"` with correct `rejectedAt`.
-- Proposal with both `TransactionRejected` and `TransactionAttested`: `status: "ATTESTED"` (attestation wins).
-- Proposal with attestation only: `status: "ATTESTED"`.
+- Proposal with one `TransactionRejected` event: `status: "REJECTED"`, one entry in `rejections`.
+- Proposal with multiple `TransactionRejected` events: `status: "REJECTED"`, multiple entries in `rejections`.
+- Proposal with both rejections and attestation: `status: "ATTESTED"` (attestation wins), `rejections` still populated.
 - Proposal past timeout with no rejection: `status: "TIMED_OUT"`.
 - Oracle proposal variants of the above.
 
@@ -374,8 +302,8 @@ const REJECTION_REASON_LABELS: Record<number, string> = {
 **Can start immediately.**
 
 Files:
-- `contracts/src/interfaces/IConsensus.sol` — `RejectionReason` enum, `TransactionRejected` and `OracleTransactionRejected` events, `AlreadyRejected` error, `rejectTransaction`, `rejectOracleTransaction`, `getTransactionRejection`, `getOracleTransactionRejection` signatures.
-- `contracts/src/Consensus.sol` — `RejectionInfo` struct, `$rejections` storage, all four function implementations. No change to `attestTransaction` or `attestOracleTransaction`.
+- `contracts/src/interfaces/IConsensus.sol` — `TransactionRejected` and `OracleTransactionRejected` events, `AlreadyRejected` error, `rejectTransaction`, `rejectOracleTransaction`, `getTransactionRejection`, `getOracleTransactionRejection` signatures.
+- `contracts/src/Consensus.sol` — `$rejections` storage, all four function implementations. No change to `attestTransaction` or `attestOracleTransaction`.
 - `contracts/test/` — Unit tests for rejection flow (regular and oracle variants).
 
 ### Phase 2a — Validator (PR 2)
@@ -394,9 +322,9 @@ Files:
 
 Files:
 - `explorer/src/lib/consensus/abi.ts` — Add `TransactionRejected`, `OracleTransactionRejected` events + selectors.
-- `explorer/src/lib/consensus/transactions.ts` — `RejectionInfo` type, updated `TransactionProposal`, updated `loadTransactionProposals` with precedence logic.
-- `explorer/src/components/transaction/SafeTxProposals.tsx` — Show rejection info.
-- `explorer/src/components/common/StatusBadge.tsx` — Add `REJECTED` color.
+- `explorer/src/lib/consensus/transactions.ts` — `RejectionEvent` type, updated `TransactionProposal`, updated `loadTransactionProposals` with precedence logic.
+- `explorer/src/components/transaction/SafeTxProposals.tsx` — Show rejection rows.
+- `explorer/src/components/common/StatusBadge.tsx` — Add `REJECTED` colour.
 - `explorer/src/lib/consensus/transactions.test.ts` — Tests.
 
 ---
@@ -405,5 +333,5 @@ Files:
 
 - **`safeTxStructHash` availability**: The validator must compute the EIP-712 struct hash from `event.transaction` when constructing the reject action. This follows the same pattern used for `attestTransaction`.
 - **`participantKey` access control**: `FROSTParticipantMap.getKey` reverts with `InvalidParticipant` for non-members (confirmed by reading the implementation). The key is only set after DKG completes, so only participants in a fully-formed group can call `rejectTransaction`. This is the desired behaviour.
-- **Rejection + attestation coexistence**: Because rejection is advisory, it is theoretically possible for both `TransactionRejected` and `TransactionAttested` to exist for the same proposal. This indicates a validator version mismatch at the time of rejection. The explorer shows `ATTESTED` in this case and the co-existence of both events is an operational signal for the team.
+- **Rejection + attestation coexistence**: Because rejection is advisory, it is possible for both `TransactionRejected` and `TransactionAttested` to exist for the same proposal. This indicates a validator version mismatch at the time of rejection. The explorer shows `ATTESTED` in this case; the rejection events remain visible for auditability.
 - **Devnet deployment**: After all three phases are merged, a devnet redeployment is required to pick up the new contract interface.

--- a/features/2026_05_19_explicit_transaction_rejection.md
+++ b/features/2026_05_19_explicit_transaction_rejection.md
@@ -7,61 +7,60 @@ Component: `all`
 
 Currently, when a validator determines a transaction is invalid, it silently drops it. The FROST signing ceremony times out with no on-chain record. From the user's and operator's perspective, "rejected" and "error/timeout" are indistinguishable.
 
-This feature adds an explicit on-chain rejection mechanism: a validator that determines a transaction is invalid submits a `rejectTransaction` (or `rejectOracleTransaction`) call to `Consensus.sol`. Each validator's rejection is recorded individually. The explorer surfaces this as a distinct "Rejected" status.
+This feature adds an explicit **decline** to the signing ceremony: a validator that determines a transaction is invalid calls `signDeclineWithCallback` on `FROSTCoordinator`. Once enough validators decline (threshold: `count - threshold + 1`), the ceremony is definitively marked rejected on-chain — further `signShare` calls revert, and a callback triggers `onSignRejected` on `Consensus`, which emits a `TransactionRejected` event. The explorer surfaces this as a distinct "Rejected" status.
 
 **Phases (separate PRs):**
-1. **Contracts** — Add `rejectTransaction`, `rejectOracleTransaction`, `getTransactionRejection`, `getOracleTransactionRejection`, `TransactionRejected`, and `OracleTransactionRejected` events.
-2. **Validator** — Emit `consensus_reject_transaction` / `consensus_reject_oracle_transaction` action on invalid transactions instead of silently returning.
-3. **Explorer** — Query `TransactionRejected` / `OracleTransactionRejected` events and display rejection status.
-
-Phases 2 and 3 can be developed in parallel once Phase 1 is merged.
+1. **FROSTCoordinator** — Add `signDecline`, threshold stopping logic, and `SignDeclined`/`SignRejected` events. No callback yet.
+2. **Consensus callback** — Add `signDeclineWithCallback` to `FROSTCoordinator`, add `onSignRejected` to `IFROSTCoordinatorCallback`, implement on `Consensus`, emit `TransactionRejected`/`OracleTransactionRejected`. Completes the on-chain rejection story.
+3. **Validator** — Add `"waiting_to_decline"` state and `sign_decline_with_callback` action. Can be developed in parallel with Phase 2, requires it before merging.
+4. **Explorer: rejection status** — Add `REJECTED` to `ProposalStatus`, derive from `TransactionRejected` events on Consensus.
+5. **Explorer: declined breakdown** — Add `declined` to `AttestationStatus`, query `SignDeclined` events on coordinator, add "Declined" row to UI. Can be developed in parallel with Phase 4, can start after Phase 1.
 
 ---
 
 ## Architecture Decision
 
-### On-chain rejection over off-chain signaling
+### Decline lives in `FROSTCoordinator`, not `Consensus`
 
-Rejection is recorded on-chain via new `rejectTransaction` / `rejectOracleTransaction` functions rather than via off-chain storage or P2P messages. This is consistent with the existing architecture where all protocol communication happens through contract events, and it ensures transparency and verifiability.
+A rejection is semantically "I am not participating in this signing ceremony." The signing ceremony is managed by `FROSTCoordinator` — it already tracks per-participant actions (`SignRevealedNonces`, `SignShared`). An explicit decline is the natural counterpart to those actions, and belongs in the same contract.
 
-### Rejection is advisory — attestation is never blocked
+`Consensus` only stores a pointer (the `FROSTSignatureId`) to the completed signature, which lives in the coordinator. The rejection state lives in the coordinator too; `Consensus` learns about it exclusively via the coordinator callback.
 
-A rejection event provides fast feedback and observability, but **does not prevent a subsequent attestation**. `attestTransaction` is not modified. If an attestation is recorded for a previously rejected proposal, the explorer shows `ATTESTED` (attestation takes precedence).
+### Decline is a flag — no reason code
 
-**Why**: The allowed-modules, allowed-guards, and allowed-fallback-handler lists are hardcoded per validator binary version (see `checks/config/modules.ts`, `guards.ts`, `fallback.ts`). During a rolling upgrade where some validators run a newer version with an expanded allowlist, a validator on the old version could reject a transaction that the majority considers valid. Making rejection block attestation would give a single outdated validator the power to permanently deny any transaction in that epoch, with no override mechanism. Keeping rejection advisory eliminates this DoS vector entirely.
+Only a per-participant boolean is stored: "did this participant decline this ceremony?" A reason code would improve user-facing messages but requires maintaining an enum in sync across the contract and validator, and adds a contract upgrade path when new checks are introduced. The flag alone is sufficient for the goals of fast feedback and observability.
 
-### Per-validator tracking
+### Decline stops signing at threshold — but never blocks attestation
 
-Each validator's rejection is stored as an individual flag. This means:
-- Multiple `TransactionRejected` events can be emitted for the same proposal, one per rejecting validator.
-- Rejection and attestation coexist naturally — no "first wins" special-casing needed.
-- The explorer can show which validators rejected, providing richer observability.
+Two distinct behaviors:
 
-### Rejection stored on `Consensus`, not `FROSTCoordinator`
+**At signing threshold**: When `decline_count >= count - threshold + 1`, enough validators have declined that the ceremony can no longer reach threshold regardless of who is left. At this point, the ceremony is definitively marked rejected. Further `signShare` calls revert with `CeremonyRejected`, and `signatureVerify`/`signatureValue` revert with `SignatureRejected` (giving a clearer error than `NotSigned`). The coordinator fires `onSignRejected` on Consensus, which emits `TransactionRejected`.
 
-Rejection is a consensus-layer concern (is this Safe transaction valid per the network's rules?) and belongs alongside attestation in `Consensus.sol`. The `FROSTCoordinator` manages low-level FROST signing mechanics and has no knowledge of Safe transactions or validator validity rules. Placing rejection there would introduce a semantic mismatch and couple the signing infrastructure to application-layer policy. Keeping both attestation and rejection in `Consensus` also maintains a consistent and complete picture of a proposal's lifecycle in one contract.
+**Attestation is never blocked before threshold**: If threshold participants sign before enough declines accumulate, the ceremony completes and the transaction is attested. `ATTESTED` always takes precedence over `REJECTED` in the explorer.
 
-### Rejection is a flag — no reason code
+**Why**: The allowed-modules, allowed-guards, and allowed-fallback-handler lists are hardcoded per validator binary version (see `checks/config/modules.ts`, `guards.ts`, `fallback.ts`). During a rolling upgrade, a validator on an older version could decline a transaction that the majority considers valid. Making even one decline block signing would give a single outdated validator the power to deny any transaction in that epoch with no recovery path. The threshold (`count - threshold + 1`) is the exact point at which the ceremony is mathematically uncompletable — blocking signing is safe only at this point.
 
-Only a boolean flag per (message, validator) is stored. A reason code would improve user-facing messages but requires maintaining a `RejectionReason` enum in sync across the contract and validator, and adds a contract upgrade path when new checks are introduced. The flag alone is sufficient for the primary goals of fast feedback and observability.
+### Rejection callback mirrors the existing signing callback pattern
 
-### Access control: FROST group participants only
+`signShareWithCallback` calls `onSignCompleted` on `Consensus` when signing completes. Rejection uses the same mechanism: `signDeclineWithCallback` calls `onSignRejected` on `Consensus` when the rejection threshold is first crossed. The callback context uses the same function-selector-prefixed ABI encoding as attestation, dispatching to `rejectTransaction` or `rejectOracleTransaction`.
 
-`rejectTransaction` calls `_COORDINATOR.participantKey($groups[epoch], msg.sender)`, which reverts with `InvalidParticipant` (from `FROSTParticipantMap.getKey`) if the caller is not a member of the epoch's signing group. This revert propagates and serves as the access control guard. No return-value check is needed.
+This avoids cross-contract event correlation in the explorer: `TransactionRejected` lives on `Consensus` alongside `TransactionProposed` and `TransactionAttested`, which simplifies queries to a single contract.
 
-### Oracle transaction parity
+### Validator uses a `"waiting_to_decline"` signing state
 
-`proposeOracleTransaction` has a parallel lifecycle with a different message derivation (includes oracle address). This feature adds `rejectOracleTransaction` to provide the same rejection visibility for oracle-checked proposals.
+When a transaction is deemed invalid in `handleTransactionProposed`, the validator creates a `"waiting_to_decline"` signing state (instead of `"waiting_for_request"` for valid transactions). When the `Sign` event from the coordinator arrives for that message, `handleSign` detects this state and emits a `sign_decline_with_callback` action rather than proceeding with nonce commitments. The signing state is then cleared.
+
+This slots into the existing state machine with minimal changes: `handleSign` already dispatches on the signing state type.
 
 ### Alternatives Considered
 
-**Off-chain validator database**: Validators could write rejections to a shared or local DB for the explorer to query. Rejected because it breaks the transparency guarantee and requires additional infrastructure.
+**Off-chain validator database**: Validators write rejections to a shared DB. Rejected because it breaks transparency and requires additional infrastructure.
 
-**Threshold-based rejection**: Require M-of-N validators to reject before marking as rejected. Would handle version-mismatch cases more gracefully, but adds significant complexity (per-validator storage, threshold parameter). Advisory rejection achieves the same safety with less complexity.
+**Single decline blocks attestation**: Making any one decline prevent signing. Creates a single-validator DoS risk. The threshold-based approach only stops signing when it is mathematically impossible anyway.
 
-**Mutual exclusivity (rejection blocks attestation)**: Initially considered for a cleaner state machine. Rejected because the hardcoded allowlists mean validators on different versions can disagree. A single old-version validator could permanently block a valid transaction in an epoch with no recovery path. See "Rejection is advisory" above.
+**Reason codes**: Storing a reason alongside the flag would improve user-facing messages. Dropped to avoid keeping TS and Solidity enums in sync and to avoid contract upgrades when new checks are added.
 
-**Reason codes**: Storing a `RejectionReason` enum alongside the flag would improve user-facing messages. Dropped in favour of the simpler flag to avoid keeping TS and Solidity enums in sync and to avoid contract upgrades when new checks are added.
+**Explorer cross-contract correlation**: Query `SignDeclined` events on the coordinator and correlate by SID to determine rejection status. Dropped in favour of `TransactionRejected` on Consensus (same source as `TransactionProposed` / `TransactionAttested`), which is simpler and avoids combining two data sources at the component level.
 
 ---
 
@@ -76,137 +75,318 @@ Transaction Proposals
 
   Proposal #1
   ┌─────────────────────────────────────────────────┐
-  │ Status:    [ REJECTED ]                         │
-  │ Proposed:  Block 12345  (Explorer Tx)           │
-  │ Rejected:  Block 12347  (Explorer Tx)           │
-  │            Block 12348  (Explorer Tx)           │
+  │ Status:       [ REJECTED ]                      │
+  │ Proposed:     Block 12345  (Explorer Tx)        │
+  │ Committed:    0x1a2b…  0x3c4d…                  │
+  │ Signed:       —                                 │
+  │ Declined:     0x5e6f…  0x7a8b…                  │
   └─────────────────────────────────────────────────┘
 ```
 
-Each rejection event is shown as a separate row. If a proposal has both rejections and an attestation, `ATTESTED` is displayed (attestation takes precedence). This state indicates a validator version mismatch during the rejection and is an operational signal, not an error.
+"Declined" is a new row in the existing attestation status breakdown (alongside "Committed" and "Signed"), showing which validators explicitly opted out of the ceremony. Status is `REJECTED` when a `TransactionRejected` event exists and no `TransactionAttested` event exists. If attestation completes before enough declines accumulate, status is `ATTESTED`.
 
 ---
 
 ## Tech Specs
 
-### Contracts
+### Phase 1 — FROSTCoordinator (`FROSTCoordinator.sol`)
 
-#### New storage in `Consensus.sol`
+No changes to `IFROSTCoordinatorCallback.sol` or `Consensus.sol` in this phase. `signDeclineWithCallback` is added in Phase 2 once `IFROSTCoordinatorCallback.onSignRejected` exists.
+
+#### Updated `Signature` struct
+
+Add `rejected` and `declineCount` fields. Both are packed into the same storage slot:
 
 ```solidity
-mapping(bytes32 message => mapping(address validator => bool)) private $rejections;
+struct Signature {
+    bytes32 message;
+    bytes32 signed;
+    bool rejected;
+    uint16 declineCount;
+    FROSTSignatureShares.T shares;
+}
 ```
 
-#### New events in `IConsensus.sol`
+#### New storage
+
+```solidity
+mapping(FROSTSignatureId.T sid => mapping(address participant => bool)) private $declined;
+```
+
+The decline count per ceremony is tracked in `$signatures[sid].declineCount` (above).
+
+#### New events
+
+```solidity
+event SignDeclined(FROSTSignatureId.T indexed sid, address indexed participant);
+event SignRejected(FROSTSignatureId.T indexed sid);
+```
+
+#### New errors
+
+```solidity
+error AlreadyDeclined();
+error SigningComplete();
+error CeremonyRejected();
+error SignatureRejected();
+```
+
+`SigningComplete` — decline called after ceremony is already signed. Confirm during implementation whether an equivalent error already exists in `FROSTCoordinator`; if so, reuse it.
+
+#### New function `signDecline`
+
+```solidity
+function signDecline(FROSTSignatureId.T sid) public returns (bool rejected);
+```
+
+Implementation:
+1. `FROSTGroupId.T gid = sid.group()`.
+2. `Group storage group = $groups[gid]`.
+3. `group.participants.getKey(msg.sender)` — reverts with `InvalidParticipant` for non-members, acting as access control.
+4. `Signature storage signature = $signatures[sid]`.
+5. `require(signature.message != bytes32(0), NotSigning())` — ceremony must exist.
+6. `require(signature.signed == bytes32(0), SigningComplete())` — ceremony must not be completed.
+7. `require(!$declined[sid][msg.sender], AlreadyDeclined())` — prevent double decline.
+8. `$declined[sid][msg.sender] = true`.
+9. `signature.declineCount++`.
+10. Emit `SignDeclined(sid, msg.sender)`.
+11. `GroupState memory state = group.state`.
+12. If `signature.declineCount >= state.count - state.threshold + 1` and `!signature.rejected`:
+    - `signature.rejected = true`.
+    - Emit `SignRejected(sid)`.
+    - Return `true`.
+13. Return `false`.
+
+Note: the guard `!signature.rejected` in step 12 ensures the event fires exactly once. If additional validators decline after the threshold is already crossed, their `SignDeclined` is still recorded (useful for observability in the explorer) but `SignRejected` is not re-emitted.
+
+#### New view functions
+
+```solidity
+function isSignDeclined(FROSTSignatureId.T sid, address participant)
+    external view returns (bool);
+
+function isSignRejected(FROSTSignatureId.T sid)
+    external view returns (bool);
+
+function signatureMessage(FROSTSignatureId.T sid)
+    external view returns (bytes32);
+```
+
+`isSignRejected` returns `$signatures[sid].rejected`. `signatureMessage` returns `$signatures[sid].message` — used by `Consensus.rejectTransaction` in Phase 2 to validate the SID corresponds to the ceremony for that message.
+
+#### Updated `signShare`
+
+Add a rejection guard after `_signatureGroupAndMessage`:
+
+```solidity
+function signShare(...) public returns (bool signed) {
+    (Group storage group, bytes32 message) = _signatureGroupAndMessage(sid);
+    require(!$signatures[sid].rejected, CeremonyRejected());  // new
+    // ... rest of existing implementation unchanged
+}
+```
+
+#### Updated `signatureVerify` and `signatureValue`
+
+Add a rejection check before the `NotSigned` check, so rejected SIDs return a clearer error than `NotSigned`:
+
+```solidity
+function signatureVerify(FROSTSignatureId.T sid, FROSTGroupId.T gid, bytes32 message)
+    external view returns (FROST.Signature memory result)
+{
+    Signature storage signature = $signatures[sid];
+    require(!signature.rejected, SignatureRejected());  // new
+    bytes32 signed = signature.signed;
+    require(signed != bytes32(0), NotSigned());
+    // ... rest unchanged
+}
+
+function signatureValue(FROSTSignatureId.T sid) external view returns (FROST.Signature memory result) {
+    Signature storage signature = $signatures[sid];
+    require(!signature.rejected, SignatureRejected());  // new
+    bytes32 signed = signature.signed;
+    require(signed != bytes32(0), NotSigned());
+    // ... rest unchanged
+}
+```
+
+#### Test cases (Phase 1)
+
+- Participant declines: `SignDeclined` emitted, `isSignDeclined` returns true.
+- Non-participant decline: reverts with `InvalidParticipant`.
+- Double decline by same participant: reverts with `AlreadyDeclined`.
+- Decline when ceremony not started (message is zero): reverts with `NotSigning`.
+- Decline after ceremony signed: reverts with `SigningComplete`.
+- Different participants can each decline the same ceremony independently.
+- Declines below threshold: `SignRejected` not emitted, `isSignRejected` returns false, ceremony still signable.
+- Declines reach `count - threshold + 1`: `SignRejected` emitted exactly once, `isSignRejected` returns true.
+- Additional declines after threshold crossed: `SignDeclined` emitted, `SignRejected` not re-emitted.
+- `signShare` after rejection: reverts with `CeremonyRejected`.
+- `signatureVerify`/`signatureValue` for rejected SID: reverts with `SignatureRejected`.
+- `signDecline` returns `true` only when the rejection threshold is first crossed, `false` otherwise.
+- Ceremony completes (signs) before rejection threshold: succeeds, no `CeremonyRejected`.
+
+---
+
+### Phase 2 — Consensus Callback (`FROSTCoordinator.sol`, `IFROSTCoordinatorCallback.sol`, `Consensus.sol`)
+
+#### New function `signDeclineWithCallback` (`FROSTCoordinator.sol`)
+
+Added in this phase alongside `onSignRejected` — the two must be introduced together since the coordinator calls into the updated interface:
+
+```solidity
+function signDeclineWithCallback(FROSTSignatureId.T sid, Callback calldata callback)
+    external
+    returns (bool rejected)
+{
+    rejected = signDecline(sid);
+    if (rejected) {
+        callback.target.onSignRejected(sid, callback.context);
+    }
+}
+```
+
+#### Updated `IFROSTCoordinatorCallback`
+
+Add the new callback method:
+
+```solidity
+interface IFROSTCoordinatorCallback {
+    function onKeyGenCompleted(FROSTGroupId.T gid, bytes calldata context) external;
+    function onSignCompleted(FROSTSignatureId.T sid, bytes calldata context) external;
+    function onSignRejected(FROSTSignatureId.T sid, bytes calldata context) external;  // new
+}
+```
+
+#### New storage (`Consensus.sol`)
+
+```solidity
+mapping(bytes32 message => FROSTSignatureId.T) private $rejections;
+```
+
+Mirrors `$attestations` for rejection state.
+
+#### New events (`IConsensus.sol`)
 
 ```solidity
 event TransactionRejected(
     bytes32 indexed safeTxHash,
-    uint256 indexed chainId,
+    uint256 chainId,
     address indexed safe,
     uint64 epoch,
-    address validator
+    FROSTSignatureId.T signatureId
 );
 
 event OracleTransactionRejected(
     bytes32 indexed safeTxHash,
-    uint256 indexed chainId,
+    uint256 chainId,
     address indexed safe,
     uint64 epoch,
     address oracle,
-    address validator
+    FROSTSignatureId.T signatureId
 );
 ```
 
-#### New errors in `Consensus.sol`
+#### New errors (`Consensus.sol`)
 
 ```solidity
 error AlreadyRejected();
+error NotRejected();
 ```
 
-#### New function `rejectTransaction` in `IConsensus.sol` / `Consensus.sol`
+`NotRejected` — thrown when `rejectTransaction` is called with a signatureId that the coordinator has not marked as rejected. Guards against direct calls bypassing the callback mechanism.
+
+#### New public functions (`Consensus.sol`)
 
 ```solidity
 function rejectTransaction(
     uint64 epoch,
     uint256 chainId,
     address safe,
-    bytes32 safeTxStructHash
-) external;
-```
+    bytes32 safeTxStructHash,
+    FROSTSignatureId.T signatureId
+) public;
 
-Implementation:
-1. Reconstruct `safeTxHash` via `SafeTransaction.partialHash(chainId, safe, safeTxStructHash)`.
-2. Reconstruct `message` via `domainSeparator().transactionProposal(epoch, safeTxHash)`.
-3. Call `_COORDINATOR.participantKey($groups[epoch], msg.sender)` — reverts with `InvalidParticipant` for non-members, acting as access control.
-4. `require($attestations[message].isZero(), AlreadyAttested())` — don't reject what's already attested.
-5. `require(!$rejections[message][msg.sender], AlreadyRejected())` — prevent double rejection by the same validator.
-6. Set `$rejections[message][msg.sender] = true`.
-7. Emit `TransactionRejected(safeTxHash, chainId, safe, epoch, msg.sender)`.
-
-#### New function `rejectOracleTransaction` in `IConsensus.sol` / `Consensus.sol`
-
-```solidity
 function rejectOracleTransaction(
     uint64 epoch,
     address oracle,
     uint256 chainId,
     address safe,
-    bytes32 safeTxStructHash
-) external;
+    bytes32 safeTxStructHash,
+    FROSTSignatureId.T signatureId
+) public;
 ```
 
-Implementation mirrors `rejectTransaction` but uses `domainSeparator().oracleTransactionProposal(epoch, oracle, safeTxHash)` as the message key.
+`rejectTransaction` implementation:
+1. Compute `safeTxHash = SafeTransaction.partialHash(chainId, safe, safeTxStructHash)`.
+2. Compute `message = domainSeparator().transactionProposal(epoch, safeTxHash)`.
+3. `require($rejections[message].isZero(), AlreadyRejected())`.
+4. `require(_COORDINATOR.isSignRejected(signatureId), NotRejected())` — validates the coordinator has marked this SID as rejected.
+5. `require(_COORDINATOR.signatureMessage(signatureId) == message, WrongSignature())` — validates the SID belongs to this specific ceremony. Without this check, a caller could pass a legitimately rejected SID from an unrelated ceremony to emit a false `TransactionRejected` event for any proposed transaction. `WrongSignature` is an existing coordinator error; add an equivalent to `Consensus.sol` or reuse a matching one.
+6. `$rejections[message] = signatureId`.
+7. Emit `TransactionRejected(safeTxHash, chainId, safe, epoch, signatureId)`.
 
-#### New view functions in `IConsensus.sol` / `Consensus.sol`
+`rejectOracleTransaction` follows the same pattern with `oracleTransactionProposal` and `OracleTransactionRejected`.
+
+#### Updated `onSignRejected` (`Consensus.sol`)
+
+Dispatches on the function selector in `context`, matching the pattern of `onSignCompleted`:
 
 ```solidity
-function getTransactionRejection(uint64 epoch, bytes32 safeTxHash, address validator)
-    external view returns (bool rejected);
-
-function getOracleTransactionRejection(uint64 epoch, address oracle, bytes32 safeTxHash, address validator)
-    external view returns (bool rejected);
+function onSignRejected(FROSTSignatureId.T signatureId, bytes calldata context)
+    external
+    onlyCoordinator
+{
+    bytes4 selector = bytes4(context);
+    if (selector == this.rejectTransaction.selector) {
+        (uint64 epoch, uint256 chainId, address safe, bytes32 safeTxStructHash) =
+            abi.decode(context[4:], (uint64, uint256, address, bytes32));
+        rejectTransaction(epoch, chainId, safe, safeTxStructHash, signatureId);
+    } else if (selector == this.rejectOracleTransaction.selector) {
+        (uint64 epoch, address oracle, uint256 chainId, address safe, bytes32 safeTxStructHash) =
+            abi.decode(context[4:], (uint64, address, uint256, address, bytes32));
+        rejectOracleTransaction(epoch, oracle, chainId, safe, safeTxStructHash, signatureId);
+    } else {
+        revert UnknownSignatureSelector();
+    }
+}
 ```
 
-#### `attestTransaction` — no change
+#### Updated `supportsInterface` (`Consensus.sol`)
 
-`attestTransaction` is **not** modified. Rejection is advisory and does not block attestation.
+`IFROSTCoordinatorCallback` now has an additional method; no code change required here as the interface ID is derived from all methods.
 
-#### Test cases
+#### Test cases (Phase 2)
 
-- Valid tx: can be attested; attempting to reject it after attestation reverts with `AlreadyAttested`.
-- Invalid tx: can be rejected by multiple validators independently; attestation can still proceed after rejection (advisory).
-- Double rejection by the same validator: second call reverts with `AlreadyRejected`.
-- Two different validators rejecting the same proposal: both succeed, two events emitted.
-- Non-participant rejection: reverts with `InvalidParticipant` (from coordinator).
-- Oracle variants: same cases for `rejectOracleTransaction`.
+- `signDeclineWithCallback`: callback fires when rejection threshold is first crossed, not on subsequent declines.
+- `signDeclineWithCallback`: no callback when threshold is not yet reached.
+- `onSignRejected` called by non-coordinator: reverts with `NotCoordinator`.
+- `onSignRejected` dispatches to `rejectTransaction` for safe tx context.
+- `onSignRejected` dispatches to `rejectOracleTransaction` for oracle tx context.
+- `onSignRejected` with unknown selector: reverts with `UnknownSignatureSelector`.
+- `rejectTransaction` emits `TransactionRejected`, stores signatureId.
+- `rejectTransaction` with unrejected signatureId (coordinator does not have it marked): reverts with `NotRejected`.
+- `rejectTransaction` with a rejected signatureId from a different ceremony (wrong message): reverts with `WrongSignature`.
+- `rejectTransaction` called twice for same message: reverts with `AlreadyRejected`.
+- `rejectOracleTransaction` mirrors the above for oracle transactions.
 
 ---
 
-### Validator
+### Phase 3 — Validator
 
-#### New protocol action types (`types.ts`)
+#### New signing state (`types.ts`)
 
 ```typescript
-export type RejectTransaction = {
-    id: "consensus_reject_transaction";
-    epoch: bigint;
-    chainId: bigint;
-    safe: Address;
-    safeTxStructHash: Hex;
-};
-
-export type RejectOracleTransaction = {
-    id: "consensus_reject_oracle_transaction";
-    epoch: bigint;
-    oracle: Address;
-    chainId: bigint;
-    safe: Address;
-    safeTxStructHash: Hex;
-};
+| {
+      id: "waiting_to_decline";
+      packet: SafeTransactionPacket | OracleTransactionPacket;
+      deadline: bigint;
+  }
 ```
 
-Add both to the `ConsensusAction` union.
+`packet` is required to conform with `BaseSigningState` and to allow the SQLite storage layer to persist and restore this state across validator restarts. Both `SafeTransactionPacket` and `OracleTransactionPacket` are available at creation time in their respective handlers.
+
+Add to the `SigningState` union alongside the existing states.
 
 #### Updated `handleTransactionProposed` (`transactionProposed.ts`)
 
@@ -214,124 +394,416 @@ When `result.status === "invalid"`, instead of `return {}`:
 
 ```typescript
 return {
-    actions: [{
-        id: "consensus_reject_transaction",
-        epoch: event.epoch,
-        chainId: protocol.chainId(),
-        safe: event.transaction.safe,
-        safeTxStructHash: event.transaction.structHash,
-    }],
+    signing: [
+        message,
+        {
+            id: "waiting_to_decline",
+            packet,
+            deadline: event.block + machineConfig.signingTimeout,
+        },
+    ],
 };
 ```
 
-The oracle transaction handler (`handleOracleTransactionProposed`) is updated analogously, using `"consensus_reject_oracle_transaction"` and including the `oracle` address.
+#### Updated `handleOracleTransactionProposed` (`oracleTransactionProposed.ts`)
 
-#### Updated `BaseProtocol` (`base.ts`)
+Same change when `result.status === "invalid"`, using `OracleTransactionPacket`.
 
-- Add `case "consensus_reject_transaction"` and `case "consensus_reject_oracle_transaction"` to `performAction`.
-- Add abstract methods `rejectTransaction` and `rejectOracleTransaction`.
+#### Updated `handleSign` (`sign.ts`)
 
-#### Updated `OnchainProtocol` (`onchain.ts`)
+Add a branch for `"waiting_to_decline"` before the existing `"waiting_for_request"` check. Nonce replenishment (`checkAvailableNonces`) is skipped — a declining validator will not participate in the ceremony:
 
-Implement both methods by calling the corresponding contract functions.
+```typescript
+if (status?.id === "waiting_to_decline") {
+    const callbackContext = buildDeclineCallbackContext(status.packet);
+    return {
+        signing: [event.message], // clears the state
+        actions: [{ id: "sign_decline_with_callback", signatureId: event.sid, callbackContext }],
+    };
+}
+```
 
-#### `AlreadyRejected` handling
+Note the absence of `...diff` (nonce replenishment diff) — a declining validator should not trigger nonce registration for a ceremony it is opting out of.
 
-When `rejectTransaction` reverts with `AlreadyRejected`, the same validator somehow submitted the rejection twice — treat it as a terminal, non-retryable outcome. When it reverts with `AlreadyAttested`, the tx was attested before rejection was submitted — also terminal. Both are caught in `onchain.ts`, resolved as completed actions, and logged at `info` rather than `warn`.
+#### New callback context builder (`signing/declines.ts`)
 
-#### Test cases
+Analogous to `buildCallbackContext` in `nonces.ts`, encoding the function selector and arguments for the Consensus callback. Place in a new `validator/src/machine/signing/declines.ts`:
 
-- Invalid tx produces a `consensus_reject_transaction` action.
-- `AlreadyRejected` revert resolves without retry and logs at info level.
-- `AlreadyAttested` revert from `rejectTransaction` resolves without retry.
-- Oracle transaction variants of the above.
+```typescript
+export const buildDeclineCallbackContext = (
+    packet: SafeTransactionPacket | OracleTransactionPacket,
+): Hex => {
+    if (packet.type === "safe_transaction_packet") {
+        const { chainId, safe, ...txData } = packet.proposal.transaction;
+        return encodeFunctionData({
+            abi: CONSENSUS_FUNCTIONS,
+            functionName: "rejectTransaction",
+            args: [packet.proposal.epoch, chainId, safe, safeTxStructHash(txData), zeroHash],
+        });
+    }
+    const { chainId, safe, ...txData } = packet.proposal.transaction;
+    return encodeFunctionData({
+        abi: CONSENSUS_FUNCTIONS,
+        functionName: "rejectOracleTransaction",
+        args: [packet.proposal.epoch, packet.proposal.oracle, chainId, safe, safeTxStructHash(txData), zeroHash],
+    });
+};
+```
+
+`CONSENSUS_FUNCTIONS` must include `rejectTransaction` and `rejectOracleTransaction` ABI entries.
+
+The `zeroHash` passed as the `signatureId` argument in both encodings is a placeholder — it is never decoded from the context. `onSignRejected` receives the actual `signatureId` as its first parameter and passes it directly to `rejectTransaction`. This is the same convention used in `buildTransactionAttestationCallback` in `nonces.ts`.
+
+#### New protocol action type (`consensus/protocol/types.ts`)
+
+```typescript
+export type DeclineSignature = {
+    id: "sign_decline_with_callback";
+    signatureId: SignatureId;
+    callbackContext: Hex;
+};
+```
+
+Add `DeclineSignature` to the `SigningAction` union.
+
+#### Updated `BaseProtocol` (`consensus/protocol/base.ts`)
+
+- Add `case "sign_decline_with_callback"` to `performAction`.
+- Add abstract method `declineSignature(args: DeclineSignature): Promise<SubmittedAction>`.
+
+#### Updated `OnchainProtocol` (`consensus/protocol/onchain.ts`)
+
+Implement `declineSignature` by calling `FROSTCoordinator.signDeclineWithCallback(sid, { target: consensus, context: callbackContext })`:
+
+```typescript
+protected declineSignature({ signatureId, callbackContext }: DeclineSignature): Promise<SubmittedAction> {
+    return this.submitAction({
+        address: this.#coordinator,
+        abi: COORDINATOR_FUNCTIONS,
+        functionName: "signDeclineWithCallback",
+        args: [
+            signatureId,
+            { target: this.#consensus, context: callbackContext },
+        ],
+        gas: 200_000n,
+    });
+}
+```
+
+`COORDINATOR_FUNCTIONS` must include `signDeclineWithCallback` ABI entry.
+
+#### `AlreadyDeclined` and `SigningComplete` handling
+
+Both are terminal, non-retryable outcomes — the same validator somehow submitted a duplicate decline, or the ceremony completed before the decline landed. Catch these reverts in `onchain.ts`, resolve as completed actions, and log at `info` rather than `warn`.
+
+#### Updated `timeouts.ts`
+
+Add a timeout case for `"waiting_to_decline"`: simply drop the state, no retry. If the `Sign` event is never observed (e.g., it was missed), the signing state times out and the validator gives up. No decline is submitted.
+
+#### Test cases (Phase 3)
+
+- Invalid safe tx produces a `"waiting_to_decline"` signing state with the correct `SafeTransactionPacket`.
+- Invalid oracle tx produces a `"waiting_to_decline"` signing state with the correct `OracleTransactionPacket`.
+- `Sign` event for a `"waiting_to_decline"` message emits `sign_decline_with_callback` action with correct callback context, clears state, and does NOT include nonce replenishment actions.
+- `Sign` event for a `"waiting_for_request"` message (valid tx) is unaffected.
+- `AlreadyDeclined` revert resolves without retry, logged at info.
+- `SigningComplete` revert resolves without retry, logged at info.
+- Validator restart while in `"waiting_to_decline"`: state is restored from SQLite and decline is submitted after the `Sign` event is re-observed.
+- Timeout in `"waiting_to_decline"`: state is cleared, no action emitted.
 
 ---
 
-### Explorer
+### Phase 4 — Explorer: Rejection Status
 
-#### Updated `ProposalStatus` (`transactions.ts`)
+#### Updated `ProposalStatus` (`consensus/transactions.ts`)
 
 ```typescript
 export type ProposalStatus = "ATTESTED" | "PROPOSED" | "TIMED_OUT" | "REJECTED";
 ```
 
-Status precedence (highest wins): `ATTESTED` > `REJECTED` > `TIMED_OUT` > `PROPOSED`.
+Status precedence: `ATTESTED` > `REJECTED` > `TIMED_OUT` > `PROPOSED`.
 
-#### Updated `TransactionProposal` type
+#### Updated status derivation (`consensus/transactions.ts`)
+
+`loadTransactionProposals` already queries `TransactionProposed` and `TransactionAttested` from Consensus. Add `TransactionRejected` to the same query. Status is `REJECTED` when `TransactionRejected` exists and no `TransactionAttested` exists for the same message. No cross-contract correlation needed.
+
+#### Updated ABI
+
+Add `TransactionRejected` and `OracleTransactionRejected` events to the Consensus ABI used by the explorer.
+
+#### Test cases (Phase 4)
+
+- `loadTransactionProposals` with `TransactionRejected` event: `status: "REJECTED"`.
+- `loadTransactionProposals` with `TransactionAttested` and `TransactionRejected` both present (should not occur in practice, but guard for precedence): `status: "ATTESTED"`.
+- Proposal past timeout with no declines: `status: "TIMED_OUT"`.
+
+---
+
+### Phase 5 — Explorer: Declined Breakdown
+
+#### Updated `AttestationStatus` type (`coordinator/signing.ts`)
 
 ```typescript
-export type RejectionEvent = {
-    validator: Address;
-    block: bigint;
-    tx: Hex;
-};
-
-export type TransactionProposal = {
-    // ...existing fields...
-    rejections: RejectionEvent[];  // one entry per rejecting validator
+type AttestationStatus = {
+    status: "pending" | "completed" | "error";
+    sid: Hex;
+    groupId: Hex;
+    sequence: bigint;
+    committed: AttestationParticipation[];
+    signed: AttestationParticipation[];
+    declined: AttestationParticipation[];   // new
+    signature?: Hex;
 };
 ```
 
-#### Updated `loadTransactionProposals` (`transactions.ts`)
+#### Updated signing progress query (`coordinator/signing.ts`)
 
-Include `TransactionRejected` (and `OracleTransactionRejected` for oracle proposals) in the `eth_getLogs` topic filter alongside `TransactionProposed` and `TransactionAttested`. Collect all rejection events per `safeTxHash:epoch` into the `rejections` array. Status is `REJECTED` if `rejections` is non-empty and no attestation exists.
+Add `SignDeclined` event to the existing log queries for a SID. Populate `declined` from those events, keyed by participant address. The SID is already known from the existing `Sign` event correlation.
 
-#### Updated ABI (`abi.ts`)
+Add `SignDeclined` event to the coordinator ABI used by the explorer.
 
-Add `TransactionRejected` and `OracleTransactionRejected` events to `consensusAbi` and their selectors to `transactionEventSelectors`.
+**SID scope note**: `signDecline` fires for all coordinator ceremonies (epoch rollover, oracle transactions). Since `useAttestationStatus` is already scoped to a specific proposal's SID (derived from the `Sign` event for that proposal's message), `SignDeclined` events are naturally filtered to the correct ceremony.
 
-#### Updated `SafeTxProposals.tsx`
+#### Updated `SafeTxAttestationStatus.tsx`
 
-- Show each entry in `rejections` as a row with block number and tx link (similar to `attestedAt`).
-- `StatusBadge` gets a red/error colour for `"REJECTED"`.
+Add a "Declined" row displaying validator addresses from `status.declined`, following the same pattern as the existing "Committed" and "Signed" rows.
 
-#### Test cases
+#### Test cases (Phase 5)
 
-- Proposal with one `TransactionRejected` event: `status: "REJECTED"`, one entry in `rejections`.
-- Proposal with multiple `TransactionRejected` events: `status: "REJECTED"`, multiple entries in `rejections`.
-- Proposal with both rejections and attestation: `status: "ATTESTED"` (attestation wins), `rejections` still populated.
-- Proposal past timeout with no rejection: `status: "TIMED_OUT"`.
-- Oracle proposal variants of the above.
+- Signing progress with `SignDeclined` events populates `declined` correctly.
+- "Declined" row renders validator addresses from `status.declined`.
 
 ---
 
 ## Implementation Phases
 
-### Phase 1 — Contracts (PR 1)
+### Phase 1 — FROSTCoordinator (PR 1)
 **Can start immediately.**
 
-Files:
-- `contracts/src/interfaces/IConsensus.sol` — `TransactionRejected` and `OracleTransactionRejected` events, `AlreadyRejected` error, `rejectTransaction`, `rejectOracleTransaction`, `getTransactionRejection`, `getOracleTransactionRejection` signatures.
-- `contracts/src/Consensus.sol` — `$rejections` storage, all four function implementations. No change to `attestTransaction` or `attestOracleTransaction`.
-- `contracts/test/` — Unit tests for rejection flow (regular and oracle variants).
-
-### Phase 2a — Validator (PR 2)
-**Can start after Phase 1 is merged (or in parallel using a local ABI draft).**
+Completes the coordinator side of the feature in isolation: decline tracking and threshold-based stopping. `signDeclineWithCallback` is intentionally excluded — it requires `IFROSTCoordinatorCallback.onSignRejected` which does not exist until Phase 2.
 
 Files:
-- `validator/src/consensus/protocol/types.ts` — `RejectTransaction`, `RejectOracleTransaction` types, updated `ConsensusAction`.
-- `validator/src/machine/consensus/transactionProposed.ts` — Return `actions` diff for invalid tx.
-- `validator/src/machine/consensus/oracleTransactionProposed.ts` (or equivalent) — Same for oracle proposals.
-- `validator/src/consensus/protocol/base.ts` — New cases in `performAction`, abstract methods.
-- `validator/src/consensus/protocol/onchain.ts` — Implement on-chain calls with `AlreadyRejected` / `AlreadyAttested` terminal handling.
+- `contracts/src/FROSTCoordinator.sol` — `Signature` struct update (`rejected`, `declineCount`), `$declined` storage, `SignDeclined`/`SignRejected` events, new errors, `signDecline`/`isSignDeclined`/`isSignRejected`/`signatureMessage`, guards on `signShare`/`signatureVerify`/`signatureValue`.
+- `contracts/test/` — Unit tests for the full decline flow, including threshold logic.
+
+### Phase 2 — Consensus Callback (PR 2)
+**Can start after Phase 1 is merged.**
+
+Completes the on-chain rejection story: `Consensus` learns about rejected ceremonies via the coordinator callback and emits `TransactionRejected`/`OracleTransactionRejected`. At this point the full on-chain flow is end-to-end testable.
+
+Files:
+- `contracts/src/FROSTCoordinator.sol` — Add `signDeclineWithCallback`.
+- `contracts/src/interfaces/IFROSTCoordinatorCallback.sol` — Add `onSignRejected`.
+- `contracts/src/interfaces/IConsensus.sol` — Add `TransactionRejected`, `OracleTransactionRejected` events.
+- `contracts/src/Consensus.sol` — `$rejections` storage, `AlreadyRejected`/`NotRejected` errors, `rejectTransaction`/`rejectOracleTransaction`, `onSignRejected` implementation.
+- `contracts/test/` — Tests for the full rejection callback chain (`signDeclineWithCallback` → `onSignRejected` → `rejectTransaction` → event emitted).
+
+### Phase 3 — Validator (PR 3)
+**Can start after Phase 1 is merged; requires Phase 2 before merging (for the Consensus ABI entries used in the callback context).**
+
+Can be developed in parallel with Phase 2 using local ABI drafts.
+
+Files:
+- `validator/src/machine/types.ts` — Add `"waiting_to_decline"` to `SigningState`.
+- `validator/src/machine/consensus/transactionProposed.ts` — Return `"waiting_to_decline"` state for invalid safe tx.
+- `validator/src/machine/consensus/oracleTransactionProposed.ts` — Same for invalid oracle tx.
+- `validator/src/machine/signing/sign.ts` — Handle `"waiting_to_decline"` state.
+- `validator/src/machine/signing/declines.ts` — `buildDeclineCallbackContext`.
+- `validator/src/machine/signing/timeouts.ts` — Add timeout case for `"waiting_to_decline"`.
+- `validator/src/consensus/protocol/types.ts` — `DeclineSignature` type, updated `SigningAction`.
+- `validator/src/consensus/protocol/base.ts` — New case in `performAction`, abstract method.
+- `validator/src/consensus/protocol/onchain.ts` — Implement `declineSignature` with terminal error handling.
+- `validator/src/machine/signing/sign.test.ts` — Tests.
 - `validator/src/machine/consensus/transactionProposed.test.ts` — Tests.
+- `validator/src/machine/consensus/oracleTransactionProposed.test.ts` — Tests.
+- `validator/src/machine/storage/sqlite.test.ts` — Test persistence and restore of `"waiting_to_decline"` state.
 
-### Phase 2b — Explorer (PR 3)
-**Can start after Phase 1 is merged, in parallel with Phase 2a.**
+### Phase 4 — Explorer: Rejection Status (PR 4)
+**Can start after Phase 2 is merged.**
+
+Adds the `REJECTED` proposal status. Entirely Consensus-side: queries `TransactionRejected` alongside existing events, no coordinator interaction.
 
 Files:
-- `explorer/src/lib/consensus/abi.ts` — Add `TransactionRejected`, `OracleTransactionRejected` events + selectors.
-- `explorer/src/lib/consensus/transactions.ts` — `RejectionEvent` type, updated `TransactionProposal`, updated `loadTransactionProposals` with precedence logic.
-- `explorer/src/components/transaction/SafeTxProposals.tsx` — Show rejection rows.
-- `explorer/src/components/common/StatusBadge.tsx` — Add `REJECTED` colour.
-- `explorer/src/lib/consensus/transactions.test.ts` — Tests.
+- `explorer/src/lib/consensus/transactions.ts` — Add `"REJECTED"` to `ProposalStatus`, query `TransactionRejected` events.
+- `explorer/src/lib/consensus/abi.ts` (or equivalent) — Add `TransactionRejected`/`OracleTransactionRejected` events.
+- Tests for the above.
+
+### Phase 5 — Explorer: Declined Breakdown (PR 5)
+**Can start after Phase 1 is merged. Can be developed in parallel with Phases 2, 3, and 4; should merge after Phase 4 for UX coherence (showing who declined is most useful once the REJECTED status is visible).**
+
+Adds the per-validator "Declined" row. Entirely coordinator-side: queries `SignDeclined` events for a known SID, no Consensus interaction.
+
+Files:
+- `explorer/src/lib/coordinator/signing.ts` — Add `declined` to `AttestationStatus`, query `SignDeclined` events.
+- `explorer/src/lib/coordinator/abi.ts` (or equivalent) — Add `SignDeclined` event.
+- `explorer/src/components/transaction/SafeTxAttestationStatus.tsx` — Add "Declined" row.
+- Tests for the above.
+
+---
+
+## PR Workflow
+
+### Dependency graph
+
+```
+PR 1 (FROSTCoordinator)
+  │
+  ├──▶ PR 2 (Consensus Callback)
+  │         │
+  │         ├──▶ PR 3 (Validator)  ──▶ (merge after PR 2)
+  │         │
+  │         └──▶ PR 4 (Explorer: Rejection Status)
+  │                   │
+  └──▶ PR 5 (Explorer: Declined Breakdown)  ──▶ (merge after PR 4)
+```
+
+### Merge sequence
+
+| PR | Merge after | Can develop after |
+|----|-------------|-------------------|
+| PR 1 | — | immediately |
+| PR 2 | PR 1 | PR 1 |
+| PR 3 | PR 2 | PR 1 (use local ABI drafts for PR 2's Consensus additions) |
+| PR 4 | PR 2 | PR 2 |
+| PR 5 | PR 4 | PR 1 (use local ABI drafts; merge after PR 4 for UX) |
+
+**Parallel tracks**: PRs 2 and 3 can be developed in parallel. PRs 4 and 5 can be developed in parallel with each other and with PR 3.
+
+**Note on local ABI drafts**: PR 3 needs `signDeclineWithCallback` (coordinator, PR 1) and `rejectTransaction`/`rejectOracleTransaction` (Consensus, PR 2) for the callback context encoding. PR 5 needs `SignDeclined` (coordinator, PR 1). When developing ahead of the upstream PR being merged, stub the relevant ABI entries locally and update to the real ABI before merging.
+
+---
+
+## PR Descriptions
+
+### PR 1 — FROSTCoordinator: Decline Tracking and Threshold Stopping
+
+> Adds per-participant decline recording and threshold-based ceremony stopping to `FROSTCoordinator`. Once enough validators decline, the ceremony is definitively marked rejected and further signing reverts.
+
+#### Context and Motivation
+
+- Currently, validators silently drop transactions they consider invalid. The signing ceremony then times out with no on-chain record, making rejection indistinguishable from a timeout or error.
+- This PR lays the on-chain foundation: validators can explicitly opt out of a ceremony via `signDecline`, and when enough have done so (`count - threshold + 1`), the ceremony is blocked from completing.
+- `signDeclineWithCallback` (the callback to Consensus) is intentionally excluded — it requires `IFROSTCoordinatorCallback.onSignRejected` which does not exist until PR 2. The two must be introduced together.
+
+#### Decisions and Tradeoffs
+
+- **Decline is a flag, no reason code**: avoids maintaining a Solidity/TypeScript enum in sync and avoids a contract upgrade path every time a new validation check is added.
+- **`rejected` and `declineCount` live in the `Signature` struct**: keeps all per-ceremony state together; both fields pack into a single new storage slot alongside the existing fields.
+- **Threshold formula `count - threshold + 1`**: this is the exact minimum number of declines that makes the ceremony mathematically uncompletable regardless of who is left. Blocking signing only at this point ensures the guard is never a false positive.
+- **Advisory before threshold**: the ceremony can still complete if threshold participants sign before enough declines accumulate. This preserves liveness during rolling validator upgrades where older-version validators may decline transactions the majority considers valid.
+- **Additional declines after threshold are accepted**: subsequent `signDecline` calls still record `SignDeclined` events (useful for the explorer's per-validator breakdown) but `SignRejected` is not re-emitted and no callback is fired (guarded by `!signature.rejected` in `signDecline`).
+- **`signDecline` returns `bool rejected`**: mirrors `signShare` returning `bool signed`, enabling the callback wrapper in PR 2 to follow the identical pattern.
+
+#### Testing
+
+- Unit tests covering: participant decline, non-participant reverts (`InvalidParticipant`), double-decline reverts (`AlreadyDeclined`), decline of non-existent ceremony (`NotSigning`), decline after signing complete (`SigningComplete`), threshold formula correctness, `SignRejected` emitted exactly once, `signShare` reverts with `CeremonyRejected` after rejection, `signatureVerify`/`signatureValue` revert with `SignatureRejected` after rejection.
+
+---
+
+### PR 2 — Consensus Callback: `onSignRejected` and `TransactionRejected`
+
+> Wires the coordinator's rejection threshold to Consensus via a callback, emitting `TransactionRejected`/`OracleTransactionRejected` on the same contract as `TransactionProposed` and `TransactionAttested`.
+
+#### Context and Motivation
+
+- PR 1 added the coordinator mechanics. This PR completes the on-chain story: when enough validators decline, `Consensus` emits `TransactionRejected`, making rejection a first-class event alongside proposal and attestation.
+- By placing `TransactionRejected` on `Consensus` (not the coordinator), the explorer can derive all proposal status from a single contract — no cross-contract SID correlation needed.
+
+#### Decisions and Tradeoffs
+
+- **`signDeclineWithCallback` added here, not in PR 1**: it calls `callback.target.onSignRejected`, which did not exist on `IFROSTCoordinatorCallback` until this PR. The coordinator function and the interface method must be introduced together.
+- **Mirrors `signShareWithCallback` → `onSignCompleted` exactly**: same `Callback` struct, same dispatch-on-selector pattern in `onSignCompleted`/`onSignRejected`, same context encoding (`abi.encode(selector, args)`). Reviewers familiar with the existing flow will find nothing surprising.
+- **`rejectTransaction`/`rejectOracleTransaction` are public**: matches `attestTransaction`/`attestOracleTransaction`. They validate via `_COORDINATOR.isSignRejected(signatureId)` to guard against direct calls that bypass the callback. The `onlyCoordinator` guard on `onSignRejected` ensures the callback path is always safe.
+- **`$rejections` storage mirrors `$attestations`**: prevents double-rejection recording and provides a consistent storage pattern.
+
+#### Testing
+
+- Full callback chain: `signDeclineWithCallback` → `onSignRejected` → `rejectTransaction` → `TransactionRejected` event emitted.
+- `onSignRejected` selector dispatch for both safe tx and oracle tx contexts.
+- `rejectTransaction` with unrejected SID reverts `NotRejected`.
+- `rejectTransaction` called twice reverts `AlreadyRejected`.
+
+---
+
+### PR 3 — Validator: `"waiting_to_decline"` State and Decline Action
+
+> Validators now explicitly decline signing ceremonies for transactions they consider invalid, instead of silently ignoring them. Adds a `"waiting_to_decline"` signing state and a `sign_decline_with_callback` protocol action.
+
+#### Context and Motivation
+
+- PRs 1 and 2 set up the on-chain machinery. This PR makes validators actually use it.
+- `handleTransactionProposed` currently returns `{}` for invalid transactions (a silent drop). This PR changes that to return a `"waiting_to_decline"` state, so when the `Sign` event arrives, the validator calls `signDeclineWithCallback` on the coordinator.
+
+#### Decisions and Tradeoffs
+
+- **`"waiting_to_decline"` slots into the existing `handleSign` dispatch**: `handleSign` already branches on `status.id`. The new branch fires before `"waiting_for_request"` and skips nonce replenishment entirely — a declining validator will never need nonces for a ceremony it is opting out of.
+- **`packet` is required in the state**: (1) `BaseSigningState` requires it, (2) the SQLite persistence layer needs it to restore state across restarts, (3) it provides `epoch`/`safe`/`chainId` to build the callback context for `onSignRejected`.
+- **Callback context built in `declines.ts`**: mirrors `buildTransactionAttestationCallback`/`buildOracleTransactionAttestationCallback` from `nonces.ts`, using `rejectTransaction`/`rejectOracleTransaction` selectors.
+- **Timeout drops the state with no retry**: if the `Sign` event is never observed, the validator gives up silently. The ceremony will time out on-chain anyway; submitting a late decline after timeout provides no value.
+- **`AlreadyDeclined` and `SigningComplete` are terminal, logged at `info` not `warn`**: these are benign races — another instance submitted the same decline, or the ceremony completed just before the decline landed. Neither requires intervention.
+
+#### Testing
+
+- Invalid safe tx and oracle tx produce correct `"waiting_to_decline"` state with the right packet.
+- `Sign` event for `"waiting_to_decline"` emits `sign_decline_with_callback` with correct callback context, clears state, no nonce replenishment.
+- `Sign` event for `"waiting_for_request"` (valid tx) is unaffected.
+- Terminal reverts (`AlreadyDeclined`, `SigningComplete`) resolve without retry, logged at `info`.
+- Validator restart: `"waiting_to_decline"` state is restored from SQLite and decline is submitted after `Sign` is re-observed.
+- Timeout: state is cleared, no action emitted.
+
+---
+
+### PR 4 — Explorer: Transaction Rejection Status
+
+> Adds `REJECTED` as a new `ProposalStatus`, derived from `TransactionRejected` events on Consensus. No coordinator interaction required.
+
+#### Context and Motivation
+
+- PR 2 emits `TransactionRejected` on `Consensus`. This PR surfaces it in the explorer so users see `REJECTED` instead of `TIMED_OUT` for transactions that were explicitly declined by the validator set.
+- The change is entirely within `consensus/transactions.ts` — `TransactionRejected` is queried alongside the existing `TransactionProposed` and `TransactionAttested` events from the same contract.
+
+#### Decisions and Tradeoffs
+
+- **Single-source status derivation**: an earlier design would have required cross-referencing `SignDeclined` events from the coordinator with the proposal's SID. By placing `TransactionRejected` on `Consensus`, the explorer needs only one contract for all proposal status logic.
+- **`ATTESTED` takes precedence over `REJECTED`**: if a ceremony somehow completes after partial declines, `ATTESTED` is shown. In practice, `signShare` reverts after the rejection threshold is crossed, so both events cannot coexist for the same message.
+
+#### Testing
+
+- `loadTransactionProposals` with `TransactionRejected`: `status: "REJECTED"`.
+- `loadTransactionProposals` with both `TransactionRejected` and `TransactionAttested`: `status: "ATTESTED"`.
+- Proposal past timeout with no rejection event: `status: "TIMED_OUT"`.
+
+---
+
+### PR 5 — Explorer: Declined Validators Breakdown
+
+> Adds a "Declined" row to the attestation status UI showing which validators explicitly opted out of a signing ceremony, sourced from `SignDeclined` events on the coordinator.
+
+#### Context and Motivation
+
+- PR 4 shows that a transaction was rejected. This PR shows who declined it — useful for debugging and operator visibility.
+- The change is entirely within the coordinator signing hook (`coordinator/signing.ts`) and the attestation status component — independent of `TransactionRejected` on Consensus.
+- Merged after PR 4 so that users see the `REJECTED` status before the breakdown is added; showing declined validators without the status label would be confusing.
+
+#### Decisions and Tradeoffs
+
+- **`SignDeclined` events are naturally scoped**: `useAttestationStatus` is already scoped to a specific proposal's SID (derived from the `Sign` event for that proposal's message). `SignDeclined` events are therefore automatically filtered to the correct ceremony — no risk of surfacing declines from epoch rollover or oracle tx ceremonies on a safe tx proposal page.
+- **Parallel development with PR 4**: PR 5 only needs `SignDeclined` from the coordinator (available since PR 1). It is developed in parallel with PRs 2–4 and merged last among the explorer PRs purely for UX coherence.
+
+#### Testing
+
+- Signing progress with `SignDeclined` events populates `declined` correctly.
+- "Declined" row renders the correct validator addresses.
 
 ---
 
 ## Open Questions / Assumptions
 
-- **`safeTxStructHash` availability**: The validator must compute the EIP-712 struct hash from `event.transaction` when constructing the reject action. This follows the same pattern used for `attestTransaction`.
-- **`participantKey` access control**: `FROSTParticipantMap.getKey` reverts with `InvalidParticipant` for non-members (confirmed by reading the implementation). The key is only set after DKG completes, so only participants in a fully-formed group can call `rejectTransaction`. This is the desired behaviour.
-- **Rejection + attestation coexistence**: Because rejection is advisory, it is possible for both `TransactionRejected` and `TransactionAttested` to exist for the same proposal. This indicates a validator version mismatch at the time of rejection. The explorer shows `ATTESTED` in this case; the rejection events remain visible for auditability.
-- **Devnet deployment**: After all three phases are merged, a devnet redeployment is required to pick up the new contract interface.
+- **`SigningComplete` error**: Confirm during Phase 1 implementation whether an equivalent error already exists in `FROSTCoordinator` (e.g., `NotSigning` covers the ceremony-not-started case, but there's no guard for ceremony-already-signed). If an equivalent exists, reuse it.
+- **`Signature` struct storage layout**: Adding `bool rejected` and `uint16 declineCount` to `Signature` packs them into a new slot alongside existing fields. Verify packing does not break any assembly or low-level access patterns in `FROSTSignatureShares`.
+- **Oracle handler name**: The spec refers to `handleOracleTransactionProposed` in `oracleTransactionProposed.ts` — confirmed from the codebase.
+- **Devnet deployment**: After all phases are merged, a devnet redeployment is required to pick up the new coordinator and consensus interfaces.
+- **Decline before `Sign` event**: Validators cannot decline before the `Sign` event because they need the SID. The `"waiting_to_decline"` state ensures the decline is submitted as soon as the `Sign` event is observed (emitted in the same transaction as `proposeTransaction`). This is by design and requires no special handling.
+- **`signRevealNonces` after rejection**: No `CeremonyRejected` guard is added to `signRevealNonces`. A validator that reveals nonces before the rejection threshold is crossed can do nothing with those nonces — `signShare` will revert. This is harmless (nonce reveals don't advance the ceremony toward completion) and not worth the additional guard.
+- **Validator that already called `signRevealNonces` can still call `signDecline`**: Nonce revelation is non-binding. A validator can partially start the signing flow and then opt out. The decline is recorded normally; the revealed nonces are unused.
+- **Gas estimate for `declineSignature`**: `200_000n` gas is set in the spec. The call chain `signDeclineWithCallback` → `onSignRejected` → `rejectTransaction` involves two cross-contract calls plus an `isSignRejected` view call and storage writes on both contracts. Verify this estimate against the actual implementation before finalising; increase if necessary (compare with `signShare`'s `400_000n` as an upper bound).


### PR DESCRIPTION
Adds a feature specification for explicit transaction rejection, replacing the current silent validator drop with an on-chain decline that the explorer surfaces as a distinct `REJECTED` status.

### Context and Motivation

- Currently, when a validator rejects a transaction as invalid it silently ignores it. The signing ceremony times out with no record. From the operator's perspective, a rejected transaction looks identical to a network fault or timeout.
- This spec defines the full feature: how the decline is recorded on-chain, how it propagates to `Consensus`, how the validator state machine handles it, and how the explorer surfaces it.

### Decisions and Tradeoffs

- **Decline lives in `FROSTCoordinator`, not `Consensus`**: a decline is a signing-protocol concept ("I am not participating in this ceremony"), not a consensus-layer one. The coordinator already owns all per-participant signing state.
- **Threshold-based stopping, not advisory**: `signShare` reverts once `count - threshold + 1` validators have declined, that is the exact point at which the ceremony is mathematically uncompletable. Before that threshold, signing is unaffected. Attestation is never blocked regardless of declines.
- **Callback pattern mirrors `signShareWithCallback` → `onSignCompleted`**: `signDeclineWithCallback` triggers `onSignRejected` on `Consensus` when the threshold is first crossed, emitting `TransactionRejected` on the same contract as `TransactionProposed` and `TransactionAttested`. This keeps the explorer's status derivation to a single contract with no cross-contract SID correlation.
- **`signDeclineWithCallback` deferred to Phase 2**: it calls `callback.target.onSignRejected` which does not exist on `IFROSTCoordinatorCallback` until Phase 2. The coordinator function and the interface method must be introduced together.
- **No "reason" code**: avoids keeping a Solidity/TypeScript enum in sync and a contract upgrade path each time a new validation check is added.
- **5 PRs**: Phase 1 (coordinator), Phase 2 (consensus callback), Phase 3 (validator), Phase 4 (explorer status), Phase 5 (explorer declined breakdown). Phases 4 and 5 are split because they touch entirely separate data sources (`Consensus` vs `FROSTCoordinator`) and can be reviewed independently.
