### PR TITLE
feat: Consensus callback — onSignRejected and TransactionRejected

### DIFF
--- a/contracts/src/Consensus.sol
+++ b/contracts/src/Consensus.sol
@@ -77,6 +77,12 @@ contract Consensus is IConsensus, IERC165, IFROSTCoordinatorCallback {
     mapping(bytes32 message => FROSTSignatureId.T) private $attestations;
 
     /**
+     * @notice Mapping message hash to rejection FROST signature ID.
+     */
+    // forge-lint: disable-next-line(mixed-case-variable)
+    mapping(bytes32 message => FROSTSignatureId.T) private $rejections;
+
+    /**
      * @notice Mapping from validator address to its staker address.
      */
     // forge-lint: disable-next-line(mixed-case-variable)
@@ -105,6 +111,21 @@ contract Consensus is IConsensus, IERC165, IFROSTCoordinatorCallback {
      * @notice Thrown when a caller is not the configured coordinator.
      */
     error NotCoordinator();
+
+    /**
+     * @notice Thrown when attempting to reject an already-rejected transaction.
+     */
+    error AlreadyRejected();
+
+    /**
+     * @notice Thrown when rejectTransaction is called with a signatureId not marked rejected by the coordinator.
+     */
+    error NotRejected();
+
+    /**
+     * @notice Thrown when a signature does not match the expected message.
+     */
+    error WrongSignature();
 
     // ============================================================
     // CONSTRUCTOR
@@ -414,6 +435,45 @@ contract Consensus is IConsensus, IERC165, IFROSTCoordinatorCallback {
         return _COORDINATOR.signatureValue($attestations[message]);
     }
 
+    /**
+     * @inheritdoc IConsensus
+     */
+    function rejectTransaction(
+        uint64 epoch,
+        uint256 chainId,
+        address safe,
+        bytes32 safeTxStructHash,
+        FROSTSignatureId.T signatureId
+    ) public {
+        bytes32 safeTxHash = SafeTransaction.partialHash(chainId, safe, safeTxStructHash);
+        bytes32 message = domainSeparator().transactionProposal(epoch, safeTxHash);
+        require($rejections[message].isZero(), AlreadyRejected());
+        require(_COORDINATOR.isSignRejected(signatureId), NotRejected());
+        require(_COORDINATOR.signatureMessage(signatureId) == message, WrongSignature());
+        $rejections[message] = signatureId;
+        emit TransactionRejected(safeTxHash, chainId, safe, epoch, signatureId);
+    }
+
+    /**
+     * @inheritdoc IConsensus
+     */
+    function rejectOracleTransaction(
+        uint64 epoch,
+        address oracle,
+        uint256 chainId,
+        address safe,
+        bytes32 safeTxStructHash,
+        FROSTSignatureId.T signatureId
+    ) public {
+        bytes32 safeTxHash = SafeTransaction.partialHash(chainId, safe, safeTxStructHash);
+        bytes32 message = domainSeparator().oracleTransactionProposal(epoch, oracle, safeTxHash);
+        require($rejections[message].isZero(), AlreadyRejected());
+        require(_COORDINATOR.isSignRejected(signatureId), NotRejected());
+        require(_COORDINATOR.signatureMessage(signatureId) == message, WrongSignature());
+        $rejections[message] = signatureId;
+        emit OracleTransactionRejected(safeTxHash, chainId, safe, epoch, oracle, signatureId);
+    }
+
     // ============================================================
     // IERC165 IMPLEMENTATION
     // ============================================================
@@ -456,6 +516,25 @@ contract Consensus is IConsensus, IERC165, IFROSTCoordinatorCallback {
             (uint64 epoch, address oracle, uint256 chainId, address safe, bytes32 safeTxStructHash) =
                 abi.decode(context[4:], (uint64, address, uint256, address, bytes32));
             attestOracleTransaction(epoch, oracle, chainId, safe, safeTxStructHash, signatureId);
+        } else {
+            revert UnknownSignatureSelector();
+        }
+    }
+
+    /**
+     * @inheritdoc IFROSTCoordinatorCallback
+     */
+    function onSignRejected(FROSTSignatureId.T signatureId, bytes calldata context) external onlyCoordinator {
+        // forge-lint: disable-next-line(unsafe-typecast)
+        bytes4 selector = bytes4(context);
+        if (selector == this.rejectTransaction.selector) {
+            (uint64 epoch, uint256 chainId, address safe, bytes32 safeTxStructHash) =
+                abi.decode(context[4:], (uint64, uint256, address, bytes32));
+            rejectTransaction(epoch, chainId, safe, safeTxStructHash, signatureId);
+        } else if (selector == this.rejectOracleTransaction.selector) {
+            (uint64 epoch, address oracle, uint256 chainId, address safe, bytes32 safeTxStructHash) =
+                abi.decode(context[4:], (uint64, address, uint256, address, bytes32));
+            rejectOracleTransaction(epoch, oracle, chainId, safe, safeTxStructHash, signatureId);
         } else {
             revert UnknownSignatureSelector();
         }

--- a/contracts/src/FROSTCoordinator.sol
+++ b/contracts/src/FROSTCoordinator.sol
@@ -111,11 +111,15 @@ contract FROSTCoordinator {
      * @notice Tracks a signing ceremony state.
      * @custom:param message The message being signed.
      * @custom:param signed The Merkle root of the signature shares.
+     * @custom:param rejected True if the ceremony has been rejected by threshold declines.
+     * @custom:param declineCount The number of participants that have declined this ceremony.
      * @custom:param shares The accumulated signature shares.
      */
     struct Signature {
         bytes32 message;
         bytes32 signed;
+        bool rejected;
+        uint16 declineCount;
         FROSTSignatureShares.T shares;
     }
 
@@ -259,6 +263,19 @@ contract FROSTCoordinator {
      */
     event SignCompleted(FROSTSignatureId.T indexed sid, bytes32 indexed selectionRoot, FROST.Signature signature);
 
+    /**
+     * @notice Emitted when a participant declines a signing ceremony.
+     * @param sid The signature ID.
+     * @param participant The participant address that declined.
+     */
+    event SignDeclined(FROSTSignatureId.T indexed sid, address indexed participant);
+
+    /**
+     * @notice Emitted when enough participants have declined to make the ceremony uncompletable.
+     * @param sid The signature ID.
+     */
+    event SignRejected(FROSTSignatureId.T indexed sid);
+
     // ============================================================
     // ERRORS
     // ============================================================
@@ -308,6 +325,26 @@ contract FROSTCoordinator {
      */
     error WrongSignature();
 
+    /**
+     * @notice Thrown when a participant attempts to decline a ceremony they already declined.
+     */
+    error AlreadyDeclined();
+
+    /**
+     * @notice Thrown when a participant attempts to decline a ceremony that has already been signed.
+     */
+    error SigningComplete();
+
+    /**
+     * @notice Thrown when attempting to sign a ceremony that has been rejected.
+     */
+    error CeremonyRejected();
+
+    /**
+     * @notice Thrown when querying a signature for a ceremony that was rejected.
+     */
+    error SignatureRejected();
+
     // ============================================================
     // STORAGE VARIABLES
     // ============================================================
@@ -323,6 +360,12 @@ contract FROSTCoordinator {
      */
     // forge-lint: disable-next-line(mixed-case-variable)
     mapping(FROSTSignatureId.T => Signature) private $signatures;
+
+    /**
+     * @notice Mapping from signature ID and participant to whether that participant has declined.
+     */
+    // forge-lint: disable-next-line(mixed-case-variable)
+    mapping(FROSTSignatureId.T sid => mapping(address participant => bool)) private $declined;
 
     // ============================================================
     // EXTERNAL AND PUBLIC FUNCTIONS - KEY GENERATION
@@ -573,6 +616,7 @@ contract FROSTCoordinator {
         bytes32[] calldata proof
     ) public returns (bool signed) {
         (Group storage group, bytes32 message) = _signatureGroupAndMessage(sid);
+        require(!$signatures[sid].rejected, CeremonyRejected());
         Secp256k1.Point memory key = group.key;
         FROST.verifyShare(key, selection.r, group.participants.getKey(msg.sender), share, message);
         Signature storage signature = $signatures[sid];
@@ -588,6 +632,53 @@ contract FROSTCoordinator {
             }
         }
         return false;
+    }
+
+    /**
+     * @notice Records an explicit decline by the sender for a signing ceremony.
+     * @param sid The signature ID.
+     * @return rejected True if the decline threshold has been crossed for the first time.
+     * @dev Once `count - threshold + 1` participants have declined, the ceremony is definitively
+     *      rejected: `signShare` will revert with `CeremonyRejected` and signature queries will
+     *      revert with `SignatureRejected`. Additional declines past the threshold are still
+     *      recorded (for observability) but `SignRejected` is not re-emitted.
+     */
+    function signDecline(FROSTSignatureId.T sid) public returns (bool rejected) {
+        FROSTGroupId.T gid = sid.group();
+        Group storage group = $groups[gid];
+        group.participants.getKey(msg.sender); // reverts InvalidParticipant for non-members
+        Signature storage signature = $signatures[sid];
+        require(signature.message != bytes32(0), NotSigning());
+        require(signature.signed == bytes32(0), SigningComplete());
+        require(!$declined[sid][msg.sender], AlreadyDeclined());
+        $declined[sid][msg.sender] = true;
+        signature.declineCount++;
+        emit SignDeclined(sid, msg.sender);
+        GroupState memory state = group.state;
+        if (signature.declineCount >= state.count - state.threshold + 1 && !signature.rejected) {
+            signature.rejected = true;
+            emit SignRejected(sid);
+            return true;
+        }
+        return false;
+    }
+
+    /**
+     * @notice Records an explicit decline and optionally executes a callback when the rejection threshold is crossed.
+     * @param sid The signature ID.
+     * @param callback The callback target and context.
+     * @return rejected True if the decline threshold has been crossed for the first time.
+     * @dev This method works identically to `signDecline` but additionally executes a callback once the rejection
+     *      threshold is first crossed. The callback is NOT fired on subsequent declines past the threshold.
+     */
+    function signDeclineWithCallback(FROSTSignatureId.T sid, Callback calldata callback)
+        external
+        returns (bool rejected)
+    {
+        rejected = signDecline(sid);
+        if (rejected) {
+            callback.target.onSignRejected(sid, callback.context);
+        }
     }
 
     /**
@@ -681,6 +772,7 @@ contract FROSTCoordinator {
         returns (FROST.Signature memory result)
     {
         Signature storage signature = $signatures[sid];
+        require(!signature.rejected, SignatureRejected());
         bytes32 signed = signature.signed;
         require(signed != bytes32(0), NotSigned());
         require(gid.eq(sid.group()) && message == signature.message, WrongSignature());
@@ -694,9 +786,38 @@ contract FROSTCoordinator {
      */
     function signatureValue(FROSTSignatureId.T sid) external view returns (FROST.Signature memory result) {
         Signature storage signature = $signatures[sid];
+        require(!signature.rejected, SignatureRejected());
         bytes32 signed = signature.signed;
         require(signed != bytes32(0), NotSigned());
         return $signatures[sid].shares.groupSignature(signed);
+    }
+
+    /**
+     * @notice Returns whether a participant has declined a specific signing ceremony.
+     * @param sid The signature ID.
+     * @param participant The participant address.
+     * @return True if the participant has declined.
+     */
+    function isSignDeclined(FROSTSignatureId.T sid, address participant) external view returns (bool) {
+        return $declined[sid][participant];
+    }
+
+    /**
+     * @notice Returns whether a signing ceremony has been rejected.
+     * @param sid The signature ID.
+     * @return True if the ceremony has been rejected.
+     */
+    function isSignRejected(FROSTSignatureId.T sid) external view returns (bool) {
+        return $signatures[sid].rejected;
+    }
+
+    /**
+     * @notice Returns the message associated with a signing ceremony.
+     * @param sid The signature ID.
+     * @return The message being signed, or zero if the ceremony does not exist.
+     */
+    function signatureMessage(FROSTSignatureId.T sid) external view returns (bytes32) {
+        return $signatures[sid].message;
     }
 
     // ============================================================

--- a/contracts/src/interfaces/IConsensus.sol
+++ b/contracts/src/interfaces/IConsensus.sol
@@ -136,6 +136,36 @@ interface IConsensus {
         FROST.Signature attestation
     );
 
+    /**
+     * @notice Emitted when a transaction is definitively rejected by the validator set.
+     * @param safeTxHash The hash of the rejected Safe transaction.
+     * @param chainId The chain ID of the Safe account.
+     * @param safe The address of the Safe account.
+     * @param epoch The epoch in which the rejected transaction was proposed.
+     * @param signatureId The FROST signature identifier of the rejected ceremony.
+     */
+    event TransactionRejected(
+        bytes32 indexed safeTxHash, uint256 chainId, address indexed safe, uint64 epoch, FROSTSignatureId.T signatureId
+    );
+
+    /**
+     * @notice Emitted when an oracle-checked transaction is definitively rejected by the validator set.
+     * @param safeTxHash The hash of the rejected Safe transaction.
+     * @param chainId The chain ID of the Safe account.
+     * @param safe The address of the Safe account.
+     * @param epoch The epoch in which the rejected transaction was proposed.
+     * @param oracle The address of the oracle contract used for evaluation.
+     * @param signatureId The FROST signature identifier of the rejected ceremony.
+     */
+    event OracleTransactionRejected(
+        bytes32 indexed safeTxHash,
+        uint256 chainId,
+        address indexed safe,
+        uint64 epoch,
+        address oracle,
+        FROSTSignatureId.T signatureId
+    );
+
     // ============================================================
     // CONFIGURATION
     // ============================================================
@@ -338,4 +368,40 @@ interface IConsensus {
         external
         view
         returns (FROST.Signature memory signature);
+
+    /**
+     * @notice Records the rejection of a transaction.
+     * @param epoch The epoch in which the transaction was proposed.
+     * @param chainId The chain ID of the Safe account.
+     * @param safe The address of the Safe account.
+     * @param safeTxStructHash The EIP-712 struct hash of the Safe transaction data.
+     * @param signatureId The FROST signature identifier of the rejected ceremony.
+     * @dev Guards against direct calls via coordinator rejection check. Normally called via the onSignRejected callback.
+     */
+    function rejectTransaction(
+        uint64 epoch,
+        uint256 chainId,
+        address safe,
+        bytes32 safeTxStructHash,
+        FROSTSignatureId.T signatureId
+    ) external;
+
+    /**
+     * @notice Records the rejection of an oracle-checked transaction.
+     * @param epoch The epoch in which the transaction was proposed.
+     * @param oracle The address of the oracle contract used for evaluation.
+     * @param chainId The chain ID of the Safe account.
+     * @param safe The address of the Safe account.
+     * @param safeTxStructHash The EIP-712 struct hash of the Safe transaction data.
+     * @param signatureId The FROST signature identifier of the rejected ceremony.
+     * @dev Guards against direct calls via coordinator rejection check. Normally called via the onSignRejected callback.
+     */
+    function rejectOracleTransaction(
+        uint64 epoch,
+        address oracle,
+        uint256 chainId,
+        address safe,
+        bytes32 safeTxStructHash,
+        FROSTSignatureId.T signatureId
+    ) external;
 }

--- a/contracts/src/interfaces/IFROSTCoordinatorCallback.sol
+++ b/contracts/src/interfaces/IFROSTCoordinatorCallback.sol
@@ -22,4 +22,11 @@ interface IFROSTCoordinatorCallback {
      * @param context The context data associated with the signature.
      */
     function onSignCompleted(FROSTSignatureId.T sid, bytes calldata context) external;
+
+    /**
+     * @notice A signature ceremony was definitively rejected.
+     * @param sid The signature ID of the rejected signing ceremony.
+     * @param context The context data associated with the signature.
+     */
+    function onSignRejected(FROSTSignatureId.T sid, bytes calldata context) external;
 }

--- a/contracts/test/ConsensusDecline.t.sol
+++ b/contracts/test/ConsensusDecline.t.sol
@@ -1,0 +1,224 @@
+// SPDX-License-Identifier: GPL-3.0-only
+pragma solidity ^0.8.30;
+
+import {Test} from "@forge-std/Test.sol";
+import {MockCoordinator} from "@test/util/MockCoordinator.sol";
+import {Consensus, IConsensus} from "@/Consensus.sol";
+import {ConsensusMessages} from "@/libraries/ConsensusMessages.sol";
+import {FROSTGroupId} from "@/libraries/FROSTGroupId.sol";
+import {FROSTSignatureId} from "@/libraries/FROSTSignatureId.sol";
+import {SafeTransaction} from "@/libraries/SafeTransaction.sol";
+
+contract ConsensusDeclineTest is Test {
+    using ConsensusMessages for bytes32;
+    using FROSTSignatureId for FROSTSignatureId.T;
+
+    FROSTGroupId.T immutable GENESIS_GROUP = FROSTGroupId.T.wrap(keccak256("genesisGroup"));
+    address constant SAFE = address(0x5afe5afE5afE5afE5afE5aFe5aFe5Afe5Afe5AfE);
+    address constant ORACLE = address(0x0000000000000000000000000000000000001234);
+
+    MockCoordinator public coordinator;
+    Consensus public consensus;
+
+    function setUp() public {
+        coordinator = new MockCoordinator();
+        consensus = new Consensus(address(coordinator), GENESIS_GROUP);
+    }
+
+    // ============================================================
+    // HELPERS
+    // ============================================================
+
+    function _transactionMessage(uint64 epoch, bytes32 safeTxStructHash)
+        internal
+        view
+        returns (bytes32 message, bytes32 safeTxHash)
+    {
+        safeTxHash = SafeTransaction.partialHash(block.chainid, SAFE, safeTxStructHash);
+        message = consensus.domainSeparator().transactionProposal(epoch, safeTxHash);
+    }
+
+    function _oracleTransactionMessage(uint64 epoch, address oracle, bytes32 safeTxStructHash)
+        internal
+        view
+        returns (bytes32 message, bytes32 safeTxHash)
+    {
+        safeTxHash = SafeTransaction.partialHash(block.chainid, SAFE, safeTxStructHash);
+        message = consensus.domainSeparator().oracleTransactionProposal(epoch, oracle, safeTxHash);
+    }
+
+    function _mockRejectedSid(bytes32 message) internal returns (FROSTSignatureId.T sid) {
+        sid = FROSTSignatureId.T.wrap(keccak256("test-sid"));
+        coordinator.setSignRejected(sid, true);
+        coordinator.setSignatureMessage(sid, message);
+    }
+
+    // ============================================================
+    // REJECT TRANSACTION
+    // ============================================================
+
+    function test_RejectTransaction_EmitsTransactionRejected() public {
+        bytes32 safeTxStructHash = bytes32(uint256(0xdeadbeef));
+        (bytes32 message, bytes32 safeTxHash) = _transactionMessage(0, safeTxStructHash);
+        FROSTSignatureId.T sid = _mockRejectedSid(message);
+
+        vm.expectEmit();
+        emit IConsensus.TransactionRejected(safeTxHash, block.chainid, SAFE, 0, sid);
+        consensus.rejectTransaction(0, block.chainid, SAFE, safeTxStructHash, sid);
+    }
+
+    function test_RejectTransaction_StoresSignatureId() public {
+        bytes32 safeTxStructHash = bytes32(uint256(0xdeadbeef));
+        (bytes32 message,) = _transactionMessage(0, safeTxStructHash);
+        FROSTSignatureId.T sid = _mockRejectedSid(message);
+
+        consensus.rejectTransaction(0, block.chainid, SAFE, safeTxStructHash, sid);
+
+        vm.expectRevert(Consensus.AlreadyRejected.selector);
+        consensus.rejectTransaction(0, block.chainid, SAFE, safeTxStructHash, sid);
+    }
+
+    function test_RejectTransaction_NotRejected_Reverts() public {
+        bytes32 safeTxStructHash = bytes32(uint256(0xdeadbeef));
+        (bytes32 message,) = _transactionMessage(0, safeTxStructHash);
+        FROSTSignatureId.T sid = FROSTSignatureId.T.wrap(keccak256("not-rejected-sid"));
+        coordinator.setSignatureMessage(sid, message);
+        // isSignRejected returns false by default
+
+        vm.expectRevert(Consensus.NotRejected.selector);
+        consensus.rejectTransaction(0, block.chainid, SAFE, safeTxStructHash, sid);
+    }
+
+    function test_RejectTransaction_WrongMessage_Reverts() public {
+        bytes32 safeTxStructHash = bytes32(uint256(0xdeadbeef));
+        bytes32 wrongMessage = keccak256("some other ceremony");
+        FROSTSignatureId.T sid = FROSTSignatureId.T.wrap(keccak256("rejected-sid"));
+        coordinator.setSignRejected(sid, true);
+        coordinator.setSignatureMessage(sid, wrongMessage);
+
+        vm.expectRevert(Consensus.WrongSignature.selector);
+        consensus.rejectTransaction(0, block.chainid, SAFE, safeTxStructHash, sid);
+    }
+
+    function test_RejectTransaction_AlreadyRejected_Reverts() public {
+        bytes32 safeTxStructHash = bytes32(uint256(0xdeadbeef));
+        (bytes32 message,) = _transactionMessage(0, safeTxStructHash);
+        FROSTSignatureId.T sid = _mockRejectedSid(message);
+
+        consensus.rejectTransaction(0, block.chainid, SAFE, safeTxStructHash, sid);
+
+        vm.expectRevert(Consensus.AlreadyRejected.selector);
+        consensus.rejectTransaction(0, block.chainid, SAFE, safeTxStructHash, sid);
+    }
+
+    // ============================================================
+    // REJECT ORACLE TRANSACTION
+    // ============================================================
+
+    function test_RejectOracleTransaction_EmitsOracleTransactionRejected() public {
+        bytes32 safeTxStructHash = bytes32(uint256(0xdeadbeef));
+        (bytes32 message, bytes32 safeTxHash) = _oracleTransactionMessage(0, ORACLE, safeTxStructHash);
+        FROSTSignatureId.T sid = _mockRejectedSid(message);
+
+        vm.expectEmit();
+        emit IConsensus.OracleTransactionRejected(safeTxHash, block.chainid, SAFE, 0, ORACLE, sid);
+        consensus.rejectOracleTransaction(0, ORACLE, block.chainid, SAFE, safeTxStructHash, sid);
+    }
+
+    function test_RejectOracleTransaction_StoresSignatureId() public {
+        bytes32 safeTxStructHash = bytes32(uint256(0xdeadbeef));
+        (bytes32 message,) = _oracleTransactionMessage(0, ORACLE, safeTxStructHash);
+        FROSTSignatureId.T sid = _mockRejectedSid(message);
+
+        consensus.rejectOracleTransaction(0, ORACLE, block.chainid, SAFE, safeTxStructHash, sid);
+
+        vm.expectRevert(Consensus.AlreadyRejected.selector);
+        consensus.rejectOracleTransaction(0, ORACLE, block.chainid, SAFE, safeTxStructHash, sid);
+    }
+
+    function test_RejectOracleTransaction_NotRejected_Reverts() public {
+        bytes32 safeTxStructHash = bytes32(uint256(0xdeadbeef));
+        (bytes32 message,) = _oracleTransactionMessage(0, ORACLE, safeTxStructHash);
+        FROSTSignatureId.T sid = FROSTSignatureId.T.wrap(keccak256("not-rejected-sid"));
+        coordinator.setSignatureMessage(sid, message);
+
+        vm.expectRevert(Consensus.NotRejected.selector);
+        consensus.rejectOracleTransaction(0, ORACLE, block.chainid, SAFE, safeTxStructHash, sid);
+    }
+
+    function test_RejectOracleTransaction_WrongMessage_Reverts() public {
+        bytes32 safeTxStructHash = bytes32(uint256(0xdeadbeef));
+        bytes32 wrongMessage = keccak256("some other ceremony");
+        FROSTSignatureId.T sid = FROSTSignatureId.T.wrap(keccak256("rejected-sid"));
+        coordinator.setSignRejected(sid, true);
+        coordinator.setSignatureMessage(sid, wrongMessage);
+
+        vm.expectRevert(Consensus.WrongSignature.selector);
+        consensus.rejectOracleTransaction(0, ORACLE, block.chainid, SAFE, safeTxStructHash, sid);
+    }
+
+    function test_RejectOracleTransaction_AlreadyRejected_Reverts() public {
+        bytes32 safeTxStructHash = bytes32(uint256(0xdeadbeef));
+        (bytes32 message,) = _oracleTransactionMessage(0, ORACLE, safeTxStructHash);
+        FROSTSignatureId.T sid = _mockRejectedSid(message);
+
+        consensus.rejectOracleTransaction(0, ORACLE, block.chainid, SAFE, safeTxStructHash, sid);
+
+        vm.expectRevert(Consensus.AlreadyRejected.selector);
+        consensus.rejectOracleTransaction(0, ORACLE, block.chainid, SAFE, safeTxStructHash, sid);
+    }
+
+    // ============================================================
+    // ON SIGN REJECTED
+    // ============================================================
+
+    function test_OnSignRejected_NotCoordinator_Reverts() public {
+        FROSTSignatureId.T sid = FROSTSignatureId.T.wrap(keccak256("sid"));
+        bytes memory context = abi.encodePacked(
+            consensus.rejectTransaction.selector, abi.encode(uint64(0), block.chainid, SAFE, bytes32(0))
+        );
+
+        vm.expectRevert(Consensus.NotCoordinator.selector);
+        consensus.onSignRejected(sid, context);
+    }
+
+    function test_OnSignRejected_DispatchesRejectTransaction() public {
+        bytes32 safeTxStructHash = bytes32(uint256(0xdeadbeef));
+        (bytes32 message, bytes32 safeTxHash) = _transactionMessage(0, safeTxStructHash);
+        FROSTSignatureId.T sid = _mockRejectedSid(message);
+
+        bytes memory context = abi.encodePacked(
+            consensus.rejectTransaction.selector, abi.encode(uint64(0), block.chainid, SAFE, safeTxStructHash)
+        );
+
+        vm.expectEmit();
+        emit IConsensus.TransactionRejected(safeTxHash, block.chainid, SAFE, 0, sid);
+        vm.prank(address(coordinator));
+        consensus.onSignRejected(sid, context);
+    }
+
+    function test_OnSignRejected_DispatchesRejectOracleTransaction() public {
+        bytes32 safeTxStructHash = bytes32(uint256(0xdeadbeef));
+        (bytes32 message, bytes32 safeTxHash) = _oracleTransactionMessage(0, ORACLE, safeTxStructHash);
+        FROSTSignatureId.T sid = _mockRejectedSid(message);
+
+        bytes memory context = abi.encodePacked(
+            consensus.rejectOracleTransaction.selector,
+            abi.encode(uint64(0), ORACLE, block.chainid, SAFE, safeTxStructHash)
+        );
+
+        vm.expectEmit();
+        emit IConsensus.OracleTransactionRejected(safeTxHash, block.chainid, SAFE, 0, ORACLE, sid);
+        vm.prank(address(coordinator));
+        consensus.onSignRejected(sid, context);
+    }
+
+    function test_OnSignRejected_UnknownSelector_Reverts() public {
+        FROSTSignatureId.T sid = FROSTSignatureId.T.wrap(keccak256("sid"));
+        bytes memory context = abi.encodePacked(bytes4(0xdeadbeef), abi.encode(uint256(42)));
+
+        vm.expectRevert(Consensus.UnknownSignatureSelector.selector);
+        vm.prank(address(coordinator));
+        consensus.onSignRejected(sid, context);
+    }
+}

--- a/contracts/test/FROSTCoordinatorDecline.t.sol
+++ b/contracts/test/FROSTCoordinatorDecline.t.sol
@@ -1,0 +1,603 @@
+// SPDX-License-Identifier: GPL-3.0-only
+pragma solidity ^0.8.30;
+
+import {Test, Vm} from "@forge-std/Test.sol";
+import {Arrays} from "@oz/utils/Arrays.sol";
+import {MerkleProof} from "@oz/utils/cryptography/MerkleProof.sol";
+import {Math} from "@oz/utils/math/Math.sol";
+import {CommitmentShareMerkleTree} from "@test/util/CommitmentShareMerkleTree.sol";
+import {ForgeSecp256k1} from "@test/util/ForgeSecp256k1.sol";
+import {ParticipantMerkleTree} from "@test/util/ParticipantMerkleTree.sol";
+import {FROSTCoordinator} from "@/FROSTCoordinator.sol";
+import {IFROSTCoordinatorCallback} from "@/interfaces/IFROSTCoordinatorCallback.sol";
+import {FROST} from "@/libraries/FROST.sol";
+import {FROSTGroupId} from "@/libraries/FROSTGroupId.sol";
+import {FROSTSignatureId} from "@/libraries/FROSTSignatureId.sol";
+import {Secp256k1} from "@/libraries/Secp256k1.sol";
+
+contract MockDeclineCallbackTarget {
+    FROSTSignatureId.T public lastRejectedSid;
+    bytes public lastContext;
+    uint256 public callCount;
+
+    function onSignRejected(FROSTSignatureId.T sid, bytes calldata context) external {
+        lastRejectedSid = sid;
+        lastContext = context;
+        callCount++;
+    }
+}
+
+contract FROSTCoordinatorDeclineTest is Test {
+    using Arrays for address[];
+    using Arrays for uint256[];
+    using ForgeSecp256k1 for ForgeSecp256k1.P;
+
+    struct Nonces {
+        ForgeSecp256k1.P d;
+        ForgeSecp256k1.P e;
+    }
+
+    uint16 public constant COUNT = 5;
+    uint16 public constant THRESHOLD = 3;
+    // count - threshold + 1 = 5 - 3 + 1 = 3
+    uint16 public constant DECLINE_THRESHOLD = COUNT - THRESHOLD + 1;
+
+    FROSTCoordinator public coordinator;
+    ParticipantMerkleTree public participants;
+
+    function setUp() public {
+        coordinator = new FROSTCoordinator();
+        participants = new ParticipantMerkleTree(_randomSortedAddresses(COUNT));
+    }
+
+    // ============================================================
+    // DECLINE BASIC BEHAVIOUR
+    // ============================================================
+
+    function test_SignDecline_EmitsSignDeclined() public {
+        (FROSTGroupId.T gid,,) = _trustedKeyGen(bytes32(0));
+        bytes32 message = keccak256("test message");
+        FROSTSignatureId.T sid = coordinator.sign(gid, message);
+
+        address participant = participants.addr(0);
+        vm.expectEmit();
+        emit FROSTCoordinator.SignDeclined(sid, participant);
+        vm.prank(participant);
+        coordinator.signDecline(sid);
+    }
+
+    function test_SignDecline_IsSignDeclined_ReturnsTrue() public {
+        (FROSTGroupId.T gid,,) = _trustedKeyGen(bytes32(0));
+        FROSTSignatureId.T sid = coordinator.sign(gid, keccak256("msg"));
+
+        address participant = participants.addr(0);
+        vm.prank(participant);
+        coordinator.signDecline(sid);
+
+        assertTrue(coordinator.isSignDeclined(sid, participant));
+    }
+
+    function test_SignDecline_IsSignDeclined_OtherParticipant_ReturnsFalse() public {
+        (FROSTGroupId.T gid,,) = _trustedKeyGen(bytes32(0));
+        FROSTSignatureId.T sid = coordinator.sign(gid, keccak256("msg"));
+
+        vm.prank(participants.addr(0));
+        coordinator.signDecline(sid);
+
+        assertFalse(coordinator.isSignDeclined(sid, participants.addr(1)));
+    }
+
+    function test_SignDecline_BelowThreshold_IsSignRejected_ReturnsFalse() public {
+        (FROSTGroupId.T gid,,) = _trustedKeyGen(bytes32(0));
+        FROSTSignatureId.T sid = coordinator.sign(gid, keccak256("msg"));
+
+        // Decline with DECLINE_THRESHOLD - 1 participants
+        for (uint256 i = 0; i < DECLINE_THRESHOLD - 1; i++) {
+            vm.prank(participants.addr(i));
+            bool rejected = coordinator.signDecline(sid);
+            assertFalse(rejected);
+        }
+
+        assertFalse(coordinator.isSignRejected(sid));
+    }
+
+    function test_SignDecline_AtThreshold_EmitsSignRejected() public {
+        (FROSTGroupId.T gid,,) = _trustedKeyGen(bytes32(0));
+        FROSTSignatureId.T sid = coordinator.sign(gid, keccak256("msg"));
+
+        // First DECLINE_THRESHOLD - 1 declines should not emit SignRejected
+        for (uint256 i = 0; i < DECLINE_THRESHOLD - 1; i++) {
+            vm.prank(participants.addr(i));
+            coordinator.signDecline(sid);
+        }
+
+        // The DECLINE_THRESHOLD-th decline crosses the threshold
+        vm.expectEmit();
+        emit FROSTCoordinator.SignRejected(sid);
+        vm.prank(participants.addr(DECLINE_THRESHOLD - 1));
+        bool rejected = coordinator.signDecline(sid);
+        assertTrue(rejected);
+    }
+
+    function test_SignDecline_AtThreshold_IsSignRejected_ReturnsTrue() public {
+        (FROSTGroupId.T gid,,) = _trustedKeyGen(bytes32(0));
+        FROSTSignatureId.T sid = coordinator.sign(gid, keccak256("msg"));
+
+        for (uint256 i = 0; i < DECLINE_THRESHOLD; i++) {
+            vm.prank(participants.addr(i));
+            coordinator.signDecline(sid);
+        }
+
+        assertTrue(coordinator.isSignRejected(sid));
+    }
+
+    function test_SignDecline_ReturnsFalse_BelowThreshold() public {
+        (FROSTGroupId.T gid,,) = _trustedKeyGen(bytes32(0));
+        FROSTSignatureId.T sid = coordinator.sign(gid, keccak256("msg"));
+
+        vm.prank(participants.addr(0));
+        bool rejected = coordinator.signDecline(sid);
+        assertFalse(rejected);
+    }
+
+    function test_SignDecline_ReturnsTrue_AtThreshold() public {
+        (FROSTGroupId.T gid,,) = _trustedKeyGen(bytes32(0));
+        FROSTSignatureId.T sid = coordinator.sign(gid, keccak256("msg"));
+
+        for (uint256 i = 0; i < DECLINE_THRESHOLD - 1; i++) {
+            vm.prank(participants.addr(i));
+            coordinator.signDecline(sid);
+        }
+
+        vm.prank(participants.addr(DECLINE_THRESHOLD - 1));
+        bool rejected = coordinator.signDecline(sid);
+        assertTrue(rejected);
+    }
+
+    // ============================================================
+    // ADDITIONAL DECLINES AFTER THRESHOLD
+    // ============================================================
+
+    function test_SignDecline_AfterThreshold_SignDeclinedEmitted_SignRejectedNotReEmitted() public {
+        (FROSTGroupId.T gid,,) = _trustedKeyGen(bytes32(0));
+        FROSTSignatureId.T sid = coordinator.sign(gid, keccak256("msg"));
+
+        // Reach threshold
+        for (uint256 i = 0; i < DECLINE_THRESHOLD; i++) {
+            vm.prank(participants.addr(i));
+            coordinator.signDecline(sid);
+        }
+
+        // One more decline: SignDeclined emitted, SignRejected NOT re-emitted
+        vm.recordLogs();
+        vm.prank(participants.addr(DECLINE_THRESHOLD));
+        bool rejected = coordinator.signDecline(sid);
+
+        Vm.Log[] memory logs = vm.getRecordedLogs();
+        assertFalse(rejected);
+
+        bool foundDeclined = false;
+        bool foundRejected = false;
+        for (uint256 i = 0; i < logs.length; i++) {
+            if (logs[i].topics[0] == FROSTCoordinator.SignDeclined.selector) foundDeclined = true;
+            if (logs[i].topics[0] == FROSTCoordinator.SignRejected.selector) foundRejected = true;
+        }
+        assertTrue(foundDeclined);
+        assertFalse(foundRejected);
+    }
+
+    function test_SignDecline_AfterThreshold_StillRecorded() public {
+        (FROSTGroupId.T gid,,) = _trustedKeyGen(bytes32(0));
+        FROSTSignatureId.T sid = coordinator.sign(gid, keccak256("msg"));
+
+        for (uint256 i = 0; i < DECLINE_THRESHOLD; i++) {
+            vm.prank(participants.addr(i));
+            coordinator.signDecline(sid);
+        }
+
+        vm.prank(participants.addr(DECLINE_THRESHOLD));
+        coordinator.signDecline(sid);
+
+        assertTrue(coordinator.isSignDeclined(sid, participants.addr(DECLINE_THRESHOLD)));
+    }
+
+    // ============================================================
+    // REVERT CASES
+    // ============================================================
+
+    function test_SignDecline_NonParticipant_Reverts() public {
+        (FROSTGroupId.T gid,,) = _trustedKeyGen(bytes32(0));
+        FROSTSignatureId.T sid = coordinator.sign(gid, keccak256("msg"));
+
+        address nonParticipant = vm.randomAddress();
+        vm.expectRevert();
+        vm.prank(nonParticipant);
+        coordinator.signDecline(sid);
+    }
+
+    function test_SignDecline_DoubleDecline_Reverts() public {
+        (FROSTGroupId.T gid,,) = _trustedKeyGen(bytes32(0));
+        FROSTSignatureId.T sid = coordinator.sign(gid, keccak256("msg"));
+
+        address participant = participants.addr(0);
+        vm.prank(participant);
+        coordinator.signDecline(sid);
+
+        vm.expectRevert(FROSTCoordinator.AlreadyDeclined.selector);
+        vm.prank(participant);
+        coordinator.signDecline(sid);
+    }
+
+    function test_SignDecline_CeremonyNotStarted_Reverts() public {
+        (FROSTGroupId.T gid,,) = _trustedKeyGen(bytes32(0));
+        // Create a SID without starting a ceremony
+        FROSTSignatureId.T fakeSid = FROSTSignatureId.create(gid, 99);
+
+        address p0 = participants.addr(0);
+        vm.expectRevert(FROSTCoordinator.NotSigning.selector);
+        vm.prank(p0);
+        coordinator.signDecline(fakeSid);
+    }
+
+    function test_SignDecline_AfterSigned_Reverts() public {
+        (FROSTGroupId.T gid, uint256[] memory s,) = _trustedKeyGen(bytes32(0));
+        FROSTSignatureId.T sid = _trustedSign(gid, s, keccak256("sign me"));
+
+        address p0 = participants.addr(0);
+        vm.expectRevert(FROSTCoordinator.SigningComplete.selector);
+        vm.prank(p0);
+        coordinator.signDecline(sid);
+    }
+
+    // ============================================================
+    // SIGSHARE AFTER REJECTION
+    // ============================================================
+
+    function test_SignShare_AfterRejection_Reverts() public {
+        (FROSTGroupId.T gid,,) = _trustedKeyGen(bytes32(0));
+        bytes32 message = keccak256("decline then sign");
+        FROSTSignatureId.T sid = coordinator.sign(gid, message);
+
+        for (uint256 i = 0; i < DECLINE_THRESHOLD; i++) {
+            vm.prank(participants.addr(i));
+            coordinator.signDecline(sid);
+        }
+
+        // Attempt signShare on rejected ceremony — use dummy selection/share/proof
+        FROSTCoordinator.SignSelection memory selection;
+        FROST.SignatureShare memory share;
+        bytes32[] memory proof;
+        address pNext = participants.addr(DECLINE_THRESHOLD);
+        vm.expectRevert(FROSTCoordinator.CeremonyRejected.selector);
+        vm.prank(pNext);
+        coordinator.signShare(sid, selection, share, proof);
+    }
+
+    // ============================================================
+    // SIGNATUREVALUE / SIGNATUREVERIFY AFTER REJECTION
+    // ============================================================
+
+    function test_SignatureValue_AfterRejection_Reverts() public {
+        (FROSTGroupId.T gid,,) = _trustedKeyGen(bytes32(0));
+        FROSTSignatureId.T sid = coordinator.sign(gid, keccak256("msg"));
+
+        for (uint256 i = 0; i < DECLINE_THRESHOLD; i++) {
+            vm.prank(participants.addr(i));
+            coordinator.signDecline(sid);
+        }
+
+        vm.expectRevert(FROSTCoordinator.SignatureRejected.selector);
+        coordinator.signatureValue(sid);
+    }
+
+    function test_SignatureVerify_AfterRejection_Reverts() public {
+        (FROSTGroupId.T gid,,) = _trustedKeyGen(bytes32(0));
+        bytes32 message = keccak256("msg");
+        FROSTSignatureId.T sid = coordinator.sign(gid, message);
+
+        for (uint256 i = 0; i < DECLINE_THRESHOLD; i++) {
+            vm.prank(participants.addr(i));
+            coordinator.signDecline(sid);
+        }
+
+        vm.expectRevert(FROSTCoordinator.SignatureRejected.selector);
+        coordinator.signatureVerify(sid, gid, message);
+    }
+
+    // ============================================================
+    // SIGNING COMPLETES BEFORE REJECTION THRESHOLD
+    // ============================================================
+
+    function test_SignDecline_BelowThreshold_CeremonyStillCompletable() public {
+        (FROSTGroupId.T gid, uint256[] memory s,) = _trustedKeyGen(bytes32(0));
+
+        // Complete a full ceremony (sequence 0) — demonstrates the group can sign.
+        FROSTSignatureId.T completedSid = _trustedSign(gid, s, keccak256("complete before decline"));
+        assertFalse(coordinator.isSignRejected(completedSid));
+
+        // Start a new ceremony (sequence 1) and have fewer than DECLINE_THRESHOLD participants decline;
+        // the ceremony must remain non-rejected.
+        FROSTSignatureId.T nextSid = coordinator.sign(gid, keccak256("next ceremony"));
+        for (uint256 i = 0; i < DECLINE_THRESHOLD - 1; i++) {
+            vm.prank(participants.addr(i));
+            coordinator.signDecline(nextSid);
+        }
+        assertFalse(coordinator.isSignRejected(nextSid));
+    }
+
+    function test_SignatureMessage_ReturnsMessage() public {
+        (FROSTGroupId.T gid,,) = _trustedKeyGen(bytes32(0));
+        bytes32 message = keccak256("check message");
+        FROSTSignatureId.T sid = coordinator.sign(gid, message);
+
+        assertEq(coordinator.signatureMessage(sid), message);
+    }
+
+    function test_SignatureMessage_NotStarted_ReturnsZero() public {
+        (FROSTGroupId.T gid,,) = _trustedKeyGen(bytes32(0));
+        FROSTSignatureId.T fakeSid = FROSTSignatureId.create(gid, 99);
+        assertEq(coordinator.signatureMessage(fakeSid), bytes32(0));
+    }
+
+    // ============================================================
+    // SIGNDECLINEWITHCALLBACK
+    // ============================================================
+
+    function test_SignDeclineWithCallback_CallbackFires_AtThreshold() public {
+        MockDeclineCallbackTarget mock = new MockDeclineCallbackTarget();
+        (FROSTGroupId.T gid,,) = _trustedKeyGen(bytes32(0));
+        FROSTSignatureId.T sid = coordinator.sign(gid, keccak256("msg"));
+        bytes memory context = abi.encode("test context");
+        FROSTCoordinator.Callback memory callback =
+            FROSTCoordinator.Callback({target: IFROSTCoordinatorCallback(address(mock)), context: context});
+
+        for (uint256 i = 0; i < DECLINE_THRESHOLD - 1; i++) {
+            vm.prank(participants.addr(i));
+            coordinator.signDeclineWithCallback(sid, callback);
+        }
+        assertEq(mock.callCount(), 0);
+
+        vm.prank(participants.addr(DECLINE_THRESHOLD - 1));
+        bool rejected = coordinator.signDeclineWithCallback(sid, callback);
+        assertTrue(rejected);
+        assertEq(mock.callCount(), 1);
+        assertEq(FROSTSignatureId.T.unwrap(mock.lastRejectedSid()), FROSTSignatureId.T.unwrap(sid));
+        assertEq(mock.lastContext(), context);
+    }
+
+    function test_SignDeclineWithCallback_NoCallback_BelowThreshold() public {
+        MockDeclineCallbackTarget mock = new MockDeclineCallbackTarget();
+        (FROSTGroupId.T gid,,) = _trustedKeyGen(bytes32(0));
+        FROSTSignatureId.T sid = coordinator.sign(gid, keccak256("msg"));
+        FROSTCoordinator.Callback memory callback =
+            FROSTCoordinator.Callback({target: IFROSTCoordinatorCallback(address(mock)), context: bytes("")});
+
+        vm.prank(participants.addr(0));
+        bool rejected = coordinator.signDeclineWithCallback(sid, callback);
+        assertFalse(rejected);
+        assertEq(mock.callCount(), 0);
+    }
+
+    function test_SignDeclineWithCallback_NoCallback_AfterThresholdAlreadyCrossed() public {
+        MockDeclineCallbackTarget mock = new MockDeclineCallbackTarget();
+        (FROSTGroupId.T gid,,) = _trustedKeyGen(bytes32(0));
+        FROSTSignatureId.T sid = coordinator.sign(gid, keccak256("msg"));
+        FROSTCoordinator.Callback memory callback =
+            FROSTCoordinator.Callback({target: IFROSTCoordinatorCallback(address(mock)), context: bytes("")});
+
+        for (uint256 i = 0; i < DECLINE_THRESHOLD; i++) {
+            vm.prank(participants.addr(i));
+            coordinator.signDeclineWithCallback(sid, callback);
+        }
+        assertEq(mock.callCount(), 1);
+
+        // Additional decline — callback must NOT fire again
+        vm.prank(participants.addr(DECLINE_THRESHOLD));
+        bool rejected = coordinator.signDeclineWithCallback(sid, callback);
+        assertFalse(rejected);
+        assertEq(mock.callCount(), 1);
+    }
+
+    // ============================================================
+    // HELPERS
+    // ============================================================
+
+    function _randomSortedAddresses(uint16 count) private view returns (address[] memory result) {
+        result = new address[](count);
+        for (uint256 i = 0; i < result.length; i++) {
+            result[i] = vm.randomAddress();
+        }
+        result.sort();
+    }
+
+    function _trustedKeyGen(bytes32 context) private returns (FROSTGroupId.T gid, uint256[] memory s, uint256 gs) {
+        s = new uint256[](COUNT);
+
+        uint256[] memory a = new uint256[](THRESHOLD);
+        for (uint256 j = 0; j < THRESHOLD; j++) {
+            a[j] = vm.randomUint(0, Secp256k1.N - 1);
+        }
+
+        FROSTCoordinator.KeyGenCommitment memory commitment;
+        commitment.q = ForgeSecp256k1.g(1).toPoint();
+        commitment.c = new Secp256k1.Point[](THRESHOLD);
+        for (uint256 i = 1; i < COUNT; i++) {
+            bytes32 root = participants.root();
+            (address participant, bytes32[] memory poap) = participants.proof(i);
+            vm.prank(participant);
+            coordinator.keyGenAndCommit(root, COUNT, THRESHOLD, context, poap, commitment);
+        }
+        {
+            for (uint256 j = 0; j < THRESHOLD; j++) {
+                commitment.c[j] = ForgeSecp256k1.g(a[j]).toPoint();
+            }
+            bytes32 root = participants.root();
+            (address participant, bytes32[] memory poap) = participants.proof(0);
+            vm.prank(participant);
+            (gid,) = coordinator.keyGenAndCommit(root, COUNT, THRESHOLD, context, poap, commitment);
+        }
+
+        FROSTCoordinator.KeyGenSecretShare memory share;
+        share.f = new uint256[](COUNT - 1);
+        for (uint256 i = 0; i < COUNT; i++) {
+            s[i] = _f(a, i);
+            share.y = ForgeSecp256k1.g(s[i]).toPoint();
+            vm.prank(participants.addr(i));
+            coordinator.keyGenSecretShare(gid, share);
+        }
+
+        for (uint256 i = 0; i < COUNT; i++) {
+            vm.prank(participants.addr(i));
+            coordinator.keyGenConfirm(gid);
+        }
+
+        gs = a[0];
+    }
+
+    function _trustedSign(FROSTGroupId.T gid, uint256[] memory s, bytes32 message)
+        private
+        returns (FROSTSignatureId.T sid)
+    {
+        bytes32[] memory nonceProof = new bytes32[](10);
+        Nonces[] memory nonces = new Nonces[](COUNT);
+        {
+            bytes32[] memory commitments = new bytes32[](COUNT);
+            for (uint256 i = 0; i < COUNT; i++) {
+                Nonces memory n = nonces[i];
+                uint256 d = FROST.nonce(bytes32(vm.randomUint()), s[i]);
+                n.d = ForgeSecp256k1.g(d);
+                uint256 e = FROST.nonce(bytes32(vm.randomUint()), s[i]);
+                n.e = ForgeSecp256k1.g(e);
+                // forge-lint: disable-next-line(asm-keccak256)
+                bytes32 leaf = keccak256(abi.encode(0, n.d.x(), n.d.y(), n.e.x(), n.e.y()));
+                commitments[i] = MerkleProof.processProof(nonceProof, leaf);
+            }
+            for (uint256 i = 0; i < COUNT; i++) {
+                vm.prank(participants.addr(i));
+                coordinator.preprocess(gid, commitments[i]);
+            }
+        }
+
+        // Build the honest participants list and reveal nonces before sorting.
+        uint256[] memory honestParticipants = new uint256[](COUNT);
+        for (uint256 i = 0; i < COUNT; i++) {
+            honestParticipants[i] = i;
+        }
+
+        sid = coordinator.sign(gid, message);
+
+        for (uint256 i = 0; i < COUNT; i++) {
+            uint256 h = honestParticipants[i];
+            Nonces memory n = nonces[h];
+            FROSTCoordinator.SignNonces memory nn = FROSTCoordinator.SignNonces({d: n.d.toPoint(), e: n.e.toPoint()});
+            vm.prank(participants.addr(h));
+            coordinator.signRevealNonces(sid, nn, nonceProof);
+        }
+
+        // Binding factors and CommitmentShareMerkleTree require participants sorted by FROST identifier.
+        _sortByParticipantId(honestParticipants);
+
+        Secp256k1.Point memory groupKey = coordinator.groupKey(gid);
+        FROSTCoordinator.SignSelection memory selection;
+        FROST.SignatureShare[] memory shares = new FROST.SignatureShare[](COUNT);
+        {
+            uint256[] memory bindingFactors;
+            {
+                FROST.Commitment[] memory coms = new FROST.Commitment[](COUNT);
+                for (uint256 i = 0; i < COUNT; i++) {
+                    uint256 h = honestParticipants[i];
+                    Nonces memory n = nonces[h];
+                    coms[i] = FROST.Commitment({participant: participants.addr(h), d: n.d.toPoint(), e: n.e.toPoint()});
+                }
+                bindingFactors = FROST.bindingFactors(groupKey, coms, message);
+            }
+
+            ForgeSecp256k1.P memory groupCommitment;
+            for (uint256 i = 0; i < COUNT; i++) {
+                uint256 h = honestParticipants[i];
+                Nonces memory n = nonces[h];
+                ForgeSecp256k1.P memory r = ForgeSecp256k1.add(n.d, ForgeSecp256k1.mul(bindingFactors[i], n.e));
+                shares[i].r = r.toPoint();
+                shares[i].l = _lagrangeCoefficient(honestParticipants, h);
+                groupCommitment = ForgeSecp256k1.add(groupCommitment, r);
+            }
+            selection.r = groupCommitment.toPoint();
+
+            uint256 challenge = FROST.challenge(selection.r, groupKey, message);
+            for (uint256 i = 0; i < COUNT; i++) {
+                uint256 h = honestParticipants[i];
+                uint256 sk = s[h];
+                Nonces memory n = nonces[h];
+                shares[i].z = addmod(
+                    n.d.w.privateKey,
+                    addmod(
+                        mulmod(n.e.w.privateKey, bindingFactors[i], Secp256k1.N),
+                        mulmod(mulmod(challenge, shares[i].l, Secp256k1.N), sk, Secp256k1.N),
+                        Secp256k1.N
+                    ),
+                    Secp256k1.N
+                );
+            }
+        }
+
+        CommitmentShareMerkleTree commitmentShares;
+        {
+            CommitmentShareMerkleTree.S[] memory cs = new CommitmentShareMerkleTree.S[](COUNT);
+            for (uint256 i = 0; i < COUNT; i++) {
+                uint256 h = honestParticipants[i];
+                cs[i] = CommitmentShareMerkleTree.S({participant: participants.addr(h), r: shares[i].r, l: shares[i].l});
+            }
+            commitmentShares = new CommitmentShareMerkleTree(selection.r, cs);
+            selection.root = commitmentShares.root();
+        }
+
+        for (uint256 i = 0; i < COUNT; i++) {
+            bytes32[] memory proof = commitmentShares.proof(i);
+            uint256 h = honestParticipants[i];
+            vm.prank(participants.addr(h));
+            coordinator.signShare(sid, selection, shares[i], proof);
+        }
+    }
+
+    function _sortByParticipantId(uint256[] memory ps) private view {
+        bool ordered = false;
+        while (!ordered) {
+            ordered = true;
+            for (uint256 i = 1; i < ps.length; i++) {
+                uint256 a = ps[i - 1];
+                uint256 b = ps[i];
+                if (FROST.identifier(participants.addr(a)) > FROST.identifier(participants.addr(b))) {
+                    ps[i - 1] = b;
+                    ps[i] = a;
+                    ordered = false;
+                }
+            }
+        }
+    }
+
+    function _f(uint256[] memory a, uint256 i) private view returns (uint256 r) {
+        r = a[0];
+        uint256 x = FROST.identifier(participants.addr(i));
+        uint256 xx = 1;
+        for (uint256 j = 1; j < a.length; j++) {
+            xx = mulmod(xx, x, Secp256k1.N);
+            r = addmod(r, mulmod(a[j], xx, Secp256k1.N), Secp256k1.N);
+        }
+    }
+
+    function _lagrangeCoefficient(uint256[] memory l, uint256 i) private view returns (uint256 lambda) {
+        uint256 numerator = 1;
+        uint256 denominator = 1;
+        uint256 minusId = Secp256k1.N - FROST.identifier(participants.addr(i));
+        for (uint256 j = 0; j < l.length; j++) {
+            uint256 jj = l[j];
+            if (i == jj) {
+                continue;
+            }
+            uint256 x = FROST.identifier(participants.addr(jj));
+            numerator = mulmod(numerator, x, Secp256k1.N);
+            denominator = mulmod(denominator, addmod(x, minusId, Secp256k1.N), Secp256k1.N);
+        }
+        return mulmod(numerator, Math.invModPrime(denominator, Secp256k1.N), Secp256k1.N);
+    }
+}

--- a/contracts/test/util/MockCoordinator.sol
+++ b/contracts/test/util/MockCoordinator.sol
@@ -8,9 +8,21 @@ import {Secp256k1} from "@/libraries/Secp256k1.sol";
 
 contract MockCoordinator {
     mapping(FROSTGroupId.T => Secp256k1.Point) groupKeys;
+    // forge-lint: disable-next-line(mixed-case-variable)
+    mapping(FROSTSignatureId.T => bool) private $rejectedSignatures;
+    // forge-lint: disable-next-line(mixed-case-variable)
+    mapping(FROSTSignatureId.T => bytes32) private $signatureMessages;
 
     function setGroupKey(FROSTGroupId.T group, Secp256k1.Point memory key) external {
         groupKeys[group] = key;
+    }
+
+    function setSignRejected(FROSTSignatureId.T sid, bool rejected) external {
+        $rejectedSignatures[sid] = rejected;
+    }
+
+    function setSignatureMessage(FROSTSignatureId.T sid, bytes32 message) external {
+        $signatureMessages[sid] = message;
     }
 
     function groupKey(FROSTGroupId.T group) external view returns (Secp256k1.Point memory key) {
@@ -26,4 +38,12 @@ contract MockCoordinator {
     {}
 
     function signatureValue(FROSTSignatureId.T) external pure returns (FROST.Signature memory) {}
+
+    function isSignRejected(FROSTSignatureId.T sid) external view returns (bool) {
+        return $rejectedSignatures[sid];
+    }
+
+    function signatureMessage(FROSTSignatureId.T sid) external view returns (bytes32) {
+        return $signatureMessages[sid];
+    }
 }


### PR DESCRIPTION
Wires the coordinator's rejection threshold to Consensus via a callback, emitting `TransactionRejected`/`OracleTransactionRejected` on the same contract as `TransactionProposed` and `TransactionAttested`.

> **Stacked on**: feat/frost-coordinator-decline-tracking (PR 1). Only the top commit on this branch is new.

### Context and Motivation

- PR 1 added the coordinator mechanics (decline tracking and threshold stopping). This PR completes the on-chain story: when enough validators decline, `Consensus` emits `TransactionRejected`, making rejection a first-class event alongside proposal and attestation.
- By placing `TransactionRejected` on `Consensus` (not the coordinator), the explorer can derive all proposal status from a single contract — no cross-contract SID correlation needed.

### Decisions and Tradeoffs

- **`signDeclineWithCallback` added here, not in PR 1**: it calls `callback.target.onSignRejected`, which did not exist on `IFROSTCoordinatorCallback` until this PR. The coordinator function and the interface method must be introduced together.
- **Mirrors `signShareWithCallback` → `onSignCompleted` exactly**: same `Callback` struct, same dispatch-on-selector pattern, same context encoding (`abi.encode(selector, args)`). Reviewers familiar with the existing flow will find nothing surprising.
- **`rejectTransaction`/`rejectOracleTransaction` are public**: matches `attestTransaction`/`attestOracleTransaction`. They validate via `_COORDINATOR.isSignRejected(signatureId)` to guard against direct calls that bypass the callback. The `onlyCoordinator` guard on `onSignRejected` ensures the callback path is always safe.
- **`$rejections` storage mirrors `$attestations`**: prevents double-rejection recording and provides a consistent storage pattern.
- **`WrongSignature` check in `rejectTransaction`**: validates the SID belongs to this specific ceremony via `signatureMessage`. Without it, a caller could pass a legitimately rejected SID from an unrelated ceremony to emit a false `TransactionRejected` for any proposed transaction.

### Testing

- Full callback chain: `signDeclineWithCallback` → `onSignRejected` → `rejectTransaction` → `TransactionRejected` event emitted.
- `signDeclineWithCallback`: callback fires only when rejection threshold is first crossed, not on subsequent declines.
- `onSignRejected` called by non-coordinator: reverts with `NotCoordinator`.
- `onSignRejected` dispatches to `rejectTransaction` for safe tx context and `rejectOracleTransaction` for oracle tx context.
- `onSignRejected` with unknown selector: reverts with `UnknownSignatureSelector`.
- `rejectTransaction` with unrejected SID: reverts with `NotRejected`.
- `rejectTransaction` with a rejected SID from a different ceremony: reverts with `WrongSignature`.
- `rejectTransaction` called twice for same message: reverts with `AlreadyRejected`.
- `rejectOracleTransaction` mirrors the above for oracle transactions.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NQP8LGdd3sws86RWJiuWqg)_