### PR TITLE
feat(contracts/test): create `FROSTMath` library and refactor `FROSTCoordinator.t.sol`

### DIFF
--- a/contracts/test/FROSTCoordinator.t.sol
+++ b/contracts/test/FROSTCoordinator.t.sol
@@ -4,9 +4,9 @@ pragma solidity ^0.8.30;
 import {Test, Vm} from "@forge-std/Test.sol";
 import {Arrays} from "@oz/utils/Arrays.sol";
 import {MerkleProof} from "@oz/utils/cryptography/MerkleProof.sol";
-import {Math} from "@oz/utils/math/Math.sol";
 import {CommitmentShareMerkleTree} from "@test/util/CommitmentShareMerkleTree.sol";
 import {ForgeSecp256k1} from "@test/util/ForgeSecp256k1.sol";
+import {FROSTMath} from "@test/util/FROSTMath.sol";
 import {ParticipantMerkleTree} from "@test/util/ParticipantMerkleTree.sol";
 import {FROSTCoordinator} from "@/FROSTCoordinator.sol";
 import {FROST} from "@/libraries/FROST.sol";
@@ -16,7 +16,6 @@ import {Secp256k1} from "@/libraries/Secp256k1.sol";
 
 contract FROSTCoordinatorTest is Test {
     using Arrays for address[];
-    using Arrays for uint256[];
     using ForgeSecp256k1 for ForgeSecp256k1.P;
 
     struct Nonces {
@@ -31,14 +30,115 @@ contract FROSTCoordinatorTest is Test {
     ParticipantMerkleTree public participants;
 
     function setUp() public {
-        // When debugging, it may be useful to use deterministic values to check
-        // intermediate steps. Uncomment the following line in order to set a
-        // deterministic seed and ensure that all random values are predictable.
+        // When debugging, it may be useful to set a deterministic seed.
+        // Uncomment the following line to make all random values predictable.
         //vm.setSeed(0x5afe);
-
         coordinator = new FROSTCoordinator();
         participants = new ParticipantMerkleTree(_randomSortedAddresses(COUNT));
     }
+
+    // ========================= Trusted Setup Helpers =========================
+
+    /// @dev Trusted dealer key generation. Returns the group ID, per-participant
+    /// secret keys, and the group private key scalar (for debugging).
+    function _trustedKeyGen(bytes32 context) internal returns (FROSTGroupId.T gid, uint256[] memory s, uint256 gs) {
+        s = new uint256[](COUNT);
+
+        uint256[] memory a = new uint256[](THRESHOLD);
+        // a[0] is the group private key; exclude 0 to avoid the point at infinity.
+        a[0] = vm.randomUint(1, Secp256k1.N - 1);
+        for (uint256 j = 1; j < THRESHOLD; j++) {
+            a[j] = vm.randomUint(0, Secp256k1.N - 1);
+        }
+
+        FROSTCoordinator.KeyGenCommitment memory commitment;
+        // Because we are in a trusted setup, we don't actually need to encrypt
+        // anything. Specify a dummy encryption key.
+        commitment.q = ForgeSecp256k1.g(1).toPoint();
+        // In our trusted key gen setup, we pretend like the first participant
+        // has the full polynomial for deriving all the shares, and all other
+        // participants do not add anything.
+        commitment.c = new Secp256k1.Point[](THRESHOLD);
+        for (uint256 i = 1; i < COUNT; i++) {
+            bytes32 root = participants.root();
+            (address participant, bytes32[] memory poap) = participants.proof(i);
+            vm.prank(participant);
+            coordinator.keyGenAndCommit(root, COUNT, THRESHOLD, context, poap, commitment);
+        }
+        {
+            for (uint256 j = 0; j < THRESHOLD; j++) {
+                commitment.c[j] = ForgeSecp256k1.g(a[j]).toPoint();
+            }
+            bytes32 root = participants.root();
+            (address participant, bytes32[] memory poap) = participants.proof(0);
+            vm.prank(participant);
+            (gid,) = coordinator.keyGenAndCommit(root, COUNT, THRESHOLD, context, poap, commitment);
+        }
+
+        // We don't actually need to encrypt and broadcast secret shares, the
+        // trusted dealer computes the private keys for each participant.
+        FROSTCoordinator.KeyGenSecretShare memory share;
+        share.f = new uint256[](COUNT - 1);
+        for (uint256 i = 0; i < COUNT; i++) {
+            s[i] = FROSTMath.evalPolynomial(a, participants.addr(i));
+            share.y = ForgeSecp256k1.g(s[i]).toPoint();
+            vm.prank(participants.addr(i));
+            coordinator.keyGenSecretShare(gid, share);
+        }
+
+        // We now finalize the key generation.
+        for (uint256 i = 0; i < COUNT; i++) {
+            vm.prank(participants.addr(i));
+            coordinator.keyGenConfirm(gid);
+        }
+
+        // For debugging purposes, also provide the group private key to the
+        // caller (even if this is typically not available).
+        gs = a[0];
+
+        assertEq(
+            keccak256(abi.encode(coordinator.groupKey(gid))), keccak256(abi.encode(ForgeSecp256k1.g(gs).toPoint()))
+        );
+    }
+
+    function _randomSortedAddresses(uint16 count) internal view returns (address[] memory result) {
+        result = new address[](count);
+        for (uint256 i = 0; i < result.length; i++) {
+            result[i] = vm.randomAddress();
+        }
+        result.sort();
+    }
+
+    function _honestParticipants() internal returns (uint256[] memory result) {
+        result = new uint256[](COUNT);
+        for (uint256 i = 0; i < COUNT; i++) {
+            result[i] = i;
+        }
+
+        result = vm.shuffle(result);
+        uint256 length = vm.randomUint(THRESHOLD, COUNT);
+        assembly ("memory-safe") {
+            mstore(result, length)
+        }
+    }
+
+    function _sortByParticipantId(uint256[] memory ps) internal view {
+        bool ordered = false;
+        while (!ordered) {
+            ordered = true;
+            for (uint256 i = 1; i < ps.length; i++) {
+                uint256 a = ps[i - 1];
+                uint256 b = ps[i];
+                if (FROST.identifier(participants.addr(a)) > FROST.identifier(participants.addr(b))) {
+                    ps[i - 1] = b;
+                    ps[i] = a;
+                    ordered = false;
+                }
+            }
+        }
+    }
+
+    // ========================= Tests =========================
 
     function test_KeyGen() public {
         // Distributed key generation algorithm from the FROST white paper.
@@ -128,7 +228,8 @@ contract FROSTCoordinatorTest is Test {
             FROSTCoordinator.KeyGenSecretShare memory share = shares[i];
 
             for (uint256 j = 0; j < COUNT; j++) {
-                share.y = Secp256k1.add(share.y, _fc(cc[j], i).toPoint());
+                share.y =
+                    Secp256k1.add(share.y, FROSTMath.evalCommitmentPolynomial(cc[j], participants.addr(i)).toPoint());
             }
 
             share.f = new uint256[](COUNT - 1);
@@ -138,7 +239,7 @@ contract FROSTCoordinatorTest is Test {
                     continue;
                 }
 
-                uint256 fi = _f(a[i], l);
+                uint256 fi = FROSTMath.evalPolynomial(a[i], participants.addr(l));
 
                 // EXTENSION: We apply ECDH to encrypt the `f_i(l)` evaluation
                 // for the target participant. This allows us to use the same
@@ -146,7 +247,7 @@ contract FROSTCoordinatorTest is Test {
                 // additional secret channel. This also implies that we only
                 // completely delete `f` in 2.3, as we need `a_0` to recover the
                 // secret shares sent by other participants.
-                fi = _ecdh(fi, q[i], qq[l]);
+                fi = FROSTMath.ecdh(fi, q[i], qq[l]);
 
                 share.f[k++] = fi;
             }
@@ -176,14 +277,14 @@ contract FROSTCoordinatorTest is Test {
 
                 // EXTENSION: We need to reverse the ECDH we applied in the
                 // previous step.
-                f[i][l] = _ecdh(f[i][l], q[i], qq[l]);
+                f[i][l] = FROSTMath.ecdh(f[i][l], q[i], qq[l]);
 
                 Secp256k1.Point memory gf = ForgeSecp256k1.g(f[i][l]).toPoint();
-                Secp256k1.Point memory fc = _fc(cc[l], i).toPoint();
+                Secp256k1.Point memory fc = FROSTMath.evalCommitmentPolynomial(cc[l], participants.addr(i)).toPoint();
                 assertEq(gf.x, fc.x);
                 assertEq(gf.y, fc.y);
             }
-            f[i][i] = _f(a[i], i);
+            f[i][i] = FROSTMath.evalPolynomial(a[i], participants.addr(i));
         }
 
         // Round 2.3
@@ -291,6 +392,10 @@ contract FROSTCoordinatorTest is Test {
         Secp256k1.Point memory groupKey = coordinator.groupKey(gid);
         FROSTCoordinator.SignSelection memory selection;
         FROST.SignatureShare[] memory shares = new FROST.SignatureShare[](honestParticipants.length);
+        address[] memory honestAddrs = new address[](honestParticipants.length);
+        for (uint256 i = 0; i < honestParticipants.length; i++) {
+            honestAddrs[i] = participants.addr(honestParticipants[i]);
+        }
         {
             uint256[] memory bindingFactors;
             {
@@ -310,7 +415,7 @@ contract FROSTCoordinatorTest is Test {
                 uint256 bindingFactor = bindingFactors[i];
                 ForgeSecp256k1.P memory r = ForgeSecp256k1.add(n.d, ForgeSecp256k1.mul(bindingFactor, n.e));
                 shares[i].r = r.toPoint();
-                shares[i].l = _lagrangeCoefficient(honestParticipants, h);
+                shares[i].l = FROSTMath.lagrangeCoefficient(honestAddrs, participants.addr(h));
                 groupCommitment = ForgeSecp256k1.add(groupCommitment, r);
             }
             selection.r = groupCommitment.toPoint();
@@ -354,140 +459,5 @@ contract FROSTCoordinatorTest is Test {
 
         FROST.Signature memory signature = coordinator.signatureValue(sid);
         FROST.verify(groupKey, signature, message);
-    }
-
-    function _randomSortedAddresses(uint16 count) private view returns (address[] memory result) {
-        result = new address[](count);
-        for (uint256 i = 0; i < result.length; i++) {
-            result[i] = vm.randomAddress();
-        }
-        result.sort();
-    }
-
-    function _trustedKeyGen(bytes32 context) private returns (FROSTGroupId.T gid, uint256[] memory s, uint256 gs) {
-        s = new uint256[](COUNT);
-
-        uint256[] memory a = new uint256[](THRESHOLD);
-        for (uint256 j = 0; j < THRESHOLD; j++) {
-            a[j] = vm.randomUint(0, Secp256k1.N - 1);
-        }
-
-        FROSTCoordinator.KeyGenCommitment memory commitment;
-        // Because we are in a trusted setup, we don't actually need to encrypt
-        // anything. Specify a dummy encryption key.
-        commitment.q = ForgeSecp256k1.g(1).toPoint();
-        // In our trusted key gen setup, we pretend like the first participant
-        // has the full polynomial for deriving all the shares, and all other
-        // participants do not add anything.
-        commitment.c = new Secp256k1.Point[](THRESHOLD);
-        for (uint256 i = 1; i < COUNT; i++) {
-            bytes32 root = participants.root();
-            (address participant, bytes32[] memory poap) = participants.proof(i);
-            vm.prank(participant);
-            coordinator.keyGenAndCommit(root, COUNT, THRESHOLD, context, poap, commitment);
-        }
-        {
-            for (uint256 j = 0; j < THRESHOLD; j++) {
-                commitment.c[j] = ForgeSecp256k1.g(a[j]).toPoint();
-            }
-            bytes32 root = participants.root();
-            (address participant, bytes32[] memory poap) = participants.proof(0);
-            vm.prank(participant);
-            (gid,) = coordinator.keyGenAndCommit(root, COUNT, THRESHOLD, context, poap, commitment);
-        }
-
-        // We don't actually need to encrypt and broadcast secret shares, the
-        // trusted dealer computes the private keys for each participant.
-        FROSTCoordinator.KeyGenSecretShare memory share;
-        share.f = new uint256[](COUNT - 1);
-        for (uint256 i = 0; i < COUNT; i++) {
-            s[i] = _f(a, i);
-            share.y = ForgeSecp256k1.g(s[i]).toPoint();
-            vm.prank(participants.addr(i));
-            coordinator.keyGenSecretShare(gid, share);
-        }
-
-        // We now finalize the key generation.
-        for (uint256 i = 0; i < COUNT; i++) {
-            vm.prank(participants.addr(i));
-            coordinator.keyGenConfirm(gid);
-        }
-
-        // For debugging purposes, also provide the group private key to the
-        // caller (even if this is typically not available).
-        gs = a[0];
-
-        assertEq(
-            keccak256(abi.encode(coordinator.groupKey(gid))), keccak256(abi.encode(ForgeSecp256k1.g(gs).toPoint()))
-        );
-    }
-
-    function _f(uint256[] memory a, uint256 i) private view returns (uint256 r) {
-        r = a[0];
-        uint256 x = FROST.identifier(participants.addr(i));
-        uint256 xx = 1;
-        for (uint256 j = 1; j < a.length; j++) {
-            xx = mulmod(xx, x, Secp256k1.N);
-            r = addmod(r, mulmod(a[j], xx, Secp256k1.N), Secp256k1.N);
-        }
-    }
-
-    function _fc(ForgeSecp256k1.P[] memory c, uint256 i) private returns (ForgeSecp256k1.P memory r) {
-        r = c[0];
-        uint256 x = FROST.identifier(participants.addr(i));
-        uint256 xx = 1;
-        for (uint256 j = 1; j < c.length; j++) {
-            xx = mulmod(xx, x, Secp256k1.N);
-            r = ForgeSecp256k1.add(r, ForgeSecp256k1.mul(xx, c[j]));
-        }
-    }
-
-    function _ecdh(uint256 x, uint256 k, ForgeSecp256k1.P memory q) private returns (uint256 encX) {
-        return x ^ ForgeSecp256k1.mul(k, q).toPoint().x;
-    }
-
-    function _honestParticipants() private returns (uint256[] memory result) {
-        result = new uint256[](COUNT);
-        for (uint256 i = 0; i < COUNT; i++) {
-            result[i] = i;
-        }
-
-        result = vm.shuffle(result);
-        uint256 length = vm.randomUint(THRESHOLD, COUNT);
-        assembly ("memory-safe") {
-            mstore(result, length)
-        }
-    }
-
-    function _sortByParticipantId(uint256[] memory ps) private view {
-        bool ordered = false;
-        while (!ordered) {
-            ordered = true;
-            for (uint256 i = 1; i < ps.length; i++) {
-                uint256 a = ps[i - 1];
-                uint256 b = ps[i];
-                if (FROST.identifier(participants.addr(a)) > FROST.identifier(participants.addr(b))) {
-                    ps[i - 1] = b;
-                    ps[i] = a;
-                    ordered = false;
-                }
-            }
-        }
-    }
-
-    function _lagrangeCoefficient(uint256[] memory l, uint256 i) private view returns (uint256 lambda) {
-        uint256 numerator = 1;
-        uint256 denominator = 1;
-        uint256 minusId = Secp256k1.N - FROST.identifier(participants.addr(i));
-        for (uint256 j = 0; j < l.length; j++) {
-            uint256 jj = l.unsafeMemoryAccess(j);
-            if (i == jj) {
-                continue;
-            }
-            uint256 x = FROST.identifier(participants.addr(jj));
-            numerator = mulmod(numerator, x, Secp256k1.N);
-            denominator = mulmod(denominator, addmod(x, minusId, Secp256k1.N), Secp256k1.N);
-        }
-        return mulmod(numerator, Math.invModPrime(denominator, Secp256k1.N), Secp256k1.N);
     }
 }

--- a/contracts/test/util/FROSTMath.sol
+++ b/contracts/test/util/FROSTMath.sol
@@ -1,0 +1,55 @@
+// SPDX-License-Identifier: GPL-3.0-only
+pragma solidity ^0.8.30;
+
+import {Math} from "@oz/utils/math/Math.sol";
+import {ForgeSecp256k1} from "@test/util/ForgeSecp256k1.sol";
+import {FROST} from "@/libraries/FROST.sol";
+import {Secp256k1} from "@/libraries/Secp256k1.sol";
+
+/// @dev Stateless FROST math helpers for test contracts, parameterised by participant
+///      addresses so they are decoupled from any specific `ParticipantMerkleTree` instance.
+library FROSTMath {
+    /// @dev Evaluate f(x) = a[0] + a[1]·x + … at the FROST identifier of `participant`.
+    function evalPolynomial(uint256[] memory a, address participant) internal view returns (uint256 r) {
+        r = a[0];
+        uint256 x = FROST.identifier(participant);
+        uint256 xx = 1;
+        for (uint256 j = 1; j < a.length; j++) {
+            xx = mulmod(xx, x, Secp256k1.N);
+            r = addmod(r, mulmod(a[j], xx, Secp256k1.N), Secp256k1.N);
+        }
+    }
+
+    /// @dev Evaluate C(x) = c[0] + c[1]·x + … (EC points) at the FROST identifier of `participant`.
+    function evalCommitmentPolynomial(ForgeSecp256k1.P[] memory c, address participant)
+        internal
+        returns (ForgeSecp256k1.P memory r)
+    {
+        r = c[0];
+        uint256 x = FROST.identifier(participant);
+        uint256 xx = 1;
+        for (uint256 j = 1; j < c.length; j++) {
+            xx = mulmod(xx, x, Secp256k1.N);
+            r = ForgeSecp256k1.add(r, ForgeSecp256k1.mul(xx, c[j]));
+        }
+    }
+
+    /// @dev Compute the Lagrange coefficient λ_i for `signer` over the set `signers`.
+    function lagrangeCoefficient(address[] memory signers, address signer) internal view returns (uint256 lambda) {
+        uint256 numerator = 1;
+        uint256 denominator = 1;
+        uint256 minusId = Secp256k1.N - FROST.identifier(signer);
+        for (uint256 j = 0; j < signers.length; j++) {
+            if (signers[j] == signer) continue;
+            uint256 x = FROST.identifier(signers[j]);
+            numerator = mulmod(numerator, x, Secp256k1.N);
+            denominator = mulmod(denominator, addmod(x, minusId, Secp256k1.N), Secp256k1.N);
+        }
+        return mulmod(numerator, Math.invModPrime(denominator, Secp256k1.N), Secp256k1.N);
+    }
+
+    /// @dev ECDH: encrypt/decrypt `x` with private key `k` and public key `q`.
+    function ecdh(uint256 x, uint256 k, ForgeSecp256k1.P memory q) internal returns (uint256) {
+        return x ^ ForgeSecp256k1.toPoint(ForgeSecp256k1.mul(k, q)).x;
+    }
+}


### PR DESCRIPTION
Introduces `FROSTMath`, a stateless test utility library for FROST math, and refactors `FROSTCoordinator.t.sol`.

### Context and Motivation

- Pure math helpers (polynomial evaluation, Lagrange coefficients, ECDH) have no dependency on test state and belong in a reusable library rather than an abstract base contract.

### Decisions and Tradeoffs

- `FROSTMath` functions are parameterised by participant `address` values, not `ParticipantMerkleTree` indices, so they can be reused by any test contract without coupling to a specific test's state.

### Testing

- `forge test --match-contract FROSTCoordinatorTest` - all tests pass.
- `forge fmt --check` and `forge lint --deny notes` pass.