### PR TITLE
Add CLA signature section to PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -27,3 +27,9 @@ Author checklist:
 - Non-obvious changes and decisions are explained.
 - Links point to the relevant section/comment/block, not just a broad document.
 -->
+
+---
+
+## CLA signature
+
+With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://docs.safefoundation.org/cla).


### PR DESCRIPTION
Added CLA signature confirmation to the pull request template.

This is to enable external contributions to our repositories while complying to legal and regulatory requirements.

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://docs.safefoundation.org/cla).