### PR TITLE
SentinelOracle - Phase 3: Use fixed, fee related bonds

### DIFF
--- a/contracts/src/SentinelOracle.sol
+++ b/contracts/src/SentinelOracle.sol
@@ -108,7 +108,7 @@ contract SentinelOracle is IOracle {
     function postRequest(bytes32 requestId) external override(IOracle) {
         require(msg.sender == CONSENSUS, NotConsensus());
         uint256 fee = REQUEST_FEE;
-        uint256 bondTarget = fee * $bondConfig.bondMultiplier;
+        uint256 bondTarget = fee * $bondConfig.currentMultiplier();
         uint256 deadline = block.number + VOTING_WINDOW;
         $requests.create(requestId, msg.sender, fee, bondTarget, deadline);
         FEE_TOKEN.safeTransferFrom(msg.sender, address(this), fee);
@@ -118,12 +118,12 @@ contract SentinelOracle is IOracle {
     // VOTING
     // ============================================================
 
-    function commitApprove(bytes32 requestId, uint256 bondAmount) external {
-        _commit(requestId, true, bondAmount);
+    function commitApprove(bytes32 requestId) external {
+        _commit(requestId, true);
     }
 
-    function commitDeny(bytes32 requestId, uint256 bondAmount) external {
-        _commit(requestId, false, bondAmount);
+    function commitDeny(bytes32 requestId) external {
+        _commit(requestId, false);
     }
 
     // ============================================================
@@ -206,7 +206,7 @@ contract SentinelOracle is IOracle {
     }
 
     function bondMultiplier() external view returns (uint256) {
-        return $bondConfig.bondMultiplier;
+        return $bondConfig.currentMultiplier();
     }
 
     function pendingBondMultiplier() external view returns (uint256) {
@@ -233,11 +233,11 @@ contract SentinelOracle is IOracle {
     // INTERNAL HELPERS
     // ============================================================
 
-    function _commit(bytes32 requestId, bool approve, uint256 bondAmount) internal {
+    function _commit(bytes32 requestId, bool approve) internal {
         require($sentinelMap.isActive(msg.sender), SentinelNotActive());
         $commitments.checkNotCommitted(requestId, msg.sender);
         SentinelOracleRequest.Request storage req = $requests.get(requestId);
-        uint256 position = req.applyCommit(approve, bondAmount);
+        (uint256 position, uint256 bondAmount) = req.applyCommit(approve);
         $commitments.add(requestId, msg.sender, approve, bondAmount, position);
         FEE_TOKEN.safeTransferFrom(msg.sender, address(this), bondAmount);
     }

--- a/contracts/src/SentinelOracle.sol
+++ b/contracts/src/SentinelOracle.sol
@@ -61,7 +61,6 @@ contract SentinelOracle is IOracle {
     error InvalidAddress();
     error ZeroFee();
     error SentinelNotActive();
-    error ZeroBond();
 
     // ============================================================
     // MODIFIERS
@@ -235,12 +234,11 @@ contract SentinelOracle is IOracle {
     // ============================================================
 
     function _commit(bytes32 requestId, bool approve, uint256 bondAmount) internal {
-        require(bondAmount > 0, ZeroBond());
         require($sentinelMap.isActive(msg.sender), SentinelNotActive());
         $commitments.checkNotCommitted(requestId, msg.sender);
         SentinelOracleRequest.Request storage req = $requests.get(requestId);
-        (uint256 effectiveBond, uint256 position) = req.applyCommit(approve, bondAmount);
-        $commitments.add(requestId, msg.sender, approve, effectiveBond, position);
-        FEE_TOKEN.safeTransferFrom(msg.sender, address(this), effectiveBond);
+        uint256 position = req.applyCommit(approve, bondAmount);
+        $commitments.add(requestId, msg.sender, approve, bondAmount, position);
+        FEE_TOKEN.safeTransferFrom(msg.sender, address(this), bondAmount);
     }
 }

--- a/contracts/src/libraries/BondConfig.sol
+++ b/contracts/src/libraries/BondConfig.sol
@@ -24,7 +24,6 @@ library BondConfig {
     // ============================================================
 
     error InvalidMultiplier();
-    error NoPendingMultiplier();
     error MultiplierNotReady();
 
     // ============================================================
@@ -38,6 +37,7 @@ library BondConfig {
 
     function schedule(T storage self, uint256 newValue, uint256 governanceDelay) internal {
         require(newValue > 0, InvalidMultiplier());
+        applyPending(self);
 
         uint256 activeAt = block.number + governanceDelay;
         self.pendingBondMultiplier = newValue;
@@ -46,7 +46,7 @@ library BondConfig {
     }
 
     function applyPending(T storage self) internal {
-        require(self.pendingBondMultiplierActiveAt != 0, NoPendingMultiplier());
+        if (self.pendingBondMultiplierActiveAt == 0) return;
         require(block.number >= self.pendingBondMultiplierActiveAt, MultiplierNotReady());
 
         uint256 newValue = self.pendingBondMultiplier;
@@ -54,5 +54,12 @@ library BondConfig {
         self.pendingBondMultiplier = 0;
         self.pendingBondMultiplierActiveAt = 0;
         emit BondMultiplierApplied(newValue);
+    }
+
+    function currentMultiplier(T storage self) internal view returns (uint256) {
+        if (self.pendingBondMultiplierActiveAt != 0 && block.number >= self.pendingBondMultiplierActiveAt) {
+            return self.pendingBondMultiplier;
+        }
+        return self.bondMultiplier;
     }
 }

--- a/contracts/src/libraries/SentinelOracleRequests.sol
+++ b/contracts/src/libraries/SentinelOracleRequests.sol
@@ -48,35 +48,27 @@ library SentinelOracleRequest {
     error RequestNotResolved();
     error VotingWindowOpen();
     error VotingWindowClosed();
-    error ThresholdAlreadyReached();
+    error InvalidBondAmount();
 
     // ============================================================
     // INTERNAL FUNCTIONS
     // ============================================================
 
-    function applyCommit(Request storage self, bool approve, uint256 bondAmount)
-        internal
-        returns (uint256 effectiveBond, uint256 position)
-    {
+    function applyCommit(Request storage self, bool approve, uint256 bondAmount) internal returns (uint256 position) {
         require(self.state == State.PENDING, RequestNotPending());
         require(block.number <= self.deadline, VotingWindowClosed());
-
-        uint256 totalBond = approve ? self.totalApproveBond : self.totalDenyBond;
-        require(totalBond < self.bondTarget, ThresholdAlreadyReached());
-
-        uint256 remaining = self.bondTarget - totalBond;
-        effectiveBond = bondAmount < remaining ? bondAmount : remaining;
+        require(bondAmount == self.bondTarget, InvalidBondAmount());
 
         if (approve) {
             self.approveSentinelCount += 1;
             position = self.approveSentinelCount;
-            self.totalApproveBond += effectiveBond;
-            self.approveTotalScore += (effectiveBond * 1e18) / position;
+            self.totalApproveBond += bondAmount;
+            self.approveTotalScore += (bondAmount * 1e18) / position;
         } else {
             self.denySentinelCount += 1;
             position = self.denySentinelCount;
-            self.totalDenyBond += effectiveBond;
-            self.denyTotalScore += (effectiveBond * 1e18) / position;
+            self.totalDenyBond += bondAmount;
+            self.denyTotalScore += (bondAmount * 1e18) / position;
         }
     }
 
@@ -84,8 +76,8 @@ library SentinelOracleRequest {
         require(self.state == State.PENDING, RequestNotPending());
         require(block.number > self.deadline, VotingWindowOpen());
 
-        bool approveMet = self.totalApproveBond >= self.bondTarget;
-        bool denyMet = self.totalDenyBond >= self.bondTarget;
+        bool approveMet = self.totalApproveBond > 0;
+        bool denyMet = self.totalDenyBond > 0;
 
         if (approveMet && denyMet) {
             self.state = State.FROZEN;
@@ -130,8 +122,8 @@ library SentinelOracleRequest {
     function isBondSlashed(Request storage self, bool approved) internal view returns (bool) {
         State state = requireResolved(self);
         if (state == State.TIMED_OUT) return false;
-        // Slashing only applies to requests resolved via arbitration (both thresholds were met).
-        if (self.totalApproveBond < self.bondTarget || self.totalDenyBond < self.bondTarget) return false;
+        // Slashing only applies to requests resolved via arbitration (both sides had votes).
+        if (self.totalApproveBond == 0 || self.totalDenyBond == 0) return false;
         return approved != (state == State.RESOLVED_APPROVED);
     }
 

--- a/contracts/src/libraries/SentinelOracleRequests.sol
+++ b/contracts/src/libraries/SentinelOracleRequests.sol
@@ -48,17 +48,15 @@ library SentinelOracleRequest {
     error RequestNotResolved();
     error VotingWindowOpen();
     error VotingWindowClosed();
-    error InvalidBondAmount();
-
     // ============================================================
     // INTERNAL FUNCTIONS
     // ============================================================
 
-    function applyCommit(Request storage self, bool approve, uint256 bondAmount) internal returns (uint256 position) {
+    function applyCommit(Request storage self, bool approve) internal returns (uint256 position, uint256 bondAmount) {
         require(self.state == State.PENDING, RequestNotPending());
         require(block.number <= self.deadline, VotingWindowClosed());
-        require(bondAmount == self.bondTarget, InvalidBondAmount());
 
+        bondAmount = self.bondTarget;
         if (approve) {
             self.approveSentinelCount += 1;
             position = self.approveSentinelCount;

--- a/contracts/test/SentinelOracle.t.sol
+++ b/contracts/test/SentinelOracle.t.sol
@@ -97,9 +97,9 @@ contract SentinelOracleTest is Test {
 
         // sentinel1 and sentinel2 each commit exactly BOND_TARGET.
         vm.prank(sentinel1);
-        oracle.commitApprove(REQUEST_ID, BOND_TARGET); // position 1
+        oracle.commitApprove(REQUEST_ID); // position 1
         vm.prank(sentinel2);
-        oracle.commitApprove(REQUEST_ID, BOND_TARGET); // position 2
+        oracle.commitApprove(REQUEST_ID); // position 2
 
         _advancePastDeadline();
 
@@ -138,14 +138,6 @@ contract SentinelOracleTest is Test {
         assertEq(token.balanceOf(sentinel2), sentinel2BalBefore + BOND_TARGET + 3_333, "sentinel2 claim incorrect");
     }
 
-    function test_Commit_RevertsOnInvalidBondAmount() public {
-        _postRequest();
-
-        vm.prank(sentinel1);
-        vm.expectRevert(SentinelOracleRequest.InvalidBondAmount.selector);
-        oracle.commitApprove(REQUEST_ID, BOND_TARGET + 1);
-    }
-
     // ============================================================
     // UNANIMOUS DENY FLOW
     // ============================================================
@@ -154,7 +146,7 @@ contract SentinelOracleTest is Test {
         _postRequest();
 
         vm.prank(sentinel1);
-        oracle.commitDeny(REQUEST_ID, BOND_TARGET); // position 1, single sentinel
+        oracle.commitDeny(REQUEST_ID); // position 1, single sentinel
 
         _advancePastDeadline();
 
@@ -201,10 +193,10 @@ contract SentinelOracleTest is Test {
 
         // sentinel1 approves, sentinel2 denies — both sides have votes → conflict
         vm.prank(sentinel1);
-        oracle.commitApprove(REQUEST_ID, BOND_TARGET);
+        oracle.commitApprove(REQUEST_ID);
 
         vm.prank(sentinel2);
-        oracle.commitDeny(REQUEST_ID, BOND_TARGET);
+        oracle.commitDeny(REQUEST_ID);
 
         _advancePastDeadline();
         oracle.finalize(REQUEST_ID);

--- a/contracts/test/SentinelOracle.t.sol
+++ b/contracts/test/SentinelOracle.t.sol
@@ -95,12 +95,11 @@ contract SentinelOracleTest is Test {
     function test_UnanimousApprove_FeeDistributedAndBondsReturned() public {
         _postRequest();
 
-        // sentinel1 and sentinel2 together reach the Approve threshold.
-        // BOND_TARGET = 20_000; sentinel1 = 15_000, sentinel2 = 5_000 (fills the gap).
+        // sentinel1 and sentinel2 each commit exactly BOND_TARGET.
         vm.prank(sentinel1);
-        oracle.commitApprove(REQUEST_ID, 15_000); // position 1
+        oracle.commitApprove(REQUEST_ID, BOND_TARGET); // position 1
         vm.prank(sentinel2);
-        oracle.commitApprove(REQUEST_ID, 5_000); // position 2
+        oracle.commitApprove(REQUEST_ID, BOND_TARGET); // position 2
 
         _advancePastDeadline();
 
@@ -119,10 +118,10 @@ contract SentinelOracleTest is Test {
         SentinelOracleRequest.Request memory req = oracle.getRequest(REQUEST_ID);
         assertEq(uint256(req.state), uint256(SentinelOracleRequest.State.RESOLVED_APPROVED));
 
-        // Score_1 = 15_000 * 1e18 / 1 = 15_000e18
-        // Score_2 = 5_000  * 1e18 / 2 = 2_500e18
-        // approveTotalScore = 17_500e18
-        assertEq(req.approveTotalScore, 17_500e18);
+        // Score_1 = 20_000 * 1e18 / 1 = 20_000e18
+        // Score_2 = 20_000 * 1e18 / 2 = 10_000e18
+        // approveTotalScore = 30_000e18
+        assertEq(req.approveTotalScore, 30_000e18);
 
         uint256 sentinel1BalBefore = token.balanceOf(sentinel1);
         uint256 sentinel2BalBefore = token.balanceOf(sentinel2);
@@ -132,34 +131,19 @@ contract SentinelOracleTest is Test {
         vm.prank(sentinel2);
         oracle.claim(REQUEST_ID);
 
-        // sentinel1: bond=15_000 returned + fee share = 10_000 x 15_000/17_500 = 8_571
-        assertEq(token.balanceOf(sentinel1), sentinel1BalBefore + 15_000 + 8_571, "sentinel1 claim incorrect");
+        // sentinel1: bond=20_000 returned + fee share = 10_000 * 20_000 / 30_000 = 6_666 (truncated)
+        assertEq(token.balanceOf(sentinel1), sentinel1BalBefore + BOND_TARGET + 6_666, "sentinel1 claim incorrect");
 
-        // sentinel2: bond=5_000 returned + fee share = 10_000 x 2_500/17_500 = 1_428
-        assertEq(token.balanceOf(sentinel2), sentinel2BalBefore + 5_000 + 1_428, "sentinel2 claim incorrect");
+        // sentinel2: bond=20_000 returned + fee share = 10_000 * 10_000 / 30_000 = 3_333 (truncated)
+        assertEq(token.balanceOf(sentinel2), sentinel2BalBefore + BOND_TARGET + 3_333, "sentinel2 claim incorrect");
     }
 
-    function test_UnanimousApprove_DenySentinelBondReturned() public {
+    function test_Commit_RevertsOnInvalidBondAmount() public {
         _postRequest();
 
         vm.prank(sentinel1);
-        oracle.commitDeny(REQUEST_ID, 3_000); // sub-threshold deny
-        vm.prank(sentinel2);
-        oracle.commitApprove(REQUEST_ID, BOND_TARGET); // full approve threshold
-
-        _advancePastDeadline();
-        oracle.finalize(REQUEST_ID);
-
-        uint256 balBefore = token.balanceOf(sentinel1);
-
-        vm.expectEmit(true, true, false, true);
-        emit SentinelOracle.Claimed(REQUEST_ID, sentinel1, 3_000, 0);
-
-        vm.prank(sentinel1);
-        oracle.claim(REQUEST_ID);
-
-        // Losing-side bond is returned without penalty - slashing only happens via Phase 2 arbitration.
-        assertEq(token.balanceOf(sentinel1), balBefore + 3_000, "losing sentinel bond should be returned");
+        vm.expectRevert(SentinelOracleRequest.InvalidBondAmount.selector);
+        oracle.commitApprove(REQUEST_ID, BOND_TARGET + 1);
     }
 
     // ============================================================
@@ -170,7 +154,7 @@ contract SentinelOracleTest is Test {
         _postRequest();
 
         vm.prank(sentinel1);
-        oracle.commitDeny(REQUEST_ID, BOND_TARGET); // position 1, single sentinel fills threshold
+        oracle.commitDeny(REQUEST_ID, BOND_TARGET); // position 1, single sentinel
 
         _advancePastDeadline();
 
@@ -183,6 +167,7 @@ contract SentinelOracleTest is Test {
 
         SentinelOracleRequest.Request memory req = oracle.getRequest(REQUEST_ID);
         assertEq(uint256(req.state), uint256(SentinelOracleRequest.State.RESOLVED_DENIED));
+        assertEq(req.denyTotalScore, BOND_TARGET * 1e18);
 
         uint256 balBefore = token.balanceOf(sentinel1);
         vm.prank(sentinel1);
@@ -195,43 +180,10 @@ contract SentinelOracleTest is Test {
     }
 
     // ============================================================
-    // TIMEOUT FLOW
+    // NO COMMITMENTS FLOW
     // ============================================================
 
-    function test_Timeout_FeeRefundedAndBondsReturned() public {
-        _postRequest();
-
-        // Post partial bonds on both sides - neither threshold reached
-        vm.prank(sentinel1);
-        oracle.commitApprove(REQUEST_ID, 1_000);
-        vm.prank(sentinel2);
-        oracle.commitDeny(REQUEST_ID, 2_000);
-
-        _advancePastDeadline();
-
-        uint256 consensusBalBefore = token.balanceOf(consensus);
-
-        vm.expectEmit(true, true, false, true);
-        emit IOracle.OracleResult(REQUEST_ID, consensus, abi.encode(SentinelOracleRequest.ResolveReason.TIMEOUT), false);
-
-        oracle.finalize(REQUEST_ID);
-
-        assertEq(token.balanceOf(consensus), consensusBalBefore + REQUEST_FEE, "fee should be refunded to consensus");
-
-        // sentinels get bonds back
-        uint256 s1Before = token.balanceOf(sentinel1);
-        uint256 s2Before = token.balanceOf(sentinel2);
-
-        vm.prank(sentinel1);
-        oracle.claim(REQUEST_ID);
-        vm.prank(sentinel2);
-        oracle.claim(REQUEST_ID);
-
-        assertEq(token.balanceOf(sentinel1), s1Before + 1_000, "sentinel1 bond refund");
-        assertEq(token.balanceOf(sentinel2), s2Before + 2_000, "sentinel2 bond refund");
-    }
-
-    function test_Timeout_NoBonds_FeeRefunded() public {
+    function test_NoCommitments_FeeRefunded() public {
         _postRequest();
         _advancePastDeadline();
 
@@ -247,15 +199,12 @@ contract SentinelOracleTest is Test {
     function test_Conflict_SetsStateFrozen() public {
         _postRequest();
 
-        // Fill Approve threshold
+        // sentinel1 approves, sentinel2 denies — both sides have votes → conflict
         vm.prank(sentinel1);
         oracle.commitApprove(REQUEST_ID, BOND_TARGET);
 
-        // sentinel2 and sentinel3 together fill Deny threshold
         vm.prank(sentinel2);
-        oracle.commitDeny(REQUEST_ID, BOND_TARGET / 2);
-        vm.prank(sentinel3);
-        oracle.commitDeny(REQUEST_ID, BOND_TARGET / 2);
+        oracle.commitDeny(REQUEST_ID, BOND_TARGET);
 
         _advancePastDeadline();
         oracle.finalize(REQUEST_ID);
@@ -289,14 +238,10 @@ contract SentinelOracleTest is Test {
         oracle.claim(REQUEST_ID);
         assertEq(token.balanceOf(sentinel1), s1Before + BOND_TARGET + REQUEST_FEE, "sentinel1 bond and fee returned");
 
-        // Losing deny sentinels (sentinel2, sentinel3) get nothing - bonds already slashed.
+        // Losing deny sentinel (sentinel2) gets nothing - bond already slashed.
         uint256 s2Before = token.balanceOf(sentinel2);
-        uint256 s3Before = token.balanceOf(sentinel3);
         vm.prank(sentinel2);
         oracle.claim(REQUEST_ID);
-        vm.prank(sentinel3);
-        oracle.claim(REQUEST_ID);
         assertEq(token.balanceOf(sentinel2), s2Before, "sentinel2 bond slashed");
-        assertEq(token.balanceOf(sentinel3), s3Before, "sentinel3 bond slashed");
     }
 }

--- a/features/2026_05_05_transaction_checker_oracle_v1.md
+++ b/features/2026_05_05_transaction_checker_oracle_v1.md
@@ -36,15 +36,16 @@ Consensus ──postRequest()──▶ CheckerOracle
 
 ### Key Design Decisions
 
-#### Symmetric Bond Thresholds
+#### Fixed Per-Sentinel Bond
 
-Both Approve and Deny sides use identical bond mechanics:
+Each sentinel commits exactly `bondTarget = fee × bondMultiplier` tokens per request — no partial or excess amounts:
 
-- **Bond target**: `fee × bondMultiplier` aggregate, applied equally to both sides.
-- A bond threshold is **reached** when the aggregate for that side equals `fee × bondMultiplier`.
-- Over-contributions beyond the threshold are excess and returned to the contributor immediately.
+- **Fee-dependent fixed bond**: `bondTarget` is computed in `postRequest` as `fee × bondMultiplier` and stored in the request. Every `commitApprove` / `commitDeny` call must supply exactly `bondTarget`; the contract reverts on any mismatch.
+- **Governance**: `bondMultiplier` can be updated by the `ARBITRATOR` via `scheduleBondMultiplier`. The new value only takes effect after `GOVERNANCE_DELAY` blocks (applied lazily at the next `postRequest`), preventing front-running of pending requests.
+- **No aggregate cap**: any number of sentinels may commit on either side without restriction.
+- A side is considered to have **voted** once `totalBond > 0` (i.e. at least one sentinel committed).
 
-Per-checker Deny caps and asymmetric ceilings are deferred to a later implementation.
+> **Frontrunning note**: because votes are public on-chain, a sentinel who observes an existing vote can immediately submit an opposing vote to force a conflict and trigger arbitration. This is an accepted risk in V1. A planned future iteration will replace the direct-commitment scheme with a commit/reveal scheme, keeping votes secret during the voting window and eliminating this attack surface.
 
 #### Explicit Finalization ("Pull over Push")
 
@@ -56,7 +57,7 @@ If the voting window expires and neither the Approve nor the Deny aggregate thre
 
 #### Grief-and-Sweep Attack
 
-With symmetric bonds the attack is no longer cheap: reaching the Deny threshold requires the same total capital (`fee × bondMultiplier`) as the Approve side. A losing Deny side has that bond slashed, and sweeping the fee on the Approve retry only recovers at most `fee` — a net loss of `fee × (bondMultiplier - 1)`. The foundation monitoring and on-chain `removeChecker` remain as an additional deterrent.
+With fixed bonds and slashing on the losing side of a dispute, the attack is not cheap: a sentinel who votes to deny a legitimate transaction risks losing `BOND_AMOUNT` if the arbitrator resolves in favour of approve. The foundation monitoring and on-chain `removeSentinel` remain as an additional deterrent.
 
 #### Arbitration (Phase 2)
 
@@ -86,15 +87,15 @@ The user submits a Safe transaction proposal through `Consensus.proposeOracleTra
 Each permissioned checker node:
 1. Observes `NewRequest(requestId, ...)` on-chain.
 2. Evaluates the transaction payload (e.g. detects address poisoning).
-3. Approves `CheckerOracle` to pull the bond amount from the checker's ERC-20 balance, then calls `commitApprove(requestId)` or `commitDeny(requestId)`. The contract pulls the bond via `transferFrom` at call time.
+3. Approves `CheckerOracle` to pull exactly `BOND_AMOUNT` from the checker's ERC-20 balance, then calls `commitApprove(requestId, BOND_AMOUNT)` or `commitDeny(requestId, BOND_AMOUNT)`. The contract validates the amount and pulls it via `transferFrom`.
 
 ### Finalization
 
 After the voting window closes:
-- **Unanimous Approve** (Approve threshold reached, Deny threshold not reached): `OracleResult` emitted with `approved=true`. Fee distributed proportionally to Approve checkers (capital-weighted speed score). Bonds returned. Any sub-threshold Deny contributions are returned without effect.
-- **Unanimous Deny** (Deny threshold reached, Approve threshold not reached): `OracleResult` emitted with `approved=false`. Fee distributed proportionally to Deny checkers (same capital-weighted speed score formula). Bonds returned. Any sub-threshold Approve contributions are returned without effect.
-- **Conflict** (both Approve and Deny thresholds fully reached): State frozen. `ARBITRATOR` triggers arbitration (Phase 2). User fee refunded from the losing side's slashed bonds.
-- **Timeout / undercapitalized** (neither threshold reached by deadline): `OracleResult` emitted with `approved=false`. Fee refunded to user. Bonds returned.
+- **Unanimous Approve** (only Approve votes cast): `OracleResult` emitted with `approved=true`. Fee distributed proportionally to Approve checkers (position-weighted score). Bonds returned.
+- **Unanimous Deny** (only Deny votes cast): `OracleResult` emitted with `approved=false`. Fee distributed proportionally to Deny checkers. Bonds returned.
+- **Conflict** (at least one Approve and one Deny vote): State frozen. `ARBITRATOR` triggers arbitration (Phase 2). Losing side's bonds are slashed.
+- **Timeout** (no votes cast by deadline): `OracleResult` emitted with `approved=false`. Fee refunded to user. No bonds to return.
 
 ---
 
@@ -108,32 +109,25 @@ After the voting window closes:
 struct Request {
     address proposer;             // Consensus contract address
     uint256 fee;                  // locked user fee
-    uint256 approveBondTarget;    // fee * bondMultiplier, locked at postRequest time
+    uint256 bondTarget;           // fee × bondMultiplier; each sentinel must commit exactly this
     uint256 deadline;             // block.number + VOTING_WINDOW
     State   state;                // PENDING | FROZEN | RESOLVED
-    uint256 totalApproveBond;     // running sum of Approve bonds; threshold reached when == approveBondTarget
-    uint256 totalDenyBond;        // running sum of Deny bonds; threshold reached when == approveBondTarget; conflict when both sides reach threshold
-    uint256 checkerCount;         // number of winning-side voters eligible for fee distribution (committed before bondTarget was met)
-    uint256 totalScore;           // running sum of checker scores, updated on each commit; avoids recomputation at claim time
-    bool    arbitrated;
+    uint256 totalApproveBond;     // running sum of Approve bonds; voted when > 0
+    uint256 totalDenyBond;        // running sum of Deny bonds; conflict when both sides > 0
+    uint256 approveTotalScore;    // running sum of approve-side scores for fee distribution
+    uint256 denyTotalScore;       // running sum of deny-side scores for fee distribution
 }
 
 struct Commitment {
     bool    approved;          // true = Approve vote, false = Deny vote
-    uint256 bondAmount;        // bond amount committed
-    uint256 position;          // arrival order (1-indexed)
+    uint256 bondAmount;        // always BOND_AMOUNT
+    uint256 position;          // arrival order within the side (1-indexed)
     bool    claimed;
 }
 
-// Governance parameters (time-delayed updates via GOVERNANCE_DELAY)
-uint256 bondMultiplier;                // current multiplier; approveBondTarget = fee * bondMultiplier
-uint256 pendingBondMultiplier;         // staged new multiplier
-uint256 bondMultiplierActiveAt;        // block at which pendingBondMultiplier becomes active (0 = none pending)
-
-mapping(address => uint256) checkerActiveAt;  // 0 = not a checker; >0 = active once block.number >= value
+mapping(address => uint256) sentinelActiveAt;  // 0 = not a sentinel; >0 = active once block.number >= value
 mapping(bytes32 requestId => Request) requests;
-mapping(bytes32 requestId => mapping(address checker => Commitment)) commitments;
-mapping(bytes32 requestId => address[]) checkerOrder; // ordered arrival list
+mapping(bytes32 requestId => mapping(address sentinel => Commitment)) commitments;
 ```
 
 #### Constants / Immutables
@@ -141,15 +135,16 @@ mapping(bytes32 requestId => address[]) checkerOrder; // ordered arrival list
 | Name | Description |
 |---|---|
 | `VOTING_WINDOW` | Duration in blocks for the voting window (12 blocks ≈ 1 minute on Gnosis Chain) |
-| `GOVERNANCE_DELAY` | Time delay in blocks applied to all governance changes: adding checkers and updating `bondMultiplier` |
+| `GOVERNANCE_DELAY` | Time delay in blocks applied to sentinel additions and bond multiplier updates |
 | `FEE_TOKEN` | ERC-20 token for bonds and fees |
-| `ARBITRATOR` | Foundation address authorised to manage checkers, update `bondMultiplier`, call `triggerArbitration` / `resolveDispute`, and recipient of slashed remainder |
+| `bondMultiplier` | Governance-controlled multiplier; per-sentinel bond = `fee × bondMultiplier` (time-delayed updates via `scheduleBondMultiplier`) |
+| `ARBITRATOR` | Foundation address authorised to manage sentinels, call `resolveDispute`, and recipient of slashed bonds |
 
 #### Events
 
 ```solidity
 event OracleResult(bytes32 indexed requestId, address indexed proposer, bytes result, bool approved); // IOracle compliance
-event NewRequest(bytes32 indexed requestId, address indexed proposer, uint256 fee, uint256 approveBondTarget, uint256 deadline);
+event NewRequest(bytes32 indexed requestId, address indexed proposer, uint256 fee, uint256 bondTarget, uint256 deadline);
 event CheckerScheduled(address indexed checker, uint256 activeAtBlock);
 event CheckerRemoved(address indexed checker);
 event BondMultiplierScheduled(uint256 newMultiplier, uint256 activeAtBlock);
@@ -170,36 +165,31 @@ enum ResolveReason { UNANIMOUS_APPROVE, UNANIMOUS_DENY, TIMEOUT, ARBITRATION }
 | Function | Access | Description |
 |---|---|---|
 | `postRequest(requestId)` | `Consensus` | Opens request, locks fee, emits `NewRequest` |
-| `commitApprove(requestId)` | Active checker | Posts Approve bond |
-| `commitDeny(requestId)` | Active checker | Posts Deny bond; aggregate target = `fee × bondMultiplier` (same as Approve) |
-| `finalize(requestId)` | Anyone | Resolves request after deadline or on full Approve threshold |
-| `claim(requestId)` | Checker | Returns bond + proportional fee reward |
-| `triggerArbitration(requestId)` | `ARBITRATOR` | Freezes conflicted request |
-| `resolveDispute(requestId, winner, loser)` | `ARBITRATOR` | Slashes loser, waterfall distribution |
-| `addChecker(checker)` | `ARBITRATOR` | Schedules a checker to become active after `GOVERNANCE_DELAY` blocks |
-| `removeChecker(checker)` | `ARBITRATOR` | Immediately removes a checker from the active set |
-| `scheduleBondMultiplier(newValue)` | `ARBITRATOR` | Stages a new bond multiplier, active after `GOVERNANCE_DELAY` blocks |
-| `applyBondMultiplier()` | Anyone | Commits the staged multiplier once its activation block is reached |
+| `commitApprove(requestId, bondAmount)` | Active sentinel | Posts Approve bond; `bondAmount` must equal `BOND_AMOUNT` |
+| `commitDeny(requestId, bondAmount)` | Active sentinel | Posts Deny bond; `bondAmount` must equal `BOND_AMOUNT` |
+| `finalize(requestId)` | Anyone | Resolves request after deadline |
+| `claim(requestId)` | Sentinel | Returns bond + proportional fee reward |
+| `resolveDispute(requestId, approveWins)` | `ARBITRATOR` | Resolves conflict; slashes losing side |
+| `addSentinel(sentinel)` | `ARBITRATOR` | Schedules a sentinel to become active after `GOVERNANCE_DELAY` blocks |
+| `removeSentinel(sentinel)` | `ARBITRATOR` | Immediately removes a sentinel from the active set |
+| `scheduleBondMultiplier(newMultiplier)` | `ARBITRATOR` | Schedules a bond multiplier update; takes effect after `GOVERNANCE_DELAY` blocks |
 
 #### Fee Distribution Math
 
-Only commitments recorded before the bond target is fully met are eligible. If a commitment overshoots the remaining gap, only the gap-filling portion counts toward the score; the excess is returned immediately.
-
-Each checker's score rewards both early arrival and capital risked:
+All sentinels commit the same `BOND_AMOUNT`, so the fee distribution is purely position-based: earlier commits earn a larger share.
 
 ```
-Score_i    = bond_i / position_i
-             (earlier arrivals receive a larger score for the same bond amount)
+Score_i    = BOND_AMOUNT / position_i
+             (earlier arrival on the winning side earns a larger share)
 
-TotalScore = Σ Score_i
-             (updated incrementally on every eligible commit; stored in Request.totalScore)
+TotalScore = Σ Score_i  (over all winning-side commitments)
 
 Payout_i   = fee × (Score_i / TotalScore)
 ```
 
 The same formula is applied to whichever side wins (Approve or Deny).
 
-> **Solidity decimal note**: integer division truncates, so `bond / position` loses precision for small bonds or large position numbers. The implementation must scale the numerator before dividing (e.g. compute `Score_i = bond_i * PRECISION / position_i` with a constant such as `PRECISION = 1e18`) and account for the same scale factor when computing payouts.
+> **Solidity decimal note**: integer division truncates. The implementation scales the numerator before dividing (`Score_i = BOND_AMOUNT * 1e18 / position_i`) and applies the same scale factor when computing payouts.
 
 ### Checker Management
 
@@ -327,21 +317,21 @@ Files touched:
 
 2. ~~**Fee escrow mechanism**~~ **Decided**: Option (a) — user pre-approves `CheckerOracle` for the fee amount; `Consensus` calls `postRequest` which pulls the fee via `transferFrom` at request time. Same pull pattern applies to checker bonds on `commitApprove` / `commitDeny`.
 
-3. ~~**`approveBondTarget` parameterization**~~ **Decided**: `approveBondTarget = fee × bondMultiplier`. `bondMultiplier` defaults to `50` and is updateable by `ARBITRATOR` with a `GOVERNANCE_DELAY` block time delay via `scheduleBondMultiplier` / `applyBondMultiplier`.
+3. ~~**Bond parameterization**~~ **Decided**: Fixed `BOND_AMOUNT` immutable per sentinel per request. No aggregate cap. No multiplier governance.
 
 4. ~~**Registry vs. Staking extension**~~ **Decided**: Checker set is managed directly inside `CheckerOracle` with no separate registry contract and no on-chain master deposit. `ARBITRATOR` manages additions (time-delayed by `GOVERNANCE_DELAY`) and removals (immediate).
 
 5. ~~**`VOTING_WINDOW` value**~~ **Decided**: 12 blocks (≈ 1 minute on Gnosis Chain).
 
-6. ~~**Slashing deficit**~~ **Resolved**: With symmetric bonds both sides post `fee × bondMultiplier` in aggregate. The slashed bond always covers the full user fee refund with no deficit.
+6. ~~**Slashing deficit**~~ **Resolved**: Slashing only applies in the arbitration path (both sides committed). The arbitrator transfers the losing side's total bond to themselves; there is no user refund deficit since fee refunds are handled separately.
 
-7. ~~**Partial Deny threshold**~~ **Decided**: Conflict requires the full Deny bond target (`fee × bondMultiplier`) to be reached, identical to the Approve side. Sub-threshold Deny votes have no effect and bonds are returned. Over-achievement on either side is not rewarded (excess returned).
+7. ~~**Partial Deny threshold**~~ **Decided**: Any deny vote triggers conflict (both sides > 0). There is no sub-threshold or partial-vote concept with fixed bonds.
 
 8. ~~**Checker banning on-chain vs. off-chain**~~ **Decided**: `ARBITRATOR` can call `removeChecker(address)` immediately on-chain. The grief-and-sweep mitigation relies on the arbitrator monitoring for the pattern and invoking this function.
 
 9. ~~**Interaction with existing oracles**~~ **Resolved**: Oracle selection is managed in the validator code. Multiple oracles can be active in parallel as long as validators mark them as valid. No migration from `SimpleOracle` / `AlwaysApproveOracle` is required; `CheckerOracle` is an additive deployment.
 
-10. ~~**Deny-vote incentive**~~ **Resolved**: On Unanimous Deny the fee is distributed proportionally to Deny checkers (same formula as Approve). This provides a financial incentive to correctly flag poisoned transactions. The earlier collusion concern (cheap Deny bonds + fee reward) no longer applies because the Deny aggregate threshold is now `fee × bondMultiplier` — a colluding group must post the same total capital as the Approve side, making griefing economically unattractive.
+10. ~~**Deny-vote incentive**~~ **Resolved**: On Unanimous Deny the fee is distributed proportionally to Deny sentinels (same formula as Approve). This provides a financial incentive to correctly flag poisoned transactions. Griefing via false Deny votes risks losing `BOND_AMOUNT` if the arbitrator resolves in favour of Approve.
 
 **Assumptions:**
 - The permissioned checker set is small (≤ 20 nodes) and operated by vetted foundation partners in V1.

--- a/validator/src/sentinel/handlers.ts
+++ b/validator/src/sentinel/handlers.ts
@@ -32,7 +32,6 @@ export function handleOracleTransactionProposed(
 export function handleNewRequest(
 	requests: ReadonlyMap<Hex, SentinelRequestState>,
 	transition: SentinelNewRequestTransition,
-	config: SentinelConfig,
 	logger: Logger,
 ): SentinelStateDiff {
 	const existing = requests.get(transition.requestId);
@@ -48,8 +47,8 @@ export function handleNewRequest(
 		actions: [
 			{ id: "sentinel_approve_token", bondAmount: transition.bondTarget },
 			approve
-				? { id: "sentinel_commit_approve", requestId: transition.requestId, bondAmount: config.bondAmount }
-				: { id: "sentinel_commit_deny", requestId: transition.requestId, bondAmount: config.bondAmount },
+				? { id: "sentinel_commit_approve", requestId: transition.requestId, bondAmount: transition.bondTarget }
+				: { id: "sentinel_commit_deny", requestId: transition.requestId, bondAmount: transition.bondTarget },
 		],
 	};
 }

--- a/validator/src/sentinel/types.ts
+++ b/validator/src/sentinel/types.ts
@@ -44,7 +44,6 @@ export type TransactionPayload = { to: Address; value: bigint; data: Hex };
 
 export type SentinelConfig = {
 	readonly account: Address;
-	readonly bondAmount: bigint;
 	readonly consensus: Address;
 	readonly oracle: Address;
 	readonly chainId: bigint;

--- a/validator/src/types/schemas.ts
+++ b/validator/src/types/schemas.ts
@@ -88,7 +88,6 @@ export const submissionConfigSchema = z.object({
 
 export const sentinelConfigSchema = z.object({
 	SENTINEL_ORACLE_ADDRESS: checkedAddressSchema,
-	SENTINEL_BOND_AMOUNT: z.coerce.bigint().positive(),
 	SENTINEL_BLOCKLIST: emptyToDefault(jsonStringToValue(z.array(checkedAddressSchema)).optional(), []),
 	// Voting window in blocks. Controls the TTL for the preparing state and when finalize becomes eligible.
 	SENTINEL_VOTING_WINDOW: emptyToDefault(z.coerce.bigint().positive(), 12n),


### PR DESCRIPTION
### Context and Motivation

Task in Phase 3 of the Sentinel Oracle ([Feature Spec](https://github.com/safe-research/safenet/blob/main/features/2026_05_05_transaction_checker_oracle_v1.md#phase-3--checker-node-service-pr-3-can-be-parallelized-with-phase-2)). Complete list of tasks can be found in the [milestone](https://github.com/safe-research/safenet/milestone/1)

In the initial implementation it was possible to have partial bonds (so bonds that don't fully cover the require bond amount) and also the total bonds where capped. This introduced complexity and some edges cases, without clear benefits. Therefore the logic is adjusted to use a fixed bond that is calculated based on the fee. Each commit is required to contain exactly this bond. Furthermore there is no cap on the total amount of bonds.

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://docs.safefoundation.org/cla).
