### PR TITLE
chore: pin actions to commits and read Node version from package.json

### DIFF
--- a/.github/actions/report-coverage/action.yaml
+++ b/.github/actions/report-coverage/action.yaml
@@ -121,7 +121,7 @@ runs:
         echo "EOF" >> $GITHUB_OUTPUT
 
     - name: Post Coverage Comment
-      uses: actions/github-script@v6
+      uses: actions/github-script@d7906e4ad0b1822421a7e6a35d5ca353c962f410 # v6
       with:
         github-token: ${{ inputs.github-token }}
         script: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,16 +13,16 @@ jobs:
   check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           submodules: recursive
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
-          node-version: "lts/*"
+          node-version-file: 'package.json'
           cache: "npm"
 
-      - uses: foundry-rs/foundry-toolchain@v1
+      - uses: foundry-rs/foundry-toolchain@c7450ba673e133f5ee30098b3b54f444d3a2ca2d # v1
         with:
           # We fix the foundry version because of a formatting bug introduced
           # in version 1.7.0.
@@ -35,6 +35,6 @@ jobs:
       
       - name: Post Coverage Report
         if: github.event_name == 'pull_request'
-        uses: ./.github/actions/report-coverage 
+        uses: ./.github/actions/report-coverage
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }} 

--- a/.github/workflows/deploy_explorer.yml
+++ b/.github/workflows/deploy_explorer.yml
@@ -21,11 +21,11 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
-          node-version: "lts/*"
+          node-version-file: 'package.json'
           cache: npm
 
       - name: Install
@@ -37,7 +37,7 @@ jobs:
       - name: Create 404 for GH pages
         run: cp explorer/dist/index.html explorer/dist/404.html
 
-      - uses: actions/upload-pages-artifact@v3
+      - uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3
         with:
           path: explorer/dist
 
@@ -47,4 +47,4 @@ jobs:
     environment:
       name: github-pages
     steps:
-      - uses: actions/deploy-pages@v4
+      - uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -16,18 +16,18 @@ jobs:
       packages: write
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           submodules: recursive
 
-      - uses: docker/login-action@v3
+      - uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5
         with:
           images: ghcr.io/safe-research/safenet-validator
           tags: |
@@ -38,10 +38,10 @@ jobs:
           flavor: |
             latest=false
 
-      - uses: docker/setup-qemu-action@v3
-      - uses: docker/setup-buildx-action@v3
+      - uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3
+      - uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 
-      - uses: docker/build-push-action@v6
+      - uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: .
           file: validator/Dockerfile

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -13,16 +13,16 @@ jobs:
       SAFENET_TEST_VERBOSE: "1"
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           submodules: recursive
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
-          node-version: "lts/*"
+          node-version-file: 'package.json'
           cache: "npm"
 
-      - uses: foundry-rs/foundry-toolchain@v1
+      - uses: foundry-rs/foundry-toolchain@c7450ba673e133f5ee30098b3b54f444d3a2ca2d # v1
 
       - run: npm ci
       - run: npm run test:integration


### PR DESCRIPTION
### Context and Motivation

Pin all third-party actions to immutable commit SHAs to prevent supply-chain
attacks via mutable floating tags. The version tag is preserved as an inline
comment after each SHA for readability.

Also replace `node-version: "lts/*"` with `node-version-file: 'package.json'`
on all `actions/setup-node` steps so the Node version is sourced from the
`engines.node` field in `package.json`, keeping the version declared in one place.

### Testing

Check commits against latest version

| Action | Version | Commit |
| --- | --- | --- |
| `actions/checkout` | [v5](https://github.com/actions/checkout/releases/tag/v5) | [`93cb6efe`](https://github.com/actions/checkout/commit/93cb6efe18208431cddfb8368fd83d5badbf9bfd) |
| `actions/checkout` | [v4](https://github.com/actions/checkout/releases/tag/v4) | [`34e11487`](https://github.com/actions/checkout/commit/34e114876b0b11c390a56381ad16ebd13914f8d5) |
| `actions/setup-node` | [v6](https://github.com/actions/setup-node/releases/tag/v6) | [`48b55a01`](https://github.com/actions/setup-node/commit/48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e) |
| `actions/setup-node` | [v4](https://github.com/actions/setup-node/releases/tag/v4) | [`49933ea5`](https://github.com/actions/setup-node/commit/49933ea5288caeca8642d1e84afbd3f7d6820020) |
| `actions/upload-pages-artifact` | [v3](https://github.com/actions/upload-pages-artifact/releases/tag/v3) | [`56afc609`](https://github.com/actions/upload-pages-artifact/commit/56afc609e74202658d3ffba0e8f6dda462b719fa) |
| `actions/deploy-pages` | [v4](https://github.com/actions/deploy-pages/releases/tag/v4) | [`d6db9016`](https://github.com/actions/deploy-pages/commit/d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e) |
| `actions/github-script` | [v6](https://github.com/actions/github-script/releases/tag/v6) | [`d7906e4a`](https://github.com/actions/github-script/commit/d7906e4ad0b1822421a7e6a35d5ca353c962f410) |
| `foundry-rs/foundry-toolchain` | [v1](https://github.com/foundry-rs/foundry-toolchain/releases/tag/v1) | [`c7450ba6`](https://github.com/foundry-rs/foundry-toolchain/commit/c7450ba673e133f5ee30098b3b54f444d3a2ca2d) |
| `docker/login-action` | [v3](https://github.com/docker/login-action/releases/tag/v3) | [`c94ce9fb`](https://github.com/docker/login-action/commit/c94ce9fb468520275223c153574b00df6fe4bcc9) |
| `docker/metadata-action` | [v5](https://github.com/docker/metadata-action/releases/tag/v5) | [`c299e40c`](https://github.com/docker/metadata-action/commit/c299e40c65443455700f0fdfc63efafe5b349051) |
| `docker/setup-qemu-action` | [v3](https://github.com/docker/setup-qemu-action/releases/tag/v3) | [`c7c53464`](https://github.com/docker/setup-qemu-action/commit/c7c53464625b32c7a7e944ae62b3e17d2b600130) |
| `docker/setup-buildx-action` | [v3](https://github.com/docker/setup-buildx-action/releases/tag/v3) | [`8d2750c6`](https://github.com/docker/setup-buildx-action/commit/8d2750c68a42422c14e847fe6c8ac0403b4cbd6f) |
| `docker/build-push-action` | [v6](https://github.com/docker/build-push-action/releases/tag/v6) | [`10e90e36`](https://github.com/docker/build-push-action/commit/10e90e3645eae34f1e60eeb005ba3a3d33f178e8) |

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://docs.safefoundation.org/cla).
