### PR TITLE
fix: prevent expression injection in report-coverage action

### DIFF
--- a/.github/actions/report-coverage/action.yaml
+++ b/.github/actions/report-coverage/action.yaml
@@ -122,12 +122,16 @@ runs:
 
     - name: Post Coverage Comment
       uses: actions/github-script@v6
+      env:
+        TOTAL_STATS: ${{ steps.process_coverage.outputs.TOTAL_STATS }}
+        SUMMARY: ${{ steps.process_coverage.outputs.SUMMARY }}
+        DETAILS: ${{ steps.process_coverage.outputs.DETAILS }}
       with:
         github-token: ${{ inputs.github-token }}
         script: |
-          const totalStats = '${{ steps.process_coverage.outputs.TOTAL_STATS }}';
-          const summary = `${{ steps.process_coverage.outputs.SUMMARY }}`;
-          const details = `${{ steps.process_coverage.outputs.DETAILS }}`;
+          const totalStats = process.env.TOTAL_STATS;
+          const summary = process.env.SUMMARY;
+          const details = process.env.DETAILS;
           
           const title = "### 🛡️ Test Coverage Report"
           const formattedBody = `


### PR DESCRIPTION
Pass step outputs as env vars and access via process.env instead of directly interpolating \${{ }} expressions into the inline script block. This eliminates the script injection risk flagged in PR #407.

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://docs.safefoundation.org/cla).
