### PR TITLE
[Backport #405]: Add Priority Fee Cap

### DIFF
--- a/docs/validator-handbook.md
+++ b/docs/validator-handbook.md
@@ -58,6 +58,9 @@ The exact amount varies by chain, but you can expect the account to consume roug
 
 Safenet Beta’s onchain components are planned for deployment on Gnosis Chain. Over the past six months (Aug 25, 2025 – Feb 25, 2026), the average base fee per gas was approximately 0.042 Gwei, translating to just under $0.05 per day in gas costs. However, daily average base fee per gas reached as high as 3.4 Gwei. Based on these figures, validators should expect to need roughly $10 in tokens to cover gas costs over the six-month Beta period. It is recommended to overfund the validator to account for base gas fee variability.
 
+> [!TIP]
+> On Gnosis Chain, the base fee is very low relative to the priority fee, so the priority fee makes up the bulk of gas costs. If your RPC occasionally returns an inflated `eth_maxPriorityFeePerGas` estimate, you can cap how much of the total fee cap can be a tip. For example, setting `PRIORITY_FEE_CAP_PERCENTAGE=95` ensures the tip never exceeds 95% of `maxFeePerGas`, protecting against runaway estimates while still allowing normal inclusion.
+
 #### Consensus Secrets
 
 While participating in consensus, validators generate short-term secrets required to attest Safe transactions and participate correctly. Specifically, it generates:

--- a/validator/.env.sample
+++ b/validator/.env.sample
@@ -270,6 +270,24 @@ BASE_FEE_MULTIPLIER=
 # Default: None — uses the chain's RPC-estimated priority fee.
 PRIORITY_FEE_PER_GAS=
 
+# Priority Fee Cap Percentage [Optional]
+#
+# Caps maxPriorityFeePerGas to a percentage of maxFeePerGas:
+#   maxPriorityFeePerGas = min(estimated, maxFeePerGas × (value / 100))
+#
+# This prevents the validator from paying excessively high tips relative to the
+# total fee cap, for example during a momentary spike in the RPC's priority fee
+# estimate. The cap is applied after any resubmission bump, so it takes effect
+# on every submission.
+#
+# Examples: "100" = tip can be up to 100% of maxFeePerGas (no effective cap)
+#           "50"  = tip cannot exceed half of maxFeePerGas
+#           "10"  = tip cannot exceed 10% of maxFeePerGas
+#
+# Values:  Any positive number, integer or decimal (e.g. "10", "50", "100")
+# Default: None — no cap applied; tip follows the estimate (and any bump).
+PRIORITY_FEE_CAP_PERCENTAGE=
+
 # ┌─────────────────────────────────────────────────────────────────────────────┐
 # │                           BLOCK WATCHING                                    │
 # └─────────────────────────────────────────────────────────────────────────────┘

--- a/validator/src/consensus/protocol/onchain.test.ts
+++ b/validator/src/consensus/protocol/onchain.test.ts
@@ -1081,7 +1081,10 @@ describe("GasFeeEstimator", () => {
 		const publicClient = {
 			estimateFeesPerGas,
 		} as unknown as PublicClient;
-		estimateFeesPerGas.mockReturnValueOnce(new Promise(() => {}));
+		estimateFeesPerGas.mockResolvedValue({
+			maxFeePerGas: 1n,
+			maxPriorityFeePerGas: 0n,
+		});
 		const estimator = new GasFeeEstimator(publicClient);
 		const original = estimator.estimateFees();
 		expect(original).toBe(estimator.estimateFees());
@@ -1090,5 +1093,42 @@ describe("GasFeeEstimator", () => {
 		const next = estimator.estimateFees();
 		expect(original).not.toBe(next);
 		expect(estimateFeesPerGas).toHaveBeenCalledTimes(2);
+	});
+
+	describe("priority fee cap", () => {
+		function createEstimator(priorityFeeCapPercentage?: number) {
+			const estimateFeesPerGas = vi.fn();
+			const publicClient = { estimateFeesPerGas } as unknown as PublicClient;
+			return { estimator: new GasFeeEstimator(publicClient, priorityFeeCapPercentage), estimateFeesPerGas };
+		}
+
+		it("should cap priority fee so that it equals the given percentage of the final maxFeePerGas", async () => {
+			const { estimator, estimateFeesPerGas } = createEstimator(50);
+			// baseFeeComponent = 400 - 300 = 100; cappedPriority = 100 * 0.5 / 0.5 = 100
+			// newF = 100 + 100 = 200; newP/newF = 100/200 = 50% ✓
+			estimateFeesPerGas.mockResolvedValueOnce({ maxFeePerGas: 400n, maxPriorityFeePerGas: 300n });
+			expect(await estimator.estimateFees()).toStrictEqual({ maxFeePerGas: 200n, maxPriorityFeePerGas: 100n });
+		});
+
+		it("should not cap when priority fee is already below the percentage", async () => {
+			const { estimator, estimateFeesPerGas } = createEstimator(50);
+			// baseFeeComponent = 400 - 100 = 300; cappedPriority = 300 * 0.5 / 0.5 = 300; 100 < 300, no cap
+			estimateFeesPerGas.mockResolvedValueOnce({ maxFeePerGas: 400n, maxPriorityFeePerGas: 100n });
+			expect(await estimator.estimateFees()).toStrictEqual({ maxFeePerGas: 400n, maxPriorityFeePerGas: 100n });
+		});
+
+		it("should support decimal percentages", async () => {
+			const { estimator, estimateFeesPerGas } = createEstimator(12.5);
+			// baseFeeComponent = 900 - 200 = 700; cappedPriority = 700 * 0.125 / 0.875 = 100
+			// newF = 700 + 100 = 800; newP/newF = 100/800 = 12.5% ✓
+			estimateFeesPerGas.mockResolvedValueOnce({ maxFeePerGas: 900n, maxPriorityFeePerGas: 200n });
+			expect(await estimator.estimateFees()).toStrictEqual({ maxFeePerGas: 800n, maxPriorityFeePerGas: 100n });
+		});
+
+		it("should not cap when priorityFeeCapPercentage is not set", async () => {
+			const { estimator, estimateFeesPerGas } = createEstimator(undefined);
+			estimateFeesPerGas.mockResolvedValueOnce({ maxFeePerGas: 400n, maxPriorityFeePerGas: 300n });
+			expect(await estimator.estimateFees()).toStrictEqual({ maxFeePerGas: 400n, maxPriorityFeePerGas: 300n });
+		});
 	});
 });

--- a/validator/src/consensus/protocol/onchain.ts
+++ b/validator/src/consensus/protocol/onchain.ts
@@ -16,7 +16,7 @@ import { CONSENSUS_FUNCTIONS, COORDINATOR_FUNCTIONS } from "../../types/abis.js"
 import type { ValidatorAccount } from "../../types/account.js";
 import { formatError } from "../../utils/errors.js";
 import type { Logger } from "../../utils/logging.js";
-import { maxBigInt } from "../../utils/math.js";
+import { maxBigInt, minBigInt } from "../../utils/math.js";
 import type { Queue } from "../../utils/queue.js";
 import { BaseProtocol, type SubmittedAction } from "./base.js";
 import type {
@@ -55,9 +55,11 @@ export interface TransactionStorage {
 export class GasFeeEstimator {
 	#cachedPrices: Promise<FeeValues> | null = null;
 	#client: PublicClient;
+	#priorityFeeCapPercentage: number | undefined;
 
-	constructor(client: PublicClient) {
+	constructor(client: PublicClient, priorityFeeCapPercentage?: number) {
 		this.#client = client;
+		this.#priorityFeeCapPercentage = priorityFeeCapPercentage;
 	}
 
 	invalidate() {
@@ -68,10 +70,33 @@ export class GasFeeEstimator {
 		if (this.#cachedPrices !== null) {
 			return this.#cachedPrices;
 		}
-		// Also cache errors, to prevent that on error too many request are fired
-		const pricePromise = this.#client.estimateFeesPerGas();
+		// Also cache errors, to prevent that on error too many requests are fired
+		const pricePromise = this.#client.estimateFeesPerGas().then((fees) => this.#capPriorityFee(fees));
 		this.#cachedPrices = pricePromise;
 		return pricePromise;
+	}
+
+	#capPriorityFee(fees: FeeValues): FeeValues {
+		if (this.#priorityFeeCapPercentage === undefined) {
+			return fees;
+		}
+
+		// Solve for newP such that newP / newF = capPercent / 100.
+		// Note that we need to do math in the bigint space, so we scale our percentage amount to allow
+		// for up to 6 digits of precision in the `#priorityFeeCapPercentage` parameter.
+		const PRECISION = 1_000_000n;
+		const scaledPercent = BigInt(Math.round((this.#priorityFeeCapPercentage / 100) * Number(PRECISION)));
+		if (scaledPercent >= PRECISION) {
+			return fees;
+		}
+
+		const baseFeeComponent = fees.maxFeePerGas - fees.maxPriorityFeePerGas;
+		const cappedPriority = (baseFeeComponent * scaledPercent) / (PRECISION - scaledPercent);
+		const maxPriorityFeePerGas = minBigInt(fees.maxPriorityFeePerGas, cappedPriority);
+		return {
+			maxPriorityFeePerGas,
+			maxFeePerGas: baseFeeComponent + maxPriorityFeePerGas,
+		};
 	}
 }
 

--- a/validator/src/service/service.ts
+++ b/validator/src/service/service.ts
@@ -49,6 +49,7 @@ export class ValidatorService {
 		metrics,
 		database,
 		skipGenesis = false,
+		priorityFeeCapPercentage,
 	}: {
 		account: ValidatorAccount;
 		transport: Transport;
@@ -59,6 +60,7 @@ export class ValidatorService {
 		metrics: Metrics;
 		database: Database;
 		skipGenesis?: boolean;
+		priorityFeeCapPercentage?: number;
 	}) {
 		this.#logger = logger;
 		this.#publicClient = createPublicClient({ chain, transport });
@@ -72,7 +74,7 @@ export class ValidatorService {
 		const verificationEngine = new VerificationEngine(verificationHandlers);
 		const actionStorage = new SqliteActionQueue(database);
 		const txStorage = new SqliteTxStorage(database);
-		const gasFeeEstimator = new GasFeeEstimator(this.#publicClient);
+		const gasFeeEstimator = new GasFeeEstimator(this.#publicClient, priorityFeeCapPercentage);
 		const protocol = new OnchainProtocol({
 			publicClient: this.#publicClient,
 			account,
@@ -163,6 +165,7 @@ export const createValidatorService = ({
 	metrics,
 	fees,
 	skipGenesis,
+	priorityFeeCapPercentage,
 }: {
 	account: ValidatorAccount;
 	rpcUrl: string;
@@ -173,6 +176,7 @@ export const createValidatorService = ({
 	metrics: Metrics;
 	fees?: ChainFees;
 	skipGenesis?: boolean;
+	priorityFeeCapPercentage?: number;
 }): ValidatorService => {
 	const transport = withTracing(rpcUrl.startsWith("wss") ? webSocket(rpcUrl) : http(rpcUrl), { logger, metrics });
 	const chain: Chain = {
@@ -193,5 +197,6 @@ export const createValidatorService = ({
 		metrics,
 		database,
 		skipGenesis,
+		priorityFeeCapPercentage,
 	});
 };

--- a/validator/src/types/schemas.test.ts
+++ b/validator/src/types/schemas.test.ts
@@ -221,6 +221,7 @@ describe("validatorConfigSchema", () => {
 			GENESIS_SALT: MOCK_GENESIS_SALT,
 			BASE_FEE_MULTIPLIER: "",
 			PRIORITY_FEE_PER_GAS: "",
+			PRIORITY_FEE_CAP_PERCENTAGE: "",
 		};
 
 		const result = validatorConfigSchema.parse(validConfig);
@@ -248,6 +249,7 @@ describe("validatorConfigSchema", () => {
 			GENESIS_SALT: MOCK_GENESIS_SALT,
 			BASE_FEE_MULTIPLIER: "2.4",
 			PRIORITY_FEE_PER_GAS: parseGwei("0.1"),
+			PRIORITY_FEE_CAP_PERCENTAGE: "1.5",
 		};
 
 		const result = validatorConfigSchema.parse(validConfig);
@@ -262,6 +264,7 @@ describe("validatorConfigSchema", () => {
 			BLOCKS_PER_EPOCH: 17280n,
 			BASE_FEE_MULTIPLIER: 2.4,
 			PRIORITY_FEE_PER_GAS: 100000000n,
+			PRIORITY_FEE_CAP_PERCENTAGE: 1.5,
 		});
 	});
 
@@ -492,6 +495,7 @@ describe("validatorConfigSchema", () => {
 			"BLOCKS_BEFORE_RESUBMIT",
 			"BASE_FEE_MULTIPLIER",
 			"PRIORITY_FEE_PER_GAS",
+			"PRIORITY_FEE_CAP_PERCENTAGE",
 			"BLOCK_TIME_OVERRIDE",
 			"MAX_REORG_DEPTH",
 			"BLOCK_PAGE_SIZE",

--- a/validator/src/types/schemas.ts
+++ b/validator/src/types/schemas.ts
@@ -81,6 +81,7 @@ export const validatorConfigSchema = z.object({
 	BLOCKS_BEFORE_RESUBMIT: emptyToDefault(z.coerce.bigint().optional()),
 	BASE_FEE_MULTIPLIER: emptyToDefault(z.coerce.number().optional()),
 	PRIORITY_FEE_PER_GAS: emptyToDefault(z.coerce.bigint().optional()),
+	PRIORITY_FEE_CAP_PERCENTAGE: emptyToDefault(z.coerce.number().optional()),
 	BLOCK_TIME_OVERRIDE: emptyToDefault(z.coerce.number().int().optional()),
 	MAX_REORG_DEPTH: emptyToDefault(z.coerce.number().int().optional()),
 	BLOCK_PAGE_SIZE: emptyToDefault(z.coerce.number().int().optional()),

--- a/validator/src/utils/math.ts
+++ b/validator/src/utils/math.ts
@@ -1,1 +1,2 @@
 export const maxBigInt = (a: bigint, b: bigint): bigint => (a > b ? a : b);
+export const minBigInt = (a: bigint, b: bigint): bigint => (a < b ? a : b);

--- a/validator/src/validator.ts
+++ b/validator/src/validator.ts
@@ -76,6 +76,7 @@ const service = createValidatorService({
 	metrics: metrics.metrics,
 	fees,
 	skipGenesis: validatorConfig.SKIP_GENESIS,
+	priorityFeeCapPercentage: validatorConfig.PRIORITY_FEE_CAP_PERCENTAGE,
 });
 
 // Handle graceful shutdown, for both `SIGINT` (i.e. Ctrl-C) and `SIGTERM` which


### PR DESCRIPTION
Backport the priority fee cap from #405 

### Testing

This PR was created with `git cherry-pick 2b11764f27fea5dd9170acd3da85754f331efe22` with a single trivial merge conflict in `validator/src/types/schemas.test.ts` related to the `ORACLE_*` configuration that was added in `main` but not part of the beta.