### PR TITLE
[Backport #358]: Show partial EIP-712 hashes

### DIFF
--- a/explorer/src/components/transaction/SafeTxHashInfo.tsx
+++ b/explorer/src/components/transaction/SafeTxHashInfo.tsx
@@ -1,0 +1,32 @@
+import { InformationCircleIcon } from "@heroicons/react/24/outline";
+import { useMemo } from "react";
+import { CopyButton } from "@/components/common/CopyButton";
+import { InfoPopover } from "@/components/common/InfoPopover";
+import { InlineHash } from "@/components/common/InlineHash";
+import type { SafeTransaction } from "@/lib/consensus";
+import { calculateDomainHash, calculateMessageHash } from "@/lib/safe/hashing";
+
+export function SafeTxHashInfo({ transaction }: { transaction: SafeTransaction }) {
+	const domainHash = useMemo(
+		() => calculateDomainHash(transaction.chainId, transaction.safe),
+		[transaction.chainId, transaction.safe],
+	);
+	const messageHash = useMemo(() => calculateMessageHash(transaction), [transaction]);
+
+	return (
+		<InfoPopover trigger={<InformationCircleIcon className="h-4 w-4 text-muted cursor-pointer" />}>
+			<div className="grid grid-cols-[max-content_auto] items-center gap-x-2 gap-y-1">
+				<span className="text-muted">Domain Hash:</span>
+				<div className="flex items-center gap-1 whitespace-nowrap">
+					<InlineHash hash={domainHash} />
+					<CopyButton value={domainHash} />
+				</div>
+				<span className="text-muted">Message Hash:</span>
+				<div className="flex items-center gap-1 whitespace-nowrap">
+					<InlineHash hash={messageHash} />
+					<CopyButton value={messageHash} />
+				</div>
+			</div>
+		</InfoPopover>
+	);
+}

--- a/explorer/src/components/transaction/SafeTxHeader.tsx
+++ b/explorer/src/components/transaction/SafeTxHeader.tsx
@@ -9,6 +9,7 @@ import { useChainInfo } from "@/hooks/useChainInfo";
 import type { ChainInfo } from "@/lib/chains";
 import type { SafeTransaction } from "@/lib/consensus";
 import { safeWalletSafeUrl, safeWalletTxUrl } from "@/lib/safe/wallet";
+import { SafeTxHashInfo } from "./SafeTxHashInfo";
 
 function SafeWalletLink({ href }: { href: string }) {
 	return (
@@ -51,6 +52,7 @@ export const SafeTxHeader = ({
 				<span className="text-sm font-medium">SafeTxHash:</span>
 				<InlineHash hash={safeTxHash} />
 				<CopyButton value={safeTxHash} />
+				<SafeTxHashInfo transaction={transaction} />
 				{fromSafeApi && chainInfo !== undefined && (
 					<SafeWalletTxLink chainInfo={chainInfo} safe={transaction.safe} safeTxHash={safeTxHash} />
 				)}

--- a/explorer/src/lib/safe/hashing.test.ts
+++ b/explorer/src/lib/safe/hashing.test.ts
@@ -1,26 +1,43 @@
 import { zeroAddress } from "viem";
 import { describe, expect, it } from "vitest";
-import { calculateSafeTxHash } from "./hashing";
+import type { SafeTransaction } from "../consensus";
+import { calculateDomainHash, calculateMessageHash, calculateSafeTxHash } from "./hashing";
 
 describe("hashing", () => {
+	const transaction: SafeTransaction = {
+		chainId: 100n,
+		safe: "0x779720809250AF7931935a192FCD007479C41299",
+		to: "0x2dC63c83040669F0aDBa5F832F713152bA862c97",
+		data: "0x",
+		value: 100000000000000000n,
+		operation: 0,
+		safeTxGas: 0n,
+		baseGas: 0n,
+		gasPrice: 0n,
+		gasToken: zeroAddress,
+		refundReceiver: zeroAddress,
+		nonce: 1n,
+	};
+
+	const expectedSafeTxHash = "0xd6a2395bd7bd650df56610d38760d1b4b8073d37db35090ce3c855ef659c1b81";
+	const expectedDomainHash = "0x82bc8380f75c44eca16d1e557c5f25b9a93076a556d074f2410440b073f61c60";
+	const expectedMessageHash = "0xe5e1f9014523ee27d09c7c545d66f53e835ce1fc3e140cea79547d909c65ded0";
+
 	describe("Safe transaction hash", () => {
 		it("should return correct hash", () => {
-			expect(
-				calculateSafeTxHash({
-					chainId: 100n,
-					safe: "0x779720809250AF7931935a192FCD007479C41299",
-					to: "0x2dC63c83040669F0aDBa5F832F713152bA862c97",
-					data: "0x",
-					value: 100000000000000000n,
-					operation: 0,
-					safeTxGas: 0n,
-					baseGas: 0n,
-					gasPrice: 0n,
-					gasToken: zeroAddress,
-					refundReceiver: zeroAddress,
-					nonce: 1n,
-				}),
-			).toBe("0xd6a2395bd7bd650df56610d38760d1b4b8073d37db35090ce3c855ef659c1b81");
+			expect(calculateSafeTxHash(transaction)).toBe(expectedSafeTxHash);
+		});
+	});
+
+	describe("Domain hash", () => {
+		it("should return correct domain hash", () => {
+			expect(calculateDomainHash(transaction.chainId, transaction.safe)).toBe(expectedDomainHash);
+		});
+	});
+
+	describe("Message hash", () => {
+		it("should return correct message hash", () => {
+			expect(calculateMessageHash(transaction)).toBe(expectedMessageHash);
 		});
 	});
 });

--- a/explorer/src/lib/safe/hashing.ts
+++ b/explorer/src/lib/safe/hashing.ts
@@ -1,5 +1,48 @@
-import { type Hex, hashTypedData } from "viem";
+import { type Address, type Hex, hashDomain, hashStruct, hashTypedData } from "viem";
 import type { SafeTransaction } from "@/lib/consensus";
+
+// EIP-712 domain separator for Safe transactions
+// Use viem's hashDomain to compute the domain hash
+export const calculateDomainHash = (chainId: bigint, verifyingContract: Address): Hex => {
+	return hashDomain({
+		domain: {
+			chainId,
+			verifyingContract,
+		},
+		types: {
+			EIP712Domain: [
+				{ name: "chainId", type: "uint256" },
+				{ name: "verifyingContract", type: "address" },
+			],
+		},
+	});
+};
+
+// EIP-712 SafeTx types - extracted for reuse
+const SAFETX_TYPES = {
+	SafeTx: [
+		{ name: "to", type: "address" },
+		{ name: "value", type: "uint256" },
+		{ name: "data", type: "bytes" },
+		{ name: "operation", type: "uint8" },
+		{ name: "safeTxGas", type: "uint256" },
+		{ name: "baseGas", type: "uint256" },
+		{ name: "gasPrice", type: "uint256" },
+		{ name: "gasToken", type: "address" },
+		{ name: "refundReceiver", type: "address" },
+		{ name: "nonce", type: "uint256" },
+	],
+} as const;
+
+// EIP-712 SafeTx message hash
+// Use viem's hashStruct to compute the message hash (struct hash without domain)
+export const calculateMessageHash = (transaction: SafeTransaction): Hex => {
+	return hashStruct({
+		data: transaction,
+		primaryType: "SafeTx",
+		types: SAFETX_TYPES,
+	});
+};
 
 export const calculateSafeTxHash = (transaction: SafeTransaction): Hex => {
 	const domain = {
@@ -7,22 +50,10 @@ export const calculateSafeTxHash = (transaction: SafeTransaction): Hex => {
 		verifyingContract: transaction.safe,
 	};
 
+	// Use viem's hashTypedData for the full EIP-712 hash
 	return hashTypedData({
 		domain,
-		types: {
-			SafeTx: [
-				{ name: "to", type: "address" },
-				{ name: "value", type: "uint256" },
-				{ name: "data", type: "bytes" },
-				{ name: "operation", type: "uint8" },
-				{ name: "safeTxGas", type: "uint256" },
-				{ name: "baseGas", type: "uint256" },
-				{ name: "gasPrice", type: "uint256" },
-				{ name: "gasToken", type: "address" },
-				{ name: "refundReceiver", type: "address" },
-				{ name: "nonce", type: "uint256" },
-			],
-		},
+		types: SAFETX_TYPES,
 		primaryType: "SafeTx",
 		message: transaction,
 	});


### PR DESCRIPTION
Verify partial hash display (to help with transaction verification on hardware devices) in the explorer from https://github.com/safe-research/safenet/pull/358

### Test

PR generated with `git cherry-pick 81431da5de5d4011d64d3726f1632f1a58ffefd6` with no merge conflicts.