### PR TITLE
[Backport  #394]: Explorer: default to Gnosis Chain RPC

### DIFF
--- a/explorer/.env.sample
+++ b/explorer/.env.sample
@@ -6,7 +6,7 @@
 # VITE_DEFAULT_CONSENSUS=0x223624cBF099e5a8f8cD5aF22aFa424a1d1acEE9
 
 # Default RPC endpoint URL.
-# VITE_DEFAULT_RPC=https://1rpc.io/gnosis
+# VITE_DEFAULT_RPC=https://rpc.gnosischain.com/
 
 # Default calldata decoder URL (must include the calldata query parameter).
 # VITE_DEFAULT_DECODER=https://calldata.swiss-knife.xyz/decoder?calldata=

--- a/explorer/vite.config.js
+++ b/explorer/vite.config.js
@@ -86,7 +86,7 @@ export default defineConfig(({ mode }) => {
 			__IMPRINT_URL__: JSON.stringify(env.VITE_IMPRINT_URL || "#imprint"),
 			// Default explorer settings — configurable per deployment, users can still override in the UI
 			__DEFAULT_CONSENSUS__: JSON.stringify(env.VITE_DEFAULT_CONSENSUS || "0x223624cBF099e5a8f8cD5aF22aFa424a1d1acEE9"),
-			__DEFAULT_RPC__: JSON.stringify(env.VITE_DEFAULT_RPC || "https://1rpc.io/gnosis"),
+			__DEFAULT_RPC__: JSON.stringify(env.VITE_DEFAULT_RPC || "https://rpc.gnosischain.com/"),
 			__DEFAULT_DECODER__: JSON.stringify(
 				env.VITE_DEFAULT_DECODER || "https://calldata.swiss-knife.xyz/decoder?calldata=",
 			),


### PR DESCRIPTION
Backport change to default Gnosis Chain RPC configuration value from #394.

### Test

PR generated with `git cherry-pick 2733864668b801afc261c7c2d0858cb5006807bf` with no merge conflicts.