### PR TITLE
[Backport #417]: Observe Validator Fixes

### DIFF
--- a/validator/src/consensus/protocol/onchain.ts
+++ b/validator/src/consensus/protocol/onchain.ts
@@ -56,10 +56,12 @@ export class GasFeeEstimator {
 	#cachedPrices: Promise<FeeValues> | null = null;
 	#client: PublicClient;
 	#priorityFeeCapPercentage: number | undefined;
+	#logger: Logger | undefined;
 
-	constructor(client: PublicClient, priorityFeeCapPercentage?: number) {
+	constructor(client: PublicClient, priorityFeeCapPercentage?: number, logger?: Logger) {
 		this.#client = client;
 		this.#priorityFeeCapPercentage = priorityFeeCapPercentage;
+		this.#logger = logger;
 	}
 
 	invalidate() {
@@ -93,6 +95,12 @@ export class GasFeeEstimator {
 		const baseFeeComponent = fees.maxFeePerGas - fees.maxPriorityFeePerGas;
 		const cappedPriority = (baseFeeComponent * scaledPercent) / (PRECISION - scaledPercent);
 		const maxPriorityFeePerGas = minBigInt(fees.maxPriorityFeePerGas, cappedPriority);
+		if (maxPriorityFeePerGas < fees.maxPriorityFeePerGas) {
+			this.#logger?.debug("Priority fee cap applied.", {
+				originalMaxPriorityFeePerGas: fees.maxPriorityFeePerGas,
+				cappedMaxPriorityFeePerGas: maxPriorityFeePerGas,
+			});
+		}
 		return {
 			maxPriorityFeePerGas,
 			maxFeePerGas: baseFeeComponent + maxPriorityFeePerGas,

--- a/validator/src/service/service.ts
+++ b/validator/src/service/service.ts
@@ -74,7 +74,7 @@ export class ValidatorService {
 		const verificationEngine = new VerificationEngine(verificationHandlers);
 		const actionStorage = new SqliteActionQueue(database);
 		const txStorage = new SqliteTxStorage(database);
-		const gasFeeEstimator = new GasFeeEstimator(this.#publicClient, priorityFeeCapPercentage);
+		const gasFeeEstimator = new GasFeeEstimator(this.#publicClient, priorityFeeCapPercentage, this.#logger);
 		const protocol = new OnchainProtocol({
 			publicClient: this.#publicClient,
 			account,

--- a/validator/src/watcher/index.ts
+++ b/validator/src/watcher/index.ts
@@ -74,6 +74,7 @@ export class Watcher<E extends Events> {
 
 				// The block we were fetching logs for was uncled. Let the event fetcher
 				// know and return that there are no more logs to fetch.
+				this.#logger.debug("Unable to fetch logs for uncled block, skipping.", { uncledBlockHash: uncle.blockHash });
 				this.#events.onBlockInvalidated(uncle);
 				return null;
 			}


### PR DESCRIPTION
Add some additional logs for improved observability on backported validator fixes from #417.

### Test

PR generated with `git cherry-pick db6a0d663460aea0ba4f23edc44def26b2820316` with no merge conflicts.