### PR TITLE
feat(explorer): show declined validators in attestation status

### DIFF
--- a/explorer/src/components/transaction/SafeTxAttestationStatus.tsx
+++ b/explorer/src/components/transaction/SafeTxAttestationStatus.tsx
@@ -49,10 +49,10 @@ export function SafeTxAttestationStatus({ proposal }: { proposal: TransactionPro
 							<p className={"ml-4"}>Declined:</p>
 							<p>
 								<ValidatorList
-									all={allValidatorIds}
+									all={status.data.declined.map((s) => s.address)}
 									active={status.data.declined.map((s) => s.address)}
-									mapInfo={mapInfo}
-									completed={false}
+									mapInfo={(suffix) => mapInfo(suffix === "✅" ? "❌" : suffix)}
+									completed={true}
 								/>
 							</p>
 						</div>

--- a/explorer/src/components/transaction/SafeTxAttestationStatus.tsx
+++ b/explorer/src/components/transaction/SafeTxAttestationStatus.tsx
@@ -44,6 +44,19 @@ export function SafeTxAttestationStatus({ proposal }: { proposal: TransactionPro
 							/>
 						</p>
 					</div>
+					{status.data.declined.length > 0 && (
+						<div className={"md:flex md:justify-between"}>
+							<p className={"ml-4"}>Declined:</p>
+							<p>
+								<ValidatorList
+									all={allValidatorIds}
+									active={status.data.declined.map((s) => s.address)}
+									mapInfo={mapInfo}
+									completed={false}
+								/>
+							</p>
+						</div>
+					)}
 				</div>
 			)}
 		</>

--- a/explorer/src/lib/coordinator/abi.ts
+++ b/explorer/src/lib/coordinator/abi.ts
@@ -15,6 +15,7 @@ export const COORDINATOR_SIGNING_INITIATED_EVENT = parseAbiItem(
 
 export const COORDINATOR_SIGNING_PROGRESS_EVENTS = parseAbi([
 	"event SignCompleted(bytes32 indexed sid, bytes32 indexed selectionRoot, ((uint256 x, uint256 y) r, uint256 z) signature)",
+	"event SignDeclined(bytes32 indexed sid, address indexed participant)",
 	"event SignRevealedNonces(bytes32 indexed sid, address participant, ((uint256 x, uint256 y) d, (uint256 x, uint256 y) e) nonces)",
 	"event SignShared(bytes32 indexed sid, bytes32 indexed selectionRoot, address participant, uint256 z)",
 ]);
@@ -48,6 +49,7 @@ export const COORDINATOR_KEY_GEN_SELECTORS = [
 
 export const COORDINATOR_SIGNING_PROGRESS_SELECTORS = [
 	"SignCompleted" as const,
+	"SignDeclined" as const,
 	"SignRevealedNonces" as const,
 	"SignShared" as const,
 ].map((eventName) =>

--- a/explorer/src/lib/coordinator/signing.test.ts
+++ b/explorer/src/lib/coordinator/signing.test.ts
@@ -9,11 +9,11 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 //
 // Each test resets the module so the module-level address cache is cleared.
 
-const CONSENSUS = "0x1111111111111111111111111111111111111111" as Address;
-const COORDINATOR_FROM_GETTER = "0xAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA" as Address;
+const CONSENSUS: Address = "0x1111111111111111111111111111111111111111";
+const COORDINATOR_FROM_GETTER: Address = "0xAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
 
 // Valid 32-byte hex (required by safeTxProposalHash's hashTypedData)
-const SAFE_TX_HASH = `0x${"ab".repeat(32)}` as `0x${string}`;
+const SAFE_TX_HASH: `0x${string}` = `0x${"ab".repeat(32)}`;
 
 type LoadLatestAttestationStatus = typeof import("./signing").loadLatestAttestationStatus;
 
@@ -28,14 +28,19 @@ const loadModule = async () => {
 // the coordinator address is resolved.
 const makeProvider = ({
 	readContractImpl,
+	getLogsImpl,
+	requestImpl,
 }: {
 	readContractImpl?: (args: { functionName: string }) => unknown;
-}): PublicClient =>
+	getLogsImpl?: (args: unknown) => unknown;
+	requestImpl?: (args: unknown) => unknown;
+} = {}): PublicClient =>
 	({
 		getBlockNumber: vi.fn().mockResolvedValue(10000n),
 		getChainId: vi.fn().mockResolvedValue(1),
-		getLogs: vi.fn().mockResolvedValue([]),
+		getLogs: getLogsImpl ? vi.fn(getLogsImpl) : vi.fn().mockResolvedValue([]),
 		readContract: readContractImpl ? vi.fn(readContractImpl) : vi.fn(),
+		request: requestImpl ? vi.fn(requestImpl) : vi.fn().mockResolvedValue([]),
 	}) as unknown as PublicClient;
 
 const baseArgs = {
@@ -116,70 +121,70 @@ describe("loadCoordinator (via loadLatestAttestationStatus)", () => {
 // Selectors for coordinator signing progress events
 const SIGN_SELECTOR = "0xb48d242879f9f3df555c800db966f65cba128c7213198748fa202ed54e092691";
 const SIGN_DECLINED_SELECTOR = "0xe6d872ab6c2f6512d506498a50ba8ba1bbc2bb3c19439ad7c6ff3d74465277d7";
+const SIGN_REVEALED_NONCES_SELECTOR = "0xa8415ae8824ba92b55156b0447b9b9bbc3ba63988b076fb0c8d8e180893d1a46";
 const SIGN_SHARED_SELECTOR = "0x25a4d6e8d11a9fdc20ffdd826473485ae4cdd453271726c072a16836c1882e7c";
 
-const SID = `0x${"aa".repeat(32)}` as `0x${string}`;
-const SID_PADDED = SID; // bytes32 is already padded
-const SELECTION_ROOT = `0x${"bb".repeat(32)}` as `0x${string}`;
-const PARTICIPANT_A = "0xaAaAaAaaAaAaAaaAaAAAAAAAAaaaAaAaAaaAaaAa" as Address;
-const PARTICIPANT_B = "0xbBbBBBBbbBBBbbbBbbBbbbbBBbBbbbbBbBbbBBbB" as Address;
+const SID: `0x${string}` = `0x${"aa".repeat(32)}`;
+const SELECTION_ROOT: `0x${string}` = `0x${"bb".repeat(32)}`;
+const PARTICIPANT_A: Address = "0xaAaAaAaaAaAaAaaAaAAAAAAAAaaaAaAaAaaAaaAa";
+const PARTICIPANT_B: Address = "0xbBbBBBBbbBBBbbbBbbBbbbbBBbBbbbbBbBbbBBbB";
 // Address padded to 32 bytes (for use as topic)
 const padAddress = (addr: string) => `0x${"00".repeat(12)}${addr.slice(2).toLowerCase()}`;
 
-// Builds a Sign-initiated raw log
-const makeSignLog = (_sid: string) => ({
+// Base raw log — shared fields for all coordinator progress events
+const makeLog = (topics: string[], data: string, blockNumber = "0x0") => ({
 	address: COORDINATOR_FROM_GETTER,
 	blockHash: `0x${"cc".repeat(32)}`,
-	blockNumber: "0x1",
-	data: `0x${"00".repeat(32)}${"00".repeat(8)}`, // sid (bytes32) + sequence (uint64)
+	blockNumber,
+	data,
 	logIndex: "0x0",
 	removed: false,
-	topics: [
-		SIGN_SELECTOR,
-		padAddress(zeroAddress), // initiator
-		`0x${"00".repeat(32)}`, // gid
-		SAFE_TX_HASH, // message
-	],
+	topics,
 	transactionHash: `0x${"dd".repeat(32)}`,
 	transactionIndex: "0x0",
+});
+
+// Builds a Sign-initiated raw log
+const makeSignLog = (_sid: string) => ({
+	...makeLog(
+		[SIGN_SELECTOR, padAddress(zeroAddress), `0x${"00".repeat(32)}`, SAFE_TX_HASH],
+		`0x${"00".repeat(40)}`, // sid (bytes32) + sequence (uint64)
+		"0x1",
+	),
 });
 
 // Builds a SignDeclined raw log
 const makeDeclinedLog = (sid: string, participant: Address, blockNumber = "0x2") => ({
-	address: COORDINATOR_FROM_GETTER,
-	blockHash: `0x${"cc".repeat(32)}`,
-	blockNumber,
-	data: "0x",
+	...makeLog([SIGN_DECLINED_SELECTOR, sid, padAddress(participant)], "0x", blockNumber),
 	logIndex: "0x1",
-	removed: false,
-	topics: [SIGN_DECLINED_SELECTOR, sid, padAddress(participant)],
-	transactionHash: `0x${"dd".repeat(32)}`,
-	transactionIndex: "0x0",
+});
+
+// Builds a SignRevealedNonces raw log
+const makeRevealedNoncesLog = (sid: string, participant: Address, blockNumber = "0x2") => ({
+	...makeLog(
+		[SIGN_REVEALED_NONCES_SELECTOR, sid],
+		// participant (address, 32 bytes) + nonces struct (4 × uint256 = 128 bytes)
+		`0x${"00".repeat(12)}${participant.slice(2).toLowerCase()}${"00".repeat(128)}`,
+		blockNumber,
+	),
+	logIndex: "0x4",
 });
 
 // Builds a SignShared raw log
+// participant is non-indexed and encoded as the first 32 bytes of data alongside z (uint256)
 const makeSharedLog = (sid: string, _participant: Address, blockNumber = "0x3") => ({
-	address: COORDINATOR_FROM_GETTER,
-	blockHash: `0x${"cc".repeat(32)}`,
-	blockNumber,
-	data: `0x${"00".repeat(32)}`, // z (uint256)
+	...makeLog([SIGN_SHARED_SELECTOR, sid, SELECTION_ROOT], `0x${"00".repeat(32)}`, blockNumber),
 	logIndex: "0x2",
-	removed: false,
-	topics: [SIGN_SHARED_SELECTOR, sid, SELECTION_ROOT],
-	// participant is non-indexed, encoded in data alongside z — but viem's parseEventLogs
-	// reads from data, so we pack participant (padded to 32) + z (uint256 = 0)
-	transactionHash: `0x${"dd".repeat(32)}`,
-	transactionIndex: "0x0",
 });
 
-// Full mock provider for declined-behavior tests (Sign event present)
+// Full mock provider for declined-behaviour tests (Sign event present).
+// The production code calls provider.request({ method: "eth_getLogs" }) directly for
+// fine-grained topic filtering, so we mock request to return the progress logs.
 const makeFullProvider = ({ progressLogs = [] }: { progressLogs?: unknown[] }): PublicClient => {
 	const signLog = makeSignLog(SID);
-	return {
-		getBlockNumber: vi.fn().mockResolvedValue(10000n),
-		getChainId: vi.fn().mockResolvedValue(1),
-		// getLogs returns the Sign-initiated event
-		getLogs: vi.fn().mockResolvedValue([
+	return makeProvider({
+		readContractImpl: async () => COORDINATOR_FROM_GETTER,
+		getLogsImpl: async () => [
 			{
 				...signLog,
 				blockNumber: 1n,
@@ -193,11 +198,9 @@ const makeFullProvider = ({ progressLogs = [] }: { progressLogs?: unknown[] }): 
 				eventName: "Sign",
 				logIndex: 0,
 			},
-		]),
-		// provider.request handles eth_getLogs for progress events
-		request: vi.fn().mockResolvedValue(progressLogs),
-		readContract: vi.fn().mockResolvedValue(COORDINATOR_FROM_GETTER),
-	} as unknown as PublicClient;
+		],
+		requestImpl: async () => progressLogs,
+	});
 };
 
 describe("loadLatestAttestationStatus — declined field", () => {
@@ -210,7 +213,7 @@ describe("loadLatestAttestationStatus — declined field", () => {
 	});
 
 	it("populates declined when a SignDeclined event is present", async () => {
-		const declinedLog = makeDeclinedLog(SID_PADDED, PARTICIPANT_A);
+		const declinedLog = makeDeclinedLog(SID, PARTICIPANT_A);
 		const provider = makeFullProvider({ progressLogs: [declinedLog] });
 		const load = await loadModule();
 
@@ -223,11 +226,11 @@ describe("loadLatestAttestationStatus — declined field", () => {
 
 	it("excludes a participant from declined when they also have a SignShared event", async () => {
 		// Participant A declines first, then signs
-		const declinedLog = makeDeclinedLog(SID_PADDED, PARTICIPANT_A, "0x2");
+		const declinedLog = makeDeclinedLog(SID, PARTICIPANT_A, "0x2");
 		// SignShared has participant encoded as non-indexed data: address (32 bytes) + z (32 bytes)
 		const sharedData = `0x${"00".repeat(12)}${PARTICIPANT_A.slice(2).toLowerCase()}${"00".repeat(32)}`;
 		const sharedLog = {
-			...makeSharedLog(SID_PADDED, PARTICIPANT_A, "0x3"),
+			...makeSharedLog(SID, PARTICIPANT_A, "0x3"),
 			data: sharedData,
 		};
 		const provider = makeFullProvider({ progressLogs: [declinedLog, sharedLog] });
@@ -242,8 +245,8 @@ describe("loadLatestAttestationStatus — declined field", () => {
 	});
 
 	it("deduplicates repeated SignDeclined events from the same participant", async () => {
-		const log1 = makeDeclinedLog(SID_PADDED, PARTICIPANT_A, "0x2");
-		const log2 = { ...makeDeclinedLog(SID_PADDED, PARTICIPANT_A, "0x3"), logIndex: "0x3" };
+		const log1 = makeDeclinedLog(SID, PARTICIPANT_A, "0x2");
+		const log2 = { ...makeDeclinedLog(SID, PARTICIPANT_A, "0x3"), logIndex: "0x3" };
 		const provider = makeFullProvider({ progressLogs: [log1, log2] });
 		const load = await loadModule();
 
@@ -255,8 +258,8 @@ describe("loadLatestAttestationStatus — declined field", () => {
 	});
 
 	it("keeps participants from different addresses in declined independently", async () => {
-		const logA = makeDeclinedLog(SID_PADDED, PARTICIPANT_A, "0x2");
-		const logB = { ...makeDeclinedLog(SID_PADDED, PARTICIPANT_B, "0x3"), logIndex: "0x3" };
+		const logA = makeDeclinedLog(SID, PARTICIPANT_A, "0x2");
+		const logB = { ...makeDeclinedLog(SID, PARTICIPANT_B, "0x3"), logIndex: "0x3" };
 		const provider = makeFullProvider({ progressLogs: [logA, logB] });
 		const load = await loadModule();
 
@@ -266,5 +269,18 @@ describe("loadLatestAttestationStatus — declined field", () => {
 		expect(result?.declined).toHaveLength(2);
 		expect(result?.declined.map((d) => d.address)).toContain(PARTICIPANT_A);
 		expect(result?.declined.map((d) => d.address)).toContain(PARTICIPANT_B);
+	});
+
+	it("excludes a participant from declined when they also have a SignRevealedNonces event", async () => {
+		const committedLog = makeRevealedNoncesLog(SID, PARTICIPANT_A, "0x2");
+		const declinedLog = { ...makeDeclinedLog(SID, PARTICIPANT_A, "0x3"), logIndex: "0x3" };
+		const provider = makeFullProvider({ progressLogs: [committedLog, declinedLog] });
+		const load = await loadModule();
+
+		const result = await load({ provider, ...baseArgs });
+
+		expect(result).not.toBeNull();
+		expect(result?.declined).toEqual([]);
+		expect(result?.committed.map((c) => c.address)).toContain(PARTICIPANT_A);
 	});
 });

--- a/explorer/src/lib/coordinator/signing.test.ts
+++ b/explorer/src/lib/coordinator/signing.test.ts
@@ -1,4 +1,5 @@
 import type { Address, PublicClient } from "viem";
+import { zeroAddress } from "viem";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 // loadCoordinator is module-private. We test it indirectly via
@@ -109,5 +110,161 @@ describe("loadCoordinator (via loadLatestAttestationStatus)", () => {
 		await load({ provider, ...baseArgs });
 
 		expect(provider.getLogs).toHaveBeenCalledWith(expect.objectContaining({ address: COORDINATOR_FROM_GETTER }));
+	});
+});
+
+// Selectors for coordinator signing progress events
+const SIGN_SELECTOR = "0xb48d242879f9f3df555c800db966f65cba128c7213198748fa202ed54e092691";
+const SIGN_DECLINED_SELECTOR = "0xe6d872ab6c2f6512d506498a50ba8ba1bbc2bb3c19439ad7c6ff3d74465277d7";
+const SIGN_SHARED_SELECTOR = "0x25a4d6e8d11a9fdc20ffdd826473485ae4cdd453271726c072a16836c1882e7c";
+
+const SID = `0x${"aa".repeat(32)}` as `0x${string}`;
+const SID_PADDED = SID; // bytes32 is already padded
+const SELECTION_ROOT = `0x${"bb".repeat(32)}` as `0x${string}`;
+const PARTICIPANT_A = "0xaAaAaAaaAaAaAaaAaAAAAAAAAaaaAaAaAaaAaaAa" as Address;
+const PARTICIPANT_B = "0xbBbBBBBbbBBBbbbBbbBbbbbBBbBbbbbBbBbbBBbB" as Address;
+// Address padded to 32 bytes (for use as topic)
+const padAddress = (addr: string) => `0x${"00".repeat(12)}${addr.slice(2).toLowerCase()}`;
+
+// Builds a Sign-initiated raw log
+const makeSignLog = (_sid: string) => ({
+	address: COORDINATOR_FROM_GETTER,
+	blockHash: `0x${"cc".repeat(32)}`,
+	blockNumber: "0x1",
+	data: `0x${"00".repeat(32)}${"00".repeat(8)}`, // sid (bytes32) + sequence (uint64)
+	logIndex: "0x0",
+	removed: false,
+	topics: [
+		SIGN_SELECTOR,
+		padAddress(zeroAddress), // initiator
+		`0x${"00".repeat(32)}`, // gid
+		SAFE_TX_HASH, // message
+	],
+	transactionHash: `0x${"dd".repeat(32)}`,
+	transactionIndex: "0x0",
+});
+
+// Builds a SignDeclined raw log
+const makeDeclinedLog = (sid: string, participant: Address, blockNumber = "0x2") => ({
+	address: COORDINATOR_FROM_GETTER,
+	blockHash: `0x${"cc".repeat(32)}`,
+	blockNumber,
+	data: "0x",
+	logIndex: "0x1",
+	removed: false,
+	topics: [SIGN_DECLINED_SELECTOR, sid, padAddress(participant)],
+	transactionHash: `0x${"dd".repeat(32)}`,
+	transactionIndex: "0x0",
+});
+
+// Builds a SignShared raw log
+const makeSharedLog = (sid: string, _participant: Address, blockNumber = "0x3") => ({
+	address: COORDINATOR_FROM_GETTER,
+	blockHash: `0x${"cc".repeat(32)}`,
+	blockNumber,
+	data: `0x${"00".repeat(32)}`, // z (uint256)
+	logIndex: "0x2",
+	removed: false,
+	topics: [SIGN_SHARED_SELECTOR, sid, SELECTION_ROOT],
+	// participant is non-indexed, encoded in data alongside z — but viem's parseEventLogs
+	// reads from data, so we pack participant (padded to 32) + z (uint256 = 0)
+	transactionHash: `0x${"dd".repeat(32)}`,
+	transactionIndex: "0x0",
+});
+
+// Full mock provider for declined-behavior tests (Sign event present)
+const makeFullProvider = ({ progressLogs = [] }: { progressLogs?: unknown[] }): PublicClient => {
+	const signLog = makeSignLog(SID);
+	return {
+		getBlockNumber: vi.fn().mockResolvedValue(10000n),
+		getChainId: vi.fn().mockResolvedValue(1),
+		// getLogs returns the Sign-initiated event
+		getLogs: vi.fn().mockResolvedValue([
+			{
+				...signLog,
+				blockNumber: 1n,
+				args: {
+					initiator: zeroAddress,
+					gid: `0x${"00".repeat(32)}`,
+					message: SAFE_TX_HASH,
+					sid: SID,
+					sequence: 0n,
+				},
+				eventName: "Sign",
+				logIndex: 0,
+			},
+		]),
+		// provider.request handles eth_getLogs for progress events
+		request: vi.fn().mockResolvedValue(progressLogs),
+		readContract: vi.fn().mockResolvedValue(COORDINATOR_FROM_GETTER),
+	} as unknown as PublicClient;
+};
+
+describe("loadLatestAttestationStatus — declined field", () => {
+	beforeEach(() => {
+		vi.resetModules();
+	});
+
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	it("populates declined when a SignDeclined event is present", async () => {
+		const declinedLog = makeDeclinedLog(SID_PADDED, PARTICIPANT_A);
+		const provider = makeFullProvider({ progressLogs: [declinedLog] });
+		const load = await loadModule();
+
+		const result = await load({ provider, ...baseArgs });
+
+		expect(result).not.toBeNull();
+		expect(result?.declined).toEqual([{ address: PARTICIPANT_A, block: 2n }]);
+		expect(result?.signed).toEqual([]);
+	});
+
+	it("excludes a participant from declined when they also have a SignShared event", async () => {
+		// Participant A declines first, then signs
+		const declinedLog = makeDeclinedLog(SID_PADDED, PARTICIPANT_A, "0x2");
+		// SignShared has participant encoded as non-indexed data: address (32 bytes) + z (32 bytes)
+		const sharedData = `0x${"00".repeat(12)}${PARTICIPANT_A.slice(2).toLowerCase()}${"00".repeat(32)}`;
+		const sharedLog = {
+			...makeSharedLog(SID_PADDED, PARTICIPANT_A, "0x3"),
+			data: sharedData,
+		};
+		const provider = makeFullProvider({ progressLogs: [declinedLog, sharedLog] });
+		const load = await loadModule();
+
+		const result = await load({ provider, ...baseArgs });
+
+		expect(result).not.toBeNull();
+		expect(result?.declined).toEqual([]);
+		// Participant A appears in signed
+		expect(result?.signed.map((s) => s.address)).toContain(PARTICIPANT_A);
+	});
+
+	it("deduplicates repeated SignDeclined events from the same participant", async () => {
+		const log1 = makeDeclinedLog(SID_PADDED, PARTICIPANT_A, "0x2");
+		const log2 = { ...makeDeclinedLog(SID_PADDED, PARTICIPANT_A, "0x3"), logIndex: "0x3" };
+		const provider = makeFullProvider({ progressLogs: [log1, log2] });
+		const load = await loadModule();
+
+		const result = await load({ provider, ...baseArgs });
+
+		expect(result).not.toBeNull();
+		expect(result?.declined).toHaveLength(1);
+		expect(result?.declined[0].address).toBe(PARTICIPANT_A);
+	});
+
+	it("keeps participants from different addresses in declined independently", async () => {
+		const logA = makeDeclinedLog(SID_PADDED, PARTICIPANT_A, "0x2");
+		const logB = { ...makeDeclinedLog(SID_PADDED, PARTICIPANT_B, "0x3"), logIndex: "0x3" };
+		const provider = makeFullProvider({ progressLogs: [logA, logB] });
+		const load = await loadModule();
+
+		const result = await load({ provider, ...baseArgs });
+
+		expect(result).not.toBeNull();
+		expect(result?.declined).toHaveLength(2);
+		expect(result?.declined.map((d) => d.address)).toContain(PARTICIPANT_A);
+		expect(result?.declined.map((d) => d.address)).toContain(PARTICIPANT_B);
 	});
 });

--- a/explorer/src/lib/coordinator/signing.ts
+++ b/explorer/src/lib/coordinator/signing.ts
@@ -80,6 +80,7 @@ type StatusAggregation = {
 	committed: AttestationParticipation[];
 	signedBySelection: Record<string, AttestationParticipation[]>;
 	declined: AttestationParticipation[];
+	priorityAddresses: Set<Address>;
 	selectionRoot?: Hex;
 	signature?: Signature;
 };
@@ -154,7 +155,13 @@ export const loadLatestAttestationStatus = async ({
 
 	const aggregate = eventLogs.reduce(
 		(agg, log) => {
-			const status = agg[log.args.sid] ?? { committed: [], signedBySelection: {}, declined: [], lastUpdate: 0n };
+			const status = agg[log.args.sid] ?? {
+				committed: [],
+				signedBySelection: {},
+				declined: [],
+				priorityAddresses: new Set<Address>(),
+				lastUpdate: 0n,
+			};
 			if (status.lastUpdate < log.blockNumber) {
 				status.lastUpdate = log.blockNumber;
 			}
@@ -167,6 +174,7 @@ export const loadLatestAttestationStatus = async ({
 					break;
 				}
 				case "SignRevealedNonces": {
+					status.priorityAddresses.add(log.args.participant);
 					status.committed.push({
 						address: log.args.participant,
 						block: log.blockNumber,
@@ -174,6 +182,7 @@ export const loadLatestAttestationStatus = async ({
 					break;
 				}
 				case "SignShared": {
+					status.priorityAddresses.add(log.args.participant);
 					const shares = status.signedBySelection[log.args.selectionRoot] ?? [];
 					shares.push({
 						address: log.args.participant,
@@ -281,16 +290,10 @@ export const loadGroupPublicKey = async (
 
 const getDeclined = (status: StatusAggregation | undefined): AttestationParticipation[] => {
 	if (status === undefined || status.declined.length === 0) return [];
-	// Participants who signed (any selection) take priority over decline events
-	const signedAddresses = new Set([
-		...Object.values(status.signedBySelection)
-			.flat()
-			.map((p) => p.address),
-	]);
-	// Deduplicate: keep only the first decline per participant
+	// Participants who committed or signed take priority — deduplicate per participant
 	const seen = new Set<Address>();
 	return status.declined.filter((p) => {
-		if (signedAddresses.has(p.address)) return false;
+		if (status.priorityAddresses.has(p.address)) return false;
 		if (seen.has(p.address)) return false;
 		seen.add(p.address);
 		return true;

--- a/explorer/src/lib/coordinator/signing.ts
+++ b/explorer/src/lib/coordinator/signing.ts
@@ -61,6 +61,7 @@ type AttestationInfo = {
 	lastUpdate: bigint;
 	committed: AttestationParticipation[];
 	signed: AttestationParticipation[];
+	declined: AttestationParticipation[];
 };
 
 export type AttestationStatus = AttestationInfo &
@@ -78,6 +79,7 @@ type StatusAggregation = {
 	lastUpdate: bigint;
 	committed: AttestationParticipation[];
 	signedBySelection: Record<string, AttestationParticipation[]>;
+	declined: AttestationParticipation[];
 	selectionRoot?: Hex;
 	signature?: Signature;
 };
@@ -152,11 +154,18 @@ export const loadLatestAttestationStatus = async ({
 
 	const aggregate = eventLogs.reduce(
 		(agg, log) => {
-			const status = agg[log.args.sid] ?? { committed: [], signedBySelection: {}, lastUpdate: 0n };
+			const status = agg[log.args.sid] ?? { committed: [], signedBySelection: {}, declined: [], lastUpdate: 0n };
 			if (status.lastUpdate < log.blockNumber) {
 				status.lastUpdate = log.blockNumber;
 			}
 			switch (log.eventName) {
+				case "SignDeclined": {
+					status.declined.push({
+						address: log.args.participant,
+						block: log.blockNumber,
+					});
+					break;
+				}
 				case "SignRevealedNonces": {
 					status.committed.push({
 						address: log.args.participant,
@@ -193,6 +202,7 @@ export const loadLatestAttestationStatus = async ({
 			const sequence = signingEvent.args.sequence;
 			const committed = status?.committed ?? [];
 			const signed = getSigned(status);
+			const declined = getDeclined(status);
 			return [
 				{
 					lastUpdate: status.lastUpdate ?? signingEvent.blockNumber,
@@ -201,6 +211,7 @@ export const loadLatestAttestationStatus = async ({
 					sequence,
 					committed,
 					signed,
+					declined,
 				},
 				status.signature,
 			];
@@ -266,6 +277,24 @@ export const loadGroupPublicKey = async (
 		// Group might not exist or key generation might not be complete
 		return undefined;
 	}
+};
+
+const getDeclined = (status: StatusAggregation | undefined): AttestationParticipation[] => {
+	if (status === undefined || status.declined.length === 0) return [];
+	// Participants who signed (any selection) take priority over decline events
+	const signedAddresses = new Set([
+		...Object.values(status.signedBySelection)
+			.flat()
+			.map((p) => p.address),
+	]);
+	// Deduplicate: keep only the first decline per participant
+	const seen = new Set<Address>();
+	return status.declined.filter((p) => {
+		if (signedAddresses.has(p.address)) return false;
+		if (seen.has(p.address)) return false;
+		seen.add(p.address);
+		return true;
+	});
 };
 
 const getSigned = (status: StatusAggregation | undefined): AttestationParticipation[] => {


### PR DESCRIPTION
The attestation breakdown now shows which validators explicitly declined to sign a transaction.

### Context and Motivation

Operators had no visibility into explicit rejections — a validator refusing to sign looked identical to one that was simply offline. The "Declined" row makes this distinction visible at a glance.

### Decisions and Tradeoffs

- A participant who has a `SignShared` event takes priority over any `SignDeclined` from the same address, since a later successful sign supersedes an earlier decline. Repeated decline events from the same participant are also deduplicated to avoid inflating the count.

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://docs.safefoundation.org/cla).

---
_Generated by [Claude Code](https://claude.ai/code/session_01NQP8LGdd3sws86RWJiuWqg)_