### PR TITLE
refactor(contracts): extract FROSTMath test utility library

### DIFF
--- a/contracts/test/FROSTCoordinator.t.sol
+++ b/contracts/test/FROSTCoordinator.t.sol
@@ -4,8 +4,8 @@ pragma solidity ^0.8.30;
 import {Test, Vm} from "@forge-std/Test.sol";
 import {Arrays} from "@oz/utils/Arrays.sol";
 import {MerkleProof} from "@oz/utils/cryptography/MerkleProof.sol";
-import {Math} from "@oz/utils/math/Math.sol";
 import {CommitmentShareMerkleTree} from "@test/util/CommitmentShareMerkleTree.sol";
+import {FROSTMath} from "@test/util/FROSTMath.sol";
 import {ForgeSecp256k1} from "@test/util/ForgeSecp256k1.sol";
 import {ParticipantMerkleTree} from "@test/util/ParticipantMerkleTree.sol";
 import {FROSTCoordinator} from "@/FROSTCoordinator.sol";
@@ -129,7 +129,8 @@ contract FROSTCoordinatorTest is Test {
             FROSTCoordinator.KeyGenSecretShare memory share = shares[i];
 
             for (uint256 j = 0; j < COUNT; j++) {
-                share.y = Secp256k1.add(share.y, _fc(cc[j], i).toPoint());
+                share.y =
+                    Secp256k1.add(share.y, FROSTMath.evalCommitmentPolynomial(cc[j], participants.addr(i)).toPoint());
             }
 
             share.f = new uint256[](COUNT - 1);
@@ -139,7 +140,7 @@ contract FROSTCoordinatorTest is Test {
                     continue;
                 }
 
-                uint256 fi = _f(a[i], l);
+                uint256 fi = FROSTMath.evalPolynomial(a[i], participants.addr(l));
 
                 // EXTENSION: We apply ECDH to encrypt the `f_i(l)` evaluation
                 // for the target participant. This allows us to use the same
@@ -147,7 +148,7 @@ contract FROSTCoordinatorTest is Test {
                 // additional secret channel. This also implies that we only
                 // completely delete `f` in 2.3, as we need `a_0` to recover the
                 // secret shares sent by other participants.
-                fi = _ecdh(fi, q[i], qq[l]);
+                fi = FROSTMath.ecdh(fi, q[i], qq[l]);
 
                 share.f[k++] = fi;
             }
@@ -177,14 +178,14 @@ contract FROSTCoordinatorTest is Test {
 
                 // EXTENSION: We need to reverse the ECDH we applied in the
                 // previous step.
-                f[i][l] = _ecdh(f[i][l], q[i], qq[l]);
+                f[i][l] = FROSTMath.ecdh(f[i][l], q[i], qq[l]);
 
                 Secp256k1.Point memory gf = ForgeSecp256k1.g(f[i][l]).toPoint();
-                Secp256k1.Point memory fc = _fc(cc[l], i).toPoint();
+                Secp256k1.Point memory fc = FROSTMath.evalCommitmentPolynomial(cc[l], participants.addr(i)).toPoint();
                 assertEq(gf.x, fc.x);
                 assertEq(gf.y, fc.y);
             }
-            f[i][i] = _f(a[i], i);
+            f[i][i] = FROSTMath.evalPolynomial(a[i], participants.addr(i));
         }
 
         // Round 2.3
@@ -289,6 +290,10 @@ contract FROSTCoordinatorTest is Test {
         // participants to reveal their nonces before being declared "dishonest").
         // <https://datatracker.ietf.org/doc/html/rfc9591#section-5.2>
         _sortByParticipantId(honestParticipants);
+        address[] memory honestAddrs = new address[](honestParticipants.length);
+        for (uint256 i = 0; i < honestParticipants.length; i++) {
+            honestAddrs[i] = participants.addr(honestParticipants[i]);
+        }
         Secp256k1.Point memory groupKey = coordinator.groupKey(gid);
         FROSTCoordinator.SignSelection memory selection;
         FROST.SignatureShare[] memory shares = new FROST.SignatureShare[](honestParticipants.length);
@@ -311,7 +316,7 @@ contract FROSTCoordinatorTest is Test {
                 uint256 bindingFactor = bindingFactors[i];
                 ForgeSecp256k1.P memory r = ForgeSecp256k1.add(n.d, ForgeSecp256k1.mul(bindingFactor, n.e));
                 shares[i].r = r.toPoint();
-                shares[i].l = _lagrangeCoefficient(honestParticipants, h);
+                shares[i].l = FROSTMath.lagrangeCoefficient(honestAddrs, participants.addr(h));
                 groupCommitment = ForgeSecp256k1.add(groupCommitment, r);
             }
             selection.r = groupCommitment.toPoint();
@@ -470,7 +475,7 @@ contract FROSTCoordinatorTest is Test {
         FROSTCoordinator.KeyGenSecretShare memory share;
         share.f = new uint256[](COUNT - 1);
         for (uint256 i = 0; i < COUNT; i++) {
-            s[i] = _f(a, i);
+            s[i] = FROSTMath.evalPolynomial(a, participants.addr(i));
             share.y = ForgeSecp256k1.g(s[i]).toPoint();
             vm.prank(participants.addr(i));
             coordinator.keyGenSecretShare(gid, share);
@@ -489,30 +494,6 @@ contract FROSTCoordinatorTest is Test {
         assertEq(
             keccak256(abi.encode(coordinator.groupKey(gid))), keccak256(abi.encode(ForgeSecp256k1.g(gs).toPoint()))
         );
-    }
-
-    function _f(uint256[] memory a, uint256 i) private view returns (uint256 r) {
-        r = a[0];
-        uint256 x = FROST.identifier(participants.addr(i));
-        uint256 xx = 1;
-        for (uint256 j = 1; j < a.length; j++) {
-            xx = mulmod(xx, x, Secp256k1.N);
-            r = addmod(r, mulmod(a[j], xx, Secp256k1.N), Secp256k1.N);
-        }
-    }
-
-    function _fc(ForgeSecp256k1.P[] memory c, uint256 i) private returns (ForgeSecp256k1.P memory r) {
-        r = c[0];
-        uint256 x = FROST.identifier(participants.addr(i));
-        uint256 xx = 1;
-        for (uint256 j = 1; j < c.length; j++) {
-            xx = mulmod(xx, x, Secp256k1.N);
-            r = ForgeSecp256k1.add(r, ForgeSecp256k1.mul(xx, c[j]));
-        }
-    }
-
-    function _ecdh(uint256 x, uint256 k, ForgeSecp256k1.P memory q) private returns (uint256 encX) {
-        return x ^ ForgeSecp256k1.mul(k, q).toPoint().x;
     }
 
     function _honestParticipants() private returns (uint256[] memory result) {
@@ -542,21 +523,5 @@ contract FROSTCoordinatorTest is Test {
                 }
             }
         }
-    }
-
-    function _lagrangeCoefficient(uint256[] memory l, uint256 i) private view returns (uint256 lambda) {
-        uint256 numerator = 1;
-        uint256 denominator = 1;
-        uint256 minusId = Secp256k1.N - FROST.identifier(participants.addr(i));
-        for (uint256 j = 0; j < l.length; j++) {
-            uint256 jj = l.unsafeMemoryAccess(j);
-            if (i == jj) {
-                continue;
-            }
-            uint256 x = FROST.identifier(participants.addr(jj));
-            numerator = mulmod(numerator, x, Secp256k1.N);
-            denominator = mulmod(denominator, addmod(x, minusId, Secp256k1.N), Secp256k1.N);
-        }
-        return mulmod(numerator, Math.invModPrime(denominator, Secp256k1.N), Secp256k1.N);
     }
 }

--- a/contracts/test/util/FROSTMath.sol
+++ b/contracts/test/util/FROSTMath.sol
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: GPL-3.0-only
+pragma solidity ^0.8.30;
+
+import {Math} from "@oz/utils/math/Math.sol";
+import {ForgeSecp256k1} from "@test/util/ForgeSecp256k1.sol";
+import {FROST} from "@/libraries/FROST.sol";
+import {Secp256k1} from "@/libraries/Secp256k1.sol";
+
+library FROSTMath {
+    function evalPolynomial(uint256[] memory a, address participant) internal view returns (uint256 r) {
+        r = a[0];
+        uint256 x = FROST.identifier(participant);
+        uint256 xx = 1;
+        for (uint256 j = 1; j < a.length; j++) {
+            xx = mulmod(xx, x, Secp256k1.N);
+            r = addmod(r, mulmod(a[j], xx, Secp256k1.N), Secp256k1.N);
+        }
+    }
+
+    function evalCommitmentPolynomial(ForgeSecp256k1.P[] memory c, address participant)
+        internal
+        returns (ForgeSecp256k1.P memory r)
+    {
+        r = c[0];
+        uint256 x = FROST.identifier(participant);
+        uint256 xx = 1;
+        for (uint256 j = 1; j < c.length; j++) {
+            xx = mulmod(xx, x, Secp256k1.N);
+            r = ForgeSecp256k1.add(r, ForgeSecp256k1.mul(xx, c[j]));
+        }
+    }
+
+    function lagrangeCoefficient(address[] memory signers, address signer) internal view returns (uint256 lambda) {
+        uint256 numerator = 1;
+        uint256 denominator = 1;
+        uint256 minusId = Secp256k1.N - FROST.identifier(signer);
+        for (uint256 j = 0; j < signers.length; j++) {
+            if (signers[j] == signer) continue;
+            uint256 x = FROST.identifier(signers[j]);
+            numerator = mulmod(numerator, x, Secp256k1.N);
+            denominator = mulmod(denominator, addmod(x, minusId, Secp256k1.N), Secp256k1.N);
+        }
+        return mulmod(numerator, Math.invModPrime(denominator, Secp256k1.N), Secp256k1.N);
+    }
+
+    function ecdh(uint256 x, uint256 k, ForgeSecp256k1.P memory q) internal returns (uint256) {
+        return x ^ ForgeSecp256k1.toPoint(ForgeSecp256k1.mul(k, q)).x;
+    }
+}

--- a/contracts/test/util/FROSTMath.sol
+++ b/contracts/test/util/FROSTMath.sol
@@ -30,16 +30,23 @@ library FROSTMath {
         }
     }
 
+    error SignerNotFound();
+
     function lagrangeCoefficient(address[] memory signers, address signer) internal view returns (uint256 lambda) {
         uint256 numerator = 1;
         uint256 denominator = 1;
         uint256 minusId = Secp256k1.N - FROST.identifier(signer);
+        bool found = false;
         for (uint256 j = 0; j < signers.length; j++) {
-            if (signers[j] == signer) continue;
+            if (signers[j] == signer) {
+                found = true;
+                continue;
+            }
             uint256 x = FROST.identifier(signers[j]);
             numerator = mulmod(numerator, x, Secp256k1.N);
             denominator = mulmod(denominator, addmod(x, minusId, Secp256k1.N), Secp256k1.N);
         }
+        if (!found) revert SignerNotFound();
         return mulmod(numerator, Math.invModPrime(denominator, Secp256k1.N), Secp256k1.N);
     }
 


### PR DESCRIPTION
### Context and Motivation

The polynomial evaluation, Lagrange coefficient, and ECDH helpers in `FROSTCoordinatorTest` were private methods tied to the test contract's `ParticipantMerkleTree` instance (parameterised by array index). This was first proposed in [#399](https://github.com/safe-research/safenet/pull/399#pullrequestreview-4374185068) but closed as out-of-scope at the time.

### Decisions and Tradeoffs

- `FROSTMath` takes `address` rather than `uint256` index, making it independent of any `ParticipantMerkleTree` instance and reusable across future test contracts.
- `Math.invModPrime` moves inside `lagrangeCoefficient`, removing the direct `@oz/utils/math/Math` import from the test contract.
- The `_trustedKeyGen` helper now requires an explicit `address[]` conversion before calling `lagrangeCoefficient`, which is a small amount of extra code at the call site but makes the library's interface unambiguous.

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://docs.safefoundation.org/cla).

---
_Generated by [Claude Code](https://claude.ai/code/session_01NQP8LGdd3sws86RWJiuWqg)_