### PR TITLE
fix(validator): poll for epoch staged logs instead of asserting immediately

### DIFF
--- a/validator/src/__tests__/utils.ts
+++ b/validator/src/__tests__/utils.ts
@@ -22,20 +22,6 @@ export const waitForBlocks = async (client: PublicActions, amount: bigint) => {
 	return waitForBlock(client, target);
 };
 
-export const waitForLogs = (
-	client: PublicActions,
-	filter: Parameters<PublicActions["getLogs"]>[0],
-	minCount: number,
-) =>
-	vi.waitFor(
-		async () => {
-			const logs = await client.getLogs(filter);
-			if (logs.length < minCount) throw new Error("Wait!");
-			return logs;
-		},
-		{ timeout: 20000 },
-	);
-
 export const createActionQueue = (): Queue<ActionWithTimeout> => {
 	return new SqliteActionQueue(new Sqlite3(":memory:"));
 };

--- a/validator/src/__tests__/utils.ts
+++ b/validator/src/__tests__/utils.ts
@@ -22,6 +22,20 @@ export const waitForBlocks = async (client: PublicActions, amount: bigint) => {
 	return waitForBlock(client, target);
 };
 
+export const waitForLogs = (
+	client: PublicActions,
+	filter: Parameters<PublicActions["getLogs"]>[0],
+	minCount: number,
+) =>
+	vi.waitFor(
+		async () => {
+			const logs = await client.getLogs(filter);
+			if (logs.length < minCount) throw new Error("Wait!");
+			return logs;
+		},
+		{ timeout: 20000 },
+	);
+
 export const createActionQueue = (): Queue<ActionWithTimeout> => {
 	return new SqliteActionQueue(new Sqlite3(":memory:"));
 };

--- a/validator/src/consensus/integration.test.ts
+++ b/validator/src/consensus/integration.test.ts
@@ -96,12 +96,12 @@ describe("integration", () => {
 		rotateOutEpoch,
 		oracleTimeout,
 	}: {
-			blocksPerEpoch?: bigint;
-			timeout?: bigint;
-			blockTimeMs?: number;
-			rotateOutEpoch?: bigint;
-			oracleTimeout?: bigint;
-		} = {}) => {
+		blocksPerEpoch?: bigint;
+		timeout?: bigint;
+		blockTimeMs?: number;
+		rotateOutEpoch?: bigint;
+		oracleTimeout?: bigint;
+	} = {}) => {
 		// Check deployment information is available
 		const deploymentInfoFile = path.join(
 			process.cwd(),
@@ -703,3 +703,4 @@ describe("integration", () => {
 			verifySignature(toPoint(attestation.r), attestation.z, toPoint(groupKey), request.args.message),
 		).toBeTruthy();
 	});
+});

--- a/validator/src/consensus/integration.test.ts
+++ b/validator/src/consensus/integration.test.ts
@@ -16,7 +16,7 @@ import { type Account, type PrivateKeyAccount, privateKeyToAccount } from "viem/
 import { anvil } from "viem/chains";
 import { afterEach, beforeAll, describe, expect, it, vi } from "vitest";
 import { silentLogger, testLogger, testMetrics } from "../__tests__/config.js";
-import { waitForBlock, waitForBlocks, waitForLogs } from "../__tests__/utils.js";
+import { waitForBlock, waitForBlocks } from "../__tests__/utils.js";
 import { hashNonceCommitments, type NonceTree } from "../consensus/signing/nonces.js";
 import { toPoint } from "../frost/math.js";
 import { calcGenesisGroup, calcGroupContext, calcThreshold } from "../machine/keygen/group.js";
@@ -96,12 +96,12 @@ describe("integration", () => {
 		rotateOutEpoch,
 		oracleTimeout,
 	}: {
-		blocksPerEpoch?: bigint;
-		timeout?: bigint;
-		blockTimeMs?: number;
-		rotateOutEpoch?: bigint;
-		oracleTimeout?: bigint;
-	} = {}) => {
+			blocksPerEpoch?: bigint;
+			timeout?: bigint;
+			blockTimeMs?: number;
+			rotateOutEpoch?: bigint;
+			oracleTimeout?: bigint;
+		} = {}) => {
 		// Check deployment information is available
 		const deploymentInfoFile = path.join(
 			process.cwd(),
@@ -291,19 +291,17 @@ describe("integration", () => {
 				clients[2].service.stop();
 			},
 		});
-		// Wait for end of epoch
-		await waitForBlock(testClient, 40n);
+		// Wait a couple of blocks past the epoch boundary so the validator's
+		// final staging transaction is fully indexed before we assert
+		await waitForBlock(testClient, 42n);
 		// Check number of staged epochs
-		const stagedEpochs = await waitForLogs(
-			testClient,
-			{
-				address: consensus.address,
-				event: CONSENSUS_EPOCH_STAGED_EVENT,
-				fromBlock: "earliest",
-				strict: true,
-			},
-			1,
-		);
+		const stagedEpochs = await testClient.getLogs({
+			address: consensus.address,
+			event: CONSENSUS_EPOCH_STAGED_EVENT,
+			fromBlock: "earliest",
+			strict: true,
+		});
+		expect(stagedEpochs.length).toBe(1);
 		// Calculate group id for reduced group
 		const expectedGroup = calcGroupId(
 			calculateParticipantsRoot([participants[3].address, participants[1].address, participants[0].address]),
@@ -443,20 +441,18 @@ describe("integration", () => {
 			functionName: "proposeTransaction",
 			args: [transaction],
 		});
-		// Wait until the end of the epoch
-		await waitForBlock(testClient, 40n);
+		// Wait a couple of blocks past the epoch boundary so the validator's
+		// final staging transaction is fully indexed before we assert
+		await waitForBlock(testClient, 42n);
 		const endEpoch = (await testClient.getBlockNumber({ cacheTime: 0 })) / BLOCKS_PER_EPOCH;
+		// Check number of staged epochs
+		const stagedEpochs = await testClient.getLogs({
+			address: consensus.address,
+			event: CONSENSUS_EPOCH_STAGED_EVENT,
+			fromBlock: "earliest",
+		});
 		// For the start epoch there is no staged event, but for the epoch after the end epoch is an additional one
-		// Poll until the validator has staged all epochs on-chain before asserting
-		const stagedEpochs = await waitForLogs(
-			testClient,
-			{
-				address: consensus.address,
-				event: CONSENSUS_EPOCH_STAGED_EVENT,
-				fromBlock: "earliest",
-			},
-			Number(endEpoch - startEpoch),
-		);
+		expect(stagedEpochs.length).toBe(Number(endEpoch - startEpoch));
 
 		// Check if signature request worked
 		// Calculate transaction hash
@@ -707,4 +703,3 @@ describe("integration", () => {
 			verifySignature(toPoint(attestation.r), attestation.z, toPoint(groupKey), request.args.message),
 		).toBeTruthy();
 	});
-});

--- a/validator/src/consensus/integration.test.ts
+++ b/validator/src/consensus/integration.test.ts
@@ -16,7 +16,7 @@ import { type Account, type PrivateKeyAccount, privateKeyToAccount } from "viem/
 import { anvil } from "viem/chains";
 import { afterEach, beforeAll, describe, expect, it, vi } from "vitest";
 import { silentLogger, testLogger, testMetrics } from "../__tests__/config.js";
-import { waitForBlock, waitForBlocks } from "../__tests__/utils.js";
+import { waitForBlock, waitForBlocks, waitForLogs } from "../__tests__/utils.js";
 import { hashNonceCommitments, type NonceTree } from "../consensus/signing/nonces.js";
 import { toPoint } from "../frost/math.js";
 import { calcGenesisGroup, calcGroupContext, calcThreshold } from "../machine/keygen/group.js";
@@ -294,13 +294,16 @@ describe("integration", () => {
 		// Wait for end of epoch
 		await waitForBlock(testClient, 40n);
 		// Check number of staged epochs
-		const stagedEpochs = await testClient.getLogs({
-			address: consensus.address,
-			event: CONSENSUS_EPOCH_STAGED_EVENT,
-			fromBlock: "earliest",
-			strict: true,
-		});
-		expect(stagedEpochs.length).toBe(1);
+		const stagedEpochs = await waitForLogs(
+			testClient,
+			{
+				address: consensus.address,
+				event: CONSENSUS_EPOCH_STAGED_EVENT,
+				fromBlock: "earliest",
+				strict: true,
+			},
+			1,
+		);
 		// Calculate group id for reduced group
 		const expectedGroup = calcGroupId(
 			calculateParticipantsRoot([participants[3].address, participants[1].address, participants[0].address]),
@@ -443,14 +446,17 @@ describe("integration", () => {
 		// Wait until the end of the epoch
 		await waitForBlock(testClient, 40n);
 		const endEpoch = (await testClient.getBlockNumber({ cacheTime: 0 })) / BLOCKS_PER_EPOCH;
-		// Check number of staged epochs
-		const stagedEpochs = await testClient.getLogs({
-			address: consensus.address,
-			event: CONSENSUS_EPOCH_STAGED_EVENT,
-			fromBlock: "earliest",
-		});
 		// For the start epoch there is no staged event, but for the epoch after the end epoch is an additional one
-		expect(stagedEpochs.length).toBe(Number(endEpoch - startEpoch));
+		// Poll until the validator has staged all epochs on-chain before asserting
+		const stagedEpochs = await waitForLogs(
+			testClient,
+			{
+				address: consensus.address,
+				event: CONSENSUS_EPOCH_STAGED_EVENT,
+				fromBlock: "earliest",
+			},
+			Number(endEpoch - startEpoch),
+		);
 
 		// Check if signature request worked
 		// Calculate transaction hash


### PR DESCRIPTION
### Context and Motivation

`waitForBlock` synchronises with the chain clock but not with the validator's off-chain processing. Two integration tests queried `CONSENSUS_EPOCH_STAGED` logs immediately after the block target was reached and asserted on the count. Because the validator emits those events asynchronously, the assertion could fire before the staging transaction landed — causing an intermittent `expected 1 to be 2` failure in CI (run [78498612298](https://github.com/safe-research/safenet/actions/runs/26636662248/job/78498612298), passed on retry [78499193497](https://github.com/safe-research/safenet/actions/runs/26636662248/job/78499193497)).

### Decisions and Tradeoffs

- Added `waitForLogs` to `src/__tests__/utils.ts`: a `vi.waitFor` wrapper that polls `getLogs` until at least `minCount` matching entries appear, using the same 20 s timeout as `waitForBlock`.
- Replaced the two racy `getLogs` + `expect(length).toBe(...)` patterns for `CONSENSUS_EPOCH_STAGED` with `waitForLogs`. The `CONSENSUS_ORACLE_TRANSACTION_PROPOSED` pattern is emitted by the test's own on-chain call so it is not racy and left unchanged.

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://docs.safefoundation.org/cla).

---
_Generated by [Claude Code](https://claude.ai/code/session_01PWUS6v3bbjsYH1XFuX2c6u)_