### PR TITLE
SentinelOracle - Phase 3: Add SentinelTransitionWatcher

### DIFF
--- a/validator/src/sentinel/watcher.ts
+++ b/validator/src/sentinel/watcher.ts
@@ -1,0 +1,44 @@
+import type { Database } from "better-sqlite3";
+import type { PublicClient } from "viem";
+import type { NewBlock } from "../machine/transitions/types.js";
+import { BlockchainWatcher, type WatcherConfig } from "../shared/watcher.js";
+import type { Logger } from "../utils/logging.js";
+import type { Metrics } from "../utils/metrics.js";
+import { logToTransition, SENTINEL_ALL_EVENTS, type SentinelOracleTransition } from "./transitions.js";
+import type { SentinelConfig } from "./types.js";
+
+export type Config = Pick<SentinelConfig, "oracle" | "consensus">;
+
+export class SentinelTransitionWatcher extends BlockchainWatcher<typeof SENTINEL_ALL_EVENTS, SentinelOracleTransition> {
+	constructor({
+		database,
+		publicClient,
+		config,
+		watcherConfig,
+		logger,
+		metrics,
+		onTransition,
+	}: {
+		database: Database;
+		publicClient: PublicClient;
+		config: Config;
+		watcherConfig: WatcherConfig;
+		onTransition: (transition: NewBlock | SentinelOracleTransition) => void;
+		logger: Logger;
+		metrics: Metrics;
+	}) {
+		super({
+			database,
+			publicClient,
+			watcherConfig,
+			logger,
+			metrics,
+			tableName: "sentinel_transition_watcher",
+			address: [config.oracle, config.consensus],
+			events: SENTINEL_ALL_EVENTS,
+			fallibleEvents: [],
+			logToTransition,
+			onTransition,
+		});
+	}
+}


### PR DESCRIPTION
### Context and Motivation

Task in Phase 3 of the Sentinel Oracle ([Feature Spec](https://github.com/safe-research/safenet/blob/main/features/2026_05_05_transaction_checker_oracle_v1.md#phase-3--checker-node-service-pr-3-can-be-parallelized-with-phase-2)). Complete list of tasks can be found in the [milestone](https://github.com/safe-research/safenet/milestone/1)

Introduce a transition watcher to watch the sentinel relevant events. This will be used by the sentinel service to invoke the correct transition handlers.

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://docs.safefoundation.org/cla).
