### PR TITLE
SentinelOracle - Phase 2.5: Adjust Fee Payment

### DIFF
--- a/contracts/src/AlwaysApproveOracle.sol
+++ b/contracts/src/AlwaysApproveOracle.sol
@@ -13,7 +13,7 @@ contract AlwaysApproveOracle is IOracle {
     /**
      * @inheritdoc IOracle
      */
-    function postRequest(bytes32 requestId, address proposer, address, uint256) external {
+    function postRequest(bytes32 requestId, address proposer, bytes calldata) external {
         emit OracleResult(requestId, proposer, "", true);
     }
 }

--- a/contracts/src/AlwaysApproveOracle.sol
+++ b/contracts/src/AlwaysApproveOracle.sol
@@ -16,5 +16,4 @@ contract AlwaysApproveOracle is IOracle {
     function postRequest(bytes32 requestId, address proposer, address, uint256) external {
         emit OracleResult(requestId, proposer, "", true);
     }
-
 }

--- a/contracts/src/AlwaysApproveOracle.sol
+++ b/contracts/src/AlwaysApproveOracle.sol
@@ -13,7 +13,8 @@ contract AlwaysApproveOracle is IOracle {
     /**
      * @inheritdoc IOracle
      */
-    function postRequest(bytes32 requestId) external {
-        emit OracleResult(requestId, msg.sender, "", true);
+    function postRequest(bytes32 requestId, address proposer, address, uint256) external {
+        emit OracleResult(requestId, proposer, "", true);
     }
+
 }

--- a/contracts/src/Consensus.sol
+++ b/contracts/src/Consensus.sol
@@ -344,12 +344,10 @@ contract Consensus is IConsensus, IERC165, IFROSTCoordinatorCallback {
     /**
      * @inheritdoc IConsensus
      */
-    function proposeOracleTransaction(
-        address oracle,
-        address rewardToken,
-        uint256 rewardAmount,
-        SafeTransaction.T memory transaction
-    ) public returns (bytes32 safeTxHash) {
+    function proposeOracleTransaction(address oracle, bytes calldata oracleData, SafeTransaction.T memory transaction)
+        public
+        returns (bytes32 safeTxHash)
+    {
         Epochs memory epochs = _processRollover();
         safeTxHash = transaction.hash();
         bytes32 message = domainSeparator().oracleTransactionProposal(epochs.active, oracle, safeTxHash);
@@ -358,7 +356,7 @@ contract Consensus is IConsensus, IERC165, IFROSTCoordinatorCallback {
             safeTxHash, transaction.chainId, transaction.safe, epochs.active, oracle, transaction
         );
         _COORDINATOR.sign($groups[epochs.active], message);
-        IOracle(oracle).postRequest(message, msg.sender, rewardToken, rewardAmount);
+        IOracle(oracle).postRequest(message, msg.sender, oracleData);
     }
 
     /**

--- a/contracts/src/Consensus.sol
+++ b/contracts/src/Consensus.sol
@@ -344,10 +344,12 @@ contract Consensus is IConsensus, IERC165, IFROSTCoordinatorCallback {
     /**
      * @inheritdoc IConsensus
      */
-    function proposeOracleTransaction(address oracle, SafeTransaction.T memory transaction)
-        public
-        returns (bytes32 safeTxHash)
-    {
+    function proposeOracleTransaction(
+        address oracle,
+        address rewardToken,
+        uint256 rewardAmount,
+        SafeTransaction.T memory transaction
+    ) public returns (bytes32 safeTxHash) {
         Epochs memory epochs = _processRollover();
         safeTxHash = transaction.hash();
         bytes32 message = domainSeparator().oracleTransactionProposal(epochs.active, oracle, safeTxHash);
@@ -356,7 +358,7 @@ contract Consensus is IConsensus, IERC165, IFROSTCoordinatorCallback {
             safeTxHash, transaction.chainId, transaction.safe, epochs.active, oracle, transaction
         );
         _COORDINATOR.sign($groups[epochs.active], message);
-        IOracle(oracle).postRequest(message);
+        IOracle(oracle).postRequest(message, msg.sender, rewardToken, rewardAmount);
     }
 
     /**

--- a/contracts/src/SentinelOracle.sol
+++ b/contracts/src/SentinelOracle.sol
@@ -61,8 +61,6 @@ contract SentinelOracle is IOracle {
     error InvalidAddress();
     error ZeroFee();
     error SentinelNotActive();
-    error InvalidRewardToken();
-    error InvalidRewardAmount();
 
     // ============================================================
     // MODIFIERS
@@ -107,13 +105,8 @@ contract SentinelOracle is IOracle {
     // IOracle IMPLEMENTATION
     // ============================================================
 
-    function postRequest(bytes32 requestId, address proposer, address rewardToken, uint256 rewardAmount)
-        external
-        override(IOracle)
-    {
+    function postRequest(bytes32 requestId, address proposer, bytes calldata) external override(IOracle) {
         require(msg.sender == CONSENSUS, NotConsensus());
-        require(rewardToken == address(FEE_TOKEN), InvalidRewardToken());
-        require(rewardAmount == REQUEST_FEE, InvalidRewardAmount());
         uint256 fee = REQUEST_FEE;
         uint256 bondTarget = fee * $bondConfig.currentMultiplier();
         uint256 deadline = block.number + VOTING_WINDOW;

--- a/contracts/src/SentinelOracle.sol
+++ b/contracts/src/SentinelOracle.sol
@@ -61,6 +61,8 @@ contract SentinelOracle is IOracle {
     error InvalidAddress();
     error ZeroFee();
     error SentinelNotActive();
+    error InvalidRewardToken();
+    error InvalidRewardAmount();
 
     // ============================================================
     // MODIFIERS
@@ -105,13 +107,18 @@ contract SentinelOracle is IOracle {
     // IOracle IMPLEMENTATION
     // ============================================================
 
-    function postRequest(bytes32 requestId) external override(IOracle) {
+    function postRequest(bytes32 requestId, address proposer, address rewardToken, uint256 rewardAmount)
+        external
+        override(IOracle)
+    {
         require(msg.sender == CONSENSUS, NotConsensus());
+        require(rewardToken == address(FEE_TOKEN), InvalidRewardToken());
+        require(rewardAmount == REQUEST_FEE, InvalidRewardAmount());
         uint256 fee = REQUEST_FEE;
         uint256 bondTarget = fee * $bondConfig.currentMultiplier();
         uint256 deadline = block.number + VOTING_WINDOW;
-        $requests.create(requestId, msg.sender, fee, bondTarget, deadline);
-        FEE_TOKEN.safeTransferFrom(msg.sender, address(this), fee);
+        $requests.create(requestId, proposer, fee, bondTarget, deadline);
+        FEE_TOKEN.safeTransferFrom(proposer, address(this), fee);
     }
 
     // ============================================================
@@ -172,7 +179,10 @@ contract SentinelOracle is IOracle {
         address proposer = req.proposer;
         uint256 slashed = req.resolveDispute(approveWins);
         SentinelOracleRequest.State outcome = req.state;
-        FEE_TOKEN.safeTransfer(ARBITRATOR, slashed);
+        uint256 refundFee = req.fee;
+        req.fee = 0;
+        FEE_TOKEN.safeTransfer(proposer, refundFee);
+        FEE_TOKEN.safeTransfer(ARBITRATOR, slashed - refundFee);
         emit DisputeResolved(requestId, outcome, slashed);
         emit OracleResult(requestId, proposer, abi.encode(SentinelOracleRequest.ResolveReason.ARBITRATION), approveWins);
     }

--- a/contracts/src/SimpleOracle.sol
+++ b/contracts/src/SimpleOracle.sol
@@ -65,9 +65,9 @@ contract SimpleOracle is IOracle {
     /**
      * @inheritdoc IOracle
      */
-    function postRequest(bytes32 requestId, address, bytes calldata) external {
+    function postRequest(bytes32 requestId, address proposer, bytes calldata) external {
         require($proposers[requestId] == address(0), RequestAlreadyPending());
-        $proposers[requestId] = msg.sender;
+        $proposers[requestId] = proposer;
     }
 
     // ============================================================

--- a/contracts/src/SimpleOracle.sol
+++ b/contracts/src/SimpleOracle.sol
@@ -65,7 +65,7 @@ contract SimpleOracle is IOracle {
     /**
      * @inheritdoc IOracle
      */
-    function postRequest(bytes32 requestId) external {
+    function postRequest(bytes32 requestId, address, address, uint256) external {
         require($proposers[requestId] == address(0), RequestAlreadyPending());
         $proposers[requestId] = msg.sender;
     }

--- a/contracts/src/SimpleOracle.sol
+++ b/contracts/src/SimpleOracle.sol
@@ -65,7 +65,7 @@ contract SimpleOracle is IOracle {
     /**
      * @inheritdoc IOracle
      */
-    function postRequest(bytes32 requestId, address, address, uint256) external {
+    function postRequest(bytes32 requestId, address, bytes calldata) external {
         require($proposers[requestId] == address(0), RequestAlreadyPending());
         $proposers[requestId] = msg.sender;
     }

--- a/contracts/src/interfaces/IConsensus.sol
+++ b/contracts/src/interfaces/IConsensus.sol
@@ -301,12 +301,18 @@ interface IConsensus {
     /**
      * @notice Proposes a transaction for oracle-checked validator approval.
      * @param oracle Address of the oracle contract to use for evaluation.
+     * @param rewardToken The ERC-20 token used for the oracle fee. The caller must have approved
+     *                    the oracle contract to spend this amount before calling.
+     * @param rewardAmount The fee amount to transfer to the oracle from msg.sender.
      * @param transaction The Safe transaction to propose.
      * @return safeTxHash The Safe transaction hash.
      */
-    function proposeOracleTransaction(address oracle, SafeTransaction.T memory transaction)
-        external
-        returns (bytes32 safeTxHash);
+    function proposeOracleTransaction(
+        address oracle,
+        address rewardToken,
+        uint256 rewardAmount,
+        SafeTransaction.T memory transaction
+    ) external returns (bytes32 safeTxHash);
 
     /**
      * @notice Attests to an oracle-checked transaction.

--- a/contracts/src/interfaces/IConsensus.sol
+++ b/contracts/src/interfaces/IConsensus.sol
@@ -301,18 +301,13 @@ interface IConsensus {
     /**
      * @notice Proposes a transaction for oracle-checked validator approval.
      * @param oracle Address of the oracle contract to use for evaluation.
-     * @param rewardToken The ERC-20 token used for the oracle fee. The caller must have approved
-     *                    the oracle contract to spend this amount before calling.
-     * @param rewardAmount The fee amount to transfer to the oracle from msg.sender.
+     * @param oracleData Arbitrary oracle-specific data passed to the oracle; not part of the signed message hash.
      * @param transaction The Safe transaction to propose.
      * @return safeTxHash The Safe transaction hash.
      */
-    function proposeOracleTransaction(
-        address oracle,
-        address rewardToken,
-        uint256 rewardAmount,
-        SafeTransaction.T memory transaction
-    ) external returns (bytes32 safeTxHash);
+    function proposeOracleTransaction(address oracle, bytes calldata oracleData, SafeTransaction.T memory transaction)
+        external
+        returns (bytes32 safeTxHash);
 
     /**
      * @notice Attests to an oracle-checked transaction.

--- a/contracts/src/interfaces/IOracle.sol
+++ b/contracts/src/interfaces/IOracle.sol
@@ -34,5 +34,4 @@ interface IOracle {
      *      proposer and refunds to proposer on resolution when applicable.
      */
     function postRequest(bytes32 requestId, address proposer, address rewardToken, uint256 rewardAmount) external;
-
 }

--- a/contracts/src/interfaces/IOracle.sol
+++ b/contracts/src/interfaces/IOracle.sol
@@ -25,7 +25,7 @@ interface IOracle {
 
     /**
      * @notice Post a signing request to the oracle for evaluation.
-     * @param requestId The EIP-712 hash of the OracleTransactionProposal message.
+     * @param requestId A unique id that allows fetching additional information related to the request.
      * @param proposer The address that offered the reward and to whom any refund is owed.
      * @param oracleData Arbitrary oracle-specific data passed by the proposer; not part of the
      *                   signed message hash. The oracle may decode this however it sees fit.

--- a/contracts/src/interfaces/IOracle.sol
+++ b/contracts/src/interfaces/IOracle.sol
@@ -26,10 +26,13 @@ interface IOracle {
     /**
      * @notice Post a signing request to the oracle for evaluation.
      * @param requestId The EIP-712 hash of the OracleTransactionProposal message.
-     * @dev The oracle records msg.sender as the proposer in OracleResult, allowing oracles to
-     *      differentiate requests from the Consensus contract versus other callers.
-     *      Transaction data is not passed here; the oracle is expected to fetch it independently
-     *      from the OracleTransactionProposed event.
+     * @param proposer The address that offered the reward and to whom any refund is owed.
+     * @param rewardToken The ERC-20 token used for the reward offer.
+     * @param rewardAmount The amount of rewardToken offered as the fee.
+     * @dev Transaction data is not passed here; the oracle is expected to fetch it independently
+     *      from the OracleTransactionProposed event. The oracle pulls the fee directly from
+     *      proposer and refunds to proposer on resolution when applicable.
      */
-    function postRequest(bytes32 requestId) external;
+    function postRequest(bytes32 requestId, address proposer, address rewardToken, uint256 rewardAmount) external;
+
 }

--- a/contracts/src/interfaces/IOracle.sol
+++ b/contracts/src/interfaces/IOracle.sol
@@ -12,7 +12,7 @@ interface IOracle {
 
     /**
      * @notice Emitted when an oracle produces a result for a request.
-     * @param requestId The EIP-712 hash of the OracleTransactionProposal message.
+     * @param requestId A unique id that allows fetching additional information related to the request.
      * @param proposer The address that posted the request (typically the Consensus contract).
      * @param result Arbitrary result data (oracle-specific encoding).
      * @param approved Whether the oracle approves the transaction.

--- a/contracts/src/interfaces/IOracle.sol
+++ b/contracts/src/interfaces/IOracle.sol
@@ -27,11 +27,11 @@ interface IOracle {
      * @notice Post a signing request to the oracle for evaluation.
      * @param requestId The EIP-712 hash of the OracleTransactionProposal message.
      * @param proposer The address that offered the reward and to whom any refund is owed.
-     * @param rewardToken The ERC-20 token used for the reward offer.
-     * @param rewardAmount The amount of rewardToken offered as the fee.
+     * @param oracleData Arbitrary oracle-specific data passed by the proposer; not part of the
+     *                   signed message hash. The oracle may decode this however it sees fit.
      * @dev Transaction data is not passed here; the oracle is expected to fetch it independently
      *      from the OracleTransactionProposed event. The oracle pulls the fee directly from
      *      proposer and refunds to proposer on resolution when applicable.
      */
-    function postRequest(bytes32 requestId, address proposer, address rewardToken, uint256 rewardAmount) external;
+    function postRequest(bytes32 requestId, address proposer, bytes calldata oracleData) external;
 }

--- a/contracts/test/AlwaysApproveOracle.t.sol
+++ b/contracts/test/AlwaysApproveOracle.t.sol
@@ -21,14 +21,14 @@ contract AlwaysApproveOracleTest is Test {
         emit IOracle.OracleResult(REQUEST_ID, requester, "", true);
 
         vm.prank(requester);
-        oracle.postRequest(REQUEST_ID);
+        oracle.postRequest(REQUEST_ID, requester, address(0), 0);
     }
 
     function test_PostRequest_EmitsApprovedTrue() public {
         vm.recordLogs();
 
         vm.prank(requester);
-        oracle.postRequest(REQUEST_ID);
+        oracle.postRequest(REQUEST_ID, requester, address(0), 0);
 
         Vm.Log[] memory logs = vm.getRecordedLogs();
         assertEq(logs.length, 1);
@@ -42,13 +42,14 @@ contract AlwaysApproveOracleTest is Test {
         assertTrue(approved);
     }
 
-    function test_PostRequest_ProposerIsCallerAddress() public {
-        address anotherCaller = vm.createWallet("other").addr;
+    function test_PostRequest_ProposerIsPassedAddress() public {
+        address proposer = vm.createWallet("proposer").addr;
+        address caller = vm.createWallet("caller").addr;
 
         vm.expectEmit(true, true, false, true);
-        emit IOracle.OracleResult(REQUEST_ID, anotherCaller, "", true);
+        emit IOracle.OracleResult(REQUEST_ID, proposer, "", true);
 
-        vm.prank(anotherCaller);
-        oracle.postRequest(REQUEST_ID);
+        vm.prank(caller);
+        oracle.postRequest(REQUEST_ID, proposer, address(0), 0);
     }
 }

--- a/contracts/test/AlwaysApproveOracle.t.sol
+++ b/contracts/test/AlwaysApproveOracle.t.sol
@@ -20,14 +20,12 @@ contract AlwaysApproveOracleTest is Test {
         vm.expectEmit(true, true, false, true);
         emit IOracle.OracleResult(REQUEST_ID, requester, "", true);
 
-        vm.prank(requester);
         oracle.postRequest(REQUEST_ID, requester, "");
     }
 
     function test_PostRequest_EmitsApprovedTrue() public {
         vm.recordLogs();
 
-        vm.prank(requester);
         oracle.postRequest(REQUEST_ID, requester, "");
 
         Vm.Log[] memory logs = vm.getRecordedLogs();

--- a/contracts/test/AlwaysApproveOracle.t.sol
+++ b/contracts/test/AlwaysApproveOracle.t.sol
@@ -21,14 +21,14 @@ contract AlwaysApproveOracleTest is Test {
         emit IOracle.OracleResult(REQUEST_ID, requester, "", true);
 
         vm.prank(requester);
-        oracle.postRequest(REQUEST_ID, requester, address(0), 0);
+        oracle.postRequest(REQUEST_ID, requester, "");
     }
 
     function test_PostRequest_EmitsApprovedTrue() public {
         vm.recordLogs();
 
         vm.prank(requester);
-        oracle.postRequest(REQUEST_ID, requester, address(0), 0);
+        oracle.postRequest(REQUEST_ID, requester, "");
 
         Vm.Log[] memory logs = vm.getRecordedLogs();
         assertEq(logs.length, 1);
@@ -50,6 +50,6 @@ contract AlwaysApproveOracleTest is Test {
         emit IOracle.OracleResult(REQUEST_ID, proposer, "", true);
 
         vm.prank(caller);
-        oracle.postRequest(REQUEST_ID, proposer, address(0), 0);
+        oracle.postRequest(REQUEST_ID, proposer, "");
     }
 }

--- a/contracts/test/Consensus.t.sol
+++ b/contracts/test/Consensus.t.sol
@@ -10,7 +10,7 @@ import {FROSTSignatureId} from "@/libraries/FROSTSignatureId.sol";
 import {SafeTransaction} from "@/libraries/SafeTransaction.sol";
 
 contract MockOracle {
-    function postRequest(bytes32, address, address, uint256) external {}
+    function postRequest(bytes32, address, bytes calldata) external {}
 }
 
 contract ConsensusTest is Test {
@@ -150,7 +150,7 @@ contract ConsensusTest is Test {
         vm.expectEmit(true, true, true, true);
         emit IConsensus.OracleTransactionProposed(safeTxHash, block.chainid, SAFE, 0, address(oracle), transaction);
 
-        consensus.proposeOracleTransaction(address(oracle), address(0), 0, transaction);
+        consensus.proposeOracleTransaction(address(oracle), "", transaction);
     }
 
     function test_ProposeOracleTransaction_AlreadyAttested_Reverts() public {
@@ -164,7 +164,7 @@ contract ConsensusTest is Test {
 
         // Proposing the same (oracle, transaction) should now revert since it is already attested.
         vm.expectRevert(Consensus.AlreadyAttested.selector);
-        consensus.proposeOracleTransaction(address(oracle), address(0), 0, transaction);
+        consensus.proposeOracleTransaction(address(oracle), "", transaction);
     }
 
     function test_AttestOracleTransaction_StoresAndEmits() public {

--- a/contracts/test/Consensus.t.sol
+++ b/contracts/test/Consensus.t.sol
@@ -10,8 +10,9 @@ import {FROSTSignatureId} from "@/libraries/FROSTSignatureId.sol";
 import {SafeTransaction} from "@/libraries/SafeTransaction.sol";
 
 contract MockOracle {
-    function postRequest(bytes32) external {}
+    function postRequest(bytes32, address, address, uint256) external {}
 }
+
 
 contract ConsensusTest is Test {
     using FROSTGroupId for FROSTGroupId.T;
@@ -150,7 +151,7 @@ contract ConsensusTest is Test {
         vm.expectEmit(true, true, true, true);
         emit IConsensus.OracleTransactionProposed(safeTxHash, block.chainid, SAFE, 0, address(oracle), transaction);
 
-        consensus.proposeOracleTransaction(address(oracle), transaction);
+        consensus.proposeOracleTransaction(address(oracle), address(0), 0, transaction);
     }
 
     function test_ProposeOracleTransaction_AlreadyAttested_Reverts() public {
@@ -164,7 +165,7 @@ contract ConsensusTest is Test {
 
         // Proposing the same (oracle, transaction) should now revert since it is already attested.
         vm.expectRevert(Consensus.AlreadyAttested.selector);
-        consensus.proposeOracleTransaction(address(oracle), transaction);
+        consensus.proposeOracleTransaction(address(oracle), address(0), 0, transaction);
     }
 
     function test_AttestOracleTransaction_StoresAndEmits() public {

--- a/contracts/test/Consensus.t.sol
+++ b/contracts/test/Consensus.t.sol
@@ -13,7 +13,6 @@ contract MockOracle {
     function postRequest(bytes32, address, address, uint256) external {}
 }
 
-
 contract ConsensusTest is Test {
     using FROSTGroupId for FROSTGroupId.T;
     using SafeTransaction for SafeTransaction.T;

--- a/contracts/test/SentinelOracle.t.sol
+++ b/contracts/test/SentinelOracle.t.sol
@@ -83,7 +83,7 @@ contract SentinelOracleTest is Test {
 
     function _postRequest() internal {
         vm.prank(consensus);
-        oracle.postRequest(REQUEST_ID, proposer, address(token), REQUEST_FEE);
+        oracle.postRequest(REQUEST_ID, proposer, "");
     }
 
     function _advancePastDeadline() internal {

--- a/contracts/test/SentinelOracle.t.sol
+++ b/contracts/test/SentinelOracle.t.sol
@@ -29,6 +29,7 @@ contract SentinelOracleTest is Test {
 
     address public arbitrator;
     address public consensus;
+    address public proposer;
     address public sentinel1;
     address public sentinel2;
     address public sentinel3;
@@ -40,6 +41,7 @@ contract SentinelOracleTest is Test {
     function setUp() public {
         arbitrator = vm.createWallet("arbitrator").addr;
         consensus = vm.createWallet("consensus").addr;
+        proposer = vm.createWallet("proposer").addr;
         sentinel1 = vm.createWallet("sentinel1").addr;
         sentinel2 = vm.createWallet("sentinel2").addr;
         sentinel3 = vm.createWallet("sentinel3").addr;
@@ -50,13 +52,13 @@ contract SentinelOracleTest is Test {
         );
 
         // Fund accounts
-        token.mint(consensus, 100_000);
+        token.mint(proposer, 100_000);
         token.mint(sentinel1, 100_000);
         token.mint(sentinel2, 100_000);
         token.mint(sentinel3, 100_000);
 
         // Approve oracle for fee pulls
-        vm.prank(consensus);
+        vm.prank(proposer);
         token.approve(address(oracle), type(uint256).max);
         vm.prank(sentinel1);
         token.approve(address(oracle), type(uint256).max);
@@ -81,7 +83,7 @@ contract SentinelOracleTest is Test {
 
     function _postRequest() internal {
         vm.prank(consensus);
-        oracle.postRequest(REQUEST_ID);
+        oracle.postRequest(REQUEST_ID, proposer, address(token), REQUEST_FEE);
     }
 
     function _advancePastDeadline() internal {
@@ -103,17 +105,17 @@ contract SentinelOracleTest is Test {
 
         _advancePastDeadline();
 
-        uint256 consensusBalBefore = token.balanceOf(consensus);
+        uint256 proposerBalBefore = token.balanceOf(proposer);
 
         vm.expectEmit(true, true, false, true);
         emit IOracle.OracleResult(
-            REQUEST_ID, consensus, abi.encode(SentinelOracleRequest.ResolveReason.UNANIMOUS_APPROVE), true
+            REQUEST_ID, proposer, abi.encode(SentinelOracleRequest.ResolveReason.UNANIMOUS_APPROVE), true
         );
 
         oracle.finalize(REQUEST_ID);
 
-        // Consensus's fee was NOT refunded (it's distributed to sentinels).
-        assertEq(token.balanceOf(consensus), consensusBalBefore, "consensus should not receive fee on approve");
+        // Proposer's fee was NOT refunded (it's distributed to sentinels).
+        assertEq(token.balanceOf(proposer), proposerBalBefore, "proposer should not receive fee on approve");
 
         SentinelOracleRequest.Request memory req = oracle.getRequest(REQUEST_ID);
         assertEq(uint256(req.state), uint256(SentinelOracleRequest.State.RESOLVED_APPROVED));
@@ -152,7 +154,7 @@ contract SentinelOracleTest is Test {
 
         vm.expectEmit(true, true, false, true);
         emit IOracle.OracleResult(
-            REQUEST_ID, consensus, abi.encode(SentinelOracleRequest.ResolveReason.UNANIMOUS_DENY), false
+            REQUEST_ID, proposer, abi.encode(SentinelOracleRequest.ResolveReason.UNANIMOUS_DENY), false
         );
 
         oracle.finalize(REQUEST_ID);
@@ -176,12 +178,12 @@ contract SentinelOracleTest is Test {
     // ============================================================
 
     function test_NoCommitments_FeeRefunded() public {
+        uint256 proposerBalBefore = token.balanceOf(proposer);
         _postRequest();
         _advancePastDeadline();
 
-        uint256 consensusBalBefore = token.balanceOf(consensus);
         oracle.finalize(REQUEST_ID);
-        assertEq(token.balanceOf(consensus), consensusBalBefore + REQUEST_FEE);
+        assertEq(token.balanceOf(proposer), proposerBalBefore);
     }
 
     // ============================================================
@@ -189,6 +191,7 @@ contract SentinelOracleTest is Test {
     // ============================================================
 
     function test_Conflict_SetsStateFrozen() public {
+        uint256 proposerBalBefore = token.balanceOf(proposer);
         _postRequest();
 
         // sentinel1 approves, sentinel2 denies — both sides have votes → conflict
@@ -207,28 +210,29 @@ contract SentinelOracleTest is Test {
         // ---- Phase 2: arbitration ----
 
         // Arbitrator resolves: approve wins.
-        uint256 consensusBalBefore = token.balanceOf(consensus);
         uint256 arbitratorBalBefore = token.balanceOf(arbitrator);
 
         vm.expectEmit(true, false, false, true);
         emit SentinelOracle.DisputeResolved(REQUEST_ID, SentinelOracleRequest.State.RESOLVED_APPROVED, BOND_TARGET);
         vm.expectEmit(true, true, false, true);
         emit IOracle.OracleResult(
-            REQUEST_ID, consensus, abi.encode(SentinelOracleRequest.ResolveReason.ARBITRATION), true
+            REQUEST_ID, proposer, abi.encode(SentinelOracleRequest.ResolveReason.ARBITRATION), true
         );
 
         vm.prank(arbitrator);
         oracle.resolveDispute(REQUEST_ID, true);
 
-        // Fee stays in contract for winners; ARBITRATOR receives all slashed bonds.
-        assertEq(token.balanceOf(consensus), consensusBalBefore, "consensus balance unchanged");
-        assertEq(token.balanceOf(arbitrator), arbitratorBalBefore + BOND_TARGET, "deny bonds slashed to arbitrator");
+        // Fee is refunded to proposer from slashed amount; arbitrator receives the remainder.
+        assertEq(token.balanceOf(proposer), proposerBalBefore, "proposer balance fully restored");
+        assertEq(
+            token.balanceOf(arbitrator), arbitratorBalBefore + BOND_TARGET - REQUEST_FEE, "deny bonds slashed to arbitrator"
+        );
 
-        // Winning approve sentinel (sentinel1) gets bond back plus full fee reward (sole winner).
+        // Winning approve sentinel (sentinel1) gets bond back; fee was refunded to proposer so no fee reward.
         uint256 s1Before = token.balanceOf(sentinel1);
         vm.prank(sentinel1);
         oracle.claim(REQUEST_ID);
-        assertEq(token.balanceOf(sentinel1), s1Before + BOND_TARGET + REQUEST_FEE, "sentinel1 bond and fee returned");
+        assertEq(token.balanceOf(sentinel1), s1Before + BOND_TARGET, "sentinel1 bond returned");
 
         // Losing deny sentinel (sentinel2) gets nothing - bond already slashed.
         uint256 s2Before = token.balanceOf(sentinel2);

--- a/contracts/test/SentinelOracle.t.sol
+++ b/contracts/test/SentinelOracle.t.sol
@@ -225,7 +225,9 @@ contract SentinelOracleTest is Test {
         // Fee is refunded to proposer from slashed amount; arbitrator receives the remainder.
         assertEq(token.balanceOf(proposer), proposerBalBefore, "proposer balance fully restored");
         assertEq(
-            token.balanceOf(arbitrator), arbitratorBalBefore + BOND_TARGET - REQUEST_FEE, "deny bonds slashed to arbitrator"
+            token.balanceOf(arbitrator),
+            arbitratorBalBefore + BOND_TARGET - REQUEST_FEE,
+            "deny bonds slashed to arbitrator"
         );
 
         // Winning approve sentinel (sentinel1) gets bond back; fee was refunded to proposer so no fee reward.

--- a/contracts/test/SimpleOracle.t.sol
+++ b/contracts/test/SimpleOracle.t.sol
@@ -20,7 +20,7 @@ contract SimpleOracleTest is Test {
 
     function test_PostRequest_RecordsProposer() public {
         vm.prank(requester);
-        oracle.postRequest(REQUEST_ID, requester, address(0), 0);
+        oracle.postRequest(REQUEST_ID, requester, "");
 
         // Verify by successfully approving — would revert with RequestNotPending if not recorded.
         vm.prank(approver);
@@ -29,16 +29,16 @@ contract SimpleOracleTest is Test {
 
     function test_PostRequest_AlreadyPending_Reverts() public {
         vm.prank(requester);
-        oracle.postRequest(REQUEST_ID, requester, address(0), 0);
+        oracle.postRequest(REQUEST_ID, requester, "");
 
         vm.expectRevert(SimpleOracle.RequestAlreadyPending.selector);
         vm.prank(requester);
-        oracle.postRequest(REQUEST_ID, requester, address(0), 0);
+        oracle.postRequest(REQUEST_ID, requester, "");
     }
 
     function test_Approve_EmitsOracleResult_True() public {
         vm.prank(requester);
-        oracle.postRequest(REQUEST_ID, requester, address(0), 0);
+        oracle.postRequest(REQUEST_ID, requester, "");
 
         vm.expectEmit(true, true, false, true);
         emit IOracle.OracleResult(REQUEST_ID, requester, "", true);
@@ -49,7 +49,7 @@ contract SimpleOracleTest is Test {
 
     function test_Reject_EmitsOracleResult_False() public {
         vm.prank(requester);
-        oracle.postRequest(REQUEST_ID, requester, address(0), 0);
+        oracle.postRequest(REQUEST_ID, requester, "");
 
         vm.expectEmit(true, true, false, true);
         emit IOracle.OracleResult(REQUEST_ID, requester, "", false);
@@ -60,7 +60,7 @@ contract SimpleOracleTest is Test {
 
     function test_Approve_NotApprover_Reverts() public {
         vm.prank(requester);
-        oracle.postRequest(REQUEST_ID, requester, address(0), 0);
+        oracle.postRequest(REQUEST_ID, requester, "");
 
         vm.expectRevert(SimpleOracle.NotApprover.selector);
         oracle.approve(REQUEST_ID);
@@ -68,7 +68,7 @@ contract SimpleOracleTest is Test {
 
     function test_Reject_NotApprover_Reverts() public {
         vm.prank(requester);
-        oracle.postRequest(REQUEST_ID, requester, address(0), 0);
+        oracle.postRequest(REQUEST_ID, requester, "");
 
         vm.expectRevert(SimpleOracle.NotApprover.selector);
         oracle.reject(REQUEST_ID);
@@ -88,7 +88,7 @@ contract SimpleOracleTest is Test {
 
     function test_Approve_ClearsRequest() public {
         vm.prank(requester);
-        oracle.postRequest(REQUEST_ID, requester, address(0), 0);
+        oracle.postRequest(REQUEST_ID, requester, "");
 
         vm.prank(approver);
         oracle.approve(REQUEST_ID);
@@ -101,7 +101,7 @@ contract SimpleOracleTest is Test {
 
     function test_Reject_ClearsRequest() public {
         vm.prank(requester);
-        oracle.postRequest(REQUEST_ID, requester, address(0), 0);
+        oracle.postRequest(REQUEST_ID, requester, "");
 
         vm.prank(approver);
         oracle.reject(REQUEST_ID);

--- a/contracts/test/SimpleOracle.t.sol
+++ b/contracts/test/SimpleOracle.t.sol
@@ -18,9 +18,9 @@ contract SimpleOracleTest is Test {
         oracle = new SimpleOracle(approver);
     }
 
-    function test_PostRequest_RecordsRequester() public {
+    function test_PostRequest_RecordsProposer() public {
         vm.prank(requester);
-        oracle.postRequest(REQUEST_ID);
+        oracle.postRequest(REQUEST_ID, requester, address(0), 0);
 
         // Verify by successfully approving — would revert with RequestNotPending if not recorded.
         vm.prank(approver);
@@ -29,16 +29,16 @@ contract SimpleOracleTest is Test {
 
     function test_PostRequest_AlreadyPending_Reverts() public {
         vm.prank(requester);
-        oracle.postRequest(REQUEST_ID);
+        oracle.postRequest(REQUEST_ID, requester, address(0), 0);
 
         vm.expectRevert(SimpleOracle.RequestAlreadyPending.selector);
         vm.prank(requester);
-        oracle.postRequest(REQUEST_ID);
+        oracle.postRequest(REQUEST_ID, requester, address(0), 0);
     }
 
     function test_Approve_EmitsOracleResult_True() public {
         vm.prank(requester);
-        oracle.postRequest(REQUEST_ID);
+        oracle.postRequest(REQUEST_ID, requester, address(0), 0);
 
         vm.expectEmit(true, true, false, true);
         emit IOracle.OracleResult(REQUEST_ID, requester, "", true);
@@ -49,7 +49,7 @@ contract SimpleOracleTest is Test {
 
     function test_Reject_EmitsOracleResult_False() public {
         vm.prank(requester);
-        oracle.postRequest(REQUEST_ID);
+        oracle.postRequest(REQUEST_ID, requester, address(0), 0);
 
         vm.expectEmit(true, true, false, true);
         emit IOracle.OracleResult(REQUEST_ID, requester, "", false);
@@ -60,7 +60,7 @@ contract SimpleOracleTest is Test {
 
     function test_Approve_NotApprover_Reverts() public {
         vm.prank(requester);
-        oracle.postRequest(REQUEST_ID);
+        oracle.postRequest(REQUEST_ID, requester, address(0), 0);
 
         vm.expectRevert(SimpleOracle.NotApprover.selector);
         oracle.approve(REQUEST_ID);
@@ -68,7 +68,7 @@ contract SimpleOracleTest is Test {
 
     function test_Reject_NotApprover_Reverts() public {
         vm.prank(requester);
-        oracle.postRequest(REQUEST_ID);
+        oracle.postRequest(REQUEST_ID, requester, address(0), 0);
 
         vm.expectRevert(SimpleOracle.NotApprover.selector);
         oracle.reject(REQUEST_ID);
@@ -88,7 +88,7 @@ contract SimpleOracleTest is Test {
 
     function test_Approve_ClearsRequest() public {
         vm.prank(requester);
-        oracle.postRequest(REQUEST_ID);
+        oracle.postRequest(REQUEST_ID, requester, address(0), 0);
 
         vm.prank(approver);
         oracle.approve(REQUEST_ID);
@@ -101,7 +101,7 @@ contract SimpleOracleTest is Test {
 
     function test_Reject_ClearsRequest() public {
         vm.prank(requester);
-        oracle.postRequest(REQUEST_ID);
+        oracle.postRequest(REQUEST_ID, requester, address(0), 0);
 
         vm.prank(approver);
         oracle.reject(REQUEST_ID);

--- a/validator/src/consensus/integration.test.ts
+++ b/validator/src/consensus/integration.test.ts
@@ -150,7 +150,7 @@ describe("integration", () => {
 			address: deploymentInfo.returns.consensus.value as Address,
 			abi: parseAbi([
 				"function proposeTransaction((uint256 chainId, address safe, address to, uint256 value, bytes data, uint8 operation, uint256 safeTxGas, uint256 baseGas, uint256 gasPrice, address gasToken, address refundReceiver, uint256 nonce) transaction) external returns (bytes32 safeTxHash)",
-				"function proposeOracleTransaction(address oracle, address rewardToken, uint256 rewardAmount, (uint256 chainId, address safe, address to, uint256 value, bytes data, uint8 operation, uint256 safeTxGas, uint256 baseGas, uint256 gasPrice, address gasToken, address refundReceiver, uint256 nonce) transaction) external returns (bytes32 safeTxHash)",
+				"function proposeOracleTransaction(address oracle, bytes oracleData, (uint256 chainId, address safe, address to, uint256 value, bytes data, uint8 operation, uint256 safeTxGas, uint256 baseGas, uint256 gasPrice, address gasToken, address refundReceiver, uint256 nonce) transaction) external returns (bytes32 safeTxHash)",
 				"function getTransactionAttestation(uint64 epoch, (uint256 chainId, address safe, address to, uint256 value, bytes data, uint8 operation, uint256 safeTxGas, uint256 baseGas, uint256 gasPrice, address gasToken, address refundReceiver, uint256 nonce) transaction) external view returns (((uint256 x, uint256 y) r, uint256 z) signature)",
 				"function getOracleTransactionAttestationByHash(uint64 epoch, address oracle, bytes32 safeTxHash) external view returns (((uint256 x, uint256 y) r, uint256 z) signature)",
 				"function getActiveEpoch() external view returns (uint64 epoch, bytes32 group)",
@@ -584,7 +584,7 @@ describe("integration", () => {
 		await testClient.writeContract({
 			...consensus,
 			functionName: "proposeOracleTransaction",
-			args: [oracleAddress, zeroAddress, 0n, transaction],
+			args: [oracleAddress, "0x", transaction],
 		});
 
 		// Wait until the end of the epoch

--- a/validator/src/consensus/integration.test.ts
+++ b/validator/src/consensus/integration.test.ts
@@ -150,7 +150,7 @@ describe("integration", () => {
 			address: deploymentInfo.returns.consensus.value as Address,
 			abi: parseAbi([
 				"function proposeTransaction((uint256 chainId, address safe, address to, uint256 value, bytes data, uint8 operation, uint256 safeTxGas, uint256 baseGas, uint256 gasPrice, address gasToken, address refundReceiver, uint256 nonce) transaction) external returns (bytes32 safeTxHash)",
-				"function proposeOracleTransaction(address oracle, (uint256 chainId, address safe, address to, uint256 value, bytes data, uint8 operation, uint256 safeTxGas, uint256 baseGas, uint256 gasPrice, address gasToken, address refundReceiver, uint256 nonce) transaction) external returns (bytes32 safeTxHash)",
+				"function proposeOracleTransaction(address oracle, address rewardToken, uint256 rewardAmount, (uint256 chainId, address safe, address to, uint256 value, bytes data, uint8 operation, uint256 safeTxGas, uint256 baseGas, uint256 gasPrice, address gasToken, address refundReceiver, uint256 nonce) transaction) external returns (bytes32 safeTxHash)",
 				"function getTransactionAttestation(uint64 epoch, (uint256 chainId, address safe, address to, uint256 value, bytes data, uint8 operation, uint256 safeTxGas, uint256 baseGas, uint256 gasPrice, address gasToken, address refundReceiver, uint256 nonce) transaction) external view returns (((uint256 x, uint256 y) r, uint256 z) signature)",
 				"function getOracleTransactionAttestationByHash(uint64 epoch, address oracle, bytes32 safeTxHash) external view returns (((uint256 x, uint256 y) r, uint256 z) signature)",
 				"function getActiveEpoch() external view returns (uint64 epoch, bytes32 group)",
@@ -584,7 +584,7 @@ describe("integration", () => {
 		await testClient.writeContract({
 			...consensus,
 			functionName: "proposeOracleTransaction",
-			args: [oracleAddress, transaction],
+			args: [oracleAddress, zeroAddress, 0n, transaction],
 		});
 
 		// Wait until the end of the epoch


### PR DESCRIPTION
### Context and Motivation

Task in Phase 2.5 of the Sentinel Oracle ([Feature Spec](https://github.com/safe-research/safenet/blob/stack/sentinels_game/features/2026_05_05_transaction_checker_oracle_v1.md#phase-25--fee-payment-fix-pr-25-depends-on-phase-1)).

So far the fee was pulled from the Consensus contract. This pushed the fee tracking responsibility to that contract. As the Oracle already tracks payments, the decision was made to trust the Consensus and pull the fee from the proposer specified by it.

Also to allow future passing of Oracle specific data a `bytes oracleData` was added. This data is passed to the Oracle and can be decoded there to handle additional parameters (i.e. reward token or different reward amounts).

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://docs.safefoundation.org/cla).
