### PR TITLE
SentinelOracle - Phase 3: Adjust ABIs to remove bonds

### DIFF
--- a/validator/src/sentinel/abis.ts
+++ b/validator/src/sentinel/abis.ts
@@ -16,8 +16,8 @@ export const SENTINEL_COMMITTED_EVENT = parseAbiItem(
 export const SENTINEL_EVENTS = [SENTINEL_NEW_REQUEST_EVENT, ORACLE_RESULT_EVENT, SENTINEL_COMMITTED_EVENT] as const;
 
 export const SENTINEL_ORACLE_FUNCTIONS = parseAbi([
-	"function commitApprove(bytes32 requestId, uint256 bondAmount) external",
-	"function commitDeny(bytes32 requestId, uint256 bondAmount) external",
+	"function commitApprove(bytes32 requestId) external",
+	"function commitDeny(bytes32 requestId) external",
 	"function finalize(bytes32 requestId) external",
 	"function claim(bytes32 requestId) external",
 	"function FEE_TOKEN() external view returns (address)",

--- a/validator/src/sentinel/handlers.ts
+++ b/validator/src/sentinel/handlers.ts
@@ -47,8 +47,8 @@ export function handleNewRequest(
 		actions: [
 			{ id: "sentinel_approve_token", bondAmount: transition.bondTarget },
 			approve
-				? { id: "sentinel_commit_approve", requestId: transition.requestId, bondAmount: transition.bondTarget }
-				: { id: "sentinel_commit_deny", requestId: transition.requestId, bondAmount: transition.bondTarget },
+				? { id: "sentinel_commit_approve", requestId: transition.requestId }
+				: { id: "sentinel_commit_deny", requestId: transition.requestId },
 		],
 	};
 }

--- a/validator/src/sentinel/protocol.ts
+++ b/validator/src/sentinel/protocol.ts
@@ -15,12 +15,10 @@ const sentinelActionSchema = z.discriminatedUnion("id", [
 	z.object({
 		id: z.literal("sentinel_commit_approve"),
 		requestId: hexDataSchema,
-		bondAmount: coercedBigIntSchema,
 	}),
 	z.object({
 		id: z.literal("sentinel_commit_deny"),
 		requestId: hexDataSchema,
-		bondAmount: coercedBigIntSchema,
 	}),
 	z.object({ id: z.literal("sentinel_finalize"), requestId: hexDataSchema }),
 	z.object({ id: z.literal("sentinel_claim"), requestId: hexDataSchema }),
@@ -71,7 +69,7 @@ export class SentinelProtocol extends BaseActionQueue<SentinelAction> {
 					data: encodeFunctionData({
 						abi: SENTINEL_ORACLE_FUNCTIONS,
 						functionName: "commitApprove",
-						args: [action.requestId, action.bondAmount],
+						args: [action.requestId],
 					}),
 					value: 0n,
 				});
@@ -81,7 +79,7 @@ export class SentinelProtocol extends BaseActionQueue<SentinelAction> {
 					data: encodeFunctionData({
 						abi: SENTINEL_ORACLE_FUNCTIONS,
 						functionName: "commitDeny",
-						args: [action.requestId, action.bondAmount],
+						args: [action.requestId],
 					}),
 					value: 0n,
 				});

--- a/validator/src/sentinel/types.ts
+++ b/validator/src/sentinel/types.ts
@@ -3,13 +3,11 @@ import type { Address, Hex } from "viem";
 export type CommitApprove = {
 	id: "sentinel_commit_approve";
 	requestId: Hex;
-	bondAmount: bigint;
 };
 
 export type CommitDeny = {
 	id: "sentinel_commit_deny";
 	requestId: Hex;
-	bondAmount: bigint;
 };
 
 export type SentinelFinalize = {


### PR DESCRIPTION
### Context and Motivation

Task in Phase 3 of the Sentinel Oracle ([Feature Spec](https://github.com/safe-research/safenet/blob/main/features/2026_05_05_transaction_checker_oracle_v1.md#phase-3--checker-node-service-pr-3-can-be-parallelized-with-phase-2)). Complete list of tasks can be found in the [milestone](https://github.com/safe-research/safenet/milestone/1)

Fixed the ABI of the SentinelOracle in the Sentinel Typescript code. Namely the bond was removed in #406.

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://docs.safefoundation.org/cla).
