### PR TITLE
feat(validator): support starting indexing from a configured block

### DIFF
--- a/validator/.env.sample
+++ b/validator/.env.sample
@@ -328,17 +328,16 @@ MAX_REORG_DEPTH=
 #
 # Block to begin indexing from when the validator starts with no persisted indexing
 # state — i.e. a fresh database. Useful for genesis, or to recover from a
-# misconfiguration, by skipping irrelevant history instead of scanning from the chain
-# start.
+# misconfiguration, by back-filling from a known block instead of starting near the
+# chain head.
 #
-# This is treated as the last already-indexed block, so indexing effectively resumes
-# from the following block (the usual maxReorgDepth re-index window still applies).
+# The value is inclusive: indexing back-fills starting at this exact block.
 #
 # Persisted state always takes precedence: once a block has been indexed, this value is
 # ignored, so a restart never rewinds or replays history. Unset it after the initial run.
 #
 # Values:  Any non-negative integer block number
-# Default: None — fresh starts index from the chain's effective start.
+# Default: None — a fresh start begins indexing from near the chain head.
 START_FROM_BLOCK=
 
 # Block Page Size [Optional]

--- a/validator/.env.sample
+++ b/validator/.env.sample
@@ -324,6 +324,23 @@ BLOCK_TIME_OVERRIDE=
 # Default: 5
 MAX_REORG_DEPTH=
 
+# Start From Block [Optional]
+#
+# Block to begin indexing from when the validator starts with no persisted indexing
+# state — i.e. a fresh database. Useful for genesis, or to recover from a
+# misconfiguration, by skipping irrelevant history instead of scanning from the chain
+# start.
+#
+# This is treated as the last already-indexed block, so indexing effectively resumes
+# from the following block (the usual maxReorgDepth re-index window still applies).
+#
+# Persisted state always takes precedence: once a block has been indexed, this value is
+# ignored, so a restart never rewinds or replays history. Unset it after the initial run.
+#
+# Values:  Any non-negative integer block number
+# Default: None — fresh starts index from the chain's effective start.
+START_FROM_BLOCK=
+
 # Block Page Size [Optional]
 #
 # Blocks per `eth_getLogs` RPC call during historic sync (startup catchup or post-reorg).

--- a/validator/src/machine/transitions/watcher.test.ts
+++ b/validator/src/machine/transitions/watcher.test.ts
@@ -1,0 +1,61 @@
+import Sqlite3 from "better-sqlite3";
+import type { PublicClient } from "viem";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { Logger } from "../../utils/logging.js";
+import type { Metrics } from "../../utils/metrics.js";
+import { watchBlocksAndEvents } from "../../watcher/index.js";
+import { OnchainTransitionWatcher, type WatcherConfig } from "./watcher.js";
+
+vi.mock("../../watcher/index.js", () => ({
+	watchBlocksAndEvents: vi.fn(async () => async () => {}),
+}));
+
+const mockWatch = vi.mocked(watchBlocksAndEvents);
+
+const ADDRESS = "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266" as const;
+
+const createWatcher = (watcherConfig: WatcherConfig) => {
+	const database = new Sqlite3(":memory:");
+	const publicClient = { chain: { id: 100 } } as unknown as PublicClient;
+	const logger = { error: vi.fn(), warn: vi.fn(), notice: vi.fn(), info: vi.fn(), debug: vi.fn(), silly: vi.fn() };
+	const watcher = new OnchainTransitionWatcher({
+		database,
+		publicClient,
+		config: { consensus: ADDRESS, coordinator: ADDRESS, allowedOracles: [] },
+		watcherConfig,
+		logger: logger as unknown as Logger,
+		metrics: {} as unknown as Metrics,
+		onTransition: () => {},
+	});
+	return watcher;
+};
+
+// `blockTimeOverride` avoids needing a chain block time on the stubbed client.
+const baseConfig: WatcherConfig = { maxReorgDepth: 5, blockTimeOverride: 5000 };
+
+const startedWithBlock = () => mockWatch.mock.calls.at(-1)?.[0].lastIndexedBlock;
+
+describe("OnchainTransitionWatcher initial block resolution", () => {
+	beforeEach(() => {
+		mockWatch.mockClear();
+	});
+
+	it("uses the configured start block when there is no persisted state", async () => {
+		const watcher = createWatcher({ ...baseConfig, startFromBlock: 456n });
+		await watcher.start();
+		expect(startedWithBlock()).toBe(456n);
+	});
+
+	it("prefers persisted indexing state over the configured start block", async () => {
+		const watcher = createWatcher({ ...baseConfig, startFromBlock: 456n });
+		watcher.updateLastIndexedBlock(123n);
+		await watcher.start();
+		expect(startedWithBlock()).toBe(123n);
+	});
+
+	it("defaults to null when neither persisted state nor a start block is set", async () => {
+		const watcher = createWatcher(baseConfig);
+		await watcher.start();
+		expect(startedWithBlock()).toBeNull();
+	});
+});

--- a/validator/src/machine/transitions/watcher.test.ts
+++ b/validator/src/machine/transitions/watcher.test.ts
@@ -33,29 +33,34 @@ const createWatcher = (watcherConfig: WatcherConfig) => {
 // `blockTimeOverride` avoids needing a chain block time on the stubbed client.
 const baseConfig: WatcherConfig = { maxReorgDepth: 5, blockTimeOverride: 5000 };
 
-const startedWithBlock = () => mockWatch.mock.calls.at(-1)?.[0].lastIndexedBlock;
+const startedWith = () => {
+	const params = mockWatch.mock.calls.at(-1)?.[0];
+	return { lastIndexedBlock: params?.lastIndexedBlock, startBlock: params?.startBlock };
+};
 
 describe("OnchainTransitionWatcher initial block resolution", () => {
 	beforeEach(() => {
 		mockWatch.mockClear();
 	});
 
-	it("uses the configured start block when there is no persisted state", async () => {
+	it("forwards the configured start block when there is no persisted state", async () => {
 		const watcher = createWatcher({ ...baseConfig, startFromBlock: 456n });
 		await watcher.start();
-		expect(startedWithBlock()).toBe(456n);
+		// The start block is passed separately (not as `lastIndexedBlock`) so the watcher back-fills
+		// via a warp instead of emitting a spurious reorg.
+		expect(startedWith()).toEqual({ lastIndexedBlock: null, startBlock: 456n });
 	});
 
 	it("prefers persisted indexing state over the configured start block", async () => {
 		const watcher = createWatcher({ ...baseConfig, startFromBlock: 456n });
 		watcher.updateLastIndexedBlock(123n);
 		await watcher.start();
-		expect(startedWithBlock()).toBe(123n);
+		expect(startedWith()).toEqual({ lastIndexedBlock: 123n, startBlock: null });
 	});
 
 	it("defaults to null when neither persisted state nor a start block is set", async () => {
 		const watcher = createWatcher(baseConfig);
 		await watcher.start();
-		expect(startedWithBlock()).toBeNull();
+		expect(startedWith()).toEqual({ lastIndexedBlock: null, startBlock: null });
 	});
 });

--- a/validator/src/machine/transitions/watcher.ts
+++ b/validator/src/machine/transitions/watcher.ts
@@ -117,18 +117,22 @@ export class OnchainTransitionWatcher {
 			throw new Error("already started");
 		}
 
-		const blockTime = this.#watcherConfig.blockTimeOverride ?? this.#publicClient.chain?.blockTime;
+		// `blockTimeOverride` and `startFromBlock` are local-only config keys consumed here; the rest
+		// are forwarded to the watcher, so we destructure them out to avoid leaking unused options.
+		const { blockTimeOverride, startFromBlock, ...watchParams } = this.#watcherConfig;
+
+		const blockTime = blockTimeOverride ?? this.#publicClient.chain?.blockTime;
 		if (blockTime === undefined) {
 			throw new Error("chain missing block time configuration");
 		}
 
 		// Persisted indexing state always takes precedence; the configured start block is only used
 		// for a fresh start, so a restart never rewinds or replays history.
-		const lastIndexedBlock = (await this.getLastIndexedBlock()) ?? this.#watcherConfig.startFromBlock ?? null;
+		const lastIndexedBlock = (await this.getLastIndexedBlock()) ?? startFromBlock ?? null;
 		this.#stop = await watchBlocksAndEvents({
 			logger: this.#logger,
 			client: this.#publicClient,
-			...this.#watcherConfig,
+			...watchParams,
 			lastIndexedBlock,
 			blockTime,
 			// Note: allowedOracles must only emit OracleResult events and must never emit events

--- a/validator/src/machine/transitions/watcher.ts
+++ b/validator/src/machine/transitions/watcher.ts
@@ -19,7 +19,12 @@ export const transitionWatcherStateSchema = z
 
 export type Config = Pick<ProtocolConfig, "coordinator" | "consensus" | "allowedOracles">;
 export type WatcherConfig = Prettify<
-	{ blockTimeOverride?: number } & Pick<
+	{
+		blockTimeOverride?: number;
+		// Block to start indexing from when there is no persisted indexing state (e.g. for genesis
+		// or recovery from a misconfiguration). Ignored once `lastIndexedBlock` has been persisted.
+		startFromBlock?: bigint;
+	} & Pick<
 		WatchParams<[]>,
 		| "maxReorgDepth"
 		| "blockPageSize"
@@ -117,7 +122,9 @@ export class OnchainTransitionWatcher {
 			throw new Error("chain missing block time configuration");
 		}
 
-		const lastIndexedBlock = (await this.getLastIndexedBlock()) ?? null;
+		// Persisted indexing state always takes precedence; the configured start block is only used
+		// for a fresh start, so a restart never rewinds or replays history.
+		const lastIndexedBlock = (await this.getLastIndexedBlock()) ?? this.#watcherConfig.startFromBlock ?? null;
 		this.#stop = await watchBlocksAndEvents({
 			logger: this.#logger,
 			client: this.#publicClient,

--- a/validator/src/machine/transitions/watcher.ts
+++ b/validator/src/machine/transitions/watcher.ts
@@ -126,14 +126,16 @@ export class OnchainTransitionWatcher {
 			throw new Error("chain missing block time configuration");
 		}
 
-		// Persisted indexing state always takes precedence; the configured start block is only used
-		// for a fresh start, so a restart never rewinds or replays history.
-		const lastIndexedBlock = (await this.getLastIndexedBlock()) ?? startFromBlock ?? null;
+		// The configured start block only applies on a fresh start (no persisted indexing state):
+		// persisted state always takes precedence, so a restart never rewinds or replays history.
+		const lastIndexedBlock = (await this.getLastIndexedBlock()) ?? null;
+		const startBlock = lastIndexedBlock === null ? (startFromBlock ?? null) : null;
 		this.#stop = await watchBlocksAndEvents({
 			logger: this.#logger,
 			client: this.#publicClient,
 			...watchParams,
 			lastIndexedBlock,
+			startBlock,
 			blockTime,
 			// Note: allowedOracles must only emit OracleResult events and must never emit events
 			// from the coordinator or consensus ABIs, as those event handlers do not filter by

--- a/validator/src/types/schemas.test.ts
+++ b/validator/src/types/schemas.test.ts
@@ -513,6 +513,7 @@ describe("validatorConfigSchema", () => {
 			"SIGNING_TIMEOUT",
 			"MAX_LOGS_PER_QUERY",
 			"SKIP_GENESIS",
+			"START_FROM_BLOCK",
 		] as const;
 
 		for (const settings of [{}, Object.fromEntries(optionals.map((key) => [key, ""]))]) {
@@ -520,6 +521,28 @@ describe("validatorConfigSchema", () => {
 			for (const optional of optionals) {
 				expect(parsed[optional]).toBeUndefined();
 			}
+		}
+	});
+
+	const baseConfig = () => ({
+		RPC_URL: MOCK_VALID_URL,
+		CONSENSUS_ADDRESS: MOCK_CHECKSUMMED_ADDRESS,
+		COORDINATOR_ADDRESS: MOCK_CHECKSUMMED_ADDRESS,
+		CHAIN_ID: 100,
+		PRIVATE_KEY: generatePrivateKey(),
+		PARTICIPANTS: VALID_PARTICIPANTS_INPUT,
+	});
+
+	it("should parse START_FROM_BLOCK as a bigint", () => {
+		const result = validatorConfigSchema.parse({ ...baseConfig(), START_FROM_BLOCK: "12345" });
+		expect(result.START_FROM_BLOCK).toBe(12345n);
+	});
+
+	it("should reject a negative START_FROM_BLOCK", () => {
+		const result = validatorConfigSchema.safeParse({ ...baseConfig(), START_FROM_BLOCK: "-1" });
+		expect(result.success).toBe(false);
+		if (!result.success) {
+			expect(result.error.issues.find((issue) => issue.path[0] === "START_FROM_BLOCK")).toBeDefined();
 		}
 	});
 });

--- a/validator/src/types/schemas.ts
+++ b/validator/src/types/schemas.ts
@@ -84,6 +84,7 @@ export const validatorConfigSchema = z.object({
 	PRIORITY_FEE_CAP_PERCENTAGE: emptyToDefault(z.coerce.number().optional()),
 	BLOCK_TIME_OVERRIDE: emptyToDefault(z.coerce.number().int().optional()),
 	MAX_REORG_DEPTH: emptyToDefault(z.coerce.number().int().optional()),
+	START_FROM_BLOCK: emptyToDefault(z.coerce.bigint().gte(0n).optional()),
 	BLOCK_PAGE_SIZE: emptyToDefault(z.coerce.number().int().optional()),
 	BLOCK_ALL_LOGS_QUERY_RETRY_COUNT: emptyToDefault(z.coerce.number().int().optional()),
 	BLOCK_SINGLE_QUERY_RETRY_COUNT: emptyToDefault(z.coerce.number().int().optional()),

--- a/validator/src/validator.ts
+++ b/validator/src/validator.ts
@@ -49,6 +49,7 @@ const config: ProtocolConfig = {
 };
 const watcherConfig: WatcherConfig = {
 	blockTimeOverride: validatorConfig.BLOCK_TIME_OVERRIDE,
+	startFromBlock: validatorConfig.START_FROM_BLOCK,
 	maxReorgDepth: validatorConfig.MAX_REORG_DEPTH ?? 5,
 	blockPageSize: validatorConfig.BLOCK_PAGE_SIZE,
 	blockAllLogsQueryRetryCount: validatorConfig.BLOCK_ALL_LOGS_QUERY_RETRY_COUNT,

--- a/validator/src/watcher/blocks.test.ts
+++ b/validator/src/watcher/blocks.test.ts
@@ -185,6 +185,18 @@ describe("BlockWatcher", () => {
 			expect(blocks.queued()).toStrictEqual([newBlockUpdate({ number: 999n }), newBlockUpdate({ number: 1000n })]);
 		});
 
+		it("only emits blocks at or after the start block within the reorg window", async () => {
+			const { create, mocks } = setupCreate({ lastIndexedBlock: null, startBlock: 1000n });
+
+			mocks.getBlock.mockReturnValueOnce(block({ number: 1000n }));
+			mocks.getBlock.mockReturnValueOnce(block({ number: 999n }));
+
+			const blocks = await create();
+
+			// Block 999 is retained for reorg detection but not emitted; only 1000 (>= startBlock) is.
+			expect(blocks.queued()).toStrictEqual([newBlockUpdate({ number: 1000n })]);
+		});
+
 		it("should support no reorg protection", async () => {
 			const { create, mocks } = setupCreate({ lastIndexedBlock: 900n, maxReorgDepth: 0 });
 

--- a/validator/src/watcher/blocks.test.ts
+++ b/validator/src/watcher/blocks.test.ts
@@ -10,7 +10,11 @@ const CONFIG = {
 	blockRetryDelays: [200, 100, 50],
 };
 
-const setupCreate = (config: { lastIndexedBlock: bigint | null; maxReorgDepth?: number }) => {
+const setupCreate = (config: {
+	lastIndexedBlock: bigint | null;
+	startBlock?: bigint | null;
+	maxReorgDepth?: number;
+}) => {
 	const getBlock = vi.fn();
 	const now = vi.fn();
 	const sleep = vi.fn();
@@ -145,6 +149,40 @@ describe("BlockWatcher", () => {
 				newBlockUpdate({ number: 999n }),
 				newBlockUpdate({ number: 1000n }),
 			]);
+		});
+
+		it("should support starting from a configured block without a fake reorg", async () => {
+			const { create, mocks } = setupCreate({ lastIndexedBlock: null, startBlock: 900n });
+
+			mocks.getBlock.mockReturnValueOnce(block({ number: 1000n }));
+			mocks.getBlock.mockReturnValueOnce(block({ number: 999n }));
+
+			const blocks = await create();
+			expect(mocks.getBlock.mock.calls).toEqual([[{ blockTag: "latest" }], [{ blockNumber: 999n }]]);
+
+			// Back-fills from the start block via a warp, with no uncle (reorg) update.
+			expect(blocks.queued()).toStrictEqual([
+				{
+					type: "watcher_update_warp_to_block",
+					fromBlock: 900n,
+					toBlock: 998n,
+				},
+				newBlockUpdate({ number: 999n }),
+				newBlockUpdate({ number: 1000n }),
+			]);
+		});
+
+		it("should not warp when the start block is within the reorg window", async () => {
+			const { create, mocks } = setupCreate({ lastIndexedBlock: null, startBlock: 999n });
+
+			mocks.getBlock.mockReturnValueOnce(block({ number: 1000n }));
+			mocks.getBlock.mockReturnValueOnce(block({ number: 999n }));
+
+			const blocks = await create();
+
+			// The start block (999) is beyond the reorg-safe block (998), so the recent-blocks loop
+			// already covers it and no warp is queued.
+			expect(blocks.queued()).toStrictEqual([newBlockUpdate({ number: 999n }), newBlockUpdate({ number: 1000n })]);
 		});
 
 		it("should support no reorg protection", async () => {

--- a/validator/src/watcher/blocks.ts
+++ b/validator/src/watcher/blocks.ts
@@ -151,17 +151,21 @@ export class BlockWatcher {
 			}
 		}
 
-		// Queue block updates for the recent blocks.
+		// Queue block updates for the recent blocks. When starting from a configured block, only
+		// emit updates for blocks at or after it; earlier blocks (which can occur when `startBlock`
+		// falls within the reorg window) are still retained in `#blocks` for reorg detection.
 		this.#queue.push(
-			...this.#blocks.map(
-				(block) =>
-					({
-						type: "watcher_update_new_block",
-						blockNumber: block.number,
-						blockHash: block.hash,
-						logsBloom: block.logsBloom,
-					}) as const,
-			),
+			...this.#blocks
+				.filter((block) => startBlock === null || block.number >= startBlock)
+				.map(
+					(block) =>
+						({
+							type: "watcher_update_new_block",
+							blockNumber: block.number,
+							blockHash: block.hash,
+							logsBloom: block.logsBloom,
+						}) as const,
+				),
 		);
 	}
 

--- a/validator/src/watcher/blocks.ts
+++ b/validator/src/watcher/blocks.ts
@@ -39,6 +39,9 @@ export type CreateParams = Prettify<
 	{
 		client: Client;
 		lastIndexedBlock: bigint | null;
+		// Block to begin a fresh index from when there is no `lastIndexedBlock`. Unlike resuming,
+		// this back-fills history via a warp without emitting a (fake) reorg.
+		startBlock?: bigint | null;
 	} & Settings &
 		Partial<Options>
 >;
@@ -89,7 +92,7 @@ export class BlockWatcher {
 		this.#queue = [];
 	}
 
-	async #initialize(lastIndexedBlock: bigint | null): Promise<void> {
+	async #initialize(lastIndexedBlock: bigint | null, startBlock: bigint | null): Promise<void> {
 		const latest = await this.#client.getBlock({ blockTag: "latest" });
 		const safe = maxBigInt(latest.number - BigInt(this.#config.maxReorgDepth), 0n);
 
@@ -112,6 +115,12 @@ export class BlockWatcher {
 			if (uncle <= safe) {
 				this.#queue.push({ type: "watcher_update_warp_to_block", fromBlock: uncle, toBlock: safe });
 			}
+		} else if (startBlock !== null && startBlock <= safe) {
+			// Fresh start from a configured block: warp to the reorg-safe block to back-fill history.
+			// Unlike resuming, there is no previously indexed state, so we must NOT emit a (fake)
+			// reorg here. If `startBlock` falls within the reorg window (i.e. `> safe`), the
+			// recent-blocks loop below already covers it.
+			this.#queue.push({ type: "watcher_update_warp_to_block", fromBlock: startBlock, toBlock: safe });
 		}
 
 		// Now query recent blocks, we only need to keep up to `maxReorgDepth` of them for reorg
@@ -325,9 +334,9 @@ export class BlockWatcher {
 	/**
 	 * Create a new block watcher with the specified paramters.
 	 */
-	static async create({ client, lastIndexedBlock, ...config }: CreateParams) {
+	static async create({ client, lastIndexedBlock, startBlock = null, ...config }: CreateParams) {
 		const self = new BlockWatcher(client, withDefaults(config, DEFAULT_OPTIONS));
-		await self.#initialize(lastIndexedBlock);
+		await self.#initialize(lastIndexedBlock, startBlock);
 		return self;
 	}
 }


### PR DESCRIPTION
Add an optional `START_FROM_BLOCK` so a validator can begin indexing from a chosen block on a fresh start.

### Context and Motivation
- Closes #321. On a fresh database (genesis, or recovery from a misconfiguration) the validator begins indexing near the chain head, so it won't pick up events from before it started. `START_FROM_BLOCK` lets an operator back-fill from a known earlier block (e.g. the deployment/genesis block).

### Decisions and Tradeoffs
- **Persisted state always wins.** The configured block is only used when there is no persisted indexing state, so a normal restart never rewinds or replays history. Operators should unset it after the initial run.
- **Back-fills via a warp, not a fake reorg.** The block is passed to the watcher as a dedicated `startBlock` (distinct from `lastIndexedBlock`), which back-fills from it inclusively without emitting an uncle/reorg update. The resume path is unchanged.
- Surfaced as an env var rather than a CLI flag, matching how the validator is otherwise configured.

### Testing
- Unit tests for env parsing/validation, start-block resolution (persisted vs. configured vs. default), and `BlockWatcher` back-fill (warp emitted, plus the no-warp case when the block is within the reorg window). Full validator suite passes.

### CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://docs.safefoundation.org/cla).