### PR TITLE
Add Observability Helpers

### DIFF
--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -9,3 +9,5 @@
 //! - Utilities for managing service state that needs to be preserved across
 //!   restarts and roll back in case of reorgs.
 //! - Reliable transaction submission with all its complexities.
+
+pub mod observability;

--- a/crates/core/src/observability/logging.rs
+++ b/crates/core/src/observability/logging.rs
@@ -1,0 +1,21 @@
+//! Default `tracing` subscriber setup for Safenet services.
+
+use std::io::IsTerminal as _;
+use tracing_subscriber::{EnvFilter, fmt, prelude::*, util::TryInitError};
+
+/// Initializes the global `tracing` subscriber with sensible defaults.
+///
+/// The `filter` controls logging verbosity. Output is human-readable when
+/// stdout is a terminal and JSON-formatted otherwise, so logs are easy to read
+/// during development and easy to aggregate in production.
+///
+/// This installs a process-global subscriber and so can only succeed once;
+/// later calls return a [`TryInitError`].
+pub fn init(filter: EnvFilter) -> Result<(), TryInitError> {
+    let registry = tracing_subscriber::registry().with(filter);
+    if std::io::stdout().is_terminal() {
+        registry.with(fmt::layer()).try_init()
+    } else {
+        registry.with(fmt::layer().json()).try_init()
+    }
+}

--- a/crates/core/src/observability/metrics.rs
+++ b/crates/core/src/observability/metrics.rs
@@ -1,0 +1,54 @@
+//! Prometheus metrics exporter for Safenet services.
+
+use metrics_exporter_prometheus::{BuildError, PrometheusBuilder};
+use std::net::SocketAddr;
+
+/// Installs the global Prometheus recorder and starts an HTTP listener that
+/// scrapers can poll for metrics.
+///
+/// The listener serves Prometheus-formatted metrics on every path except
+/// `/health`, which returns a plain `OK` for liveness probes. Individual
+/// metrics are not registered here; services record them lazily through the
+/// [`metrics`](https://docs.rs/metrics) facade and they appear automatically.
+///
+/// This installs a process-global recorder and so can only succeed once; later
+/// calls return a [`BuildError`].
+pub fn serve(addr: impl Into<SocketAddr>) -> Result<(), BuildError> {
+    PrometheusBuilder::new()
+        .with_http_listener(addr.into())
+        .install()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloy::transports::http::reqwest::{self, StatusCode};
+    use std::net::TcpListener;
+
+    /// Issues a minimal HTTP/1.1 GET and returns the full raw response.
+    async fn http_get(addr: SocketAddr, path: &str) -> (StatusCode, String) {
+        let result = reqwest::get(format!("http://{addr}{path}")).await.unwrap();
+        (result.status(), result.text().await.unwrap())
+    }
+
+    #[tokio::test]
+    async fn serves_metrics_and_health() {
+        // Reserve an ephemeral port, then hand it to the exporter. The listener
+        // binds eagerly during `serve`, so it is ready once `serve` returns.
+        let addr = TcpListener::bind("127.0.0.1:0")
+            .unwrap()
+            .local_addr()
+            .unwrap();
+        serve(addr).unwrap();
+
+        metrics::counter!("safenet_core_test_total").increment(1);
+
+        let (status, metrics) = http_get(addr, "/metrics").await;
+        assert_eq!(status, StatusCode::OK);
+        assert!(metrics.contains("safenet_core_test_total"));
+
+        let (status, health) = http_get(addr, "/health").await;
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(health, "OK");
+    }
+}

--- a/crates/core/src/observability/mod.rs
+++ b/crates/core/src/observability/mod.rs
@@ -1,0 +1,100 @@
+//! Observability helpers shared across Safenet services: a default `tracing`
+//! logging setup and a Prometheus metrics exporter.
+
+use serde::{Deserialize, Deserializer, de};
+use std::{
+    borrow::Cow,
+    net::{Ipv4Addr, SocketAddr},
+};
+use tracing_subscriber::EnvFilter;
+
+pub mod logging;
+pub mod metrics;
+
+/// Configuration for the observability module.
+///
+/// Deserializes from a configuration file and fills in defaults for any omitted
+/// field, so a consumer only specifies the values it needs to override.
+#[derive(Clone, Debug, Deserialize)]
+#[serde(default)]
+pub struct Config {
+    /// The `tracing` env-filter directive controlling log verbosity (see
+    /// [`logging::init`]). Defaults to `info`.
+    #[serde(deserialize_with = "deserialize_log_filter")]
+    pub log_filter: EnvFilter,
+    /// The address the Prometheus metrics HTTP listener binds to (see
+    /// [`metrics::serve`]). Defaults to `127.0.0.1:0`, which picks an ephemeral
+    /// port on the loopback interface.
+    pub metrics_address: SocketAddr,
+}
+
+impl Default for Config {
+    fn default() -> Self {
+        Self {
+            log_filter: EnvFilter::new("info"),
+            metrics_address: SocketAddr::from((Ipv4Addr::LOCALHOST, 0)),
+        }
+    }
+}
+
+/// Error returned when initializing observability fails. Both logging and
+/// metrics install process-global state, so the most common cause is that
+/// [`init`] (or its components) was already called in this process.
+#[derive(Debug, thiserror::Error)]
+pub enum InitError {
+    /// The global `tracing` subscriber could not be installed.
+    #[error("failed to initialize logging: {0}")]
+    Logging(#[from] tracing_subscriber::util::TryInitError),
+    /// The global Prometheus recorder or scrape listener could not be installed.
+    #[error("failed to initialize metrics: {0}")]
+    Metrics(#[from] metrics_exporter_prometheus::BuildError),
+}
+
+/// Initializes logging and metrics from the given [`Config`].
+///
+/// This installs the global `tracing` subscriber (see [`logging::init`]) and
+/// the global Prometheus recorder and scrape listener (see [`metrics::serve`]).
+/// It can only succeed once per process; a later call returns an [`InitError`].
+pub fn init(config: Config) -> Result<(), InitError> {
+    logging::init(config.log_filter)?;
+    metrics::serve(config.metrics_address)?;
+    Ok(())
+}
+
+fn deserialize_log_filter<'de, D>(deserializer: D) -> Result<EnvFilter, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    EnvFilter::try_new(Cow::deserialize(deserializer)?).map_err(de::Error::custom)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn defaults() {
+        let config = serde_json::from_str::<Config>("{}").unwrap();
+        assert_eq!(
+            config.log_filter.to_string(),
+            Config::default().log_filter.to_string(),
+        );
+        assert_eq!(config.metrics_address, Config::default().metrics_address);
+    }
+
+    #[test]
+    fn deserializes_overrides() {
+        let config = serde_json::from_str::<Config>(
+            r#"{
+                "log_filter": "debug",
+                "metrics_address": "0.0.0.0:9000"
+            }"#,
+        )
+        .unwrap();
+        assert_eq!(config.log_filter.to_string(), "debug");
+        assert_eq!(
+            config.metrics_address,
+            SocketAddr::from(([0, 0, 0, 0], 9000)),
+        );
+    }
+}


### PR DESCRIPTION
This PR adds shared helpers that setup observability for the Safenet Rust services.

### Context and Motivation

In particular, it exposes a new `observability::init(config)` method that sets up both logging and a Prometheus metrics HTTP server (so our Prometheus instance can scrape metrics from the services) that doubles as a liveliness check (with a /health endpoint - turns out this is just a built-in feature from the crate we use :tada:).

### Decisions and Tradeoffs

Note that we added a `Config` struct at the root of the `observability` module that implements `Deserialize`. This will allow us to create configuration types for the validator and sentinel that include `config: observability::Config` field and automatically load the required values.

### Testing

Added some basic tests on deserialization and that metrics serving works as expected.

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://docs.safefoundation.org/cla).
