### PR TITLE
Increase Epoch Length in Integration Tests

### DIFF
--- a/validator/src/consensus/integration.test.ts
+++ b/validator/src/consensus/integration.test.ts
@@ -41,9 +41,9 @@ import { calcGroupId } from "./keyGen/utils.js";
 import { calculateMerkleRoot, calculateParticipantsRoot } from "./merkle.js";
 import { verifySignature } from "./signing/verify.js";
 
-const BLOCK_TIME_MS = 250;
+const BLOCK_TIME_MS = 500;
 const BLOCKS_PER_EPOCH = 20n;
-const TEST_RUNTIME_IN_SECONDS = 60;
+const TEST_RUNTIME_IN_SECONDS = 120;
 
 // Anvil account 6 — sentinel used in the oracle signing flow test
 const SENTINEL_PK: Hex = "0x92db14e403b83dfe3df233f83dfa3a0d7096f21ca9b0d6d6b8d88b2b4ec1564e";

--- a/validator/src/consensus/integration.test.ts
+++ b/validator/src/consensus/integration.test.ts
@@ -41,9 +41,9 @@ import { calcGroupId } from "./keyGen/utils.js";
 import { calculateMerkleRoot, calculateParticipantsRoot } from "./merkle.js";
 import { verifySignature } from "./signing/verify.js";
 
-const BLOCK_TIME_MS = 500;
-const BLOCKS_PER_EPOCH = 20n;
-const TEST_RUNTIME_IN_SECONDS = 120;
+const BLOCK_TIME_MS = 250;
+const BLOCKS_PER_EPOCH = 30n;
+const TEST_RUNTIME_IN_SECONDS = 60;
 
 // Anvil account 6 — sentinel used in the oracle signing flow test
 const SENTINEL_PK: Hex = "0x92db14e403b83dfe3df233f83dfa3a0d7096f21ca9b0d6d6b8d88b2b4ec1564e";
@@ -319,7 +319,8 @@ describe("integration", () => {
 	});
 
 	it("keygen timeout", { timeout: TEST_RUNTIME_IN_SECONDS * 1000 * 5 }, async ({ skip }) => {
-		const setupInfo = await setup({ timeout: 5n, blocksPerEpoch: 40n, rotateOutEpoch: 2n });
+		const blocksPerEpoch = 40n;
+		const setupInfo = await setup({ timeout: 5n, blocksPerEpoch, rotateOutEpoch: 2n });
 		if (setupInfo === undefined) {
 			skip();
 			// Don't run the test code
@@ -342,7 +343,7 @@ describe("integration", () => {
 			},
 		});
 		// Wait for end of epoch
-		await waitForBlock(testClient, 40n);
+		await waitForBlock(testClient, blocksPerEpoch);
 		// Check number of staged epochs
 		const stagedEpochs = await testClient.getLogs({
 			address: consensus.address,
@@ -369,8 +370,9 @@ describe("integration", () => {
 		// Restart client and calculate next group
 		clients[2].service.start();
 
-		// Wait for end of epoch
-		await waitForBlock(testClient, 60n);
+		// Wait a few blocks after the epoch, after which the group key will have
+		// been calculated.
+		await waitForBlock(testClient, blocksPerEpoch + blocksPerEpoch / 2n);
 
 		const expectedGroupEpoch2 = calcGroupId(
 			calculateParticipantsRoot([
@@ -468,7 +470,7 @@ describe("integration", () => {
 		const startEpoch = (await testClient.getBlockNumber({ cacheTime: 0 })) / BLOCKS_PER_EPOCH;
 		await triggerKeyGen();
 
-		await waitForBlocks(testClient, 15n);
+		await waitForBlocks(testClient, BLOCKS_PER_EPOCH / 2n);
 		// Setup done ... SchildNetz läuft ... lets send some signature requests
 		const transaction = {
 			chainId: 1n,
@@ -491,7 +493,7 @@ describe("integration", () => {
 			args: [transaction],
 		});
 		// Wait until the end of the epoch
-		await waitForBlock(testClient, 40n);
+		await waitForBlock(testClient, BLOCKS_PER_EPOCH * 2n);
 		const endEpoch = (await testClient.getBlockNumber({ cacheTime: 0 })) / BLOCKS_PER_EPOCH;
 		// Check number of staged epochs
 		const stagedEpochs = await testClient.getLogs({
@@ -697,7 +699,7 @@ describe("integration", () => {
 		await sentinelService.start();
 
 		await triggerKeyGen();
-		await waitForBlocks(testClient, 15n);
+		await waitForBlocks(testClient, BLOCKS_PER_EPOCH / 2n);
 
 		// Propose an oracle-checked transaction — Consensus calls postRequest on SentinelOracle
 		testLogger.notice(


### PR DESCRIPTION
Integration tests (`npm run test:integration`) have become flaky. This PR increases the default epoch length in order to reduce the flakiness.

### Context and Motivation

Recently, tests have started failing more often than before. I was not able to pinpoint exactly why. Some things I tried:

- Git bisecting with the last v0.1.0 release on `main`: it turns out that when running integration tests on old commits, the are _also_ flaky right now! This implies that something that is not tracked by our source is the root cause of the flakiness.
- Older versions of tools (in particular, before the flakiness was observed, we were on v24.14.1 - v24.15.0 of NodeJS); this did not seem to have an effect.

### Decisions and Tradeoffs

In order to move forward for now, I propose to increase the default block time. This will increase the test run time by ~20% but makes the tests much more stable.

The choice of increasing the epoch size was because every failure I observed was because epoch or transaction signing could not be completed in time. The few additional blocks makes the difference!

### Testing

```
for i in $(seq 1 10); do npm run test:integration; done
```

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://docs.safefoundation.org/cla).
