### PR TITLE
Block Watcher Initialization

### DIFF
--- a/crates/core/src/index/blocks.rs
+++ b/crates/core/src/index/blocks.rs
@@ -1,0 +1,219 @@
+//! Block watcher.
+//!
+//! Reliably produces a stream of block updates while following the chain head,
+//! and keeps a bounded history of recent blocks so chain reorgs can be detected.
+
+use alloy::{
+    eips::BlockId,
+    primitives::{B256, Bloom},
+    providers::Provider,
+    rpc::types::Block,
+    transports::TransportError,
+};
+use std::collections::VecDeque;
+
+/// Block watcher configuration.
+#[derive(Clone, Debug)]
+pub struct Config {
+    /// Expected time between blocks, in milliseconds.
+    pub block_time: u64,
+    /// How many blocks deep a reorg can be before it is considered final.
+    pub max_reorg_depth: u64,
+    /// Block to begin a fresh index from when there is no resume point. Unlike
+    /// resuming, this back-fills history via a warp without emitting a (fake)
+    /// reorg.
+    pub start_block: Option<u64>,
+}
+
+/// A block update produced by the watcher.
+#[derive(Clone, Debug, PartialEq, Eq)]
+// NOTE: The large enum variant warning is there because of the `bloom` field on
+// the `New` variant. Since this is the most common variant, boxing the value
+// will not be beneficial.
+#[allow(clippy::large_enum_variant)]
+pub enum BlockUpdate {
+    /// Skip ahead over a reorg-safe range `from..=to`, which can be queried in
+    /// bulk without risk of including an uncled block.
+    Warp { from: u64, to: u64 },
+    /// The block at `number` was removed from the canonical chain.
+    Uncle { number: u64 },
+    /// A new canonical block.
+    New {
+        number: u64,
+        hash: B256,
+        logs_bloom: Bloom,
+    },
+}
+
+/// Error produced by the block watcher.
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+    /// An RPC request failed.
+    #[error(transparent)]
+    Rpc(#[from] TransportError),
+    /// A block at or below the chain head was missing, indicating an
+    /// inconsistent RPC node.
+    #[error("block {0} is unexpectedly missing")]
+    MissingBlock(BlockId),
+}
+
+/// The next block the watcher expects to fetch, and the earliest time it is
+/// worth trying to (its expected mining time, in milliseconds).
+#[derive(Clone, Debug)]
+struct PendingBlock {
+    number: u64,
+    timestamp_ms: u64,
+}
+
+/// Watches the chain head, producing [`BlockUpdate`]s and detecting reorgs.
+pub struct BlockWatcher<P> {
+    provider: P,
+    config: Config,
+    pending: PendingBlock,
+    /// The most recent blocks (up to `max_reorg_depth`), kept for reorg
+    /// detection. Ordered oldest-first.
+    recent: VecDeque<Block>,
+    queue: VecDeque<BlockUpdate>,
+}
+
+impl<P> BlockWatcher<P>
+where
+    P: Provider,
+{
+    /// Creates and initializes a block watcher.
+    ///
+    /// When `last_indexed_block` is set, the watcher resumes from it, replaying
+    /// the last `max_reorg_depth` blocks via a deliberate "fake" reorg so any
+    /// reorg that happened while the service was down is re-indexed. Otherwise,
+    /// when `Config::start_block` is set, it back-fills from there via a warp
+    /// without a (fake) reorg.
+    pub async fn create(
+        provider: P,
+        config: Config,
+        last_indexed_block: Option<u64>,
+    ) -> Result<Self, Error> {
+        let mut watcher = Self {
+            provider,
+            config,
+            pending: PendingBlock {
+                number: 0,
+                timestamp_ms: 0,
+            },
+            recent: VecDeque::new(),
+            queue: VecDeque::new(),
+        };
+        watcher.initialize(last_indexed_block).await?;
+        Ok(watcher)
+    }
+
+    /// Fetches a block that is expected to exist, erroring if the node does not
+    /// have it.
+    async fn require_block(&self, id: BlockId) -> Result<Block, Error> {
+        self.provider
+            .get_block(id)
+            .hashes()
+            .await?
+            .ok_or(Error::MissingBlock(id))
+    }
+
+    async fn initialize(&mut self, last_indexed_block: Option<u64>) -> Result<(), Error> {
+        let latest = self.require_block(BlockId::latest()).await?;
+        let safe = latest
+            .header
+            .number
+            .saturating_sub(self.config.max_reorg_depth);
+
+        self.update_next_pending_block(latest.header.number, latest.header.timestamp);
+
+        if let Some(last_indexed) = last_indexed_block {
+            // To guard against a reorg of a block right as the service restarted,
+            // we always create a "fake" reorg `max_reorg_depth` deep to re-index
+            // the last blocks before shutdown. Queue an uncle for the block right
+            // after the last reorg-safe indexed block.
+            let uncle = (last_indexed + 1).saturating_sub(self.config.max_reorg_depth);
+            if uncle <= last_indexed {
+                self.queue.push_back(BlockUpdate::Uncle { number: uncle });
+            }
+
+            // If possible, warp up to the reorg-safe block to allow bulk log
+            // queries. We cannot warp to the latest block, as a range query
+            // could then return data for a block that later gets uncled.
+            if uncle <= safe {
+                self.queue.push_back(BlockUpdate::Warp {
+                    from: uncle,
+                    to: safe,
+                });
+            }
+        } else if let Some(start) = self.config.start_block {
+            // Fresh start from a configured block: if possible back-fill via a
+            // warp. Unlike resuming, there is no prior state, so do not emit a
+            // fake reorg like we do when resuming.
+            if start <= safe {
+                self.queue.push_back(BlockUpdate::Warp {
+                    from: start,
+                    to: safe,
+                });
+            }
+        }
+
+        // Query the recent blocks (those within the reorg window) so we can
+        // detect reorgs going forward. On the rare chance of observing a reorg
+        // mid-init, tear down and start the range again.
+        let latest_number = latest.header.number;
+        let mut parent_hash = None;
+        let mut canonical_latest = Some(latest);
+        let mut number = safe + 1;
+        while number <= latest_number {
+            // Avoid an additional RPC request for the latest block, but only if
+            // we know for sure it is still canonical.
+            let cached_block = if number == latest_number {
+                canonical_latest.take()
+            } else {
+                None
+            };
+            let block = match cached_block {
+                Some(block) => block,
+                None => self.require_block(BlockId::number(number)).await?,
+            };
+
+            if parent_hash.is_none_or(|hash| hash == block.header.parent_hash) {
+                parent_hash = Some(block.header.hash);
+                self.recent.push_back(block);
+                number += 1;
+            } else {
+                // Reorg observed mid-init: discard and re-query the range. We
+                // will also need to re-fetch `latest`, as it may have been uncled.
+                parent_hash = None;
+                canonical_latest = None;
+                self.recent.clear();
+                number = safe + 1;
+            }
+        }
+
+        // Queue new-block updates for the recent blocks. When starting from a
+        // configured block, only emit those at or after it; earlier blocks (which
+        // occur when `start_block` is within the reorg window) are still retained
+        // for reorg detection.
+        for block in self.recent.iter().filter(|block| {
+            self.config
+                .start_block
+                .is_none_or(|start| block.header.number >= start)
+        }) {
+            self.queue.push_back(BlockUpdate::New {
+                number: block.header.number,
+                hash: block.header.hash,
+                logs_bloom: block.header.logs_bloom,
+            });
+        }
+
+        Ok(())
+    }
+
+    /// Updates the pending block to follow the given latest block.
+    fn update_next_pending_block(&mut self, number: u64, timestamp: u64) {
+        self.pending = PendingBlock {
+            number: number + 1,
+            timestamp_ms: timestamp * 1000 + self.config.block_time,
+        };
+    }
+}

--- a/crates/core/src/index/blocks.rs
+++ b/crates/core/src/index/blocks.rs
@@ -125,13 +125,13 @@ where
 
         self.update_next_pending_block(latest.header.number, latest.header.timestamp);
 
-        if let Some(last_indexed) = last_indexed_block {
+        if let Some(last_indexed_block) = last_indexed_block {
             // To guard against a reorg of a block right as the service restarted,
             // we always create a "fake" reorg `max_reorg_depth` deep to re-index
             // the last blocks before shutdown. Queue an uncle for the block right
             // after the last reorg-safe indexed block.
-            let uncle = (last_indexed + 1).saturating_sub(self.config.max_reorg_depth);
-            if uncle <= last_indexed {
+            let uncle = (last_indexed_block + 1).saturating_sub(self.config.max_reorg_depth);
+            if uncle <= last_indexed_block {
                 self.queue.push_back(BlockUpdate::Uncle { number: uncle });
             }
 
@@ -144,16 +144,16 @@ where
                     to: safe,
                 });
             }
-        } else if let Some(start) = self.config.start_block {
+        } else if let Some(start_block) = self.config.start_block
+            && start_block <= safe
+        {
             // Fresh start from a configured block: if possible back-fill via a
             // warp. Unlike resuming, there is no prior state, so do not emit a
             // fake reorg like we do when resuming.
-            if start <= safe {
-                self.queue.push_back(BlockUpdate::Warp {
-                    from: start,
-                    to: safe,
-                });
-            }
+            self.queue.push_back(BlockUpdate::Warp {
+                from: start_block,
+                to: safe,
+            });
         }
 
         // Query the recent blocks (those within the reorg window) so we can
@@ -197,7 +197,7 @@ where
         for block in self.recent.iter().filter(|block| {
             self.config
                 .start_block
-                .is_none_or(|start| block.header.number >= start)
+                .is_none_or(|start_block| block.header.number >= start_block)
         }) {
             self.queue.push_back(BlockUpdate::New {
                 number: block.header.number,

--- a/crates/core/src/index/mod.rs
+++ b/crates/core/src/index/mod.rs
@@ -2,4 +2,6 @@
 //! event logs in order, and handling chain reorgs.
 
 #[allow(dead_code)]
+mod blocks;
+#[allow(dead_code)]
 mod bloom;

--- a/epics/2026_06_09_safenet_core_crate.md
+++ b/epics/2026_06_09_safenet_core_crate.md
@@ -206,14 +206,17 @@ crates/core/
 
 ### Indexing (port of `validator/src/watcher/`, typed)
 
-- **`blocks.rs`** ← `blocks.ts`. `BlockWatcher` following the head: `BlockUpdate` enum
-  (`WarpToBlock { from, to }`, `UncleBlock { number }`, `NewBlock { number, hash, logs_bloom }`),
-  settings (`block_time`, `max_reorg_depth`), options (`block_propagation_delay`,
-  `block_retry_delays`, injectable timer), a recent-block ring buffer for parent-hash reorg
-  detection, `next()`, and `revalidate_last_block()` (handles RPC nodes that report a block but
-  not its logs). Includes the resume/fresh-start/warp init logic. The `block_retry_delays` poll
-  ("the next block isn't available yet") stays here; it is distinct from RPC rate-limit backoff,
-  which the provider's `RetryBackoffLayer` owns. Mirrors `blocks.test.ts`.
+- **`blocks.rs`** ← `blocks.ts`. `BlockWatcher` following the head, generic over an alloy
+  `Provider` and working with full alloy block types directly (rather than a TS-style minimal
+  block-source/`Block` projection). `BlockUpdate` enum (`WarpToBlock { from, to }`,
+  `UncleBlock { number }`, `NewBlock { number, hash, logs_bloom }`), a `Config`
+  (`block_time`, `max_reorg_depth`, `block_propagation_delay`, `block_retry_delays`, `start_block`),
+  a recent-block ring buffer for parent-hash reorg detection, `next()`, and
+  `revalidate_last_block()` (handles RPC nodes that report a block but not its logs). Includes the
+  resume/fresh-start/warp init logic; `start_block` comes from `Config` while the runtime resume
+  point (`last_indexed_block`) is a `create` parameter. The `block_retry_delays` poll ("the next
+  block isn't available yet") stays here; it is distinct from RPC rate-limit backoff, which the
+  provider's `RetryBackoffLayer` owns. Mirrors `blocks.test.ts`.
 - **`bloom.rs`** ← `utils/bloom.ts`. Thin helpers on `alloy_primitives::Bloom`: "can this block
   bloom possibly contain a watched (address, topic0)?" (topic0s derived from the typed event set)
   and "compute bloom from a log set" (for the all-logs integrity check).
@@ -322,9 +325,21 @@ ordering; everything else may proceed in parallel.
 
 - **C1 — Bloom helpers.** `index/bloom.rs` over `alloy_primitives::Bloom` + tests. Depends on A1.
   _(∥ C2)_
-- **C2 — BlockWatcher.** `index/blocks.rs` + tests. Depends on A1, A2. _(∥ C1)_ — if it exceeds the
-  size budget, split into C2a (types + chain-follow + reorg detection) and C2b (init/resume/warp +
-  `revalidate_last_block`).
+- **C2 — BlockWatcher.** `index/blocks.rs`. Depends on A1, A2. _(∥ C1)_ The watcher works directly
+  over an alloy `Provider` and full alloy block types (no bespoke block-source/`Block` projection
+  trait), and takes its `start_block` from `Config` rather than as a constructor parameter
+  (`last_indexed_block`, a runtime resume value, stays a parameter). Split into four PRs, since the
+  whole thing is well over the size budget:
+  - **C2a — Initialization.** Types (`Config`, `BlockUpdate`, `Error`), the `BlockWatcher` struct,
+    and `create`/init (latest fetch, resume "fake" reorg, fresh-start warp, recent-block fetch with
+    mid-init reorg restart).
+  - **C2b — Background task.** `next()` (pending-block wait/poll with `block_retry_delays` +
+    skipped-slot handling, reorg detection) and `revalidate_last_block()`.
+  - **C2c — Test mocking facilities.** Helpers for driving the watcher deterministically, built on
+    alloy's built-in mock provider (`ProviderBuilder::connect_mocked_client` + `Asserter`) rather
+    than a hand-rolled mock, paired with controllable time (`tokio::time` pause/advance).
+  - **C2d — Tests.** Port `blocks.test.ts` (init variants, retry/skip-slot timing, deep reorgs,
+    revalidate cases) onto the C2c facilities.
 - **C3 — EventWatcher (typed).** `index/events.rs` + tests; generic over a `sol!` event set via
   `SolEventInterface`. Depends on C1 — split into C3a (state machine + warp) and C3b (single-block
   fallback strategies + decoding) if needed.


### PR DESCRIPTION
This PR is the first piece towards porting the block watcher to Rust.

### Context and Motivation

The "phase C-2" which ports the block watcher to Rust needed to be split into multiple chunks for reviewability. This PR is the first piece which _just_ ports the initialization logic. In particular, this includes the startup requests to build:

- The queue of updates that will be produced on the first calls to `next` (warping, uncling, and canonical blocks)
- The recent blocks used for reorg detection.

The plan was also updated to include the expected 4 PRs for this sub-phase.

### Decisions and Tradeoffs

For now, the port is pretty much a 1:1 port of the TypeScript logic, with only a small difference (the starting block is considered a configuration option instead of a runtime initialization option).

### Testing

Compare with the initialization logic in the TypeScript version: https://github.com/safe-research/safenet/blob/e4cc8e5cf35fc5f28eede4e88224a3ec09ccf4e7/validator/src/watcher/blocks.ts#L95-L180

Properly mocked provider tests will be added in a follow up.

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://docs.safefoundation.org/cla).
