### PR TITLE
Implement Log Fetching

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3787,6 +3787,7 @@ name = "safenet-core"
 version = "0.2.0"
 dependencies = [
  "alloy",
+ "futures",
  "metrics",
  "metrics-exporter-prometheus",
  "serde",

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -6,6 +6,7 @@ publish = false
 
 [dependencies]
 alloy = { version = "2", features = ["full"] }
+futures = "0.3"
 metrics = "0.24"
 metrics-exporter-prometheus = "0.18"
 serde = { version = "1", features = ["derive"] }

--- a/crates/core/src/index/events.rs
+++ b/crates/core/src/index/events.rs
@@ -8,7 +8,7 @@
 use alloy::{
     primitives::{Address, B256},
     providers::Provider,
-    rpc::types::Log,
+    rpc::types::{Filter, Log},
     transports::TransportError,
 };
 use std::marker::PhantomData;
@@ -41,6 +41,40 @@ pub enum Error {
     DecodeLog(Option<B256>),
 }
 
+/// The blocks a log query is scoped to.
+#[derive(Clone, Copy, Debug)]
+enum BlockFilter {
+    /// A single block, identified by its hash.
+    Hash(B256),
+    /// An inclusive range of block numbers.
+    Range { from: u64, to: u64 },
+}
+
+impl BlockFilter {
+    /// Builds the base `eth_getLogs` filter scoped to these blocks.
+    fn into_filter(self) -> Filter {
+        match self {
+            BlockFilter::Hash(hash) => Filter::new().at_block_hash(hash),
+            BlockFilter::Range { from, to } => Filter::new().from_block(from).to_block(to),
+        }
+    }
+}
+
+/// How to fetch the logs for a set of blocks.
+#[derive(Clone, Copy, Debug)]
+enum Fetch {
+    /// A single query for all watched events, filtered by the node.
+    SingleQuery(BlockFilter),
+    /// One query per watched event, filtered by the node. Queries less data per
+    /// request than [`SingleQuery`](Fetch::SingleQuery), for nodes that cap the
+    /// response size.
+    MultipleQueries(BlockFilter),
+    /// A single query for all of a block's logs, filtered by the client. Hedges
+    /// against nodes that fail to serve a block's filtered logs reliably, at the
+    /// cost of fetching every log in the block.
+    ClientFiltered(B256),
+}
+
 /// Watches for the logs of the events `E` emitted by a set of addresses.
 pub struct EventWatcher<P, E> {
     provider: P,
@@ -62,6 +96,46 @@ where
             topics: E::topics(),
             _events: PhantomData,
         }
+    }
+
+    /// Fetches the watched logs for some blocks using the given strategy,
+    /// returning them decoded and in `(block_number, log_index)` order.
+    async fn fetch_logs(&self, fetch: Fetch) -> Result<Vec<E>, Error> {
+        let logs = match fetch {
+            Fetch::SingleQuery(blocks) => {
+                let filter = blocks
+                    .into_filter()
+                    .address(self.addresses.clone())
+                    .event_signature(self.topics.clone());
+                self.provider.get_logs(&filter).await?
+            }
+            Fetch::MultipleQueries(blocks) => {
+                futures::future::try_join_all(self.topics.iter().map(|topic| async move {
+                    let filter = blocks
+                        .into_filter()
+                        .address(self.addresses.clone())
+                        .event_signature(*topic);
+                    self.provider.get_logs(&filter).await
+                }))
+                .await?
+                .concat()
+            }
+            Fetch::ClientFiltered(hash) => {
+                let filter = BlockFilter::Hash(hash).into_filter();
+                self.provider
+                    .get_logs(&filter)
+                    .await?
+                    .into_iter()
+                    .filter(|log| {
+                        self.addresses.contains(&log.address())
+                            && log
+                                .topic0()
+                                .is_some_and(|topic| self.topics.contains(topic))
+                    })
+                    .collect()
+            }
+        };
+        decode_and_sort(logs)
     }
 }
 
@@ -149,8 +223,18 @@ macro_rules! watcher_events {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use alloy::{primitives::Address, sol, sol_types::SolEvent, uint};
+    use alloy::{
+        primitives::{Address, address},
+        providers::{ProviderBuilder, RootProvider},
+        sol,
+        sol_types::SolEvent,
+        transports::mock::Asserter,
+        uint,
+    };
     use std::assert_matches;
+
+    const WATCHED: Address = address!("0x1111111111111111111111111111111111111111");
+    const OTHER: Address = address!("0x2222222222222222222222222222222222222222");
 
     sol! {
         #[derive(Debug, Default, Eq, PartialEq)]
@@ -163,6 +247,11 @@ mod tests {
         contract Erc721 {
             event Transfer(address indexed from, address indexed to, uint256 indexed tokenId);
             event Approval(address indexed owner, address indexed approved, uint256 indexed tokenId);
+        }
+
+        #[derive(Debug, Default, Eq, PartialEq)]
+        contract Weth {
+            event Deposit(address indexed dst, uint256 wad);
         }
     }
 
@@ -182,13 +271,18 @@ mod tests {
     {
         Log {
             inner: alloy::primitives::Log {
-                address: Address::ZERO,
+                address: WATCHED,
                 data: event.encode_log_data(),
             },
             block_number: Some(block_number),
             log_index: Some(log_index),
             ..Default::default()
         }
+    }
+
+    fn watcher(asserter: &Asserter) -> EventWatcher<RootProvider, Erc20::Erc20Events> {
+        let provider = ProviderBuilder::default().connect_mocked_client(asserter.clone());
+        EventWatcher::new(provider, vec![WATCHED])
     }
 
     #[test]
@@ -286,5 +380,158 @@ mod tests {
                 })),
             ]
         );
+    }
+
+    #[tokio::test]
+    async fn single_query_fetches_all_events_at_once() {
+        let asserter = Asserter::new();
+        let events = watcher(&asserter);
+
+        asserter.push_success(&vec![
+            log(
+                (2, 0),
+                Erc20::Transfer {
+                    amount: uint!(1_U256),
+                    ..Default::default()
+                },
+            ),
+            log(
+                (1, 1),
+                Erc20::Approval {
+                    amount: uint!(2_U256),
+                    ..Default::default()
+                },
+            ),
+        ]);
+
+        let logs = events
+            .fetch_logs(Fetch::SingleQuery(BlockFilter::Range { from: 1, to: 2 }))
+            .await
+            .unwrap();
+
+        assert_eq!(
+            logs,
+            [
+                Erc20::Erc20Events::Approval(Erc20::Approval {
+                    amount: uint!(2_U256),
+                    ..Default::default()
+                }),
+                Erc20::Erc20Events::Transfer(Erc20::Transfer {
+                    amount: uint!(1_U256),
+                    ..Default::default()
+                }),
+            ]
+        );
+        assert!(asserter.read_q().is_empty());
+    }
+
+    #[tokio::test]
+    async fn multiple_queries_fetches_one_event_per_query() {
+        let asserter = Asserter::new();
+        let events = watcher(&asserter);
+
+        asserter.push_success(&vec![log(
+            (2, 0),
+            Erc20::Transfer {
+                amount: uint!(1_U256),
+                ..Default::default()
+            },
+        )]);
+        asserter.push_success(&vec![log(
+            (1, 1),
+            Erc20::Approval {
+                amount: uint!(2_U256),
+                ..Default::default()
+            },
+        )]);
+
+        let logs = events
+            .fetch_logs(Fetch::MultipleQueries(BlockFilter::Range {
+                from: 1,
+                to: 2,
+            }))
+            .await
+            .unwrap();
+
+        // Both responses are consumed (one query per event) and merged in order.
+        assert_eq!(
+            logs,
+            [
+                Erc20::Erc20Events::Approval(Erc20::Approval {
+                    amount: uint!(2_U256),
+                    ..Default::default()
+                }),
+                Erc20::Erc20Events::Transfer(Erc20::Transfer {
+                    amount: uint!(1_U256),
+                    ..Default::default()
+                }),
+            ]
+        );
+        assert!(asserter.read_q().is_empty());
+    }
+
+    #[tokio::test]
+    async fn client_filtered_filters_logs_by_address_and_event() {
+        let asserter = Asserter::new();
+        let events = watcher(&asserter);
+
+        // A single query returns every log in the block; the watcher keeps only
+        // those from a watched address with a watched event.
+        asserter.push_success(&vec![
+            log(
+                (1, 0),
+                Erc20::Transfer {
+                    amount: uint!(1_U256),
+                    ..Default::default()
+                },
+            ),
+            // Watched event, but from an unwatched address.
+            {
+                let mut log = log(
+                    (1, 1),
+                    Erc20::Transfer {
+                        amount: uint!(2_U256),
+                        ..Default::default()
+                    },
+                );
+                log.inner.address = OTHER;
+                log
+            },
+            // Watched address, but an unwatched event.
+            log(
+                (1, 2),
+                Weth::Deposit {
+                    wad: uint!(3_U256),
+                    ..Default::default()
+                },
+            ),
+            log(
+                (1, 3),
+                Erc20::Approval {
+                    amount: uint!(4_U256),
+                    ..Default::default()
+                },
+            ),
+        ]);
+
+        let logs = events
+            .fetch_logs(Fetch::ClientFiltered(B256::repeat_byte(0x42)))
+            .await
+            .unwrap();
+
+        assert_eq!(
+            logs,
+            [
+                Erc20::Erc20Events::Transfer(Erc20::Transfer {
+                    amount: uint!(1_U256),
+                    ..Default::default()
+                }),
+                Erc20::Erc20Events::Approval(Erc20::Approval {
+                    amount: uint!(4_U256),
+                    ..Default::default()
+                }),
+            ]
+        );
+        assert!(asserter.read_q().is_empty());
     }
 }


### PR DESCRIPTION
This PR adds the log fetching methods used by the events watcher.

### Context and Motivation

It implements the same 3 log fetching methods that are implemented by the TypeScript port:
- A single query for all logs
- A query per log
- A query for all logs for a block, with local filtering

### Decisions and Tradeoffs

This PR _just_ implements the fetching mechanisms. We will introduce the additional protections (against nodes silently dropping logs when there are too many, and returning empty logs even if there are some) in a follow up PR (as the added logic, configuration, and tests would make it too hard to review).

### Testing

Added some tests that verify the logic.

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://docs.safefoundation.org/cla).
