### PR TITLE
Log Fetching Client-Side Error Detection

### DIFF
--- a/crates/core/src/index/bloom.rs
+++ b/crates/core/src/index/bloom.rs
@@ -5,7 +5,10 @@
 //! positives but never false negatives, so a negative result lets the indexer
 //! skip fetching a block's logs entirely.
 
-use alloy::primitives::{Address, B256, Bloom, BloomInput};
+use alloy::{
+    primitives::{Address, B256, Bloom, BloomInput},
+    rpc::types::Log,
+};
 
 /// Returns whether a block with the given `logs_bloom` may contain a log the
 /// indexer cares about: one emitted by any of the watched `addresses` whose
@@ -29,6 +32,11 @@ pub fn may_contain_log(bloom: &Bloom, addresses: &[Address], topics: &[B256]) ->
             .any(|topic| bloom.contains_input(BloomInput::Raw(topic.as_slice())))
     };
     contains_at_least_one_address() && contains_at_least_one_topic()
+}
+
+/// Computes the bloom filter for some logs.
+pub fn compute_logs_bloom(logs: &[Log]) -> Bloom {
+    alloy::primitives::logs_bloom(logs.iter().map(|log| &log.inner))
 }
 
 #[cfg(test)]

--- a/crates/core/src/index/events.rs
+++ b/crates/core/src/index/events.rs
@@ -5,6 +5,7 @@
 //! macro over `alloy` `sol!`-generated `*Events` enums, yielding a type that
 //! implements [`Events`] which the watcher decodes raw logs into.
 
+use super::bloom;
 use alloy::{
     primitives::{Address, B256, Bloom},
     providers::Provider,
@@ -168,7 +169,7 @@ where
 
                 // Verify the node served a complete set of logs for the block by
                 // recomputing the bloom filter over every returned log.
-                if compute_logs_bloom(&logs) != logs_bloom {
+                if bloom::compute_logs_bloom(&logs) != logs_bloom {
                     return Err(Error::IncompleteLogs { block_hash });
                 }
 
@@ -217,11 +218,6 @@ where
             })
         })
         .collect()
-}
-
-/// Computes the bloom filter for some logs.
-fn compute_logs_bloom(logs: &[Log]) -> Bloom {
-    alloy::primitives::logs_bloom(logs.iter().map(|log| &log.inner))
 }
 
 /// Defines an [`Events`] type that decodes logs for one or more `alloy`
@@ -591,7 +587,7 @@ mod tests {
         let logs = events
             .fetch_logs(Fetch::ClientFiltered {
                 block_hash: B256::repeat_byte(0x42),
-                logs_bloom: compute_logs_bloom(&logs),
+                logs_bloom: bloom::compute_logs_bloom(&logs),
             })
             .await
             .unwrap();

--- a/crates/core/src/index/events.rs
+++ b/crates/core/src/index/events.rs
@@ -6,12 +6,12 @@
 //! implements [`Events`] which the watcher decodes raw logs into.
 
 use alloy::{
-    primitives::{Address, B256},
+    primitives::{Address, B256, Bloom},
     providers::Provider,
     rpc::types::{Filter, Log},
     transports::TransportError,
 };
-use std::marker::PhantomData;
+use std::{collections::BTreeSet, marker::PhantomData, num::NonZeroUsize};
 
 /// A typed set of EVM events that raw logs can be decoded into.
 ///
@@ -30,6 +30,18 @@ pub trait Events: Sized {
     fn decode_log(topics: &[B256], data: &[u8]) -> Option<Self>;
 }
 
+/// Event watcher configuration.
+#[derive(Clone, Debug, Default)]
+pub struct Config {
+    /// The maximum number of logs a single query is expected to return. A query
+    /// returning at least this many is treated as potentially truncated by the
+    /// node and raises an error. `None` disables the check.
+    pub max_logs_per_query: Option<NonZeroUsize>,
+    /// The topic0 of events that may be dropped on failure rather than
+    /// propagating the error. Use this to mark events as noncritical.
+    pub fallible_events: BTreeSet<B256>,
+}
+
 /// Error produced by the event watcher.
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
@@ -37,8 +49,16 @@ pub enum Error {
     #[error(transparent)]
     Rpc(#[from] TransportError),
     /// An error decoding a log into an event.
-    #[error("failed to decode log with topic0 {0:?}")]
-    DecodeLog(Option<B256>),
+    #[error("failed to decode log index {log_index} on block {block_hash:?}")]
+    DecodeLog { block_hash: B256, log_index: u64 },
+    /// A query returned at least `max_logs_per_query` logs, so the node may have
+    /// silently dropped some.
+    #[error("query returned at least the maximum number of logs, some may have been dropped")]
+    TooManyLogs,
+    /// The logs returned for a block did not match its bloom filter, indicating
+    /// the node served an incomplete set.
+    #[error("logs for block {block_hash:?} do not match the block bloom filter")]
+    IncompleteLogs { block_hash: B256 },
 }
 
 /// The blocks a log query is scoped to.
@@ -62,6 +82,10 @@ impl BlockFilter {
 
 /// How to fetch the logs for a set of blocks.
 #[derive(Clone, Copy, Debug)]
+// NOTE: The large enum variant warning is there because of the `logs_bloom`
+// field on the `ClientFiltered` variant. The enum is short-lived and passed by
+// value into a single call, so boxing the bloom would not be beneficial.
+#[allow(clippy::large_enum_variant)]
 enum Fetch {
     /// A single query for all watched events, filtered by the node.
     SingleQuery(BlockFilter),
@@ -69,15 +93,17 @@ enum Fetch {
     /// request than [`SingleQuery`](Fetch::SingleQuery), for nodes that cap the
     /// response size.
     MultipleQueries(BlockFilter),
-    /// A single query for all of a block's logs, filtered by the client. Hedges
-    /// against nodes that fail to serve a block's filtered logs reliably, at the
-    /// cost of fetching every log in the block.
-    ClientFiltered(B256),
+    /// A single query for all of a block's logs, filtered by the client and
+    /// verified against the block's bloom filter. Hedges against nodes that fail
+    /// to serve a block's filtered logs reliably, at the cost of fetching every
+    /// log in the block.
+    ClientFiltered { block_hash: B256, logs_bloom: Bloom },
 }
 
 /// Watches for the logs of the events `E` emitted by a set of addresses.
 pub struct EventWatcher<P, E> {
     provider: P,
+    config: Config,
     addresses: Vec<Address>,
     topics: Vec<B256>,
     _events: PhantomData<fn() -> E>,
@@ -89,9 +115,10 @@ where
     E: Events,
 {
     /// Creates an event watcher for the events `E` emitted by `addresses`.
-    pub fn new(provider: P, addresses: Vec<Address>) -> Self {
+    pub fn new(provider: P, config: Config, addresses: Vec<Address>) -> Self {
         Self {
             provider,
+            config,
             addresses,
             topics: E::topics(),
             _events: PhantomData,
@@ -107,25 +134,45 @@ where
                     .into_filter()
                     .address(self.addresses.clone())
                     .event_signature(self.topics.clone());
-                self.provider.get_logs(&filter).await?
+                let logs = self.provider.get_logs(&filter).await?;
+                self.check_logs_limit(logs)?
             }
             Fetch::MultipleQueries(blocks) => {
                 futures::future::try_join_all(self.topics.iter().map(|topic| async move {
-                    let filter = blocks
-                        .into_filter()
-                        .address(self.addresses.clone())
-                        .event_signature(*topic);
-                    self.provider.get_logs(&filter).await
+                    let result: Result<Vec<Log>, Error> = async {
+                        let filter = blocks
+                            .into_filter()
+                            .address(self.addresses.clone())
+                            .event_signature(*topic);
+                        let logs = self.provider.get_logs(&filter).await?;
+                        self.check_logs_limit(logs)
+                    }
+                    .await;
+
+                    // A failed query for a non-critical event is dropped rather
+                    // than failing the whole fetch.
+                    match result {
+                        Err(_) if self.config.fallible_events.contains(topic) => Ok(Vec::new()),
+                        result => result,
+                    }
                 }))
                 .await?
                 .concat()
             }
-            Fetch::ClientFiltered(hash) => {
-                let filter = BlockFilter::Hash(hash).into_filter();
-                self.provider
-                    .get_logs(&filter)
-                    .await?
-                    .into_iter()
+            Fetch::ClientFiltered {
+                block_hash,
+                logs_bloom,
+            } => {
+                let filter = BlockFilter::Hash(block_hash).into_filter();
+                let logs = self.provider.get_logs(&filter).await?;
+
+                // Verify the node served a complete set of logs for the block by
+                // recomputing the bloom filter over every returned log.
+                if compute_logs_bloom(&logs) != logs_bloom {
+                    return Err(Error::IncompleteLogs { block_hash });
+                }
+
+                logs.into_iter()
                     .filter(|log| {
                         self.addresses.contains(&log.address())
                             && log
@@ -136,6 +183,18 @@ where
             }
         };
         decode_and_sort(logs)
+    }
+
+    /// Guards against nodes that silently cap the number of returned logs: a
+    /// query returning at least `max_logs_per_query` logs is assumed to have
+    /// dropped some.
+    fn check_logs_limit(&self, logs: Vec<Log>) -> Result<Vec<Log>, Error> {
+        if let Some(max) = self.config.max_logs_per_query
+            && logs.len() >= max.get()
+        {
+            return Err(Error::TooManyLogs);
+        }
+        Ok(logs)
     }
 }
 
@@ -148,10 +207,21 @@ where
     logs.sort_unstable_by_key(|log| (log.block_number, log.log_index));
     logs.iter()
         .map(|log| {
-            E::decode_log(log.topics(), &log.data().data)
-                .ok_or_else(|| Error::DecodeLog(log.topic0().copied()))
+            E::decode_log(log.topics(), &log.data().data).ok_or_else(|| Error::DecodeLog {
+                // This is an unfortunate typing quirk of `alloy`, but we
+                // should never have a log without a block hash or index set.
+                // If we do, its not the end of the world, and we would just
+                // report an error with weird data.
+                block_hash: log.block_hash.unwrap_or(B256::repeat_byte(0xff)),
+                log_index: log.log_index.unwrap_or(u64::MAX),
+            })
         })
         .collect()
+}
+
+/// Computes the bloom filter for some logs.
+fn compute_logs_bloom(logs: &[Log]) -> Bloom {
+    alloy::primitives::logs_bloom(logs.iter().map(|log| &log.inner))
 }
 
 /// Defines an [`Events`] type that decodes logs for one or more `alloy`
@@ -280,9 +350,12 @@ mod tests {
         }
     }
 
-    fn watcher(asserter: &Asserter) -> EventWatcher<RootProvider, Erc20::Erc20Events> {
+    fn watcher(
+        asserter: &Asserter,
+        config: Config,
+    ) -> EventWatcher<RootProvider, Erc20::Erc20Events> {
         let provider = ProviderBuilder::default().connect_mocked_client(asserter.clone());
-        EventWatcher::new(provider, vec![WATCHED])
+        EventWatcher::new(provider, config, vec![WATCHED])
     }
 
     #[test]
@@ -359,7 +432,7 @@ mod tests {
 
         assert_matches!(
             decode_and_sort::<Erc20::Erc20Events>(logs.clone()),
-            Err(Error::DecodeLog(topic0)) if topic0 == Some(Erc721::Transfer::SIGNATURE_HASH)
+            Err(Error::DecodeLog { log_index, .. }) if log_index == 1
         );
 
         let events = decode_and_sort::<TokenEvents>(logs).unwrap();
@@ -385,7 +458,7 @@ mod tests {
     #[tokio::test]
     async fn single_query_fetches_all_events_at_once() {
         let asserter = Asserter::new();
-        let events = watcher(&asserter);
+        let events = watcher(&asserter, Config::default());
 
         asserter.push_success(&vec![
             log(
@@ -428,7 +501,7 @@ mod tests {
     #[tokio::test]
     async fn multiple_queries_fetches_one_event_per_query() {
         let asserter = Asserter::new();
-        let events = watcher(&asserter);
+        let events = watcher(&asserter, Config::default());
 
         asserter.push_success(&vec![log(
             (2, 0),
@@ -473,11 +546,11 @@ mod tests {
     #[tokio::test]
     async fn client_filtered_filters_logs_by_address_and_event() {
         let asserter = Asserter::new();
-        let events = watcher(&asserter);
+        let events = watcher(&asserter, Config::default());
 
         // A single query returns every log in the block; the watcher keeps only
         // those from a watched address with a watched event.
-        asserter.push_success(&vec![
+        let logs = vec![
             log(
                 (1, 0),
                 Erc20::Transfer {
@@ -512,10 +585,14 @@ mod tests {
                     ..Default::default()
                 },
             ),
-        ]);
+        ];
+        asserter.push_success(&logs);
 
         let logs = events
-            .fetch_logs(Fetch::ClientFiltered(B256::repeat_byte(0x42)))
+            .fetch_logs(Fetch::ClientFiltered {
+                block_hash: B256::repeat_byte(0x42),
+                logs_bloom: compute_logs_bloom(&logs),
+            })
             .await
             .unwrap();
 
@@ -533,5 +610,170 @@ mod tests {
             ]
         );
         assert!(asserter.read_q().is_empty());
+    }
+
+    #[tokio::test]
+    async fn single_query_errors_when_too_many_logs() {
+        let asserter = Asserter::new();
+        let events = watcher(
+            &asserter,
+            Config {
+                max_logs_per_query: Some(NonZeroUsize::new(10).unwrap()),
+                ..Default::default()
+            },
+        );
+
+        // The query returns as many logs as the limit, so some may be missing.
+        asserter.push_success(&vec![
+            log(
+                (1, 0),
+                Erc20::Transfer {
+                    amount: uint!(1_U256),
+                    ..Default::default()
+                },
+            );
+            10
+        ]);
+
+        assert_matches!(
+            events
+                .fetch_logs(Fetch::SingleQuery(BlockFilter::Range { from: 1, to: 1 }))
+                .await,
+            Err(Error::TooManyLogs)
+        );
+    }
+
+    #[tokio::test]
+    async fn multiple_queries_errors_when_a_query_returns_too_many_logs() {
+        let asserter = Asserter::new();
+        let events = watcher(
+            &asserter,
+            Config {
+                max_logs_per_query: Some(NonZeroUsize::new(10).unwrap()),
+                ..Default::default()
+            },
+        );
+
+        // Each per-event query returns as many logs as the limit.
+        asserter.push_success(&vec![
+            log(
+                (1, 0),
+                Erc20::Transfer {
+                    amount: uint!(1_U256),
+                    ..Default::default()
+                },
+            );
+            10
+        ]);
+        asserter.push_success(&vec![log(
+            (1, 1),
+            Erc20::Approval {
+                amount: uint!(2_U256),
+                ..Default::default()
+            },
+        )]);
+
+        assert_matches!(
+            events
+                .fetch_logs(Fetch::MultipleQueries(BlockFilter::Range {
+                    from: 1,
+                    to: 1
+                }))
+                .await,
+            Err(Error::TooManyLogs)
+        );
+    }
+
+    #[tokio::test]
+    async fn multiple_queries_propagates_a_failed_query() {
+        let asserter = Asserter::new();
+        let events = watcher(&asserter, Config::default());
+
+        asserter.push_failure_msg("query failed");
+        asserter.push_success(&vec![log(
+            (1, 0),
+            Erc20::Approval {
+                amount: uint!(1_U256),
+                ..Default::default()
+            },
+        )]);
+
+        assert_matches!(
+            events
+                .fetch_logs(Fetch::MultipleQueries(BlockFilter::Range {
+                    from: 1,
+                    to: 1
+                }))
+                .await,
+            Err(Error::Rpc(_))
+        );
+    }
+
+    #[tokio::test]
+    async fn multiple_queries_drops_fallible_events() {
+        let asserter = Asserter::new();
+        let events = watcher(
+            &asserter,
+            Config {
+                fallible_events: BTreeSet::from([Erc20::Transfer::SIGNATURE_HASH]),
+                ..Default::default()
+            },
+        );
+
+        for topic in <Erc20::Erc20Events as Events>::topics() {
+            if topic == Erc20::Transfer::SIGNATURE_HASH {
+                asserter.push_failure_msg("transfer query failed");
+            } else {
+                asserter.push_success(&vec![log(
+                    (1, 0),
+                    Erc20::Approval {
+                        amount: uint!(7_U256),
+                        ..Default::default()
+                    },
+                )]);
+            }
+        }
+
+        let logs = events
+            .fetch_logs(Fetch::MultipleQueries(BlockFilter::Range {
+                from: 1,
+                to: 1,
+            }))
+            .await
+            .unwrap();
+
+        // The failed `Transfer` query is dropped, leaving only the `Approval`.
+        assert_eq!(
+            logs,
+            [Erc20::Erc20Events::Approval(Erc20::Approval {
+                amount: uint!(7_U256),
+                ..Default::default()
+            })]
+        );
+        assert!(asserter.read_q().is_empty());
+    }
+
+    #[tokio::test]
+    async fn client_filtered_errors_when_logs_do_not_match_bloom() {
+        let asserter = Asserter::new();
+        let events = watcher(&asserter, Config::default());
+
+        asserter.push_success(&vec![log(
+            (1, 0),
+            Erc20::Transfer {
+                amount: uint!(1_U256),
+                ..Default::default()
+            },
+        )]);
+
+        assert_matches!(
+            events
+                .fetch_logs(Fetch::ClientFiltered {
+                    block_hash: B256::repeat_byte(0x42),
+                    logs_bloom: Bloom::repeat_byte(0xcd),
+                })
+                .await,
+            Err(Error::IncompleteLogs { block_hash }) if block_hash == B256::repeat_byte(0x42)
+        );
     }
 }


### PR DESCRIPTION
This ports the client-side error detection strategies from the TypeScript logs fetcher.

### Context and Motivation

We can detect node `eth_getLogs` bad behaviour in some cases and produce errors in the event watcher. Unfortunately, this happens often enough that it is worth porting this logic over to Rust in order to maintain a reliable event stream.

### Decisions and Tradeoffs

I reworked some of the errors to be more helpful. In particular, we error with the block and log index when we fail to decode (making it easier to pinpoint the log in a block explorer for example).

### Testing

Tested the new error conditions, the log fetching logic should now match the TypeScript implementation: https://github.com/safe-research/safenet/blob/86d5d0fada3a19d2c6a3f3b5b6ba585702a29206/validator/src/watcher/events.ts#L111-L218

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://docs.safefoundation.org/cla).
