### PR TITLE
Implement Watcher

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -28,6 +28,7 @@ dependencies = [
  "alloy-core",
  "alloy-eips",
  "alloy-genesis",
+ "alloy-json-rpc",
  "alloy-network",
  "alloy-provider",
  "alloy-pubsub",

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -19,4 +19,5 @@ tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt", "json"]
 url = { version = "2", features = ["serde"] }
 
 [dev-dependencies]
+alloy = { version = "2", features = ["json-rpc"] }
 tokio = { version = "1", features = ["test-util"] }

--- a/crates/core/src/index/blocks.rs
+++ b/crates/core/src/index/blocks.rs
@@ -104,7 +104,7 @@ where
     /// reorg that happened while the service was down is re-indexed. Otherwise,
     /// when `Config::start_block` is set, it back-fills from there via a warp
     /// without a (fake) reorg.
-    pub async fn create(
+    pub async fn new(
         provider: P,
         config: Config,
         last_indexed_block: Option<u64>,
@@ -413,7 +413,7 @@ mod tests {
         for number in (1000 - config.max_reorg_depth + 1)..1000 {
             asserter.push_success(&block(number));
         }
-        let mut blocks = BlockWatcher::create(mock_provider(asserter), config, None)
+        let mut blocks = BlockWatcher::new(mock_provider(asserter), config, None)
             .await
             .unwrap();
         let _ = blocks.ready();
@@ -428,7 +428,7 @@ mod tests {
         // historic block fetched on startup for reorg detection
         asserter.push_success(&block(999));
 
-        let mut blocks = BlockWatcher::create(mock_provider(&asserter), config(), None)
+        let mut blocks = BlockWatcher::new(mock_provider(&asserter), config(), None)
             .await
             .unwrap();
 
@@ -448,7 +448,7 @@ mod tests {
         asserter.push_success(&block(1000));
         asserter.push_success(&block(999));
 
-        let mut blocks = BlockWatcher::create(mock_provider(&asserter), config(), Some(900))
+        let mut blocks = BlockWatcher::new(mock_provider(&asserter), config(), Some(900))
             .await
             .unwrap();
 
@@ -470,7 +470,7 @@ mod tests {
         asserter.push_success(&block(1000));
         asserter.push_success(&block(999));
 
-        let mut blocks = BlockWatcher::create(
+        let mut blocks = BlockWatcher::new(
             mock_provider(&asserter),
             Config {
                 start_block: Some(900),
@@ -498,7 +498,7 @@ mod tests {
         asserter.push_success(&block(1000));
         asserter.push_success(&block(999));
 
-        let mut blocks = BlockWatcher::create(
+        let mut blocks = BlockWatcher::new(
             mock_provider(&asserter),
             Config {
                 start_block: Some(999),
@@ -524,7 +524,7 @@ mod tests {
         asserter.push_success(&block(1000));
         asserter.push_success(&block(999));
 
-        let mut blocks = BlockWatcher::create(
+        let mut blocks = BlockWatcher::new(
             mock_provider(&asserter),
             Config {
                 start_block: Some(1000),
@@ -546,7 +546,7 @@ mod tests {
         let asserter = Asserter::new();
         asserter.push_success(&block(1000));
 
-        let mut blocks = BlockWatcher::create(
+        let mut blocks = BlockWatcher::new(
             mock_provider(&asserter),
             Config {
                 max_reorg_depth: 0,
@@ -582,7 +582,7 @@ mod tests {
         asserter.push_success(&block(999));
         asserter.push_success(&block(1000));
 
-        let mut blocks = BlockWatcher::create(
+        let mut blocks = BlockWatcher::new(
             mock_provider(&asserter),
             Config {
                 max_reorg_depth: 3,
@@ -806,7 +806,7 @@ mod tests {
         asserter.push_success(&block(1000));
         asserter.push_success(&block(998));
         asserter.push_success(&block(999));
-        let mut blocks = BlockWatcher::create(
+        let mut blocks = BlockWatcher::new(
             mock_provider(&asserter),
             Config {
                 max_reorg_depth: 3,

--- a/crates/core/src/index/mod.rs
+++ b/crates/core/src/index/mod.rs
@@ -1,10 +1,356 @@
 //! Indexing of onchain blocks and events: following the chain head, fetching
 //! event logs in order, and handling chain reorgs.
 
-#[allow(dead_code)]
-mod blocks;
+pub mod blocks;
 #[allow(dead_code)]
 mod bloom;
 mod clock;
-#[allow(dead_code)]
-mod events;
+pub mod events;
+
+use alloy::{primitives::Address, providers::Provider, rpc::types::error::EthRpcErrorCode};
+use blocks::BlockWatcher;
+use events::{EventWatcher, Events};
+
+pub use blocks::BlockUpdate;
+
+/// Watcher configuration, aggregating the block and event watcher configs.
+#[derive(Clone, Debug)]
+pub struct Config {
+    /// Block watcher configuration.
+    pub blocks: blocks::Config,
+    /// Event watcher configuration.
+    pub events: events::Config,
+}
+
+/// Error produced by the [`Watcher`].
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+    /// An error from the block watcher.
+    #[error(transparent)]
+    Blocks(#[from] blocks::Error),
+    /// An error from the event watcher.
+    #[error(transparent)]
+    Events(#[from] events::Error),
+}
+
+/// An update produced by the [`Watcher`].
+#[derive(Clone, Debug, PartialEq, Eq)]
+// NOTE: The large enum variant warning is there because of the `logs_bloom`
+// carried by the `Block` variant. Both variants are produced about as often, and
+// the value is consumed immediately, so boxing would not be beneficial.
+#[allow(clippy::large_enum_variant)]
+pub enum Update<E> {
+    /// The chain head advanced, warped over a range, or reorged.
+    Block(BlockUpdate),
+    /// A nonempty batch of decoded event logs, in `(block_number, log_index)`
+    /// order.
+    Logs(Vec<E>),
+}
+
+/// Watches the chain head and the logs of the events `E`, producing an ordered
+/// stream of [`Update`]s.
+pub struct Watcher<P, E> {
+    blocks: BlockWatcher<P>,
+    events: EventWatcher<P, E>,
+}
+
+impl<P, E> Watcher<P, E>
+where
+    P: Provider + Clone,
+    E: Events,
+{
+    /// Creates and initializes a watcher for the events `E` emitted by
+    /// `addresses`, resuming from `last_indexed_block` (see
+    /// [`BlockWatcher::create`]).
+    pub async fn create(
+        provider: P,
+        config: Config,
+        addresses: Vec<Address>,
+        last_indexed_block: Option<u64>,
+    ) -> Result<Self, Error> {
+        let blocks =
+            BlockWatcher::create(provider.clone(), config.blocks, last_indexed_block).await?;
+        let events = EventWatcher::new(provider, config.events, addresses);
+        Ok(Self { blocks, events })
+    }
+
+    /// Produces the next watcher update.
+    ///
+    /// Returns the next batch of logs or blocks and waits for a new block to
+    /// be mined.
+    pub async fn next(&mut self) -> Result<Update<E>, Error> {
+        loop {
+            let update = match self.next_logs().await? {
+                // The query produced nothing for us; keep draining.
+                Some(logs) if logs.is_empty() => continue,
+                Some(logs) => Update::Logs(logs),
+                None => {
+                    // The event watcher is drained, so advance the chain head and
+                    // hand the update to the event watcher to fetch its logs from.
+                    let update = self.blocks.next().await?;
+                    self.events.on_block_update(update.clone())?;
+                    Update::Block(update)
+                }
+            };
+            return Ok(update);
+        }
+    }
+
+    /// Fetches the next batch of logs, recovering from a node that exposed a
+    /// block it then cannot serve logs for by checking whether it was uncled.
+    async fn next_logs(&mut self) -> Result<Option<Vec<E>>, Error> {
+        match self.events.next().await {
+            Ok(logs) => Ok(logs),
+            Err(err) if is_resource_not_found(&err) => {
+                // Some RPC nodes will see an uncled block but not support querying
+                // logs for it (for example, Reth). Ask the `BlockWatcher` to revalidate
+                // the last block it produced and make sure it is still canonical.
+                match self.blocks.revalidate_last_block().await? {
+                    // It was uncled; tell the event watcher to move on.
+                    Some(invalidated) => {
+                        self.events.on_block_invalidated(invalidated.hash)?;
+                        Ok(None)
+                    }
+                    // It is still canonical; the logs just are not available yet.
+                    None => Err(err.into()),
+                }
+            }
+            Err(err) => Err(err.into()),
+        }
+    }
+}
+
+/// Whether an event watcher failure was caused by a JSON-RPC "resource not
+/// found" error. See [EIP-1474](https://eips.ethereum.org/EIPS/eip-1474).
+fn is_resource_not_found(err: &events::Error) -> bool {
+    matches!(
+        err,
+        events::Error::Rpc(rpc)
+            if rpc.as_error_resp().is_some_and(|payload| payload.code
+                == EthRpcErrorCode::ResourceNotFound.code() as i64)
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::watcher_events;
+    use alloy::{
+        consensus,
+        primitives::{Address, B256, Bloom, U256, address},
+        providers::{ProviderBuilder, RootProvider},
+        rpc::{
+            json_rpc::ErrorPayload,
+            types::{Block, Header, Log},
+        },
+        sol,
+        sol_types::SolEvent,
+        transports::mock::Asserter,
+    };
+
+    const WATCHED: Address = address!("0x1111111111111111111111111111111111111111");
+
+    sol! {
+        #[derive(Debug, Default, Eq, PartialEq)]
+        contract Weth {
+            event Deposit(address indexed dst, uint256 wad);
+        }
+    }
+
+    watcher_events!(Weth::WethEvents);
+
+    fn config() -> Config {
+        Config {
+            blocks: blocks::Config {
+                block_time: 2_000,
+                block_propagation_delay: 500,
+                block_retry_delays: vec![],
+                max_reorg_depth: 3,
+                start_block: None,
+            },
+            events: Default::default(),
+        }
+    }
+
+    async fn watcher(
+        asserter: &Asserter,
+        config: Config,
+        last_indexed_block: Option<u64>,
+    ) -> Watcher<RootProvider, Weth::WethEvents> {
+        let provider = ProviderBuilder::default().connect_mocked_client(asserter.clone());
+        Watcher::create(provider, config, vec![WATCHED], last_indexed_block)
+            .await
+            .unwrap()
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn emits_block_updates_then_their_logs() {
+        let asserter = Asserter::new();
+
+        asserter.push_success(&block(1000));
+        asserter.push_success(&block(998));
+        asserter.push_success(&block(999));
+        let mut watcher = watcher(&asserter, config(), Some(850)).await;
+
+        assert_eq!(
+            watcher.next().await.unwrap(),
+            Update::Block(BlockUpdate::Uncle { number: 848 })
+        );
+        assert_eq!(
+            watcher.next().await.unwrap(),
+            Update::Block(BlockUpdate::Warp { from: 848, to: 997 })
+        );
+
+        // Log query from range 848..=947
+        asserter.push_success(&vec![log(weth_deposit(1))]);
+        assert_eq!(
+            watcher.next().await.unwrap(),
+            logs_update([weth_deposit(1)])
+        );
+
+        // Log query from range 948..=997
+        asserter.push_success(&vec![log(weth_deposit(2))]);
+        assert_eq!(
+            watcher.next().await.unwrap(),
+            logs_update([weth_deposit(2)])
+        );
+
+        assert_eq!(watcher.next().await.unwrap(), new_block_update(998));
+
+        asserter.push_success(&vec![log(weth_deposit(3))]);
+        assert_eq!(
+            watcher.next().await.unwrap(),
+            logs_update([weth_deposit(3)])
+        );
+
+        assert_eq!(watcher.next().await.unwrap(), new_block_update(999));
+
+        asserter.push_success(&vec![log(weth_deposit(4))]);
+        assert_eq!(
+            watcher.next().await.unwrap(),
+            logs_update([weth_deposit(4)])
+        );
+
+        assert_eq!(watcher.next().await.unwrap(), new_block_update(1000));
+
+        asserter.push_success(&vec![log(weth_deposit(5))]);
+        assert_eq!(
+            watcher.next().await.unwrap(),
+            logs_update([weth_deposit(5)])
+        );
+
+        // Fetch another block from the RPC node.
+        asserter.push_success(&block(1001));
+        assert_eq!(watcher.next().await.unwrap(), new_block_update(1001));
+
+        asserter.push_success(&vec![log(weth_deposit(6))]);
+        assert_eq!(
+            watcher.next().await.unwrap(),
+            logs_update([weth_deposit(6)])
+        );
+
+        assert!(asserter.read_q().is_empty());
+    }
+
+    #[tokio::test]
+    async fn recovers_from_an_uncled_block_with_unavailable_logs() {
+        let asserter = Asserter::new();
+        asserter.push_success(&block(1000));
+
+        let mut watcher = watcher(
+            &asserter,
+            {
+                let mut config = config();
+                config.blocks.max_reorg_depth = 1;
+                config
+            },
+            None,
+        )
+        .await;
+
+        // The new block is emitted first.
+        assert_eq!(
+            watcher.next().await.unwrap(),
+            Update::Block(BlockUpdate::New {
+                number: 1000,
+                hash: block_hash(1000),
+                logs_bloom: block_bloom(1000),
+            })
+        );
+
+        // The node exposed the block but cannot serve its logs...
+        asserter.push_failure(ErrorPayload {
+            code: -32001,
+            message: "resource not found".into(),
+            data: None,
+        });
+        // ...and revalidation finds it was uncled (a different hash at that
+        // height now).
+        asserter.push_success(&{
+            let mut block = block(1000);
+            block.header.hash = B256::repeat_byte(0x42);
+            block
+        });
+
+        // So the watcher emits the uncle instead of any logs.
+        assert_eq!(
+            watcher.next().await.unwrap(),
+            Update::Block(BlockUpdate::Uncle { number: 1000 })
+        );
+    }
+
+    fn block(number: u64) -> Block {
+        Block::empty(Header {
+            hash: block_hash(number),
+            inner: consensus::Header {
+                parent_hash: number.checked_sub(1).map(block_hash).unwrap_or_default(),
+                number,
+                timestamp: number * 2,
+                logs_bloom: block_bloom(number),
+                ..Default::default()
+            },
+            ..Default::default()
+        })
+    }
+
+    fn block_hash(number: u64) -> B256 {
+        let mut bytes = [0; 32];
+        bytes[24..].copy_from_slice(&number.to_be_bytes());
+        B256::from(bytes)
+    }
+
+    fn block_bloom(number: u64) -> Bloom {
+        let mut bytes = [0; 256];
+        bytes[248..].copy_from_slice(&number.to_be_bytes());
+        Bloom::from(bytes)
+    }
+
+    fn new_block_update<E>(number: u64) -> Update<E> {
+        Update::Block(BlockUpdate::New {
+            number,
+            hash: block_hash(number),
+            logs_bloom: block_bloom(number),
+        })
+    }
+
+    fn log(event: impl SolEvent) -> Log {
+        Log {
+            inner: alloy::primitives::Log {
+                address: WATCHED,
+                data: event.encode_log_data(),
+            },
+            ..Default::default()
+        }
+    }
+
+    fn weth_deposit(wad: u64) -> Weth::Deposit {
+        Weth::Deposit {
+            wad: U256::from(wad),
+            ..Default::default()
+        }
+    }
+
+    fn logs_update(logs: impl IntoIterator<Item = Weth::Deposit>) -> Update<Weth::WethEvents> {
+        Update::Logs(logs.into_iter().map(Weth::WethEvents::Deposit).collect())
+    }
+}

--- a/crates/core/src/index/mod.rs
+++ b/crates/core/src/index/mod.rs
@@ -61,15 +61,14 @@ where
 {
     /// Creates and initializes a watcher for the events `E` emitted by
     /// `addresses`, resuming from `last_indexed_block` (see
-    /// [`BlockWatcher::create`]).
-    pub async fn create(
+    /// [`BlockWatcher::new`]).
+    pub async fn new(
         provider: P,
         config: Config,
         addresses: Vec<Address>,
         last_indexed_block: Option<u64>,
     ) -> Result<Self, Error> {
-        let blocks =
-            BlockWatcher::create(provider.clone(), config.blocks, last_indexed_block).await?;
+        let blocks = BlockWatcher::new(provider.clone(), config.blocks, last_indexed_block).await?;
         let events = EventWatcher::new(provider, config.events, addresses);
         Ok(Self { blocks, events })
     }
@@ -81,16 +80,17 @@ where
     pub async fn next(&mut self) -> Result<Update<E>, Error> {
         loop {
             let update = match self.next_logs().await? {
-                // The query produced nothing for us; keep draining.
-                Some(logs) if logs.is_empty() => continue,
-                Some(logs) => Update::Logs(logs),
+                // The event watcher is drained, so advance the chain head and
+                // hand the update to the event watcher to fetch its logs from.
                 None => {
-                    // The event watcher is drained, so advance the chain head and
-                    // hand the update to the event watcher to fetch its logs from.
                     let update = self.blocks.next().await?;
                     self.events.on_block_update(update.clone())?;
                     Update::Block(update)
                 }
+                // The query produced logs, return them as an update.
+                Some(logs) if !logs.is_empty() => Update::Logs(logs),
+                // The query produced nothing for us; keep draining.
+                _ => continue,
             };
             return Ok(update);
         }
@@ -178,7 +178,7 @@ mod tests {
         last_indexed_block: Option<u64>,
     ) -> Watcher<RootProvider, Weth::WethEvents> {
         let provider = ProviderBuilder::default().connect_mocked_client(asserter.clone());
-        Watcher::create(provider, config, vec![WATCHED], last_indexed_block)
+        Watcher::new(provider, config, vec![WATCHED], last_indexed_block)
             .await
             .unwrap()
     }


### PR DESCRIPTION
This PR hooks up the block and event watchers to make the top level watcher used by the services.

### Decisions and Tradeoffs

Unlike in TypeScript, we don't need the "start" function, the background worker, or subscriptions. We can trivially turn the watcher into a `std::futures::Stream` of updates using `tokio` helper methods, that we can chain with the handler. This simplifies the code, and makes it easier to compose :tada:.

### Testing

Added tests to verify the block invalidation logic. The logic should match the TypeScript implementation: https://github.com/safe-research/safenet/blob/86d5d0fada3a19d2c6a3f3b5b6ba585702a29206/validator/src/watcher/index.ts#L60-L108

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://docs.safefoundation.org/cla).
