### PR TITLE
Database Storage Layer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4255,6 +4255,8 @@ dependencies = [
  "sha2 0.10.9",
  "smallvec",
  "thiserror",
+ "tokio",
+ "tokio-stream",
  "tracing",
  "url",
 ]
@@ -4294,6 +4296,7 @@ dependencies = [
  "sqlx-sqlite",
  "syn 2.0.117",
  "thiserror",
+ "tokio",
  "url",
 ]
 

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -11,7 +11,7 @@ metrics = "0.24"
 metrics-exporter-prometheus = "0.18"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-sqlx = { version = "0.9", features = ["sqlite"] }
+sqlx = { version = "0.9", features = ["sqlite", "runtime-tokio"] }
 thiserror = "2"
 tokio = { version = "1", features = ["full"] }
 tracing = "0.1"

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -12,3 +12,4 @@
 
 pub mod index;
 pub mod observability;
+pub mod state;

--- a/crates/core/src/state/mod.rs
+++ b/crates/core/src/state/mod.rs
@@ -1,0 +1,7 @@
+//! Reorg-aware state management with persistent storage.
+//!
+//! This module provides helpers for managing service state in a way that
+//! supports pure state transitions with filesystem backed storage with roll
+//! backs in case of reorgs.
+
+pub mod storage;

--- a/crates/core/src/state/storage.rs
+++ b/crates/core/src/state/storage.rs
@@ -36,7 +36,7 @@ pub enum Error {
 /// Generic over a serializable state value `S`, stored as JSON.
 pub struct SnapshotStore<S> {
     pool: SqlitePool,
-    _state: PhantomData<fn() -> S>,
+    _state: PhantomData<S>,
 }
 
 impl<S> SnapshotStore<S>
@@ -214,6 +214,8 @@ mod tests {
         ));
         // The failed rollback did not delete the snapshots above the target.
         assert_eq!(store.current().await.unwrap(), Some((3, state(30))));
+        // Block 2 is still in the store.
+        assert_eq!(store.reorg(3).await.unwrap(), (2, state(20)));
     }
 
     #[tokio::test]

--- a/crates/core/src/state/storage.rs
+++ b/crates/core/src/state/storage.rs
@@ -67,12 +67,14 @@ where
     /// On startup this is the resume point: the block number is the indexer's
     /// last indexed block.
     pub async fn current(&self) -> Result<Option<(u64, S)>, Error> {
-        sqlx::query_as::<_, (u64, String)>(
+        sqlx::query_as::<_, (i64, String)>(
             "SELECT block_number, state FROM snapshots ORDER BY block_number DESC LIMIT 1",
         )
         .fetch_optional(&self.pool)
         .await?
-        .map(|(block_number, state)| Ok((block_number, serde_json::from_str(&state)?)))
+        .map(|(block_number, state)| {
+            Ok((u64::try_from(block_number)?, serde_json::from_str(&state)?))
+        })
         .transpose()
     }
 
@@ -84,7 +86,7 @@ where
             "INSERT INTO snapshots (block_number, state) VALUES (?, ?)
              ON CONFLICT (block_number) DO UPDATE SET state = excluded.state",
         )
-        .bind(block_number as i64)
+        .bind(i64::try_from(block_number)?)
         .bind(state)
         .execute(&self.pool)
         .await?;
@@ -123,7 +125,7 @@ where
     /// a reorg can still roll back to it.
     pub async fn prune(&self, safe_block: u64) -> Result<(), Error> {
         sqlx::query("DELETE FROM snapshots WHERE block_number < ?")
-            .bind(safe_block as i64)
+            .bind(i64::try_from(safe_block)?)
             .execute(&self.pool)
             .await?;
         Ok(())

--- a/crates/core/src/state/storage.rs
+++ b/crates/core/src/state/storage.rs
@@ -94,12 +94,12 @@ where
     }
 
     /// Rolls the store back, discarding `uncle` and every snapshot above it, and
-    /// returns the restored state at its parent.
+    /// returns the parent block number and its restored state.
     ///
     /// Used to recover from a reorg, where `uncle` was removed from the canonical
     /// chain. Errors with [`Error::MissingSnapshot`] if there is no snapshot at
     /// the parent of `uncle`, leaving the store unchanged.
-    pub async fn reorg(&self, uncle: u64) -> Result<S, Error> {
+    pub async fn reorg(&self, uncle: u64) -> Result<(u64, S), Error> {
         let parent = uncle.checked_sub(1).ok_or(Error::BlockNumberOverflow)?;
 
         // Only commit the deletion once we know the target snapshot exists and
@@ -117,7 +117,7 @@ where
                 .ok_or_else(|| Error::MissingSnapshot(parent))?;
         let state = serde_json::from_str(&state)?;
         tx.commit().await?;
-        Ok(state)
+        Ok((parent, state))
     }
 
     /// Removes snapshots below `safe_block`, which the indexer has determined can
@@ -194,7 +194,7 @@ mod tests {
         store.commit(3, &state(30)).await.unwrap();
 
         // A reorg uncles blocks 2 and 3; roll back to the common ancestor.
-        assert_eq!(store.reorg(2).await.unwrap(), state(10));
+        assert_eq!(store.reorg(2).await.unwrap(), (1, state(10)));
         assert_eq!(store.current().await.unwrap(), Some((1, state(10))));
 
         // Re-apply forward on the new canonical chain.
@@ -226,7 +226,7 @@ mod tests {
         store.prune(2).await.unwrap();
 
         // Block 1 is gone; the safe block and above remain.
-        assert_eq!(store.reorg(3).await.unwrap(), state(20));
+        assert_eq!(store.reorg(3).await.unwrap(), (2, state(20)));
         assert!(matches!(
             store.reorg(2).await,
             Err(Error::MissingSnapshot(1))

--- a/crates/core/src/state/storage.rs
+++ b/crates/core/src/state/storage.rs
@@ -1,0 +1,232 @@
+//! Reorg-aware persistent storage for service state.
+//!
+//! Safenet services derive their state by indexing the chain. That state must
+//! survive restarts and, because the chain head can reorg, be able to roll back
+//! to an earlier block. [`SnapshotStore`] provides both by keeping a bounded
+//! history of per-block state snapshots in SQLite.
+//!
+//! Each indexed block's state is committed as a snapshot keyed by block number
+//! A rollback restores the snapshot at the reorg's common ancestor and discards
+//! everything above it. Snapshots below a `safe` block are pruned.
+
+use serde::{Serialize, de::DeserializeOwned};
+use sqlx::sqlite::SqlitePool;
+use std::{marker::PhantomData, num::TryFromIntError};
+
+/// Error produced by the [`SnapshotStore`].
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+    /// A database operation failed.
+    #[error(transparent)]
+    Database(#[from] sqlx::Error),
+    /// A snapshot's state could not be serialized or deserialized.
+    #[error("failed to serialize or deserialize snapshot state")]
+    Serialization(#[from] serde_json::Error),
+    /// An arithmetic overflow in block number computations.
+    #[error("arithmetic overflow in block number computation")]
+    BlockNumberOverflow,
+    /// A rollback targeted a block with no snapshot, so the state could not be
+    /// restored.
+    #[error("no snapshot found at block {0}")]
+    MissingSnapshot(u64),
+}
+
+/// A reorg-aware store of per-block state snapshots, backed by SQLite.
+///
+/// Generic over a serializable state value `S`, stored as JSON.
+pub struct SnapshotStore<S> {
+    pool: SqlitePool,
+    _state: PhantomData<fn() -> S>,
+}
+
+impl<S> SnapshotStore<S>
+where
+    S: Serialize + DeserializeOwned,
+{
+    /// Opens the store described by `config`, creating the snapshot table if it
+    /// does not already exist.
+    pub async fn new(pool: SqlitePool) -> Result<Self, Error> {
+        sqlx::query(
+            "CREATE TABLE IF NOT EXISTS snapshots (
+                 block_number INTEGER PRIMARY KEY,
+                 state        TEXT    NOT NULL
+             )",
+        )
+        .execute(&pool)
+        .await?;
+
+        Ok(Self {
+            pool,
+            _state: PhantomData,
+        })
+    }
+
+    /// Returns the tip snapshot (the one with the highest block number) and its
+    /// block number, or `None` when the store is empty.
+    ///
+    /// On startup this is the resume point: the block number is the indexer's
+    /// last indexed block.
+    pub async fn current(&self) -> Result<Option<(u64, S)>, Error> {
+        sqlx::query_as::<_, (u64, String)>(
+            "SELECT block_number, state FROM snapshots ORDER BY block_number DESC LIMIT 1",
+        )
+        .fetch_optional(&self.pool)
+        .await?
+        .map(|(block_number, state)| Ok((block_number, serde_json::from_str(&state)?)))
+        .transpose()
+    }
+
+    /// Records `state` as the snapshot for `block_number`, replacing any existing
+    /// snapshot at that block.
+    pub async fn commit(&self, block_number: u64, state: &S) -> Result<(), Error> {
+        let state = serde_json::to_string(state)?;
+        sqlx::query(
+            "INSERT INTO snapshots (block_number, state) VALUES (?, ?)
+             ON CONFLICT (block_number) DO UPDATE SET state = excluded.state",
+        )
+        .bind(block_number as i64)
+        .bind(state)
+        .execute(&self.pool)
+        .await?;
+        Ok(())
+    }
+
+    /// Rolls the store back, discarding `uncle` and every snapshot above it.
+    /// Returns the restored state.
+    ///
+    /// Used to recover from a reorg, where `block_number` was removed from the
+    /// canonical chain. Errors with [`Error::MissingSnapshot`] if there is no
+    /// snapshot before `block_number`, leaving the store unchanged.
+    pub async fn reorg(&self, uncle: u64) -> Result<S, Error> {
+        let parent = uncle.checked_sub(1).ok_or(Error::BlockNumberOverflow)?;
+
+        // Only commit the deletion once we know the target snapshot exists and
+        // decodes; otherwise the transaction is dropped and rolled back.
+        let mut tx = self.pool.begin().await?;
+        sqlx::query("DELETE FROM snapshots WHERE block_number >= ?")
+            .bind(i64::try_from(uncle)?)
+            .execute(&mut *tx)
+            .await?;
+        let (state,) =
+            sqlx::query_as::<_, (String,)>("SELECT state FROM snapshots WHERE block_number = ?")
+                .bind(i64::try_from(parent)?)
+                .fetch_optional(&mut *tx)
+                .await?
+                .ok_or_else(|| Error::MissingSnapshot(parent))?;
+        let state = serde_json::from_str(&state)?;
+        tx.commit().await?;
+        Ok(state)
+    }
+
+    /// Removes snapshots below `safe_block`, which the indexer has determined can
+    /// no longer be reorged. Snapshots from `safe_block` upward are retained, so
+    /// a reorg can still roll back to it.
+    pub async fn prune(&self, safe_block: u64) -> Result<(), Error> {
+        sqlx::query("DELETE FROM snapshots WHERE block_number < ?")
+            .bind(safe_block as i64)
+            .execute(&self.pool)
+            .await?;
+        Ok(())
+    }
+}
+
+impl From<TryFromIntError> for Error {
+    fn from(_: TryFromIntError) -> Self {
+        Self::BlockNumberOverflow
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde::Deserialize;
+    use sqlx::sqlite::SqlitePoolOptions;
+
+    #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+    struct State {
+        value: u64,
+    }
+
+    fn state(value: u64) -> State {
+        State { value }
+    }
+
+    async fn store() -> SnapshotStore<State> {
+        let pool = SqlitePoolOptions::new()
+            .connect_with("sqlite::memory:".parse().unwrap())
+            .await
+            .unwrap();
+        SnapshotStore::new(pool).await.unwrap()
+    }
+
+    #[tokio::test]
+    async fn current_is_none_when_empty() {
+        let store = store().await;
+        assert_eq!(store.current().await.unwrap(), None);
+    }
+
+    #[tokio::test]
+    async fn commits_and_reads_back_the_tip() {
+        let store = store().await;
+        store.commit(1, &state(10)).await.unwrap();
+        store.commit(2, &state(20)).await.unwrap();
+
+        assert_eq!(store.current().await.unwrap(), Some((2, state(20))));
+    }
+
+    #[tokio::test]
+    async fn commit_replaces_an_existing_snapshot() {
+        let store = store().await;
+        store.commit(1, &state(10)).await.unwrap();
+        store.commit(1, &state(11)).await.unwrap();
+
+        assert_eq!(store.current().await.unwrap(), Some((1, state(11))));
+    }
+
+    #[tokio::test]
+    async fn reorgs_a_block_and_re_applies() {
+        let store = store().await;
+        store.commit(1, &state(10)).await.unwrap();
+        store.commit(2, &state(20)).await.unwrap();
+        store.commit(3, &state(30)).await.unwrap();
+
+        // A reorg uncles blocks 2 and 3; roll back to the common ancestor.
+        assert_eq!(store.reorg(2).await.unwrap(), state(10));
+        assert_eq!(store.current().await.unwrap(), Some((1, state(10))));
+
+        // Re-apply forward on the new canonical chain.
+        store.commit(2, &state(21)).await.unwrap();
+        assert_eq!(store.current().await.unwrap(), Some((2, state(21))));
+    }
+
+    #[tokio::test]
+    async fn rollback_to_a_missing_block_errors_and_leaves_the_store_unchanged() {
+        let store = store().await;
+        store.commit(2, &state(20)).await.unwrap();
+        store.commit(3, &state(30)).await.unwrap();
+
+        assert!(matches!(
+            store.reorg(2).await,
+            Err(Error::MissingSnapshot(1))
+        ));
+        // The failed rollback did not delete the snapshots above the target.
+        assert_eq!(store.current().await.unwrap(), Some((3, state(30))));
+    }
+
+    #[tokio::test]
+    async fn prunes_snapshots_below_the_safe_block() {
+        let store = store().await;
+        store.commit(1, &state(10)).await.unwrap();
+        store.commit(2, &state(20)).await.unwrap();
+        store.commit(3, &state(30)).await.unwrap();
+
+        store.prune(2).await.unwrap();
+
+        // Block 1 is gone; the safe block and above remain.
+        assert_eq!(store.reorg(3).await.unwrap(), state(20));
+        assert!(matches!(
+            store.reorg(2).await,
+            Err(Error::MissingSnapshot(1))
+        ));
+    }
+}

--- a/crates/core/src/state/storage.rs
+++ b/crates/core/src/state/storage.rs
@@ -5,7 +5,7 @@
 //! to an earlier block. [`SnapshotStore`] provides both by keeping a bounded
 //! history of per-block state snapshots in SQLite.
 //!
-//! Each indexed block's state is committed as a snapshot keyed by block number
+//! Each indexed block's state is committed as a snapshot keyed by block number.
 //! A rollback restores the snapshot at the reorg's common ancestor and discards
 //! everything above it. Snapshots below a `safe` block are pruned.
 
@@ -43,8 +43,8 @@ impl<S> SnapshotStore<S>
 where
     S: Serialize + DeserializeOwned,
 {
-    /// Opens the store described by `config`, creating the snapshot table if it
-    /// does not already exist.
+    /// Creates a store backed by `pool`, creating the snapshot table if it does
+    /// not already exist.
     pub async fn new(pool: SqlitePool) -> Result<Self, Error> {
         sqlx::query(
             "CREATE TABLE IF NOT EXISTS snapshots (
@@ -93,12 +93,12 @@ where
         Ok(())
     }
 
-    /// Rolls the store back, discarding `uncle` and every snapshot above it.
-    /// Returns the restored state.
+    /// Rolls the store back, discarding `uncle` and every snapshot above it, and
+    /// returns the restored state at its parent.
     ///
-    /// Used to recover from a reorg, where `block_number` was removed from the
-    /// canonical chain. Errors with [`Error::MissingSnapshot`] if there is no
-    /// snapshot before `block_number`, leaving the store unchanged.
+    /// Used to recover from a reorg, where `uncle` was removed from the canonical
+    /// chain. Errors with [`Error::MissingSnapshot`] if there is no snapshot at
+    /// the parent of `uncle`, leaving the store unchanged.
     pub async fn reorg(&self, uncle: u64) -> Result<S, Error> {
         let parent = uncle.checked_sub(1).ok_or(Error::BlockNumberOverflow)?;
 
@@ -155,6 +155,7 @@ mod tests {
 
     async fn store() -> SnapshotStore<State> {
         let pool = SqlitePoolOptions::new()
+            .max_connections(1)
             .connect_with("sqlite::memory:".parse().unwrap())
             .await
             .unwrap();
@@ -202,7 +203,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn rollback_to_a_missing_block_errors_and_leaves_the_store_unchanged() {
+    async fn reorg_with_a_missing_parent_errors_and_leaves_the_store_unchanged() {
         let store = store().await;
         store.commit(2, &state(20)).await.unwrap();
         store.commit(3, &state(30)).await.unwrap();


### PR DESCRIPTION
This PR implements a simple filesystem storage for recording state updates, in a way that allows for rollbacks in case of reorgs.

### Decisions and Tradeoffs

For absolute simplicity and trivial correctness, we implemented a system with snapshots, where we store the full state for each block. Older blocks can be pruned in order to prevent unbounded growth of the state database.

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://docs.safefoundation.org/cla).
