### PR TITLE
Additional Information to Subscribers

### DIFF
--- a/crates/core/src/index/blocks.rs
+++ b/crates/core/src/index/blocks.rs
@@ -76,6 +76,9 @@ pub enum BlockUpdate {
         number: u64,
         hash: B256,
         logs_bloom: Bloom,
+        /// The highest block that can no longer reorg. State at or below it is
+        /// final, so older snapshots may be pruned.
+        safe: u64,
     },
 }
 
@@ -253,20 +256,11 @@ where
                 number: block.header.number,
                 hash: block.header.hash,
                 logs_bloom: block.header.logs_bloom,
+                safe,
             });
         }
 
         Ok(())
-    }
-
-    /// Gets the highest block that can no longer be reorged. State at or below
-    /// it is considered final by the block indexer.
-    pub fn safe_block(&self) -> u64 {
-        self.recent
-            .front()
-            .map(|block| block.header.number)
-            .unwrap_or(self.pending.number)
-            .saturating_sub(1)
     }
 
     /// Retrieves all ready updates without blocking.
@@ -322,23 +316,34 @@ where
             });
         }
 
+        let number = block.header.number;
+        let hash = block.header.hash;
+        let logs_bloom = block.header.logs_bloom;
+
         // Record the new block, keeping at most `max_reorg_depth` recent blocks,
         // and advance the pending block.
-        let update = BlockUpdate::New {
-            number: block.header.number,
-            hash: block.header.hash,
-            logs_bloom: block.header.logs_bloom,
-        };
         self.update_next_pending_block(block.header.number, block.header.timestamp);
         self.recent.push_back(block);
-
         // TODO: This should be replaced by `VecDeque::truncate_front` once the
         // API stabilizes.
         while self.recent.len() as u64 > self.config.max_reorg_depth {
             self.recent.pop_front();
         }
 
-        Ok(update)
+        // Compute the updated safe block
+        let safe = self
+            .recent
+            .front()
+            .map(|block| block.header.number)
+            .unwrap_or(self.pending.number)
+            .saturating_sub(1);
+
+        Ok(BlockUpdate::New {
+            number,
+            hash,
+            logs_bloom,
+            safe,
+        })
     }
 
     /// Re-validates that the last seen block is still canonical on the connected
@@ -435,9 +440,8 @@ where
 
 #[cfg(test)]
 mod tests {
-    use crate::index::clock;
-
     use super::*;
+    use crate::index::clock;
     use alloy::{
         primitives::keccak256,
         providers::{ProviderBuilder, RootProvider},
@@ -512,8 +516,8 @@ mod tests {
         assert_eq!(
             blocks.ready().collect::<Vec<_>>(),
             [
-                new_block_update(&block(999)),
-                new_block_update(&block(1000))
+                new_block_update(&block(999), 998),
+                new_block_update(&block(1000), 998)
             ]
         );
         assert!(asserter.read_q().is_empty());
@@ -534,8 +538,8 @@ mod tests {
             [
                 BlockUpdate::Uncle { number: 899 },
                 BlockUpdate::Warp { from: 899, to: 998 },
-                new_block_update(&block(999)),
-                new_block_update(&block(1000)),
+                new_block_update(&block(999), 998),
+                new_block_update(&block(1000), 998),
             ]
         );
         assert!(asserter.read_q().is_empty());
@@ -562,8 +566,8 @@ mod tests {
             blocks.ready().collect::<Vec<_>>(),
             [
                 BlockUpdate::Warp { from: 900, to: 998 },
-                new_block_update(&block(999)),
-                new_block_update(&block(1000)),
+                new_block_update(&block(999), 998),
+                new_block_update(&block(1000), 998),
             ]
         );
         assert!(asserter.read_q().is_empty());
@@ -589,8 +593,8 @@ mod tests {
         assert_eq!(
             blocks.ready().collect::<Vec<_>>(),
             [
-                new_block_update(&block(999)),
-                new_block_update(&block(1000))
+                new_block_update(&block(999), 998),
+                new_block_update(&block(1000), 998)
             ]
         );
     }
@@ -614,7 +618,7 @@ mod tests {
 
         assert_eq!(
             blocks.ready().collect::<Vec<_>>(),
-            [new_block_update(&block(1000))]
+            [new_block_update(&block(1000), 998)]
         );
     }
 
@@ -673,9 +677,9 @@ mod tests {
         assert_eq!(
             blocks.ready().collect::<Vec<_>>(),
             [
-                new_block_update(&block(998)),
-                new_block_update(&block(999)),
-                new_block_update(&block(1000)),
+                new_block_update(&block(998), 997),
+                new_block_update(&block(999), 997),
+                new_block_update(&block(1000), 997),
             ]
         );
         assert!(asserter.read_q().is_empty());
@@ -692,7 +696,7 @@ mod tests {
         asserter.push_success(&next_block.clone());
 
         let update = blocks.next().await.unwrap();
-        assert_eq!(update, new_block_update(&next_block));
+        assert_eq!(update, new_block_update(&next_block, 999));
         assert_eq!(
             start.elapsed(),
             Duration::from_millis(blocks.block_time + config.block_propagation_delay)
@@ -714,7 +718,7 @@ mod tests {
         asserter.push_success(&block(1002));
 
         let update = blocks.next().await.unwrap();
-        assert_eq!(update, new_block_update(&block(1001)));
+        assert_eq!(update, new_block_update(&block(1001), 999));
         assert_eq!(
             start.elapsed(),
             Duration::from_millis(
@@ -726,7 +730,7 @@ mod tests {
         );
 
         let update = blocks.next().await.unwrap();
-        assert_eq!(update, new_block_update(&block(1002)));
+        assert_eq!(update, new_block_update(&block(1002), 1000));
         // This is a bit counter-intuitive, but delays are relative to a
         // _target_ block time. This means that for the second block, since we
         // only needed to retry once, we will be at start plus two block times
@@ -760,7 +764,7 @@ mod tests {
         asserter.push_success(&block(1001));
 
         let update = blocks.next().await.unwrap();
-        assert_eq!(update, new_block_update(&block(1001)));
+        assert_eq!(update, new_block_update(&block(1001), 999));
         assert_eq!(
             start.elapsed(),
             Duration::from_millis(
@@ -825,10 +829,13 @@ mod tests {
             blocks.next().await.unwrap(),
             BlockUpdate::Uncle { number: 998 }
         );
-        assert_eq!(blocks.next().await.unwrap(), new_block_update(&reorg_998));
         assert_eq!(
             blocks.next().await.unwrap(),
-            new_block_update(&canonical_999)
+            new_block_update(&reorg_998, 995)
+        );
+        assert_eq!(
+            blocks.next().await.unwrap(),
+            new_block_update(&canonical_999, 995)
         );
         assert!(asserter.read_q().is_empty());
     }
@@ -894,8 +901,14 @@ mod tests {
         .await
         .unwrap();
 
-        assert_eq!(blocks.next().await.unwrap(), new_block_update(&block(998)));
-        assert_eq!(blocks.next().await.unwrap(), new_block_update(&block(999)));
+        assert_eq!(
+            blocks.next().await.unwrap(),
+            new_block_update(&block(998), 997)
+        );
+        assert_eq!(
+            blocks.next().await.unwrap(),
+            new_block_update(&block(999), 997)
+        );
 
         asserter.push_success(&block_with(999, |header| {
             header.hash = keccak256("new999");
@@ -911,40 +924,11 @@ mod tests {
         );
     }
 
-    #[tokio::test]
-    async fn safe_block_is_the_deepest_reorg_rollback_target() {
-        let asserter = Asserter::new();
-        let blocks = initialized_watcher_skip_ready(&asserter, config()).await;
-
-        // The reorg window is [999, 1000] (max_reorg_depth = 2), so the deepest
-        // reorg uncles 999 and rolls back to 998 -- the highest final block.
-        assert_eq!(blocks.safe_block(), 998);
-    }
-
     #[tokio::test(start_paused = true)]
-    async fn safe_block_does_not_change_during_reorg() {
-        let asserter = Asserter::new();
-        let mut blocks = initialized_watcher_skip_ready(&asserter, config()).await;
-
-        let safe_block = blocks.safe_block();
-
-        asserter.push_success(&block_with(1001, |header| {
-            header.hash = keccak256("reorg1001");
-            header.parent_hash = keccak256("reorg1000");
-        }));
-
-        assert_eq!(
-            blocks.next().await.unwrap(),
-            BlockUpdate::Uncle { number: 1000 }
-        );
-        assert_eq!(blocks.safe_block(), safe_block);
-    }
-
-    #[tokio::test]
     async fn safe_block_without_reorg_protection_is_the_last_indexed_block() {
         let asserter = Asserter::new();
         asserter.push_success(&block(1000));
-        let blocks = BlockWatcher::new(
+        let mut blocks = BlockWatcher::new(
             mock_provider(&asserter),
             Config {
                 max_reorg_depth: 0,
@@ -956,7 +940,11 @@ mod tests {
         .unwrap();
 
         // With no reorg window, the latest block is final immediately.
-        assert_eq!(blocks.safe_block(), 1000);
+        asserter.push_success(&block(1001));
+        assert_eq!(
+            blocks.next().await.unwrap(),
+            new_block_update(&block(1001), 1001)
+        );
     }
 
     fn block_hash(number: u64) -> B256 {
@@ -997,11 +985,12 @@ mod tests {
         Block::empty(header)
     }
 
-    fn new_block_update(block: &Block) -> BlockUpdate {
+    fn new_block_update(block: &Block, safe: u64) -> BlockUpdate {
         BlockUpdate::New {
             number: block.header.number,
             hash: block.header.hash,
             logs_bloom: block.header.logs_bloom,
+            safe,
         }
     }
 

--- a/crates/core/src/index/blocks.rs
+++ b/crates/core/src/index/blocks.rs
@@ -259,6 +259,16 @@ where
         Ok(())
     }
 
+    /// Gets the highest block that can no longer be reorged. State at or below
+    /// it is considered final by the block indexer.
+    pub fn safe_block(&self) -> u64 {
+        self.recent
+            .front()
+            .map(|block| block.header.number)
+            .unwrap_or(self.pending.number)
+            .saturating_sub(1)
+    }
+
     /// Retrieves all ready updates without blocking.
     pub fn ready(&mut self) -> impl Iterator<Item = BlockUpdate> + '_ {
         self.queue.drain(..)
@@ -899,6 +909,54 @@ mod tests {
             blocks.ready().collect::<Vec<_>>(),
             vec![BlockUpdate::Uncle { number: 999 }]
         );
+    }
+
+    #[tokio::test]
+    async fn safe_block_is_the_deepest_reorg_rollback_target() {
+        let asserter = Asserter::new();
+        let blocks = initialized_watcher_skip_ready(&asserter, config()).await;
+
+        // The reorg window is [999, 1000] (max_reorg_depth = 2), so the deepest
+        // reorg uncles 999 and rolls back to 998 -- the highest final block.
+        assert_eq!(blocks.safe_block(), 998);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn safe_block_does_not_change_during_reorg() {
+        let asserter = Asserter::new();
+        let mut blocks = initialized_watcher_skip_ready(&asserter, config()).await;
+
+        let safe_block = blocks.safe_block();
+
+        asserter.push_success(&block_with(1001, |header| {
+            header.hash = keccak256("reorg1001");
+            header.parent_hash = keccak256("reorg1000");
+        }));
+
+        assert_eq!(
+            blocks.next().await.unwrap(),
+            BlockUpdate::Uncle { number: 1000 }
+        );
+        assert_eq!(blocks.safe_block(), safe_block);
+    }
+
+    #[tokio::test]
+    async fn safe_block_without_reorg_protection_is_the_last_indexed_block() {
+        let asserter = Asserter::new();
+        asserter.push_success(&block(1000));
+        let blocks = BlockWatcher::new(
+            mock_provider(&asserter),
+            Config {
+                max_reorg_depth: 0,
+                ..config()
+            },
+            None,
+        )
+        .await
+        .unwrap();
+
+        // With no reorg window, the latest block is final immediately.
+        assert_eq!(blocks.safe_block(), 1000);
     }
 
     fn block_hash(number: u64) -> B256 {

--- a/crates/core/src/index/events.rs
+++ b/crates/core/src/index/events.rs
@@ -17,6 +17,7 @@ use std::{
     collections::BTreeSet,
     marker::PhantomData,
     num::{NonZeroU64, NonZeroUsize},
+    range::RangeInclusive,
 };
 
 /// A typed set of EVM events that raw logs can be decoded into.
@@ -34,6 +35,21 @@ pub trait Events: Sized {
     /// Decodes a raw log, given its `topics` and `data`, into the event set;
     /// returns `None` when the log is not one of the events in the set.
     fn decode_log(topics: &[B256], data: &[u8]) -> Option<Self>;
+}
+
+/// A batch of decoded event logs together with the inclusive range of blocks
+/// `from..=to` they were fetched for.
+///
+/// The range lets a consumer commit the resulting state against the blocks it
+/// covers (`to` being the latest processed block) and detect events arriving out
+/// of order, for example after a reorg whose rollback could not be applied.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct EventUpdate<E> {
+    /// The block range for the events.
+    pub blocks: RangeInclusive<u64>,
+    /// The decoded logs in `(block_number, log_index)` order. May be empty when
+    /// no watched events occurred in the range.
+    pub logs: Vec<E>,
 }
 
 /// Event watcher configuration.
@@ -157,6 +173,7 @@ enum Step {
     /// Fetching the logs of a single new block by hash, having already failed
     /// `retries` times.
     Block {
+        block_number: u64,
         block_hash: B256,
         logs_bloom: Bloom,
         retries: u64,
@@ -209,8 +226,11 @@ where
             // Uncled blocks never had canonical logs, so there is nothing to do.
             BlockUpdate::Uncle { .. } => Step::Idle,
             BlockUpdate::New {
-                hash, logs_bloom, ..
+                number,
+                hash,
+                logs_bloom,
             } => Step::Block {
+                block_number: number,
                 block_hash: hash,
                 logs_bloom,
                 retries: 0,
@@ -240,9 +260,10 @@ where
     /// Fetches the next batch of logs, advancing the state machine.
     ///
     /// Returns `None` once the current work is complete and the watcher is idle,
-    /// or `Some(logs)` with the next batch of decoded logs in
-    /// `(block_number, log_index)` order (which may be empty).
-    pub async fn next(&mut self) -> Result<Option<Vec<E>>, Error> {
+    /// or `Some(update)` with the next [`EventUpdate`]: the decoded logs in
+    /// `(block_number, log_index)` order (which may be empty) and the block range
+    /// they were fetched for.
+    pub async fn next(&mut self) -> Result<Option<EventUpdate<E>>, Error> {
         match self.step {
             Step::Idle => Ok(None),
             Step::Warping {
@@ -251,10 +272,14 @@ where
                 page_size,
             } => self.warp(from_block, to_block, page_size).await.map(Some),
             Step::Block {
+                block_number,
                 block_hash,
                 logs_bloom,
                 retries,
-            } => self.block(block_hash, logs_bloom, retries).await.map(Some),
+            } => self
+                .block(block_number, block_hash, logs_bloom, retries)
+                .await
+                .map(Some),
         }
     }
 
@@ -265,7 +290,7 @@ where
         from_block: u64,
         to_block: u64,
         page_size: NonZeroU64,
-    ) -> Result<Vec<E>, Error> {
+    ) -> Result<EventUpdate<E>, Error> {
         // Note that block query ranges are inclusive.
         let query_to_block = to_block.min(from_block.saturating_add(page_size.get() - 1));
 
@@ -306,7 +331,11 @@ where
                 page_size,
             }
         };
-        result
+
+        result.map(|logs| EventUpdate {
+            blocks: range(from_block..=query_to_block),
+            logs,
+        })
     }
 
     /// Fetches the logs of a single new block, returning to idle on success and
@@ -317,10 +346,11 @@ where
     /// those are exhausted it falls back to one query per event.
     async fn block(
         &mut self,
+        block_number: u64,
         block_hash: B256,
         logs_bloom: Bloom,
         retries: u64,
-    ) -> Result<Vec<E>, Error> {
+    ) -> Result<EventUpdate<E>, Error> {
         let fetch = if retries < self.config.block_single_query_retry_count.get() {
             if self.config.use_client_filtering {
                 Fetch::ClientFiltered {
@@ -339,12 +369,17 @@ where
             Step::Idle
         } else {
             Step::Block {
+                block_number,
                 block_hash,
                 logs_bloom,
                 retries: retries + 1,
             }
         };
-        result
+
+        result.map(|logs| EventUpdate {
+            blocks: range(block_number..=block_number),
+            logs,
+        })
     }
 
     /// Fetches the watched logs for some blocks using the given strategy,
@@ -439,6 +474,15 @@ where
             })
         })
         .collect()
+}
+
+/// Utility to convert between a `std::ops::RangeInclusive` and the more modern
+/// `std::range::RangeInclusive`.
+///
+/// See [RFC 3550](https://rust-lang.github.io/rfcs/3550-new-range.html) for
+/// more information.
+fn range(legacy: std::ops::RangeInclusive<u64>) -> RangeInclusive<u64> {
+    legacy.into()
 }
 
 /// Defines an [`Events`] type that decodes logs for one or more `alloy`
@@ -1020,12 +1064,21 @@ mod tests {
 
         assert_eq!(
             events.next().await.unwrap(),
-            Some(vec![Erc20::Erc20Events::Transfer(Erc20::Transfer {
-                amount: uint!(1_U256),
-                ..Default::default()
-            })])
+            Some(EventUpdate {
+                blocks: range(1..=5),
+                logs: vec![Erc20::Erc20Events::Transfer(Erc20::Transfer {
+                    amount: uint!(1_U256),
+                    ..Default::default()
+                })],
+            })
         );
-        assert_eq!(events.next().await.unwrap(), Some(vec![]));
+        assert_eq!(
+            events.next().await.unwrap(),
+            Some(EventUpdate {
+                blocks: range(6..=10),
+                logs: vec![],
+            })
+        );
         // The range is fully warped, so the watcher is idle again.
         assert_eq!(events.next().await.unwrap(), None);
         assert!(asserter.read_q().is_empty());
@@ -1055,9 +1108,27 @@ mod tests {
         asserter.push_success(&Vec::<Log>::new());
 
         assert_matches!(events.next().await, Err(Error::Rpc(_)));
-        assert_eq!(events.next().await.unwrap(), Some(vec![]));
-        assert_eq!(events.next().await.unwrap(), Some(vec![]));
-        assert_eq!(events.next().await.unwrap(), Some(vec![]));
+        assert_eq!(
+            events.next().await.unwrap(),
+            Some(EventUpdate {
+                blocks: range(1..=3),
+                logs: vec![],
+            })
+        );
+        assert_eq!(
+            events.next().await.unwrap(),
+            Some(EventUpdate {
+                blocks: range(4..=8),
+                logs: vec![],
+            })
+        );
+        assert_eq!(
+            events.next().await.unwrap(),
+            Some(EventUpdate {
+                blocks: range(9..=10),
+                logs: vec![],
+            })
+        );
         assert_eq!(events.next().await.unwrap(), None);
         assert!(asserter.read_q().is_empty());
     }
@@ -1098,16 +1169,19 @@ mod tests {
         assert_matches!(events.next().await, Err(Error::Rpc(_)));
         assert_eq!(
             events.next().await.unwrap(),
-            Some(vec![
-                Erc20::Erc20Events::Transfer(Erc20::Transfer {
-                    amount: uint!(1_U256),
-                    ..Default::default()
-                }),
-                Erc20::Erc20Events::Approval(Erc20::Approval {
-                    amount: uint!(2_U256),
-                    ..Default::default()
-                }),
-            ])
+            Some(EventUpdate {
+                blocks: range(5..=5),
+                logs: vec![
+                    Erc20::Erc20Events::Transfer(Erc20::Transfer {
+                        amount: uint!(1_U256),
+                        ..Default::default()
+                    }),
+                    Erc20::Erc20Events::Approval(Erc20::Approval {
+                        amount: uint!(2_U256),
+                        ..Default::default()
+                    }),
+                ],
+            })
         );
         assert_eq!(events.next().await.unwrap(), None);
         assert!(asserter.read_q().is_empty());
@@ -1136,10 +1210,13 @@ mod tests {
         // A single query returns the block's logs, then the watcher is idle.
         assert_eq!(
             events.next().await.unwrap(),
-            Some(vec![Erc20::Erc20Events::Transfer(Erc20::Transfer {
-                amount: uint!(1_U256),
-                ..Default::default()
-            })])
+            Some(EventUpdate {
+                blocks: range(1337..=1337),
+                logs: vec![Erc20::Erc20Events::Transfer(Erc20::Transfer {
+                    amount: uint!(1_U256),
+                    ..Default::default()
+                })],
+            })
         );
         assert_eq!(events.next().await.unwrap(), None);
         assert!(asserter.read_q().is_empty());
@@ -1191,10 +1268,13 @@ mod tests {
         // Only the watched-address log is kept, by client-side filtering.
         assert_eq!(
             events.next().await.unwrap(),
-            Some(vec![Erc20::Erc20Events::Transfer(Erc20::Transfer {
-                amount: uint!(1_U256),
-                ..Default::default()
-            })])
+            Some(EventUpdate {
+                blocks: range(1337..=1337),
+                logs: vec![Erc20::Erc20Events::Transfer(Erc20::Transfer {
+                    amount: uint!(1_U256),
+                    ..Default::default()
+                })],
+            })
         );
         assert_eq!(events.next().await.unwrap(), None);
         assert!(asserter.read_q().is_empty());
@@ -1242,16 +1322,19 @@ mod tests {
         assert_matches!(events.next().await, Err(Error::Rpc(_)));
         assert_eq!(
             events.next().await.unwrap(),
-            Some(vec![
-                Erc20::Erc20Events::Transfer(Erc20::Transfer {
-                    amount: uint!(1_U256),
-                    ..Default::default()
-                }),
-                Erc20::Erc20Events::Approval(Erc20::Approval {
-                    amount: uint!(2_U256),
-                    ..Default::default()
-                })
-            ])
+            Some(EventUpdate {
+                blocks: range(1337..=1337),
+                logs: vec![
+                    Erc20::Erc20Events::Transfer(Erc20::Transfer {
+                        amount: uint!(1_U256),
+                        ..Default::default()
+                    }),
+                    Erc20::Erc20Events::Approval(Erc20::Approval {
+                        amount: uint!(2_U256),
+                        ..Default::default()
+                    })
+                ],
+            })
         );
         assert_eq!(events.next().await.unwrap(), None);
         assert!(asserter.read_q().is_empty());

--- a/crates/core/src/index/events.rs
+++ b/crates/core/src/index/events.rs
@@ -229,6 +229,7 @@ where
                 number,
                 hash,
                 logs_bloom,
+                ..
             } => Step::Block {
                 block_number: number,
                 block_hash: hash,
@@ -566,6 +567,7 @@ mod tests {
 
     const WATCHED: Address = address!("0x1111111111111111111111111111111111111111");
     const OTHER: Address = address!("0x2222222222222222222222222222222222222222");
+    const UNUSED: u64 = u64::MAX;
 
     sol! {
         #[derive(Debug, Default, Eq, PartialEq)]
@@ -1196,6 +1198,7 @@ mod tests {
                 number: 1337,
                 hash: B256::repeat_byte(0x13),
                 logs_bloom: Bloom::ZERO,
+                safe: UNUSED,
             })
             .unwrap();
 
@@ -1261,6 +1264,7 @@ mod tests {
                 number: 1337,
                 hash: B256::repeat_byte(0x13),
                 logs_bloom: bloom::compute_logs_bloom(&block_logs),
+                safe: UNUSED,
             })
             .unwrap();
         asserter.push_success(&block_logs);
@@ -1295,6 +1299,7 @@ mod tests {
                 number: 1337,
                 hash: B256::repeat_byte(0x13),
                 logs_bloom: Bloom::ZERO,
+                safe: UNUSED,
             })
             .unwrap();
 
@@ -1351,6 +1356,7 @@ mod tests {
                 number: 1337,
                 hash,
                 logs_bloom: Bloom::ZERO,
+                safe: UNUSED,
             })
             .unwrap();
 
@@ -1397,6 +1403,7 @@ mod tests {
                 number: 1337,
                 hash: B256::repeat_byte(0x13),
                 logs_bloom: Bloom::ZERO,
+                safe: UNUSED,
             })
             .unwrap();
 

--- a/crates/core/src/index/mod.rs
+++ b/crates/core/src/index/mod.rs
@@ -268,7 +268,7 @@ mod tests {
             logs_update(948..=997, [weth_deposit(2)])
         );
 
-        assert_eq!(watcher.next().await.unwrap(), new_block_update(998));
+        assert_eq!(watcher.next().await.unwrap(), new_block_update(998, 997));
 
         asserter.push_success(&vec![log(weth_deposit(3))]);
         assert_eq!(
@@ -276,7 +276,7 @@ mod tests {
             logs_update(998..=998, [weth_deposit(3)])
         );
 
-        assert_eq!(watcher.next().await.unwrap(), new_block_update(999));
+        assert_eq!(watcher.next().await.unwrap(), new_block_update(999, 997));
 
         asserter.push_success(&vec![log(weth_deposit(4))]);
         assert_eq!(
@@ -284,7 +284,7 @@ mod tests {
             logs_update(999..=999, [weth_deposit(4)])
         );
 
-        assert_eq!(watcher.next().await.unwrap(), new_block_update(1000));
+        assert_eq!(watcher.next().await.unwrap(), new_block_update(1000, 997));
 
         asserter.push_success(&vec![log(weth_deposit(5))]);
         assert_eq!(
@@ -294,7 +294,7 @@ mod tests {
 
         // Fetch another block from the RPC node.
         asserter.push_success(&block(1001));
-        assert_eq!(watcher.next().await.unwrap(), new_block_update(1001));
+        assert_eq!(watcher.next().await.unwrap(), new_block_update(1001, 998));
 
         asserter.push_success(&vec![log(weth_deposit(6))]);
         assert_eq!(
@@ -328,6 +328,7 @@ mod tests {
                 number: 1000,
                 hash: block_hash(1000),
                 logs_bloom: block_bloom(1000),
+                safe: 999,
             })
         );
 
@@ -378,11 +379,12 @@ mod tests {
         Bloom::from(bytes)
     }
 
-    fn new_block_update<E>(number: u64) -> Update<E> {
+    fn new_block_update<E>(number: u64, safe: u64) -> Update<E> {
         Update::Block(BlockUpdate::New {
             number,
             hash: block_hash(number),
             logs_bloom: block_bloom(number),
+            safe,
         })
     }
 

--- a/crates/core/src/index/mod.rs
+++ b/crates/core/src/index/mod.rs
@@ -13,6 +13,7 @@ use events::{EventWatcher, Events};
 use serde::Deserialize;
 
 pub use blocks::BlockUpdate;
+pub use events::EventUpdate;
 
 /// Watcher configuration, aggregating the block and event watcher configs.
 #[derive(Clone, Debug, Default, Deserialize, PartialEq, Eq)]
@@ -46,9 +47,9 @@ pub enum Error {
 pub enum Update<E> {
     /// The chain head advanced, warped over a range, or reorged.
     Block(BlockUpdate),
-    /// A nonempty batch of decoded event logs, in `(block_number, log_index)`
-    /// order.
-    Logs(Vec<E>),
+    /// A batch of decoded event logs in `(block_number, log_index)` order, along
+    /// with the block range they were fetched for.
+    Logs(EventUpdate<E>),
 }
 
 /// Watches the chain head and the logs of the events `E`, producing an ordered
@@ -82,27 +83,22 @@ where
     /// Returns the next batch of logs or blocks and waits for a new block to
     /// be mined.
     pub async fn next(&mut self) -> Result<Update<E>, Error> {
-        loop {
-            let update = match self.next_logs().await? {
-                // The event watcher is drained, so advance the chain head and
-                // hand the update to the event watcher to fetch its logs from.
-                None => {
-                    let update = self.blocks.next().await?;
-                    self.events.on_block_update(update.clone())?;
-                    Update::Block(update)
-                }
-                // The query produced logs, return them as an update.
-                Some(logs) if !logs.is_empty() => Update::Logs(logs),
-                // The query produced nothing for us; keep draining.
-                _ => continue,
-            };
-            return Ok(update);
+        if let Some(events) = self.next_logs().await? {
+            // The query produced an update for the blocks it covers; return it,
+            // even when empty, so consumers can commit state across the range.
+            Ok(Update::Logs(events))
+        } else {
+            // The event watcher is drained, so advance the chain head and hand
+            // the update to the event watcher to fetch its logs from.
+            let update = self.blocks.next().await?;
+            self.events.on_block_update(update.clone())?;
+            Ok(Update::Block(update))
         }
     }
 
     /// Fetches the next batch of logs, recovering from a node that exposed a
     /// block it then cannot serve logs for by checking whether it was uncled.
-    async fn next_logs(&mut self) -> Result<Option<Vec<E>>, Error> {
+    async fn next_logs(&mut self) -> Result<Option<EventUpdate<E>>, Error> {
         match self.events.next().await {
             Ok(logs) => Ok(logs),
             Err(err) if is_resource_not_found(&err) => {
@@ -262,14 +258,14 @@ mod tests {
         asserter.push_success(&vec![log(weth_deposit(1))]);
         assert_eq!(
             watcher.next().await.unwrap(),
-            logs_update([weth_deposit(1)])
+            logs_update(848..=947, [weth_deposit(1)])
         );
 
         // Log query from range 948..=997
         asserter.push_success(&vec![log(weth_deposit(2))]);
         assert_eq!(
             watcher.next().await.unwrap(),
-            logs_update([weth_deposit(2)])
+            logs_update(948..=997, [weth_deposit(2)])
         );
 
         assert_eq!(watcher.next().await.unwrap(), new_block_update(998));
@@ -277,7 +273,7 @@ mod tests {
         asserter.push_success(&vec![log(weth_deposit(3))]);
         assert_eq!(
             watcher.next().await.unwrap(),
-            logs_update([weth_deposit(3)])
+            logs_update(998..=998, [weth_deposit(3)])
         );
 
         assert_eq!(watcher.next().await.unwrap(), new_block_update(999));
@@ -285,7 +281,7 @@ mod tests {
         asserter.push_success(&vec![log(weth_deposit(4))]);
         assert_eq!(
             watcher.next().await.unwrap(),
-            logs_update([weth_deposit(4)])
+            logs_update(999..=999, [weth_deposit(4)])
         );
 
         assert_eq!(watcher.next().await.unwrap(), new_block_update(1000));
@@ -293,7 +289,7 @@ mod tests {
         asserter.push_success(&vec![log(weth_deposit(5))]);
         assert_eq!(
             watcher.next().await.unwrap(),
-            logs_update([weth_deposit(5)])
+            logs_update(1000..=1000, [weth_deposit(5)])
         );
 
         // Fetch another block from the RPC node.
@@ -303,7 +299,7 @@ mod tests {
         asserter.push_success(&vec![log(weth_deposit(6))]);
         assert_eq!(
             watcher.next().await.unwrap(),
-            logs_update([weth_deposit(6)])
+            logs_update(1001..=1001, [weth_deposit(6)])
         );
 
         assert!(asserter.read_q().is_empty());
@@ -407,7 +403,13 @@ mod tests {
         }
     }
 
-    fn logs_update(logs: impl IntoIterator<Item = Weth::Deposit>) -> Update<Weth::WethEvents> {
-        Update::Logs(logs.into_iter().map(Weth::WethEvents::Deposit).collect())
+    fn logs_update(
+        blocks: std::ops::RangeInclusive<u64>,
+        logs: impl IntoIterator<Item = Weth::Deposit>,
+    ) -> Update<Weth::WethEvents> {
+        Update::Logs(EventUpdate {
+            blocks: blocks.into(),
+            logs: logs.into_iter().map(Weth::WethEvents::Deposit).collect(),
+        })
     }
 }


### PR DESCRIPTION
Add some additional information to the indexer updates for the storage layer.

### Context and Motivation

In order to fully handle reorgs and pruning at the storage layer, we need some additional context:

- The safe block that will never reorg, to decide what can be pruned
- The event block ranges, so we know which blocks to commit states to and whether or not events can be skipped in case of a failed reorg

### Decisions and Tradeoffs

This PR does just that in an unintrucive way:

- The block listener has a method for retrieving the current safe block
- Event updates now include block ranges

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://docs.safefoundation.org/cla).
