### PR TITLE
Epoch Rollover Library

### DIFF
--- a/contracts/src/libraries/EpochRollover.sol
+++ b/contracts/src/libraries/EpochRollover.sol
@@ -16,21 +16,17 @@ library EpochRollover {
     // ============================================================
 
     struct State {
-        mapping(bytes32 entryId => bool known) entries;
+        mapping(uint256 groupKeyX => mapping(uint256 groupKeyY => mapping(uint64 epoch => bool known))) entries;
     }
 
     // ============================================================
     // EVENTS
     // ============================================================
 
-    event EpochInitialized(bytes32 indexed entryId, uint64 indexed epoch, Secp256k1.Point groupKey);
+    event EpochInitialized(uint64 indexed epoch, Secp256k1.Point groupKey);
 
     event EpochRolledOver(
-        bytes32 indexed parentEntryId,
-        bytes32 indexed entryId,
-        uint64 indexed epoch,
-        uint64 parentEpoch,
-        Secp256k1.Point groupKey
+        uint64 indexed parentEpoch, uint64 indexed epoch, Secp256k1.Point parentKey, Secp256k1.Point groupKey
     );
 
     // ============================================================
@@ -48,9 +44,8 @@ library EpochRollover {
     // Seeds the genesis entry; call exactly once (e.g. in the consumer's constructor).
     function initialize(State storage self, uint64 genesisEpoch, Secp256k1.Point memory genesisKey) internal {
         Secp256k1.requireNonZero(genesisKey);
-        bytes32 entryId = _entryId(genesisKey, genesisEpoch);
-        self.entries[entryId] = true;
-        emit EpochInitialized(entryId, genesisEpoch, genesisKey);
+        self.entries[genesisKey.x][genesisKey.y][genesisEpoch] = true;
+        emit EpochInitialized(genesisEpoch, genesisKey);
     }
 
     function rollover(
@@ -62,9 +57,8 @@ library EpochRollover {
         uint64 rolloverBlock,
         Secp256k1.Point calldata newGroupKey,
         FROST.Signature calldata signature
-    ) internal returns (bytes32 entryId) {
-        bytes32 parentEntryId = _entryId(parentKey, parentEpoch);
-        require(self.entries[parentEntryId], UnknownParent());
+    ) internal {
+        require(self.entries[parentKey.x][parentKey.y][parentEpoch], UnknownParent());
         require(proposedEpoch > parentEpoch, EpochNotAdvancing());
         Secp256k1.requireNonZero(newGroupKey);
 
@@ -72,23 +66,13 @@ library EpochRollover {
             ConsensusMessages.epochRollover(domainSeparator, parentEpoch, proposedEpoch, rolloverBlock, newGroupKey);
         FROST.verify(parentKey, signature, message);
 
-        entryId = _entryId(newGroupKey, proposedEpoch);
-        if (!self.entries[entryId]) {
-            self.entries[entryId] = true;
-            emit EpochRolledOver(parentEntryId, entryId, proposedEpoch, parentEpoch, newGroupKey);
+        if (!self.entries[newGroupKey.x][newGroupKey.y][proposedEpoch]) {
+            self.entries[newGroupKey.x][newGroupKey.y][proposedEpoch] = true;
+            emit EpochRolledOver(parentEpoch, proposedEpoch, parentKey, newGroupKey);
         }
     }
 
     function isKnown(State storage self, Secp256k1.Point memory groupKey, uint64 epoch) internal view returns (bool) {
-        return self.entries[_entryId(groupKey, epoch)];
-    }
-
-    // ============================================================
-    // PRIVATE FUNCTIONS
-    // ============================================================
-
-    function _entryId(Secp256k1.Point memory groupKey, uint64 epoch) private pure returns (bytes32) {
-        // forge-lint: disable-next-line(asm-keccak256)
-        return keccak256(abi.encode(groupKey.x, groupKey.y, epoch));
+        return self.entries[groupKey.x][groupKey.y][epoch];
     }
 }

--- a/contracts/src/libraries/EpochRollover.sol
+++ b/contracts/src/libraries/EpochRollover.sol
@@ -1,0 +1,94 @@
+// SPDX-License-Identifier: GPL-3.0-only
+pragma solidity ^0.8.30;
+
+import {ConsensusMessages} from "@/libraries/ConsensusMessages.sol";
+import {FROST} from "@/libraries/FROST.sol";
+import {Secp256k1} from "@/libraries/Secp256k1.sol";
+
+/**
+ * @title EpochRollover
+ * @notice Stores known `(group key, epoch)` pairs and verifies epoch rollovers against them.
+ * @dev v1: keeps every pair and accepts all branches (no fork choice).
+ */
+library EpochRollover {
+    // ============================================================
+    // STRUCTS
+    // ============================================================
+
+    struct State {
+        mapping(bytes32 entryId => bool known) entries;
+    }
+
+    // ============================================================
+    // EVENTS
+    // ============================================================
+
+    event EpochInitialized(bytes32 indexed entryId, uint64 indexed epoch, Secp256k1.Point groupKey);
+
+    event EpochRolledOver(
+        bytes32 indexed parentEntryId,
+        bytes32 indexed entryId,
+        uint64 indexed epoch,
+        uint64 parentEpoch,
+        Secp256k1.Point groupKey
+    );
+
+    // ============================================================
+    // ERRORS
+    // ============================================================
+
+    error EpochNotAdvancing();
+
+    error UnknownParent();
+
+    // ============================================================
+    // INTERNAL FUNCTIONS
+    // ============================================================
+
+    // Seeds the genesis entry; call exactly once (e.g. in the consumer's constructor).
+    function initialize(State storage self, uint64 genesisEpoch, Secp256k1.Point memory genesisKey) internal {
+        Secp256k1.requireNonZero(genesisKey);
+        bytes32 entryId = _entryId(genesisKey, genesisEpoch);
+        self.entries[entryId] = true;
+        emit EpochInitialized(entryId, genesisEpoch, genesisKey);
+    }
+
+    function rollover(
+        State storage self,
+        bytes32 domainSeparator,
+        Secp256k1.Point calldata parentKey,
+        uint64 parentEpoch,
+        uint64 proposedEpoch,
+        uint64 rolloverBlock,
+        Secp256k1.Point calldata newGroupKey,
+        FROST.Signature calldata signature
+    ) internal returns (bytes32 entryId) {
+        bytes32 parentEntryId = _entryId(parentKey, parentEpoch);
+        require(self.entries[parentEntryId], UnknownParent());
+        require(proposedEpoch > parentEpoch, EpochNotAdvancing());
+        Secp256k1.requireNonZero(newGroupKey);
+
+        bytes32 message =
+            ConsensusMessages.epochRollover(domainSeparator, parentEpoch, proposedEpoch, rolloverBlock, newGroupKey);
+        FROST.verify(parentKey, signature, message);
+
+        entryId = _entryId(newGroupKey, proposedEpoch);
+        if (!self.entries[entryId]) {
+            self.entries[entryId] = true;
+            emit EpochRolledOver(parentEntryId, entryId, proposedEpoch, parentEpoch, newGroupKey);
+        }
+    }
+
+    function isKnown(State storage self, Secp256k1.Point memory groupKey, uint64 epoch) internal view returns (bool) {
+        return self.entries[_entryId(groupKey, epoch)];
+    }
+
+    // ============================================================
+    // PRIVATE FUNCTIONS
+    // ============================================================
+
+    function _entryId(Secp256k1.Point memory groupKey, uint64 epoch) private pure returns (bytes32) {
+        // forge-lint: disable-next-line(asm-keccak256)
+        return keccak256(abi.encode(groupKey.x, groupKey.y, epoch));
+    }
+}

--- a/contracts/src/libraries/EpochRollover.sol
+++ b/contracts/src/libraries/EpochRollover.sol
@@ -15,7 +15,7 @@ library EpochRollover {
     // STRUCTS
     // ============================================================
 
-    struct State {
+    struct T {
         mapping(uint256 groupKeyX => mapping(uint256 groupKeyY => mapping(uint64 epoch => bool known))) entries;
     }
 
@@ -42,23 +42,23 @@ library EpochRollover {
     // ============================================================
 
     // Seeds the genesis entry; call exactly once (e.g. in the consumer's constructor).
-    function initialize(State storage self, uint64 genesisEpoch, Secp256k1.Point memory genesisKey) internal {
+    function initialize(T storage self, uint64 genesisEpoch, Secp256k1.Point memory genesisKey) internal {
         Secp256k1.requireNonZero(genesisKey);
         self.entries[genesisKey.x][genesisKey.y][genesisEpoch] = true;
         emit EpochInitialized(genesisEpoch, genesisKey);
     }
 
     function rollover(
-        State storage self,
+        T storage self,
         bytes32 domainSeparator,
-        Secp256k1.Point calldata parentKey,
+        Secp256k1.Point memory parentKey,
         uint64 parentEpoch,
         uint64 proposedEpoch,
         uint64 rolloverBlock,
-        Secp256k1.Point calldata newGroupKey,
-        FROST.Signature calldata signature
+        Secp256k1.Point memory newGroupKey,
+        FROST.Signature memory signature
     ) internal {
-        require(self.entries[parentKey.x][parentKey.y][parentEpoch], UnknownParent());
+        require(isKnown(self, parentKey, parentEpoch), UnknownParent());
         require(proposedEpoch > parentEpoch, EpochNotAdvancing());
         Secp256k1.requireNonZero(newGroupKey);
 
@@ -66,13 +66,13 @@ library EpochRollover {
             ConsensusMessages.epochRollover(domainSeparator, parentEpoch, proposedEpoch, rolloverBlock, newGroupKey);
         FROST.verify(parentKey, signature, message);
 
-        if (!self.entries[newGroupKey.x][newGroupKey.y][proposedEpoch]) {
+        if (!isKnown(self, newGroupKey, proposedEpoch)) {
             self.entries[newGroupKey.x][newGroupKey.y][proposedEpoch] = true;
             emit EpochRolledOver(parentEpoch, proposedEpoch, parentKey, newGroupKey);
         }
     }
 
-    function isKnown(State storage self, Secp256k1.Point memory groupKey, uint64 epoch) internal view returns (bool) {
+    function isKnown(T storage self, Secp256k1.Point memory groupKey, uint64 epoch) internal view returns (bool) {
         return self.entries[groupKey.x][groupKey.y][epoch];
     }
 }


### PR DESCRIPTION
Add a standalone `EpochRollover` Solidity library that stores known `(group key, epoch)` pairs and verifies epoch-rollover attestations, so any guard can share one implementation instead of re-implementing it inline.

### Context and Motivation

Safenet guards keep a local copy of the consensus epoch state on chains where the `Consensus` contract doesn't live, advancing it by verifying the FROST-signed *attestation chain* (genesis → each rollover signed by the outgoing group). Today this logic is re-implemented inline in each guard prototype, with subtly different storage and identical first-come-first-served acceptance.

The [PR #389 discussion](https://github.com/safe-research/safenet/pull/389#issuecomment-4563818854) surfaced that under chain reorgs a FROST signature can exist for a rollover the canonical chain never adopted - so more than one validly-signed rollover per source epoch is possible. This library is where that will eventually be resolved. This PR is intentionally **v1: the minimal storage + verification foundation, with no fork resolution yet** (acceptance is deliberately permissive - see below). Tests, Natspec and guard integration land in separate follow-up PRs.

### Decisions and Tradeoffs

- **Membership is keyed by the full `(group key, epoch)` triple via a native nested mapping (`mapping(uint256 x => mapping(uint256 y => mapping(uint64 epoch => bool)))`), not `epoch => key`.** A per-epoch slot can hold only one key, so two valid rollovers sharing an epoch number (a reorg twin) would silently overwrite each other; keying by the full triple gives each its own slot, lets the same key exist at different epochs, and removes any zero/sentinel ambiguity for a genesis at epoch 0. The nested mapping lets Solidity's built-in key hashing do the work - no hand-rolled hash or `abi.encode`. Consequence: a key alone isn't a lookup handle (you can't derive an epoch from a key), so `isKnown(key, epoch)` takes both - fine operationally, since a rollover submitter knows the parent epoch and an attestation names its epoch in the signed message.
- **Pure set with no "active" cursor, and all branches are accepted (no fork choice).** Under branching a single active epoch is ill-defined. v1 accepts any validly-signed rollover from any known parent - including, in principle, an orphaned-but-signed one - because the validator set is permissioned and reorg-induced branches are shallow. The challenge-window / supersession / longest-chain hardening is deferred to later work.
- **Keep-everything retention.** Every pair is stored forever, so in-flight signing ceremonies and lagging guards never lose the key they need.
- **Rollover is idempotent (no-op), not reverting, on an already-recorded pair.** It is permissionless, so duplicate submissions (reorg replays, racing relayers) are normal; re-submitting a recorded rollover does nothing rather than reverting. Verification runs before the dedup check, so a successful call always implies a valid signature was presented.
- **`rolloverBlock` is folded into the signed message but not otherwise checked** - a remote chain cannot observe Gnosis block numbers, matching existing guard behaviour.