### PR TITLE
Validator 7702 Account

### DIFF
--- a/contracts/src/Validator7702Account.sol
+++ b/contracts/src/Validator7702Account.sol
@@ -3,12 +3,13 @@ pragma solidity ^0.8.30;
 
 /**
  * @title Validator 7702 Account
- * @notice A minimal EIP-7702 account implementation that lets the validator EOA batch multiple calls to the
- *         Safenet {Consensus} contract into a single transaction.
+ * @notice A minimal EIP-7702 account implementation that lets the validator EOA batch multiple calls into a
+ *         single transaction.
  * @dev This contract is intended to be set as the EIP-7702 delegation target of the validator's EOA. Once the
  *      EOA has delegated to this implementation, the validator can submit a single transaction to its own
- *      address that invokes {execute}, proposing (or attesting to) multiple Safe transactions at once instead
- *      of being limited to a single consensus call per transaction as a plain EOA.
+ *      address that invokes {execute}, performing multiple calls (for example to the Safenet Consensus and
+ *      FROST coordinator contracts) at once instead of being limited to one call per transaction as a plain
+ *      EOA.
  *
  *      Authorization is provided entirely by EIP-7702. When the validator EOA initiates a transaction to its
  *      own address, the EVM sets `msg.sender == address(this)`, which {execute} requires. Producing such a
@@ -16,18 +17,25 @@ pragma solidity ^0.8.30;
  *      so no additional signature or nonce handling is implemented here.
  *
  *      The account is intentionally minimal and is NOT ERC-4337 compatible: it has no entry point, no
- *      signature validation, and no functionality beyond batching calls to the {Consensus} contract and
- *      receiving the native token used to fund gas.
+ *      signature validation, and no functionality beyond batching calls and receiving the native token used
+ *      to fund gas.
  */
 contract Validator7702Account {
     // ============================================================
-    // STORAGE VARIABLES
+    // STRUCTS
     // ============================================================
 
     /**
-     * @notice The Safenet Consensus contract that this account is allowed to call.
+     * @notice A single call to execute as part of a batch.
+     * @custom:param to The target address of the call.
+     * @custom:param gasLimit The maximum amount of gas to forward to the call.
+     * @custom:param data The calldata of the call.
      */
-    address public immutable CONSENSUS;
+    struct Call {
+        address to;
+        uint256 gasLimit;
+        bytes data;
+    }
 
     // ============================================================
     // EVENTS
@@ -53,36 +61,23 @@ contract Validator7702Account {
     error OnlySelf();
 
     // ============================================================
-    // CONSTRUCTOR
-    // ============================================================
-
-    /**
-     * @notice Constructs the account implementation.
-     * @param consensus The address of the Safenet Consensus contract that this account may call.
-     */
-    constructor(address consensus) {
-        CONSENSUS = consensus;
-    }
-
-    // ============================================================
     // EXTERNAL FUNCTIONS
     // ============================================================
 
     /**
-     * @notice Executes a batch of calls to the Consensus contract on a best-effort basis.
-     * @dev Each entry in `calls` is forwarded verbatim as calldata to the {Consensus} contract, in order. The
-     *      batch is NOT atomic: if a call reverts, its index and revert data are recorded with a {CallFailed}
-     *      event and execution continues with the remaining calls, so one failing call does not prevent the
-     *      others from running. The only condition that reverts the whole transaction is the self-call guard
-     *      (see {OnlySelf}). As this runs as the validator's own transaction, failures are observable via the
-     *      {CallFailed} logs in the receipt, while successful proposals are observable via the Consensus
-     *      contract's own events.
-     * @param calls The calldata payloads to forward to the Consensus contract, in order.
+     * @notice Executes a batch of calls on a best-effort basis.
+     * @dev Each entry in `calls` is forwarded to its target `to` with at most `gasLimit` gas. The batch is NOT
+     *      atomic: if a call reverts, its index and revert data are recorded with a {CallFailed} event and
+     *      execution continues with the remaining calls, so one failing call does not prevent the others from
+     *      running. Bounding each call's gas also prevents a single call from consuming the gas needed by the
+     *      rest of the batch. The only condition that reverts the whole transaction is the self-call guard (see
+     *      {OnlySelf}).
+     * @param calls The calls to execute, in order.
      */
-    function execute(bytes[] calldata calls) external {
+    function execute(Call[] calldata calls) external {
         require(msg.sender == address(this), OnlySelf());
         for (uint256 i = 0; i < calls.length; ++i) {
-            (bool success, bytes memory result) = CONSENSUS.call(calls[i]);
+            (bool success, bytes memory result) = calls[i].to.call{gas: calls[i].gasLimit}(calls[i].data);
             if (!success) {
                 emit CallFailed(i, result);
             }

--- a/contracts/src/Validator7702Account.sol
+++ b/contracts/src/Validator7702Account.sol
@@ -5,6 +5,11 @@ pragma solidity ^0.8.30;
  * @title Validator 7702 Account
  * @notice A minimal EIP-7702 account implementation that lets the validator EOA batch multiple calls into a
  *         single transaction.
+ * @custom:warning NOT a general-purpose smart account; do not reuse it as one. It is purpose-built solely as
+ *                 the EIP-7702 delegation target for the Safenet validator EOA. It authorizes only the EOA
+ *                 itself (no ERC-1271 / ERC-4337 signature validation, no relayed or sponsored execution),
+ *                 executes batches best-effort (failures are swallowed and only logged via {CallFailed}), and
+ *                 relies on the EOA transaction nonce for replay protection.
  * @dev This contract is intended to be set as the EIP-7702 delegation target of the validator's EOA. Once the
  *      EOA has delegated to this implementation, the validator can submit a single transaction to its own
  *      address that invokes {execute}, performing multiple calls (for example to the Safenet Consensus and

--- a/contracts/src/Validator7702Account.sol
+++ b/contracts/src/Validator7702Account.sol
@@ -1,0 +1,100 @@
+// SPDX-License-Identifier: GPL-3.0-only
+pragma solidity ^0.8.30;
+
+/**
+ * @title Validator 7702 Account
+ * @notice A minimal EIP-7702 account implementation that lets the validator EOA batch multiple calls to the
+ *         Safenet {Consensus} contract into a single transaction.
+ * @dev This contract is intended to be set as the EIP-7702 delegation target of the validator's EOA. Once the
+ *      EOA has delegated to this implementation, the validator can submit a single transaction to its own
+ *      address that invokes {execute}, proposing (or attesting to) multiple Safe transactions at once instead
+ *      of being limited to a single consensus call per transaction as a plain EOA.
+ *
+ *      Authorization is provided entirely by EIP-7702. When the validator EOA initiates a transaction to its
+ *      own address, the EVM sets `msg.sender == address(this)`, which {execute} requires. Producing such a
+ *      call requires the EOA's private key, and replay protection is provided by the EOA's transaction nonce,
+ *      so no additional signature or nonce handling is implemented here.
+ *
+ *      The account is intentionally minimal and is NOT ERC-4337 compatible: it has no entry point, no
+ *      signature validation, and no functionality beyond batching calls to the {Consensus} contract and
+ *      receiving the native token used to fund gas.
+ */
+contract Validator7702Account {
+    // ============================================================
+    // STORAGE VARIABLES
+    // ============================================================
+
+    /**
+     * @notice The Safenet Consensus contract that this account is allowed to call.
+     */
+    address public immutable CONSENSUS;
+
+    // ============================================================
+    // EVENTS
+    // ============================================================
+
+    /**
+     * @notice Emitted when a call within a batch fails, after which the remaining calls still execute.
+     * @param index The position of the failing call within the `calls` array passed to {execute}.
+     * @param result The revert data returned by the failing call.
+     */
+    event CallFailed(uint256 index, bytes result);
+
+    // ============================================================
+    // ERRORS
+    // ============================================================
+
+    /**
+     * @notice Thrown when {execute} is called by any address other than the account itself.
+     * @dev Under EIP-7702, a call with `msg.sender == address(this)` is only possible when the delegating EOA
+     *      initiates a transaction to its own address, which requires its private key. This restricts
+     *      {execute} to the EOA that owns the account.
+     */
+    error OnlySelf();
+
+    // ============================================================
+    // CONSTRUCTOR
+    // ============================================================
+
+    /**
+     * @notice Constructs the account implementation.
+     * @param consensus The address of the Safenet Consensus contract that this account may call.
+     */
+    constructor(address consensus) {
+        CONSENSUS = consensus;
+    }
+
+    // ============================================================
+    // EXTERNAL FUNCTIONS
+    // ============================================================
+
+    /**
+     * @notice Executes a batch of calls to the Consensus contract on a best-effort basis.
+     * @dev Each entry in `calls` is forwarded verbatim as calldata to the {Consensus} contract, in order. The
+     *      batch is NOT atomic: if a call reverts, its index and revert data are recorded with a {CallFailed}
+     *      event and execution continues with the remaining calls, so one failing call does not prevent the
+     *      others from running. The only condition that reverts the whole transaction is the self-call guard
+     *      (see {OnlySelf}). As this runs as the validator's own transaction, failures are observable via the
+     *      {CallFailed} logs in the receipt, while successful proposals are observable via the Consensus
+     *      contract's own events.
+     * @param calls The calldata payloads to forward to the Consensus contract, in order.
+     */
+    function execute(bytes[] calldata calls) external {
+        require(msg.sender == address(this), OnlySelf());
+        for (uint256 i = 0; i < calls.length; ++i) {
+            (bool success, bytes memory result) = CONSENSUS.call(calls[i]);
+            if (!success) {
+                emit CallFailed(i, result);
+            }
+        }
+    }
+
+    // ============================================================
+    // RECEIVE
+    // ============================================================
+
+    /**
+     * @notice Accepts the native token so that the validator EOA can be funded with gas for batched calls.
+     */
+    receive() external payable {}
+}


### PR DESCRIPTION
Add a minimal, stateless EIP-7702 account that lets the validator EOA batch multiple calls into a single transaction.

### Context and Motivation

The validator currently operates as a plain EOA, so it can only submit one call per transaction (one propose/attest at a time). By delegating the validator EOA to this account via EIP-7702, the validator can batch multiple calls — typically across the Consensus and FROST coordinator contracts — into a single transaction.

This PR intentionally contains **only the contract**, to get an early review of the design and security model from the team. The Foundry tests and the deployment script will follow in a separate PR once the contract is agreed upon.

Authorization relies entirely on EIP-7702: when the delegating EOA sends a transaction to its own address, `msg.sender == address(this)`, which `execute` requires. Replay protection comes from the EOA's transaction nonce, so no additional signature or nonce handling is implemented.

### Decisions and Tradeoffs

- **Per-call target, no hardcoding.** Each `Call` carries its own `to`, so a batch can route to different contracts (Consensus, coordinator, …) rather than a single fixed address. The contract holds no state — no immutable, no constructor.
- **Per-call gas limit.** Each call forwards at most `gasLimit` gas (`.call{gas: ...}`). This bounds each call so a single runaway/expensive call cannot consume the gas needed by the rest of the batch. No per-call `value` field — the targeted functions are non-payable; easy to add later if needed.
- **Best-effort, not atomic.** A failing call emits `CallFailed(index, result)` and the batch continues, rather than reverting the whole transaction. Failures are observable via `CallFailed` logs in the receipt; successful calls via the target contracts' own events.
- **Deliberately minimal, not ERC-4337.** No entry point, no signature validation, no fallback — only `execute` (self-only) and a payable `receive` so the account can be funded with gas.
