### PR TITLE
7702 Account Deployment Script

### DIFF
--- a/contracts/script/DeployValidator7702Account.s.sol
+++ b/contracts/script/DeployValidator7702Account.s.sol
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: GPL-3.0-only
+pragma solidity ^0.8.30;
+
+import {Script, console} from "@forge-std/Script.sol";
+import {DeterministicDeployment} from "@script/util/DeterministicDeployment.sol";
+import {getFactory} from "@script/util/GetFactory.sol";
+import {Validator7702Account} from "@/Validator7702Account.sol";
+
+contract DeployValidator7702AccountScript is Script {
+    using DeterministicDeployment for DeterministicDeployment.Factory;
+
+    function run() public returns (address account) {
+        DeterministicDeployment.Factory factory = getFactory(vm);
+
+        vm.startBroadcast();
+
+        account = factory.deploy(bytes32(0), type(Validator7702Account).creationCode);
+
+        vm.stopBroadcast();
+
+        console.log("Validator7702Account deployed at:", account);
+    }
+}


### PR DESCRIPTION
Add the Forge deployment script for `Validator7702Account` (contract merged in #472; tests in review in #475).

### Context and Motivation

This is the final piece of the `Validator7702Account` work, split across three PRs for reviewability: the contract landed in #472, its test suite is in review in #475, and this PR adds the script to deploy the implementation. `Validator7702Account` is the EIP-7702 delegation target a proposer EOA delegates to in order to batch calls; this script deploys that shared implementation. No contract or test changes.

### Decisions and Tradeoffs

- **Deterministic CREATE2 deployment.** The script uses the project's shared `DeterministicDeployment` factory (`getFactory(vm)` → `factory.deploy(...)`), mirroring `DeployCosigner` / `DeploySentinelOracle`. Because the contract is an EIP-7702 delegation target deployed once and shared by every delegating EOA, a deterministic address yields the **same implementation address across chains**, which keeps the EOA authorizations that point at it uniform.
- **Argless deploy.** The contract is stateless (no immutable, no constructor), so there are no constructor arguments and — unlike `DeployCosigner`, which reads `CONSENSUS_ADDRESS` — no contract-specific environment variables. The only input is the optional `FACTORY` selector consumed by `getFactory`.

### Testing

Deploy-only change with no runtime logic to unit-test. Verified it compiles (`forge build`) and follows the existing deterministic-deployment script pattern; the resulting address is reproducible from the factory, salt, and creation code.
