### PR TITLE
Epoch Rollover Natspec Update

### DIFF
--- a/contracts/src/libraries/EpochRollover.sol
+++ b/contracts/src/libraries/EpochRollover.sol
@@ -7,14 +7,24 @@ import {Secp256k1} from "@/libraries/Secp256k1.sol";
 
 /**
  * @title EpochRollover
- * @notice Stores known `(group key, epoch)` pairs and verifies epoch rollovers against them.
- * @dev v1: keeps every pair and accepts all branches (no fork choice).
+ * @notice Tracks the set of trusted `(group key, epoch)` pairs forming the Safenet epoch attestation
+ *         chain, and advances it by verifying FROST-signed epoch rollovers.
+ * @dev The set is a forest rooted at the genesis epoch: each rollover is signed by an already-known
+ *      parent group and records its successor. Every pair is kept forever (no pruning) and every
+ *      validly-signed branch is accepted — fork choice and retention are deliberately out of scope
+ *      for v1.
  */
 library EpochRollover {
     // ============================================================
     // STRUCTS
     // ============================================================
 
+    /**
+     * @notice The set of trusted epoch group keys.
+     * @custom:param entries Maps a group key's coordinates and an epoch to whether that
+     *               `(group key, epoch)` pair is trusted. The same epoch may hold several keys (reorg
+     *               branches) and the same key may appear at several epochs, both without collision.
+     */
     struct T {
         mapping(uint256 groupKeyX => mapping(uint256 groupKeyY => mapping(uint64 epoch => bool known))) entries;
     }
@@ -23,8 +33,21 @@ library EpochRollover {
     // EVENTS
     // ============================================================
 
+    /**
+     * @notice Emitted when the genesis `(group key, epoch)` pair is seeded.
+     * @param epoch The genesis epoch number.
+     * @param groupKey The genesis group public key.
+     */
     event EpochInitialized(uint64 indexed epoch, Secp256k1.Point groupKey);
 
+    /**
+     * @notice Emitted when a rollover records a new `(group key, epoch)` pair. Both endpoints are
+     *         included so the forest can be reconstructed off-chain.
+     * @param parentEpoch The epoch rolled over from.
+     * @param epoch The newly recorded epoch.
+     * @param parentKey The group key that signed the rollover.
+     * @param groupKey The newly recorded group public key.
+     */
     event EpochRolledOver(
         uint64 indexed parentEpoch, uint64 indexed epoch, Secp256k1.Point parentKey, Secp256k1.Point groupKey
     );
@@ -33,21 +56,49 @@ library EpochRollover {
     // ERRORS
     // ============================================================
 
+    /**
+     * @notice Thrown when the proposed epoch is not strictly greater than the parent epoch.
+     */
     error EpochNotAdvancing();
 
+    /**
+     * @notice Thrown when the `(parentKey, parentEpoch)` pair a rollover extends is not in the set.
+     */
     error UnknownParent();
 
     // ============================================================
     // INTERNAL FUNCTIONS
     // ============================================================
 
-    // Seeds the genesis entry; call exactly once (e.g. in the consumer's constructor).
+    /**
+     * @notice Seeds the trusted genesis pair, the root of the attestation chain.
+     * @dev Must be called exactly once (e.g. in the consumer's constructor). Genesis is trusted
+     *      directly, so no signature is verified.
+     * @param self The storage struct.
+     * @param genesisEpoch The genesis epoch number.
+     * @param genesisKey The genesis group public key; must be a non-zero curve point.
+     */
     function initialize(T storage self, uint64 genesisEpoch, Secp256k1.Point memory genesisKey) internal {
         Secp256k1.requireNonZero(genesisKey);
         self.entries[genesisKey.x][genesisKey.y][genesisEpoch] = true;
         emit EpochInitialized(genesisEpoch, genesisKey);
     }
 
+    /**
+     * @notice Verifies a FROST-signed rollover from a known parent and records the new pair.
+     * @dev Verification runs before the membership write, so a successful call always implies a
+     *      valid signature. The write is idempotent: re-submitting an already-known pair is a no-op
+     *      (no revert, no event), so reorg replays and racing submitters are harmless.
+     * @param self The storage struct.
+     * @param domainSeparator The EIP-712 domain separator binding the signature to the Consensus deployment.
+     * @param parentKey The group key being rolled over from; the `(parentKey, parentEpoch)` pair must be known.
+     * @param parentEpoch The epoch of `parentKey`.
+     * @param proposedEpoch The new epoch; must be strictly greater than `parentEpoch`.
+     * @param rolloverBlock Folded into the verified message but not checked here — a Consensus-chain
+     *        block number with no meaning on a remote chain.
+     * @param newGroupKey The new group public key; must be a non-zero curve point.
+     * @param signature The FROST signature produced by the parent group over the rollover message.
+     */
     function rollover(
         T storage self,
         bytes32 domainSeparator,
@@ -72,7 +123,15 @@ library EpochRollover {
         }
     }
 
-    function isKnown(T storage self, Secp256k1.Point memory groupKey, uint64 epoch) internal view returns (bool) {
+    /**
+     * @notice Returns whether the `(groupKey, epoch)` pair has been recorded.
+     * @dev Membership is exact on the pair: a known key at a different epoch returns false.
+     * @param self The storage struct.
+     * @param groupKey The group public key to check.
+     * @param epoch The epoch to check.
+     * @return known True if the `(groupKey, epoch)` pair is recorded.
+     */
+    function isKnown(T storage self, Secp256k1.Point memory groupKey, uint64 epoch) internal view returns (bool known) {
         return self.entries[groupKey.x][groupKey.y][epoch];
     }
 }


### PR DESCRIPTION
Add NatSpec documentation to the `EpochRollover` library.

### Context and Motivation

The `EpochRollover` library (merged in #468) shipped with only terse inline comments; detailed NatSpec was explicitly deferred to a follow-up. This PR adds that documentation, matching the repo's existing conventions (`@title`/`@notice`/`@dev`, `@param` including `@param self`, `@return`, `@custom:param` on the struct, and `@param` on event fields). No behavior change.

### Decisions and Tradeoffs

- The docs explain the **non-obvious** behavior rather than restating signatures: genesis is seeded once and trusted without a signature; `rollover` verifies *before* the idempotent write (so a successful call implies a valid signature, and reorg replays / racing submitters are harmless no-ops); `rolloverBlock` is folded into the signed message but not checked locally (a Consensus-chain block number, meaningless on a remote chain); and membership is exact on the `(key, epoch)` pair.
- One non-comment line: `isKnown` now names its return (`returns (bool known)`) so the `@return known` tag matches the signature, consistent with the repo's named-return style. Cosmetic, no behavior change.

### Testing

Aside from the named return this is comment-only. `forge build`, `forge fmt --check`, `forge lint`, and the existing `EpochRollover` test suite all pass.