### PR TITLE
Transaction Submission Queue

### DIFF
--- a/crates/core/src/state/mod.rs
+++ b/crates/core/src/state/mod.rs
@@ -23,7 +23,7 @@ pub enum Error {
     #[error("end of chain")]
     EndOfChain,
     /// Received an update that is either out-of-order or has unexpected data.
-    #[error("bad update")]
+    #[error("out-of-order update")]
     BadUpdate,
     /// The state machine is in a poisoned state, where a previous state
     /// transition failed in a non-recoverable way.

--- a/crates/core/src/state/mod.rs
+++ b/crates/core/src/state/mod.rs
@@ -23,7 +23,7 @@ pub enum Error {
     #[error("end of chain")]
     EndOfChain,
     /// Received an update that is either out-of-order or has unexpected data.
-    #[error("out-of-order update")]
+    #[error("bad update")]
     BadUpdate,
     /// The state machine is in a poisoned state, where a previous state
     /// transition failed in a non-recoverable way.

--- a/crates/core/src/tx/fees.rs
+++ b/crates/core/src/tx/fees.rs
@@ -1,0 +1,90 @@
+//! EIP-1559 fee calculations for reliable transaction submission.
+
+use alloy::eips::eip1559::Eip1559Estimation;
+
+/// Caps the priority fee of `fees` so it is at most `cap_percentage` percent of
+/// the total max fee per gas, leaving the base-fee component unchanged.
+///
+/// Mirrors the validator's gas fee estimator: it solves for the largest priority
+/// fee `p` with `p / (base_fee + p) <= cap_percentage / 100`, then lowers the
+/// priority fee to it (never raising it). A cap of 100% or more is a no-op.
+pub fn cap_priority_fee(fees: Eip1559Estimation, cap_percentage: f64) -> Eip1559Estimation {
+    // Scale the percentage into integer space for the fee math, allowing up to
+    // six digits of precision in `cap_percentage`.
+    const PRECISION: u128 = 1_000_000;
+    let scaled_percent = ((cap_percentage / 100.0) * PRECISION as f64).round() as u128;
+    if scaled_percent >= PRECISION {
+        return fees;
+    }
+
+    let base_fee = fees
+        .max_fee_per_gas
+        .saturating_sub(fees.max_priority_fee_per_gas);
+    let capped = base_fee.saturating_mul(scaled_percent) / (PRECISION - scaled_percent);
+    let max_priority_fee_per_gas = fees.max_priority_fee_per_gas.min(capped);
+
+    Eip1559Estimation {
+        max_priority_fee_per_gas,
+        max_fee_per_gas: base_fee + max_priority_fee_per_gas,
+    }
+}
+
+/// Returns the `fresh` fee estimate with each component raised to at least 10%
+/// above the matching `previous` fee, when a previous submission exists, so a
+/// resubmitted transaction replaces rather than duplicates the pending one;
+/// nodes reject a replacement that does not raise the fee enough.
+pub fn bump(fresh: Eip1559Estimation, previous: Option<Eip1559Estimation>) -> Eip1559Estimation {
+    let Some(previous) = previous else {
+        return fresh;
+    };
+    Eip1559Estimation {
+        max_fee_per_gas: bump_fee(fresh.max_fee_per_gas, previous.max_fee_per_gas),
+        max_priority_fee_per_gas: bump_fee(
+            fresh.max_priority_fee_per_gas,
+            previous.max_priority_fee_per_gas,
+        ),
+    }
+}
+
+/// Returns `fresh`, raised to at least 10% above `previous`.
+fn bump_fee(fresh: u128, previous: u128) -> u128 {
+    fresh.max(previous.saturating_mul(110) / 100)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn fees(max_fee_per_gas: u128, max_priority_fee_per_gas: u128) -> Eip1559Estimation {
+        Eip1559Estimation {
+            max_fee_per_gas,
+            max_priority_fee_per_gas,
+        }
+    }
+
+    #[test]
+    fn caps_the_priority_fee_at_a_percentage_of_the_max_fee() {
+        // A priority fee already below the cap is unchanged.
+        assert_eq!(cap_priority_fee(fees(100, 10), 50.0), fees(100, 10));
+
+        // Above the cap it is lowered, preserving the base-fee component: the
+        // base fee is 40, so the priority fee is capped to 40 * 25/75 = 13 and
+        // the max fee to 40 + 13 = 53.
+        assert_eq!(cap_priority_fee(fees(100, 60), 25.0), fees(53, 13));
+
+        // A cap of 100% or more never reduces the fee.
+        assert_eq!(cap_priority_fee(fees(100, 60), 100.0), fees(100, 60));
+    }
+
+    #[test]
+    fn bumps_replacement_fees_by_at_least_ten_percent() {
+        // A first submission (no previous fees) keeps the fresh estimate.
+        assert_eq!(bump(fees(100, 10), None), fees(100, 10));
+
+        // A resubmission raises each fee to 10% above the previous one.
+        assert_eq!(bump(fees(100, 10), Some(fees(100, 10))), fees(110, 11));
+
+        // ...unless the fresh estimate already exceeds that.
+        assert_eq!(bump(fees(200, 50), Some(fees(100, 10))), fees(200, 50));
+    }
+}

--- a/crates/core/src/tx/fees.rs
+++ b/crates/core/src/tx/fees.rs
@@ -7,12 +7,13 @@ use alloy::eips::eip1559::Eip1559Estimation;
 ///
 /// Mirrors the validator's gas fee estimator: it solves for the largest priority
 /// fee `p` with `p / (base_fee + p) <= cap_percentage / 100`, then lowers the
-/// priority fee to it (never raising it). A cap of 100% or more is a no-op.
+/// priority fee to it (never raising it). A cap of of 0% or negative disables
+/// priority fees, and a cap of 100% or more is a no-op.
 pub fn cap_priority_fee(fees: Eip1559Estimation, cap_percentage: f64) -> Eip1559Estimation {
     // Scale the percentage into integer space for the fee math, allowing up to
     // six digits of precision in `cap_percentage`.
     const PRECISION: u128 = 1_000_000;
-    let scaled_percent = ((cap_percentage / 100.0) * PRECISION as f64).round() as u128;
+    let scaled_percent = ((cap_percentage.max(0.0) / 100.0) * PRECISION as f64).round() as u128;
     if scaled_percent >= PRECISION {
         return fees;
     }
@@ -48,7 +49,7 @@ pub fn bump(fresh: Eip1559Estimation, previous: Option<Eip1559Estimation>) -> Ei
 
 /// Returns `fresh`, raised to at least 10% above `previous`.
 fn bump_fee(fresh: u128, previous: u128) -> u128 {
-    fresh.max(previous.saturating_mul(110) / 100)
+    fresh.max(previous.saturating_mul(110).div_ceil(100))
 }
 
 #[cfg(test)]

--- a/crates/core/src/tx/fees.rs
+++ b/crates/core/src/tx/fees.rs
@@ -1,13 +1,13 @@
 //! EIP-1559 fee calculations for reliable transaction submission.
 
-use alloy::eips::eip1559::Eip1559Estimation;
+use alloy::{eips::eip1559::Eip1559Estimation, primitives::U256, uint};
 
 /// Caps the priority fee of `fees` so it is at most `cap_percentage` percent of
 /// the total max fee per gas, leaving the base-fee component unchanged.
 ///
 /// Mirrors the validator's gas fee estimator: it solves for the largest priority
 /// fee `p` with `p / (base_fee + p) <= cap_percentage / 100`, then lowers the
-/// priority fee to it (never raising it). A cap of of 0% or negative disables
+/// priority fee to it (never raising it). A cap of 0% or negative disables
 /// priority fees, and a cap of 100% or more is a no-op.
 pub fn cap_priority_fee(fees: Eip1559Estimation, cap_percentage: f64) -> Eip1559Estimation {
     // Scale the percentage into integer space for the fee math, allowing up to
@@ -34,6 +34,8 @@ pub fn cap_priority_fee(fees: Eip1559Estimation, cap_percentage: f64) -> Eip1559
 /// above the matching `previous` fee, when a previous submission exists, so a
 /// resubmitted transaction replaces rather than duplicates the pending one;
 /// nodes reject a replacement that does not raise the fee enough.
+///
+/// Note that fee bumps can cause priority fee caps to not be observed.
 pub fn bump(fresh: Eip1559Estimation, previous: Option<Eip1559Estimation>) -> Eip1559Estimation {
     let Some(previous) = previous else {
         return fresh;
@@ -49,7 +51,12 @@ pub fn bump(fresh: Eip1559Estimation, previous: Option<Eip1559Estimation>) -> Ei
 
 /// Returns `fresh`, raised to at least 10% above `previous`.
 fn bump_fee(fresh: u128, previous: u128) -> u128 {
-    fresh.max(previous.saturating_mul(110).div_ceil(100))
+    let bumped = U256::from(previous)
+        .wrapping_mul(uint!(110_U256))
+        .div_ceil(uint!(100_U256))
+        .try_into()
+        .unwrap_or(u128::MAX);
+    fresh.max(bumped)
 }
 
 #[cfg(test)]

--- a/crates/core/src/tx/mod.rs
+++ b/crates/core/src/tx/mod.rs
@@ -3,9 +3,450 @@
 //! Safenet services submit transactions to advance the protocol onchain. This
 //! module provides a transaction queue that accepts transactions to execute and
 //! reliably gets them onchain: managing nonces, signing and submitting via a
-//! local [`account`], and resubmitting with bumped fees when a transaction is
+//! local [`signer`], and resubmitting with bumped fees when a transaction is
 //! stuck.
 
+mod fees;
 pub mod signer;
+mod storage;
+pub mod types;
 
-pub use self::signer::Signer;
+use self::{
+    fees::cap_priority_fee,
+    signer::SigningError,
+    storage::{Status, Submission, TransactionStorage},
+};
+pub use self::{signer::Signer, types::Transaction};
+use crate::{index::BlockUpdate, tx::types::TransactionWithNonce};
+use alloy::{eips::eip1559::Eip1559Estimation, providers::Provider, transports::TransportError};
+use serde::Deserialize;
+use sqlx::sqlite::SqlitePool;
+
+/// Error produced by the [`TransactionQueue`].
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+    /// A transaction storage error.
+    #[error(transparent)]
+    Storage(#[from] storage::Error),
+    /// An RPC request failed.
+    #[error(transparent)]
+    Rpc(#[from] TransportError),
+    /// A transaction could not be signed.
+    #[error(transparent)]
+    Signing(#[from] SigningError),
+    /// A block update arrived out of order or has unexpected or invalid data.
+    #[error("bad block update")]
+    BadUpdate,
+}
+
+/// Transaction queue configuration.
+#[derive(Clone, Debug, Deserialize, PartialEq)]
+#[serde(default)]
+pub struct Config {
+    /// The maximum number of transactions that may be in flight (submitted
+    /// onchain but not yet executed) at any one time. The queue only submits new
+    /// transactions while it is below this limit.
+    pub max_in_flight_transactions: usize,
+    /// How many blocks a submitted transaction may go unexecuted before it is
+    /// resubmitted with a bumped fee.
+    pub blocks_before_resubmit: u64,
+    /// Caps the priority fee of estimated fees to at most this percentage of the
+    /// total max fee per gas, lowering the priority fee (and max fee) when an
+    /// estimate exceeds it. `None` applies no cap.
+    pub priority_fee_cap_percentage: Option<f64>,
+}
+
+impl Default for Config {
+    fn default() -> Self {
+        Self {
+            max_in_flight_transactions: 16,
+            blocks_before_resubmit: 2,
+            priority_fee_cap_percentage: None,
+        }
+    }
+}
+
+/// A queue of transactions to submit onchain.
+pub struct TransactionQueue<P> {
+    provider: P,
+    chain_id: u64,
+    signer: Signer,
+    storage: TransactionStorage,
+    config: Config,
+    /// The latest block the queue has observed, used to stamp submissions and
+    /// drive expiry. `None` until the first block update.
+    block: Option<u64>,
+    /// The signer nonce, cached until the next block update.
+    nonce_cache: Option<u64>,
+    /// The fee estimate, cached until the next block update.
+    fee_cache: Option<Eip1559Estimation>,
+}
+
+impl<P> TransactionQueue<P>
+where
+    P: Provider,
+{
+    /// Creates a transaction queue that signs `chain_id` transactions with
+    /// `signer`, reads chain state and broadcasts through `provider`, and
+    /// persists its state in `pool`.
+    pub async fn new(
+        provider: P,
+        chain_id: u64,
+        signer: Signer,
+        pool: SqlitePool,
+        config: Config,
+    ) -> Result<Self, Error> {
+        let storage = TransactionStorage::new(pool).await?;
+        Ok(Self {
+            provider,
+            chain_id,
+            signer,
+            storage,
+            config,
+            block: None,
+            nonce_cache: None,
+            fee_cache: None,
+        })
+    }
+
+    /// Queues `transaction` for execution, to be dropped if it has not been
+    /// submitted by block `expires_at`, then attempts to submit it (and any
+    /// other queued transactions) onchain.
+    pub async fn queue(&mut self, transaction: Transaction, expires_at: u64) -> Result<(), Error> {
+        self.storage.enqueue(transaction, expires_at).await?;
+        self.submit_pending().await
+    }
+
+    /// Handles an indexer [`BlockUpdate`], performing the queue's per-block
+    /// housekeeping: invalidating cached chain state, marking executed
+    /// transactions, pruning finalized and expired ones, resubmitting stale
+    /// transactions and submitting newly queued ones.
+    pub async fn handle_block_update(&mut self, update: BlockUpdate) -> Result<(), Error> {
+        self.nonce_cache = None;
+        self.fee_cache = None;
+        match update {
+            BlockUpdate::New { number, safe, .. } => {
+                if self
+                    .block
+                    .is_some_and(|latest| latest.checked_add(1) != Some(number))
+                    || safe > number
+                {
+                    return Err(Error::BadUpdate);
+                }
+                self.progress_block(number, safe).await?;
+            }
+            BlockUpdate::Uncle { number } => {
+                if self.block.is_some_and(|latest| latest < number) {
+                    return Err(Error::BadUpdate);
+                }
+                self.block = Some(number.saturating_sub(1));
+                self.storage.unmark_executed(number).await?;
+            }
+            BlockUpdate::Warp { to, .. } => {
+                if self.block.is_some_and(|latest| latest >= to) {
+                    return Err(Error::BadUpdate);
+                }
+                self.progress_block(to, to).await?;
+            }
+        }
+        Ok(())
+    }
+
+    /// Progresses to a new latest `block`, finalizing state at or below `safe`.
+    async fn progress_block(&mut self, block: u64, safe: u64) -> Result<(), Error> {
+        self.block = Some(block);
+
+        // The signer nonce is an RPC round-trip needed only to mark executed
+        // transactions and to assign nonces to queued ones; both are moot unless
+        // a transaction is still outstanding, so skip it (and the work that
+        // needs it) otherwise. Pruning needs no nonce and always runs, before
+        // submission so expired transactions are dropped rather than broadcast.
+        let outstanding = self.storage.count_outstanding(block).await? > 0;
+        if outstanding {
+            let nonce = self.nonce().await?;
+            self.storage.mark_executed(Status { block, nonce }).await?;
+        }
+        self.storage.prune(safe).await?;
+        if outstanding {
+            self.resubmit_stale(block).await?;
+            self.submit_pending().await?;
+        }
+        Ok(())
+    }
+
+    /// Submits queued transactions while fewer than
+    /// `config.max_in_flight_transactions` are in flight.
+    ///
+    /// Does nothing until the first block update is observed, since a submission
+    /// is stamped with the current block.
+    async fn submit_pending(&mut self) -> Result<(), Error> {
+        let Some(block) = self.block else {
+            return Ok(());
+        };
+
+        let in_flight = self.storage.count_in_flight().await?;
+        for _ in in_flight..self.config.max_in_flight_transactions {
+            let nonce = self.nonce().await?;
+            let Some(transaction) = self
+                .storage
+                .next_transaction(Status { nonce, block })
+                .await?
+            else {
+                break;
+            };
+            self.submit_transaction(transaction, block).await?;
+        }
+
+        Ok(())
+    }
+
+    /// Rebuilds and rebroadcasts in-flight transactions that have gone
+    /// unexecuted for at least `config.blocks_before_resubmit` blocks, bumping
+    /// their fees so they replace the previous submission.
+    async fn resubmit_stale(&mut self, block: u64) -> Result<(), Error> {
+        let Some(submitted_before) = block.checked_sub(self.config.blocks_before_resubmit) else {
+            return Ok(());
+        };
+
+        let stale = self.storage.stale_submissions(submitted_before).await?;
+        if stale.is_empty() {
+            return Ok(());
+        }
+
+        for transaction in stale {
+            self.submit_transaction(transaction, block).await?;
+        }
+
+        Ok(())
+    }
+
+    /// Signs `transaction` and broadcasts it, recording the submission at
+    /// `block`.
+    async fn submit_transaction(
+        &mut self,
+        transaction: TransactionWithNonce,
+        block: u64,
+    ) -> Result<(), Error> {
+        let fees = self.fees().await?;
+        let transaction = transaction.build(self.chain_id, fees);
+        let submission = Submission {
+            block,
+            nonce: transaction.nonce,
+            fees: Eip1559Estimation {
+                max_fee_per_gas: transaction.max_fee_per_gas,
+                max_priority_fee_per_gas: transaction.max_priority_fee_per_gas,
+            },
+        };
+
+        let signed = self.signer.sign_transaction(transaction)?;
+        // Record the submission regardless of whether the RPC request succeeds:
+        // on error we cannot be sure the transaction did not reach the mempool.
+        self.storage.record_submission(submission).await?;
+        let _ = self.provider.send_raw_transaction(signed.as_raw()).await;
+        Ok(())
+    }
+
+    /// Returns the signer's onchain nonce (its transaction count), fetched from
+    /// the chain on a cache miss and cached until the next block update.
+    async fn nonce(&mut self) -> Result<u64, Error> {
+        match self.nonce_cache {
+            Some(nonce) => Ok(nonce),
+            None => {
+                let nonce = self
+                    .provider
+                    .get_transaction_count(self.signer.address())
+                    .await?;
+                self.nonce_cache = Some(nonce);
+                Ok(nonce)
+            }
+        }
+    }
+
+    /// Returns the current EIP-1559 fee estimate, with the configured priority
+    /// fee cap applied, fetched from the chain on a cache miss and cached until
+    /// the next block update.
+    async fn fees(&mut self) -> Result<Eip1559Estimation, Error> {
+        match self.fee_cache {
+            Some(fees) => Ok(fees),
+            None => {
+                let fees = self.provider.estimate_eip1559_fees().await?;
+                let fees = match self.config.priority_fee_cap_percentage {
+                    Some(cap) => cap_priority_fee(fees, cap),
+                    None => fees,
+                };
+                self.fee_cache = Some(fees);
+                Ok(fees)
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloy::{
+        primitives::{Address, B256, Bloom, U64, address, keccak256},
+        providers::{ProviderBuilder, RootProvider},
+        rpc::types::FeeHistory,
+        signers::k256::ecdsa::SigningKey,
+        transports::mock::Asserter,
+    };
+    use sqlx::sqlite::SqlitePoolOptions;
+
+    const CHAIN_ID: u64 = 1;
+    const ENTRY_POINT: Address = address!("0x5FF137D4b0FDCD49DcA30c7CF57E578a026d2789");
+
+    /// A transaction queue backed by a mocked RPC client and an in-memory pool.
+    async fn queue(asserter: &Asserter) -> TransactionQueue<RootProvider> {
+        let provider = ProviderBuilder::default().connect_mocked_client(asserter.clone());
+        let private_key = SigningKey::from_slice(keccak256("test signer").as_slice()).unwrap();
+        let signer = Signer::new(private_key);
+        let pool = SqlitePoolOptions::new()
+            .max_connections(1)
+            .connect_with("sqlite::memory:".parse().unwrap())
+            .await
+            .unwrap();
+        TransactionQueue::new(provider, CHAIN_ID, signer, pool, Config::default())
+            .await
+            .unwrap()
+    }
+
+    /// A transaction carrying `input` as its calldata.
+    fn transaction(input: &str) -> Transaction {
+        Transaction {
+            to: ENTRY_POINT,
+            input: input.parse().unwrap(),
+            ..Default::default()
+        }
+    }
+
+    /// A new-block update at `number`, finalizing state up to `safe`.
+    fn new_block(number: u64) -> BlockUpdate {
+        BlockUpdate::New {
+            number,
+            hash: B256::ZERO,
+            logs_bloom: Bloom::ZERO,
+            safe: 0,
+        }
+    }
+
+    /// A fee-history response yielding an estimate of a 210 max fee and 10
+    /// priority fee (base fee 100, doubled, plus the 10 priority fee).
+    fn fee_history() -> FeeHistory {
+        FeeHistory {
+            base_fee_per_gas: vec![100, 100],
+            reward: Some(vec![vec![10]]),
+            ..Default::default()
+        }
+    }
+
+    #[tokio::test]
+    async fn submits_queued_transactions_with_reorg_awareness() {
+        let asserter = Asserter::new();
+        let mut queue = queue(&asserter).await;
+        queue.queue(transaction("0x01"), 1000).await.unwrap();
+
+        asserter.push_success(&U64::from(0)); // signer transaction count
+        asserter.push_success(&fee_history()); // fee estimate
+        asserter.push_success(&B256::ZERO); // transaction hash from submission
+        queue.handle_block_update(new_block(10)).await.unwrap();
+
+        // At block 11 the signer nonce has advanced to 1, so nonce 0 executed.
+        // The safe block (5) is below the execution, so it is marked but not
+        // pruned. No transaction is broadcast, so only the nonce is fetched.
+        asserter.push_success(&U64::from(1));
+        queue.handle_block_update(new_block(11)).await.unwrap();
+        assert!(asserter.read_q().is_empty());
+
+        // Block 11 is uncled, reverting the execution: the transaction is in
+        // flight again.
+        queue
+            .handle_block_update(BlockUpdate::Uncle { number: 11 })
+            .await
+            .unwrap();
+        assert!(asserter.read_q().is_empty());
+
+        // We update up to block 12, where the nonce stays the same. This means
+        // that it is not submitted and gets resubmitted (since it did not get
+        // executed on the new canonical chain since the reorg).
+        asserter.push_success(&U64::from(0)); // signer transaction count
+        queue.handle_block_update(new_block(11)).await.unwrap();
+        assert!(asserter.read_q().is_empty());
+
+        asserter.push_success(&U64::from(0)); // signer transaction count
+        asserter.push_success(&fee_history()); // fee estimate
+        asserter.push_success(&B256::ZERO); // transaction hash from submission
+        queue.handle_block_update(new_block(12)).await.unwrap();
+        assert!(asserter.read_q().is_empty());
+
+        // Now the transaction gets picked up, and since there are no remaining
+        // outstanding transactions we avoid any additional RPC requests on
+        // future blocks.
+        asserter.push_success(&U64::from(1)); // signer transaction count
+        queue.handle_block_update(new_block(13)).await.unwrap();
+        assert!(asserter.read_q().is_empty());
+
+        for block in 14..=20 {
+            queue.handle_block_update(new_block(block)).await.unwrap();
+            assert!(asserter.read_q().is_empty());
+        }
+    }
+
+    #[tokio::test]
+    async fn does_not_submit_expired_transactions() {
+        let asserter = Asserter::new();
+        let mut queue = queue(&asserter).await;
+
+        // Fill up the queue with transactions that will not execute.
+        asserter.push_success(&U64::from(0)); // signer transaction count
+        asserter.push_success(&fee_history()); // fee estimate
+        for i in 0..queue.config.max_in_flight_transactions {
+            queue
+                .queue(transaction(&format!("0x{i:02x}")), 12)
+                .await
+                .unwrap();
+            asserter.push_success(&B256::ZERO); // transaction hash from submission
+        }
+
+        // Add two more transactions that cannot be submitted because of the
+        // in-flight limit.
+        queue.queue(transaction("0xf0"), 12).await.unwrap();
+        queue.queue(transaction("0xf1"), 12).await.unwrap();
+
+        // Observe a block to submit some of the transactions.
+        queue.handle_block_update(new_block(10)).await.unwrap();
+        assert!(asserter.read_q().is_empty());
+
+        // At block 11, the nonce advances by 1, opening up one more transaction
+        // to be submitted.
+        asserter.push_success(&U64::from(1)); // signer transaction count
+        asserter.push_success(&fee_history()); // fee estimate
+        asserter.push_success(&B256::ZERO); // transaction hash from submission
+        queue.handle_block_update(new_block(11)).await.unwrap();
+        assert!(asserter.read_q().is_empty());
+
+        // At block 12, another transaction gets mined, but the outstanding
+        // transaction has already expired and is not executed. However, we
+        // do get resubmissions of the remaining original inflight transactions
+        // because of the resubmit deadline, despite being past the expiry. This
+        // is because once a transaction is in the mempool, it has to execute.
+        asserter.push_success(&U64::from(2)); // signer transaction count
+        asserter.push_success(&fee_history()); // fee estimate
+        for _ in 2..queue.config.max_in_flight_transactions {
+            asserter.push_success(&B256::ZERO); // transaction hash from submission
+        }
+        queue.handle_block_update(new_block(12)).await.unwrap();
+        assert!(asserter.read_q().is_empty());
+
+        // At block 13, all the remaining transactions get mined, the second
+        // transaction was already expired and does not resubmit.
+        asserter.push_success(&U64::from(queue.config.max_in_flight_transactions + 1)); // signer transaction count
+        queue.handle_block_update(new_block(13)).await.unwrap();
+        assert!(asserter.read_q().is_empty());
+
+        // At block 14, there are no outstanding transactions and therefore no
+        // RPC requests are made.
+        queue.handle_block_update(new_block(14)).await.unwrap();
+        assert!(asserter.read_q().is_empty());
+    }
+}

--- a/crates/core/src/tx/mod.rs
+++ b/crates/core/src/tx/mod.rs
@@ -18,7 +18,11 @@ use self::{
 };
 pub use self::{signer::Signer, types::Transaction};
 use crate::{index::BlockUpdate, tx::types::TransactionWithNonce};
-use alloy::{eips::eip1559::Eip1559Estimation, providers::Provider, transports::TransportError};
+use alloy::{
+    eips::{BlockId, eip1559::Eip1559Estimation},
+    providers::Provider,
+    transports::TransportError,
+};
 use serde::Deserialize;
 use sqlx::sqlite::SqlitePool;
 
@@ -34,6 +38,10 @@ pub enum Error {
     /// A transaction could not be signed.
     #[error(transparent)]
     Signing(#[from] SigningError),
+    /// We have reached the end of the block chain and cannot continue handling
+    /// updates.
+    #[error("end of chain")]
+    EndOfChain,
     /// A block update arrived out of order or has unexpected or invalid data.
     #[error("bad block update")]
     BadUpdate,
@@ -73,13 +81,15 @@ pub struct TransactionQueue<P> {
     signer: Signer,
     storage: TransactionStorage,
     config: Config,
-    /// The latest block the queue has observed, used to stamp submissions and
-    /// drive expiry. `None` until the first block update.
-    block: Option<u64>,
-    /// The signer nonce, cached until the next block update.
+    block: Block,
     nonce_cache: Option<u64>,
-    /// The fee estimate, cached until the next block update.
     fee_cache: Option<Eip1559Estimation>,
+}
+
+enum Block {
+    Initalized,
+    Latest { block: u64 },
+    Warping { to: u64 },
 }
 
 impl<P> TransactionQueue<P>
@@ -103,7 +113,7 @@ where
             signer,
             storage,
             config,
-            block: None,
+            block: Block::Initalized,
             nonce_cache: None,
             fee_cache: None,
         })
@@ -126,50 +136,57 @@ where
         self.fee_cache = None;
         match update {
             BlockUpdate::New { number, safe, .. } => {
-                if self
-                    .block
-                    .is_some_and(|latest| latest.checked_add(1) != Some(number))
-                    || safe > number
-                {
+                if self.next_block()?.is_some_and(|next| next != number) || safe > number {
                     return Err(Error::BadUpdate);
                 }
-                self.progress_block(number, safe).await?;
+                self.block = Block::Latest { block: number };
+
+                // The signer nonce is an RPC round-trip needed only to mark executed
+                // transactions and to assign nonces to queued ones; both are moot unless
+                // a transaction is still outstanding, so skip it (and the work that
+                // needs it) otherwise. Pruning needs no nonce and always runs, before
+                // submission so expired transactions are dropped rather than broadcast.
+                let outstanding = self.storage.count_outstanding(number).await? > 0;
+                if outstanding {
+                    let nonce = self.nonce().await?;
+                    self.storage
+                        .mark_executed(Status {
+                            block: number,
+                            nonce,
+                        })
+                        .await?;
+                }
+
+                self.storage.prune(safe).await?;
+                if outstanding {
+                    self.resubmit_stale(number).await?;
+                    self.submit_pending().await?;
+                }
             }
             BlockUpdate::Uncle { number } => {
-                if self.block.is_some_and(|latest| latest < number) {
+                if self.latest_block().is_some_and(|latest| latest < number) {
                     return Err(Error::BadUpdate);
                 }
-                self.block = Some(number.saturating_sub(1));
+                self.block = Block::Latest {
+                    block: number.checked_sub(1).ok_or(Error::BadUpdate)?,
+                };
                 self.storage.unmark_executed(number).await?;
             }
-            BlockUpdate::Warp { to, .. } => {
-                if self.block.is_some_and(|latest| latest >= to) {
+            BlockUpdate::Warp { from, to } => {
+                if self.next_block()?.is_some_and(|next| next != from) || to < from {
                     return Err(Error::BadUpdate);
                 }
-                self.progress_block(to, to).await?;
+
+                // We do not handle warping (it gets weird with transaction
+                // submission and getting transaction counts). It is not worth
+                // it either as warping is historic and most transactions are
+                // too far in the past to execute anyway. Put us into the state
+                // where we are waiting for the next new block update, so queued
+                // transactions do not execute right away. This ensures that
+                // transactions that are queued already expired while warping do
+                // execute.
+                self.block = Block::Warping { to };
             }
-        }
-        Ok(())
-    }
-
-    /// Progresses to a new latest `block`, finalizing state at or below `safe`.
-    async fn progress_block(&mut self, block: u64, safe: u64) -> Result<(), Error> {
-        self.block = Some(block);
-
-        // The signer nonce is an RPC round-trip needed only to mark executed
-        // transactions and to assign nonces to queued ones; both are moot unless
-        // a transaction is still outstanding, so skip it (and the work that
-        // needs it) otherwise. Pruning needs no nonce and always runs, before
-        // submission so expired transactions are dropped rather than broadcast.
-        let outstanding = self.storage.count_outstanding(block).await? > 0;
-        if outstanding {
-            let nonce = self.nonce().await?;
-            self.storage.mark_executed(Status { block, nonce }).await?;
-        }
-        self.storage.prune(safe).await?;
-        if outstanding {
-            self.resubmit_stale(block).await?;
-            self.submit_pending().await?;
         }
         Ok(())
     }
@@ -180,7 +197,7 @@ where
     /// Does nothing until the first block update is observed, since a submission
     /// is stamped with the current block.
     async fn submit_pending(&mut self) -> Result<(), Error> {
-        let Some(block) = self.block else {
+        let Some(block) = self.latest_block() else {
             return Ok(());
         };
 
@@ -246,6 +263,27 @@ where
         Ok(())
     }
 
+    /// Returns the latest block received from block updates, or `None` if none
+    /// have been received or during warping.
+    fn latest_block(&self) -> Option<u64> {
+        match self.block {
+            Block::Latest { block } => Some(block),
+            _ => None,
+        }
+    }
+
+    /// Returns the expected next block for block updates, or `None` if none
+    /// no block updates have been received.
+    fn next_block(&self) -> Result<Option<u64>, Error> {
+        match self.block {
+            Block::Latest { block } | Block::Warping { to: block } => {
+                let next = block.checked_add(1).ok_or(Error::EndOfChain)?;
+                Ok(Some(next))
+            }
+            _ => Ok(None),
+        }
+    }
+
     /// Returns the signer's onchain nonce (its transaction count), fetched from
     /// the chain on a cache miss and cached until the next block update.
     async fn nonce(&mut self) -> Result<u64, Error> {
@@ -255,6 +293,11 @@ where
                 let nonce = self
                     .provider
                     .get_transaction_count(self.signer.address())
+                    .block_id(
+                        self.latest_block()
+                            .map(BlockId::from)
+                            .unwrap_or_else(BlockId::latest),
+                    )
                     .await?;
                 self.nonce_cache = Some(nonce);
                 Ok(nonce)
@@ -447,6 +490,27 @@ mod tests {
         // At block 14, there are no outstanding transactions and therefore no
         // RPC requests are made.
         queue.handle_block_update(new_block(14)).await.unwrap();
+        assert!(asserter.read_q().is_empty());
+    }
+
+    #[tokio::test]
+    async fn expired_transactions_while_warping_are_ignored() {
+        let asserter = Asserter::new();
+        let mut queue = queue(&asserter).await;
+
+        // Observe a warp update.
+        queue
+            .handle_block_update(BlockUpdate::Warp { from: 0, to: 1000 })
+            .await
+            .unwrap();
+        assert!(asserter.read_q().is_empty());
+
+        // queue a transaction long expired.
+        queue.queue(transaction("0x01"), 42).await.unwrap();
+
+        // now queue a block update, the transaction is not submitted as it is
+        // expired and was never submitted to an RPC node.
+        queue.handle_block_update(new_block(1001)).await.unwrap();
         assert!(asserter.read_q().is_empty());
     }
 }

--- a/crates/core/src/tx/mod.rs
+++ b/crates/core/src/tx/mod.rs
@@ -20,6 +20,7 @@ pub use self::{signer::Signer, types::Transaction};
 use crate::{index::BlockUpdate, tx::types::TransactionWithNonce};
 use alloy::{
     eips::{BlockId, eip1559::Eip1559Estimation},
+    primitives::U256,
     providers::Provider,
     transports::TransportError,
 };
@@ -84,10 +85,11 @@ pub struct TransactionQueue<P> {
     block: Block,
     nonce_cache: Option<u64>,
     fee_cache: Option<Eip1559Estimation>,
+    balance_cache: Option<U256>,
 }
 
 enum Block {
-    Initalized,
+    Initialized,
     Latest { block: u64 },
     Warping { to: u64 },
 }
@@ -113,9 +115,10 @@ where
             signer,
             storage,
             config,
-            block: Block::Initalized,
+            block: Block::Initialized,
             nonce_cache: None,
             fee_cache: None,
+            balance_cache: None,
         })
     }
 
@@ -134,6 +137,7 @@ where
     pub async fn handle_block_update(&mut self, update: BlockUpdate) -> Result<(), Error> {
         self.nonce_cache = None;
         self.fee_cache = None;
+        self.balance_cache = None;
         match update {
             BlockUpdate::New { number, safe, .. } => {
                 if self.next_block()?.is_some_and(|next| next != number) || safe > number {
@@ -247,24 +251,51 @@ where
         let fees = self.fees().await?;
         let transaction = transaction.build(self.chain_id, fees);
         let submission = Submission {
-            block,
+            block: Some(block),
             nonce: transaction.nonce,
             fees: Eip1559Estimation {
                 max_fee_per_gas: transaction.max_fee_per_gas,
                 max_priority_fee_per_gas: transaction.max_priority_fee_per_gas,
             },
         };
+        let max_cost = transaction.value.saturating_add(
+            U256::from(transaction.gas_limit) * U256::from(transaction.max_fee_per_gas),
+        );
 
         let signed = self.signer.sign_transaction(transaction)?;
-        // Record the submission regardless of whether the RPC request succeeds:
-        // on error we cannot be sure the transaction did not reach the mempool.
-        self.storage.record_submission(submission).await?;
-        let _ = self.provider.send_raw_transaction(signed.as_raw()).await;
+        match self.provider.send_raw_transaction(signed.as_raw()).await {
+            Ok(_) => self.storage.record_submission(submission).await?,
+            // If the transaction is rejected because of insufficient balance,
+            // then do not record the submission because we do not want to bump
+            // fees for a transaction that is not allowed to be in the mempool.
+            // Otherwise, we can get into unbounded fee grown if a signer runs
+            // out of funds. Note that this is a best effort - we will still
+            // potentially fee bump in cases where we do have insufficient
+            // balance when including in-flight transactions for previous
+            // nonces. This approximation is fine for now (we want to err on the
+            // side of caution and fee bump to prevent transactions submission
+            // getting stuck, and we still have an upper bound on the current
+            // balance for the signer, so we are protected from unbounded fee
+            // increases).
+            Err(_) if self.balance().await.is_ok_and(|balance| balance < max_cost) => {}
+            // Otherwise, record the used gas parameters even if the RPC request
+            // failed: for general errors we cannot be sure the transaction did
+            // not reach the mempool. We record the submission without a block
+            // so that it is retried immediately on the next block.
+            _ => {
+                self.storage
+                    .record_submission(Submission {
+                        block: None,
+                        ..submission
+                    })
+                    .await?
+            }
+        }
         Ok(())
     }
 
-    /// Returns the latest block received from block updates, or `None` if none
-    /// have been received or during warping.
+    /// Returns the latest block received from block updates, or `None` if no
+    /// updates have been received or during warping.
     fn latest_block(&self) -> Option<u64> {
         match self.block {
             Block::Latest { block } => Some(block),
@@ -272,8 +303,8 @@ where
         }
     }
 
-    /// Returns the expected next block for block updates, or `None` if none
-    /// no block updates have been received.
+    /// Returns the expected next block for block updates, or `None` if no block
+    /// updates have been received.
     fn next_block(&self) -> Result<Option<u64>, Error> {
         match self.block {
             Block::Latest { block } | Block::Warping { to: block } => {
@@ -322,13 +353,26 @@ where
             }
         }
     }
+
+    /// Returns the cached account balance, used to detect whether or not a
+    /// submitted transaction was rejected because of insufficient fees.
+    async fn balance(&mut self) -> Result<U256, Error> {
+        match self.balance_cache {
+            Some(balance) => Ok(balance),
+            None => {
+                let balance = self.provider.get_balance(self.signer.address()).await?;
+                self.balance_cache = Some(balance);
+                Ok(balance)
+            }
+        }
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
     use alloy::{
-        primitives::{Address, B256, Bloom, U64, address, keccak256},
+        primitives::{Address, B256, Bloom, U64, U256, address, keccak256},
         providers::{ProviderBuilder, RootProvider},
         rpc::types::FeeHistory,
         signers::k256::ecdsa::SigningKey,
@@ -511,6 +555,53 @@ mod tests {
         // now queue a block update, the transaction is not submitted as it is
         // expired and was never submitted to an RPC node.
         queue.handle_block_update(new_block(1001)).await.unwrap();
+        assert!(asserter.read_q().is_empty());
+    }
+
+    #[tokio::test]
+    async fn retries_failed_submissions_on_the_next_block() {
+        let asserter = Asserter::new();
+        let mut queue = queue(&asserter).await;
+
+        // Queue two transactions that will both fail to submit. The first is
+        // cheap enough for the signer to afford, so its failure is treated as a
+        // general error; the second has a high gas limit the signer cannot
+        // afford, so its failure is treated as the node rejecting it.
+        queue.queue(transaction("0x01"), 1000).await.unwrap();
+        queue
+            .queue(
+                Transaction {
+                    gas: 1_000_000,
+                    ..transaction("0x02")
+                },
+                1000,
+            )
+            .await
+            .unwrap();
+
+        // At block 10 both submissions fail. The signer balance (100M) covers
+        // the cheap transaction (21000 gas * 210 max fee = ~4.4M) but not the
+        // expensive one (1M gas * 210 max fee = 210M). Only the cheap one is
+        // recorded as submitted (without a block, so it retries immediately);
+        // the expensive one is left unrecorded so its fees are not bumped.
+        asserter.push_success(&U64::from(0)); // signer transaction count
+        asserter.push_success(&fee_history()); // fee estimate
+        asserter.push_failure_msg("no connection"); // cheap submission fails
+        asserter.push_success(&U256::from(100_000_000)); // signer balance
+        asserter.push_failure_msg("insufficient funds"); // expensive submission fails
+        queue.handle_block_update(new_block(10)).await.unwrap();
+        assert!(asserter.read_q().is_empty());
+
+        // At block 11 neither transaction executed (the nonce is unchanged), so
+        // both are resubmitted regardless of how they failed: the recorded one
+        // because its submission block is unset, and the unrecorded one because
+        // its reserved nonce was never submitted. The balance is not queried as
+        // both resubmissions succeed.
+        asserter.push_success(&U64::from(0)); // signer transaction count
+        asserter.push_success(&fee_history()); // fee estimate
+        asserter.push_success(&B256::ZERO); // cheap resubmission
+        asserter.push_success(&B256::ZERO); // expensive resubmission
+        queue.handle_block_update(new_block(11)).await.unwrap();
         assert!(asserter.read_q().is_empty());
     }
 }

--- a/crates/core/src/tx/mod.rs
+++ b/crates/core/src/tx/mod.rs
@@ -15,9 +15,10 @@ use self::{
     fees::cap_priority_fee,
     signer::SigningError,
     storage::{Status, Submission, TransactionStorage},
+    types::TransactionWithNonce,
 };
 pub use self::{signer::Signer, types::Transaction};
-use crate::{index::BlockUpdate, tx::types::TransactionWithNonce};
+use crate::index::BlockUpdate;
 use alloy::{
     eips::{BlockId, eip1559::Eip1559Estimation},
     primitives::U256,
@@ -145,11 +146,12 @@ where
                 }
                 self.block = Block::Latest { block: number };
 
-                // The signer nonce is an RPC round-trip needed only to mark executed
-                // transactions and to assign nonces to queued ones; both are moot unless
-                // a transaction is still outstanding, so skip it (and the work that
-                // needs it) otherwise. Pruning needs no nonce and always runs, before
-                // submission so expired transactions are dropped rather than broadcast.
+                // The signer nonce is an RPC round-trip needed only to mark
+                // executed transactions and to assign nonces to queued ones;
+                // both are moot unless a transaction is still outstanding, so
+                // skip it (and the work that needs it) otherwise. Pruning needs
+                // no nonce and always runs, before submission so expired
+                // transactions are dropped rather than broadcast.
                 let outstanding = self.storage.count_outstanding(number).await? > 0;
                 if outstanding {
                     let nonce = self.nonce().await?;
@@ -225,10 +227,7 @@ where
     /// unexecuted for at least `config.blocks_before_resubmit` blocks, bumping
     /// their fees so they replace the previous submission.
     async fn resubmit_stale(&mut self, block: u64) -> Result<(), Error> {
-        let Some(submitted_before) = block.checked_sub(self.config.blocks_before_resubmit) else {
-            return Ok(());
-        };
-
+        let submitted_before = block.checked_sub(self.config.blocks_before_resubmit);
         let stale = self.storage.stale_submissions(submitted_before).await?;
         if stale.is_empty() {
             return Ok(());

--- a/crates/core/src/tx/storage.rs
+++ b/crates/core/src/tx/storage.rs
@@ -241,7 +241,7 @@ impl TransactionStorage {
     /// are not stranded holding a reserved nonce).
     pub async fn stale_submissions(
         &self,
-        submitted_before: u64,
+        submitted_before: Option<u64>,
     ) -> Result<Vec<TransactionWithNonce>, Error> {
         sqlx::query_scalar::<_, String>(
             "SELECT json_set(request, '$.nonce', nonce)
@@ -250,7 +250,12 @@ impl TransactionStorage {
                AND (submitted_at IS NULL OR submitted_at <= ?)
              ORDER BY nonce ASC",
         )
-        .bind(i64::try_from(submitted_before)?)
+        .bind(
+            submitted_before
+                .map(i64::try_from)
+                .transpose()?
+                .unwrap_or(-1),
+        )
         .fetch_all(&self.pool)
         .await?
         .into_iter()
@@ -356,32 +361,6 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn submit_floors_the_nonce_at_the_account_nonce() {
-        let storage = storage().await;
-        storage.enqueue(request("0x5afe01"), 100).await.unwrap();
-        storage.enqueue(request("0x5afe02"), 100).await.unwrap();
-
-        let first = storage
-            .next_transaction(Status { nonce: 5, block: 0 })
-            .await
-            .unwrap()
-            .unwrap();
-        assert_eq!(first.nonce, 5);
-
-        // The account nonce jumped (e.g. a transaction was submitted outside the
-        // queue), so the next nonce is the account nonce, not in-flight + 1.
-        let second = storage
-            .next_transaction(Status {
-                nonce: 10,
-                block: 0,
-            })
-            .await
-            .unwrap()
-            .unwrap();
-        assert_eq!(second.nonce, 10);
-    }
-
-    #[tokio::test]
     async fn record_submission_stamps_the_block_and_fees() {
         let storage = storage().await;
         storage.enqueue(request("0x5afe"), 100).await.unwrap();
@@ -400,7 +379,7 @@ mod tests {
             .await
             .unwrap();
 
-        let transactions = storage.stale_submissions(42).await.unwrap();
+        let transactions = storage.stale_submissions(Some(42)).await.unwrap();
         assert_eq!(
             transactions,
             vec![TransactionWithNonce {
@@ -434,81 +413,6 @@ mod tests {
         ));
     }
 
-    /// Enqueues `count` transactions and assigns each a nonce from `0`.
-    async fn enqueue_and_assign(storage: &TransactionStorage, count: usize) {
-        for i in 0..count {
-            storage
-                .enqueue(request(&format!("0x5afe0{i}")), 100)
-                .await
-                .unwrap();
-        }
-        for _ in 0..count {
-            storage
-                .next_transaction(Status { nonce: 0, block: 0 })
-                .await
-                .unwrap()
-                .unwrap();
-        }
-    }
-
-    /// The total number of transactions in storage, queued or in flight.
-    async fn total(storage: &TransactionStorage) -> i64 {
-        sqlx::query_scalar::<_, i64>("SELECT COUNT(*) FROM transactions")
-            .fetch_one(&storage.pool)
-            .await
-            .unwrap()
-    }
-
-    #[tokio::test]
-    async fn marks_transactions_below_the_account_nonce_executed() {
-        let storage = storage().await;
-        enqueue_and_assign(&storage, 3).await;
-        assert_eq!(storage.count_in_flight().await.unwrap(), 3);
-        assert_eq!(storage.count_outstanding(0).await.unwrap(), 3);
-
-        // The account nonce advanced to 2, so nonces 0 and 1 have executed.
-        storage
-            .mark_executed(Status { block: 5, nonce: 2 })
-            .await
-            .unwrap();
-        assert_eq!(storage.count_in_flight().await.unwrap(), 1);
-        assert_eq!(storage.count_outstanding(0).await.unwrap(), 1);
-        assert_eq!(total(&storage).await, 3);
-    }
-
-    #[tokio::test]
-    async fn prunes_transactions_finalized_at_or_below_the_safe_block() {
-        let storage = storage().await;
-        enqueue_and_assign(&storage, 3).await;
-
-        // Nonces 0 and 1 execute at block 5, which is also reorg-safe, so they
-        // are pruned; nonce 2 is still in flight.
-        storage
-            .mark_executed(Status { block: 5, nonce: 2 })
-            .await
-            .unwrap();
-        storage.prune(5).await.unwrap();
-        assert_eq!(total(&storage).await, 1);
-        assert_eq!(storage.count_in_flight().await.unwrap(), 1);
-    }
-
-    #[tokio::test]
-    async fn uncle_clears_executions_at_or_above_the_uncled_block() {
-        let storage = storage().await;
-        enqueue_and_assign(&storage, 2).await;
-        // Marked but not pruned (no `prune` call), so the uncle has something
-        // to revert.
-        storage
-            .mark_executed(Status { block: 5, nonce: 2 })
-            .await
-            .unwrap();
-        assert_eq!(storage.count_in_flight().await.unwrap(), 0);
-
-        // Block 5 is uncled, reverting the executions recorded at it.
-        storage.unmark_executed(5).await.unwrap();
-        assert_eq!(storage.count_in_flight().await.unwrap(), 2);
-    }
-
     #[tokio::test]
     async fn prunes_queued_transactions_past_their_expiry() {
         let storage = storage().await;
@@ -525,59 +429,5 @@ mod tests {
             .unwrap()
             .unwrap();
         assert_eq!(next.transaction.input, request("0x5afe02").input);
-        assert_eq!(
-            storage
-                .next_transaction(Status { nonce: 0, block: 0 })
-                .await
-                .unwrap(),
-            None
-        );
-    }
-
-    #[tokio::test]
-    async fn stale_submissions_returns_long_pending_transactions() {
-        let storage = storage().await;
-        storage.enqueue(request("0x5afe"), 100).await.unwrap();
-        let submitted = storage
-            .next_transaction(Status { nonce: 0, block: 0 })
-            .await
-            .unwrap()
-            .unwrap();
-        storage
-            .record_submission(Submission {
-                block: Some(5),
-                nonce: submitted.nonce,
-                fees: fees(100, 10),
-            })
-            .await
-            .unwrap();
-
-        // Nothing was submitted at or before block 4.
-        assert!(storage.stale_submissions(4).await.unwrap().is_empty());
-
-        // The transaction submitted at block 5 is returned, carrying its nonce
-        // and recorded fees.
-        let stale = storage.stale_submissions(5).await.unwrap();
-        assert_eq!(stale.len(), 1);
-        assert_eq!(stale[0].nonce, 0);
-        assert_eq!(stale[0].max_fee_per_gas, Some(100));
-    }
-
-    #[tokio::test]
-    async fn stale_submissions_includes_nonce_assigned_but_never_submitted() {
-        let storage = storage().await;
-        storage.enqueue(request("0x5afe"), 100).await.unwrap();
-        // A nonce was reserved but the submission was never recorded (e.g. a
-        // crash before `record_submission`).
-        storage
-            .next_transaction(Status { nonce: 0, block: 0 })
-            .await
-            .unwrap()
-            .unwrap();
-
-        // It is stale regardless of the threshold, so its nonce is not stranded.
-        let stale = storage.stale_submissions(0).await.unwrap();
-        assert_eq!(stale.len(), 1);
-        assert_eq!(stale[0].nonce, 0);
     }
 }

--- a/crates/core/src/tx/storage.rs
+++ b/crates/core/src/tx/storage.rs
@@ -1,0 +1,581 @@
+//! Persistent storage for the transaction queue.
+//!
+//! Holds the transactions a service has queued for execution, each as a
+//! serialized [`Transaction`] alongside the bookkeeping the queue needs: when it
+//! expires, its allocated nonce, when it was submitted and executed.
+
+use crate::tx::types::{Transaction, TransactionWithNonce};
+use alloy::eips::eip1559::Eip1559Estimation;
+use sqlx::sqlite::SqlitePool;
+use std::num::TryFromIntError;
+
+/// Error produced by the [`TransactionStorage`].
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+    /// A database operation failed.
+    #[error(transparent)]
+    Database(#[from] sqlx::Error),
+    /// A transaction request could not be serialized or deserialized.
+    #[error("failed to serialize or deserialize a transaction request")]
+    Serialization(#[from] serde_json::Error),
+    /// An arithmetic overflow converting a nonce or block number to or from the
+    /// database integer type.
+    #[error("integer conversion overflow")]
+    Overflow,
+    /// No transaction was found for a given nonce.
+    #[error("no transaction found with nonce {0}")]
+    NonceNotFound(u64),
+}
+
+/// Submission information for a transaction.
+pub struct Submission {
+    /// The block head at the time of submission. The transaction can be
+    /// included earliest `block + 1`.
+    pub block: u64,
+    /// The nonce of the submitted transaction.
+    pub nonce: u64,
+    /// The fees used for the submitted transaction. These need to be tracked in
+    /// order to correctly bump the fee on new blocks.
+    pub fees: Eip1559Estimation,
+}
+
+/// The onchain status for the transacting account.
+pub struct Status {
+    /// The current latest block.
+    pub block: u64,
+    /// The account's onchain nonce (transaction count) at `block`.
+    pub nonce: u64,
+}
+
+/// SQLite-backed storage for the transaction queue.
+pub struct TransactionStorage {
+    pool: SqlitePool,
+}
+
+impl TransactionStorage {
+    /// Creates a store backed by `pool`, creating the transactions table if it
+    /// does not already exist.
+    pub async fn new(pool: SqlitePool) -> Result<Self, Error> {
+        sqlx::query(
+            "CREATE TABLE IF NOT EXISTS transactions (
+                 id           INTEGER PRIMARY KEY,
+                 request      TEXT    NOT NULL,
+                 expires_at   INTEGER NOT NULL,
+                 nonce        INTEGER DEFAULT NULL,
+                 submitted_at INTEGER DEFAULT NULL,
+                 executed_at  INTEGER DEFAULT NULL
+             )",
+        )
+        .execute(&pool)
+        .await?;
+
+        Ok(Self { pool })
+    }
+
+    /// Stores `transaction` as a queued transaction that expires at block
+    /// `expires_at` if it has not been submitted by then.
+    pub async fn enqueue(&self, transaction: Transaction, expires_at: u64) -> Result<(), Error> {
+        let request = serde_json::to_string(&transaction)?;
+        sqlx::query("INSERT INTO transactions (request, expires_at) VALUES (?, ?)")
+            .bind(request)
+            .bind(i64::try_from(expires_at)?)
+            .execute(&self.pool)
+            .await?;
+        Ok(())
+    }
+
+    /// Returns the number of in-flight transactions, those that have been
+    /// assigned a nonce but are not yet executed.
+    pub async fn count_in_flight(&self) -> Result<usize, Error> {
+        let count = sqlx::query_scalar::<_, i64>(
+            "SELECT COUNT(*) FROM transactions
+             WHERE nonce IS NOT NULL AND executed_at IS NULL",
+        )
+        .fetch_one(&self.pool)
+        .await?;
+        Ok(usize::try_from(count)?)
+    }
+
+    /// Selects the oldest queued transaction that has not expired and assigns
+    /// it a nonce. Returns `None` when nothing is queued.
+    ///
+    /// The nonce is the first free nonce at or above `status.nonce` (the
+    /// account's current onchain transaction count, passed in so nonces
+    /// consumed by transactions submitted outside the queue are respected),
+    /// accounting for the nonces of other in-flight transactions. Selecting th
+    /// nonce and reserving it for the transaction happen atomically.
+    pub async fn next_transaction(
+        &self,
+        status: Status,
+    ) -> Result<Option<TransactionWithNonce>, Error> {
+        let Some(request) = sqlx::query_scalar::<_, String>(
+            "UPDATE transactions
+             SET nonce = MAX(?, COALESCE(
+                     (SELECT MAX(nonce) + 1 FROM transactions),
+                     0
+                 ))
+             WHERE id = (
+                 SELECT id FROM transactions
+                 WHERE nonce IS NULL AND expires_at > ?
+                 ORDER BY id ASC
+                 LIMIT 1
+             )
+             RETURNING json_set(request, '$.nonce', nonce)",
+        )
+        .bind(i64::try_from(status.nonce)?)
+        .bind(i64::try_from(status.block)?)
+        .fetch_optional(&self.pool)
+        .await?
+        else {
+            return Ok(None);
+        };
+
+        let transaction = serde_json::from_str::<TransactionWithNonce>(&request)?;
+        Ok(Some(transaction))
+    }
+
+    /// Marks the transaction with `submission.nonce` as submitted at
+    /// `submission.block`, recording the `submission.fees` it was submitted with
+    /// in the stored request. Errors if no transaction has that nonce.
+    pub async fn record_submission(&self, submission: Submission) -> Result<(), Error> {
+        let Submission { block, nonce, fees } = submission;
+        let updated = sqlx::query(
+            "UPDATE transactions
+             SET submitted_at = ?,
+                 request = json_set(
+                     request,
+                     '$.maxFeePerGas', ?,
+                     '$.maxPriorityFeePerGas', ?
+                 )
+             WHERE nonce = ?",
+        )
+        .bind(i64::try_from(block)?)
+        .bind(format!("0x{:x}", fees.max_fee_per_gas))
+        .bind(format!("0x{:x}", fees.max_priority_fee_per_gas))
+        .bind(i64::try_from(nonce)?)
+        .execute(&self.pool)
+        .await?;
+
+        if updated.rows_affected() == 0 {
+            return Err(Error::NonceNotFound(nonce));
+        }
+        Ok(())
+    }
+
+    /// Returns the number of outstanding transactions at `block`: those not yet
+    /// executed that are either in flight or queued and not yet expired.
+    ///
+    /// Queued transactions expired by `block` are excluded, since they will not
+    /// be submitted even though they linger in storage until the reorg-safe
+    /// block passes their expiry.
+    pub async fn count_outstanding(&self, block: u64) -> Result<usize, Error> {
+        let count = sqlx::query_scalar::<_, i64>(
+            "SELECT COUNT(*) FROM transactions
+             WHERE executed_at IS NULL AND (nonce IS NOT NULL OR expires_at > ?)",
+        )
+        .bind(i64::try_from(block)?)
+        .fetch_one(&self.pool)
+        .await?;
+        Ok(usize::try_from(count)?)
+    }
+
+    /// Marks every in-flight transaction the account has moved past (nonce below
+    /// `execution.nonce`) as executed at `execution.block`.
+    pub async fn mark_executed(&self, status: Status) -> Result<(), Error> {
+        sqlx::query(
+            "UPDATE transactions
+             SET executed_at = ?
+             WHERE nonce IS NOT NULL AND nonce < ? AND executed_at IS NULL",
+        )
+        .bind(i64::try_from(status.block)?)
+        .bind(i64::try_from(status.nonce)?)
+        .execute(&self.pool)
+        .await?;
+        Ok(())
+    }
+
+    /// Prunes transactions that can no longer be affected by a reorg: those
+    /// executed at or below the reorg-safe block `safe`, and queued transactions
+    /// that expired at or before it.
+    ///
+    /// Expiry is measured against `safe` rather than the latest block because a
+    /// deep reorg can lower the head back below a transaction's expiry; only
+    /// pruning past the safe block guarantees a removed transaction can never
+    /// become unexpired again.
+    pub async fn prune(&self, safe: u64) -> Result<(), Error> {
+        let safe = i64::try_from(safe)?;
+        let mut tx = self.pool.begin().await?;
+
+        // Prune transactions executed at or below the reorg-safe block.
+        sqlx::query("DELETE FROM transactions WHERE executed_at IS NOT NULL AND executed_at <= ?")
+            .bind(safe)
+            .execute(&mut *tx)
+            .await?;
+
+        // Remove queued (not-yet-submitted) transactions that expired at or
+        // before the reorg-safe block.
+        sqlx::query("DELETE FROM transactions WHERE nonce IS NULL AND expires_at <= ?")
+            .bind(safe)
+            .execute(&mut *tx)
+            .await?;
+
+        tx.commit().await?;
+        Ok(())
+    }
+
+    /// Clears the executed marker from transactions executed at or after `block`,
+    /// used when `block` is uncled by a reorg.
+    pub async fn unmark_executed(&self, block: u64) -> Result<(), Error> {
+        sqlx::query("UPDATE transactions SET executed_at = NULL WHERE executed_at >= ?")
+            .bind(i64::try_from(block)?)
+            .execute(&self.pool)
+            .await?;
+        Ok(())
+    }
+
+    /// Returns the in-flight transactions due for (re)submission, ordered by
+    /// nonce: those last submitted at or before `submitted_before`, as well as
+    /// any that were assigned a nonce but never recorded as submitted (so they
+    /// are not stranded holding a reserved nonce).
+    pub async fn stale_submissions(
+        &self,
+        submitted_before: u64,
+    ) -> Result<Vec<TransactionWithNonce>, Error> {
+        sqlx::query_scalar::<_, String>(
+            "SELECT json_set(request, '$.nonce', nonce)
+             FROM transactions
+             WHERE nonce IS NOT NULL AND executed_at IS NULL
+               AND (submitted_at IS NULL OR submitted_at <= ?)
+             ORDER BY nonce ASC",
+        )
+        .bind(i64::try_from(submitted_before)?)
+        .fetch_all(&self.pool)
+        .await?
+        .into_iter()
+        .map(|request| serde_json::from_str(&request).map_err(Error::from))
+        .collect()
+    }
+}
+
+impl From<TryFromIntError> for Error {
+    fn from(_: TryFromIntError) -> Self {
+        Self::Overflow
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloy::primitives::{Address, Bytes, address};
+    use sqlx::sqlite::SqlitePoolOptions;
+
+    const ENTRY_POINT: Address = address!("0x5FF137D4b0FDCD49DcA30c7CF57E578a026d2789");
+
+    async fn storage() -> TransactionStorage {
+        let pool = SqlitePoolOptions::new()
+            .max_connections(1)
+            .connect_with("sqlite::memory:".parse().unwrap())
+            .await
+            .unwrap();
+        TransactionStorage::new(pool).await.unwrap()
+    }
+
+    /// A queued transaction (no nonce or fees yet).
+    fn request(data: &str) -> Transaction {
+        Transaction {
+            to: ENTRY_POINT,
+            input: data.parse::<Bytes>().unwrap(),
+            ..Default::default()
+        }
+    }
+
+    fn fees(max_fee_per_gas: u128, max_priority_fee_per_gas: u128) -> Eip1559Estimation {
+        Eip1559Estimation {
+            max_fee_per_gas,
+            max_priority_fee_per_gas,
+        }
+    }
+
+    #[tokio::test]
+    async fn submit_next_is_none_when_empty() {
+        let storage = storage().await;
+        assert_eq!(
+            storage
+                .next_transaction(Status { nonce: 0, block: 0 })
+                .await
+                .unwrap(),
+            None
+        );
+    }
+
+    #[tokio::test]
+    async fn submit_assigns_the_account_nonce_and_fees() {
+        let storage = storage().await;
+        storage.enqueue(request("0x5afe"), 100).await.unwrap();
+
+        let submitted = storage
+            .next_transaction(Status { nonce: 5, block: 0 })
+            .await
+            .unwrap()
+            .unwrap();
+
+        // The returned transaction carries the assigned nonce.
+        assert_eq!(submitted.nonce, 5);
+
+        // It is now in flight and no longer queued.
+        assert_eq!(storage.count_in_flight().await.unwrap(), 1);
+        assert_eq!(
+            storage
+                .next_transaction(Status { nonce: 5, block: 0 })
+                .await
+                .unwrap(),
+            None
+        );
+    }
+
+    #[tokio::test]
+    async fn submit_assigns_sequential_nonces_in_queue_order() {
+        let storage = storage().await;
+        storage.enqueue(request("0x5afe01"), 100).await.unwrap();
+        storage.enqueue(request("0x5afe02"), 100).await.unwrap();
+        storage.enqueue(request("0x5afe03"), 100).await.unwrap();
+
+        // Each submission picks the next free nonce above the in-flight ones, in
+        // FIFO order.
+        for (data, nonce) in [("0x5afe01", 5), ("0x5afe02", 6), ("0x5afe03", 7)] {
+            let submitted = storage
+                .next_transaction(Status { nonce: 5, block: 0 })
+                .await
+                .unwrap()
+                .unwrap();
+            assert_eq!(submitted.nonce, nonce);
+            assert_eq!(submitted.transaction.input, request(data).input);
+        }
+    }
+
+    #[tokio::test]
+    async fn submit_floors_the_nonce_at_the_account_nonce() {
+        let storage = storage().await;
+        storage.enqueue(request("0x5afe01"), 100).await.unwrap();
+        storage.enqueue(request("0x5afe02"), 100).await.unwrap();
+
+        let first = storage
+            .next_transaction(Status { nonce: 5, block: 0 })
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(first.nonce, 5);
+
+        // The account nonce jumped (e.g. a transaction was submitted outside the
+        // queue), so the next nonce is the account nonce, not in-flight + 1.
+        let second = storage
+            .next_transaction(Status {
+                nonce: 10,
+                block: 0,
+            })
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(second.nonce, 10);
+    }
+
+    #[tokio::test]
+    async fn record_submission_stamps_the_block_and_fees() {
+        let storage = storage().await;
+        storage.enqueue(request("0x5afe"), 100).await.unwrap();
+        let submitted = storage
+            .next_transaction(Status { nonce: 5, block: 0 })
+            .await
+            .unwrap()
+            .unwrap();
+
+        storage
+            .record_submission(Submission {
+                block: 42,
+                nonce: submitted.nonce,
+                fees: fees(100, 10),
+            })
+            .await
+            .unwrap();
+
+        let transactions = storage.stale_submissions(42).await.unwrap();
+        assert_eq!(
+            transactions,
+            vec![TransactionWithNonce {
+                nonce: 5,
+                transaction: request("0x5afe"),
+                max_fee_per_gas: Some(100),
+                max_priority_fee_per_gas: Some(10),
+            }]
+        );
+    }
+
+    #[tokio::test]
+    async fn record_submission_errors_for_an_unknown_nonce() {
+        let storage = storage().await;
+        storage.enqueue(request("0x5afe"), 100).await.unwrap();
+        storage
+            .next_transaction(Status { nonce: 5, block: 0 })
+            .await
+            .unwrap()
+            .unwrap();
+
+        assert!(matches!(
+            storage
+                .record_submission(Submission {
+                    block: 42,
+                    nonce: 9,
+                    fees: fees(1, 1),
+                })
+                .await,
+            Err(Error::NonceNotFound(9))
+        ));
+    }
+
+    /// Enqueues `count` transactions and assigns each a nonce from `0`.
+    async fn enqueue_and_assign(storage: &TransactionStorage, count: usize) {
+        for i in 0..count {
+            storage
+                .enqueue(request(&format!("0x5afe0{i}")), 100)
+                .await
+                .unwrap();
+        }
+        for _ in 0..count {
+            storage
+                .next_transaction(Status { nonce: 0, block: 0 })
+                .await
+                .unwrap()
+                .unwrap();
+        }
+    }
+
+    /// The total number of transactions in storage, queued or in flight.
+    async fn total(storage: &TransactionStorage) -> i64 {
+        sqlx::query_scalar::<_, i64>("SELECT COUNT(*) FROM transactions")
+            .fetch_one(&storage.pool)
+            .await
+            .unwrap()
+    }
+
+    #[tokio::test]
+    async fn marks_transactions_below_the_account_nonce_executed() {
+        let storage = storage().await;
+        enqueue_and_assign(&storage, 3).await;
+        assert_eq!(storage.count_in_flight().await.unwrap(), 3);
+        assert_eq!(storage.count_outstanding(0).await.unwrap(), 3);
+
+        // The account nonce advanced to 2, so nonces 0 and 1 have executed.
+        storage
+            .mark_executed(Status { block: 5, nonce: 2 })
+            .await
+            .unwrap();
+        assert_eq!(storage.count_in_flight().await.unwrap(), 1);
+        assert_eq!(storage.count_outstanding(0).await.unwrap(), 1);
+        assert_eq!(total(&storage).await, 3);
+    }
+
+    #[tokio::test]
+    async fn prunes_transactions_finalized_at_or_below_the_safe_block() {
+        let storage = storage().await;
+        enqueue_and_assign(&storage, 3).await;
+
+        // Nonces 0 and 1 execute at block 5, which is also reorg-safe, so they
+        // are pruned; nonce 2 is still in flight.
+        storage
+            .mark_executed(Status { block: 5, nonce: 2 })
+            .await
+            .unwrap();
+        storage.prune(5).await.unwrap();
+        assert_eq!(total(&storage).await, 1);
+        assert_eq!(storage.count_in_flight().await.unwrap(), 1);
+    }
+
+    #[tokio::test]
+    async fn uncle_clears_executions_at_or_above_the_uncled_block() {
+        let storage = storage().await;
+        enqueue_and_assign(&storage, 2).await;
+        // Marked but not pruned (no `prune` call), so the uncle has something
+        // to revert.
+        storage
+            .mark_executed(Status { block: 5, nonce: 2 })
+            .await
+            .unwrap();
+        assert_eq!(storage.count_in_flight().await.unwrap(), 0);
+
+        // Block 5 is uncled, reverting the executions recorded at it.
+        storage.unmark_executed(5).await.unwrap();
+        assert_eq!(storage.count_in_flight().await.unwrap(), 2);
+    }
+
+    #[tokio::test]
+    async fn prunes_queued_transactions_past_their_expiry() {
+        let storage = storage().await;
+        storage.enqueue(request("0x5afe01"), 10).await.unwrap();
+        storage.enqueue(request("0x5afe02"), 20).await.unwrap();
+
+        // Pruning at a safe block of 15 removes the first transaction (expiry
+        // 10); the second (expiry 20) is not yet expired.
+        storage.prune(15).await.unwrap();
+
+        let next = storage
+            .next_transaction(Status { nonce: 0, block: 0 })
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(next.transaction.input, request("0x5afe02").input);
+        assert_eq!(
+            storage
+                .next_transaction(Status { nonce: 0, block: 0 })
+                .await
+                .unwrap(),
+            None
+        );
+    }
+
+    #[tokio::test]
+    async fn stale_submissions_returns_long_pending_transactions() {
+        let storage = storage().await;
+        storage.enqueue(request("0x5afe"), 100).await.unwrap();
+        let submitted = storage
+            .next_transaction(Status { nonce: 0, block: 0 })
+            .await
+            .unwrap()
+            .unwrap();
+        storage
+            .record_submission(Submission {
+                block: 5,
+                nonce: submitted.nonce,
+                fees: fees(100, 10),
+            })
+            .await
+            .unwrap();
+
+        // Nothing was submitted at or before block 4.
+        assert!(storage.stale_submissions(4).await.unwrap().is_empty());
+
+        // The transaction submitted at block 5 is returned, carrying its nonce
+        // and recorded fees.
+        let stale = storage.stale_submissions(5).await.unwrap();
+        assert_eq!(stale.len(), 1);
+        assert_eq!(stale[0].nonce, 0);
+        assert_eq!(stale[0].max_fee_per_gas, Some(100));
+    }
+
+    #[tokio::test]
+    async fn stale_submissions_includes_nonce_assigned_but_never_submitted() {
+        let storage = storage().await;
+        storage.enqueue(request("0x5afe"), 100).await.unwrap();
+        // A nonce was reserved but the submission was never recorded (e.g. a
+        // crash before `record_submission`).
+        storage
+            .next_transaction(Status { nonce: 0, block: 0 })
+            .await
+            .unwrap()
+            .unwrap();
+
+        // It is stale regardless of the threshold, so its nonce is not stranded.
+        let stale = storage.stale_submissions(0).await.unwrap();
+        assert_eq!(stale.len(), 1);
+        assert_eq!(stale[0].nonce, 0);
+    }
+}

--- a/crates/core/src/tx/storage.rs
+++ b/crates/core/src/tx/storage.rs
@@ -29,9 +29,11 @@ pub enum Error {
 
 /// Submission information for a transaction.
 pub struct Submission {
-    /// The block head at the time of submission. The transaction can be
-    /// included earliest `block + 1`.
-    pub block: u64,
+    /// The block head at the time of submission, or `None` if the submission
+    /// failed, indicating it should be retried.
+    ///
+    /// The transaction can be included earliest `block + 1`.
+    pub block: Option<u64>,
     /// The nonce of the submitted transaction.
     pub nonce: u64,
     /// The fees used for the submitted transaction. These need to be tracked in
@@ -102,7 +104,7 @@ impl TransactionStorage {
     /// The nonce is the first free nonce at or above `status.nonce` (the
     /// account's current onchain transaction count, passed in so nonces
     /// consumed by transactions submitted outside the queue are respected),
-    /// accounting for the nonces of other in-flight transactions. Selecting th
+    /// accounting for the nonces of other in-flight transactions. Selecting the
     /// nonce and reserving it for the transaction happen atomically.
     pub async fn next_transaction(
         &self,
@@ -149,7 +151,7 @@ impl TransactionStorage {
                  )
              WHERE nonce = ?",
         )
-        .bind(i64::try_from(block)?)
+        .bind(block.map(i64::try_from).transpose()?)
         .bind(format!("0x{:x}", fees.max_fee_per_gas))
         .bind(format!("0x{:x}", fees.max_priority_fee_per_gas))
         .bind(i64::try_from(nonce)?)
@@ -391,7 +393,7 @@ mod tests {
 
         storage
             .record_submission(Submission {
-                block: 42,
+                block: Some(42),
                 nonce: submitted.nonce,
                 fees: fees(100, 10),
             })
@@ -423,7 +425,7 @@ mod tests {
         assert!(matches!(
             storage
                 .record_submission(Submission {
-                    block: 42,
+                    block: Some(42),
                     nonce: 9,
                     fees: fees(1, 1),
                 })
@@ -543,7 +545,7 @@ mod tests {
             .unwrap();
         storage
             .record_submission(Submission {
-                block: 5,
+                block: Some(5),
                 nonce: submitted.nonce,
                 fees: fees(100, 10),
             })

--- a/crates/core/src/tx/types.rs
+++ b/crates/core/src/tx/types.rs
@@ -1,0 +1,87 @@
+//! Transaction types for the queue.
+
+use crate::tx::fees;
+use alloy::{
+    consensus::TxEip1559,
+    eips::eip1559::Eip1559Estimation,
+    primitives::{Address, Bytes, TxKind, U256},
+    rpc::types::AccessList,
+};
+use serde::{Deserialize, Serialize};
+
+/// A transaction to submit onchain.
+///
+/// Analogous to alloy's [`TransactionRequest`], carrying the fields the queue
+/// requires to build an EIP-1559 transaction.
+///
+/// [`TransactionRequest`]: alloy::rpc::types::TransactionRequest
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Transaction {
+    /// The destination of the transaction; `None` deploys a contract.
+    pub to: Address,
+    /// The destination of the transaction; `None` deploys a contract.
+    pub value: U256,
+    /// The transaction calldata.
+    pub input: Bytes,
+    /// The gas limit. Unlike alloy's transaction request, this is mandatory.
+    pub gas: u64,
+}
+
+impl Default for Transaction {
+    fn default() -> Self {
+        Self {
+            to: Address::ZERO,
+            value: U256::ZERO,
+            input: Bytes::new(),
+            gas: 21_000,
+        }
+    }
+}
+
+/// A [`Transaction`] with a nonce that is ready for submission.
+///
+/// It may contain fees from a previous submission.
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TransactionWithNonce {
+    /// The nonce assigned to the transaction by the queue.
+    pub nonce: u64,
+    /// The transaction.
+    #[serde(flatten)]
+    pub transaction: Transaction,
+    /// The maximum total fee per gas, set by the queue on submission.
+    #[serde(default, with = "alloy::serde::quantity::opt")]
+    pub max_fee_per_gas: Option<u128>,
+    /// The maximum priority fee per gas, set by the queue on submission.
+    #[serde(default, with = "alloy::serde::quantity::opt")]
+    pub max_priority_fee_per_gas: Option<u128>,
+}
+
+impl TransactionWithNonce {
+    /// Builds a concrete EIP-1559 transaction for signing, bumping `estimate`
+    /// above any fees from a previous submission so that it replaces it.
+    pub fn build(self, chain_id: u64, estimate: Eip1559Estimation) -> TxEip1559 {
+        let fees = fees::bump(estimate, self.fees());
+        TxEip1559 {
+            chain_id,
+            nonce: self.nonce,
+            gas_limit: self.transaction.gas,
+            max_fee_per_gas: fees.max_fee_per_gas,
+            max_priority_fee_per_gas: fees.max_priority_fee_per_gas,
+            to: TxKind::Call(self.transaction.to),
+            value: self.transaction.value,
+            access_list: AccessList::default(),
+            input: self.transaction.input,
+        }
+    }
+
+    /// The fees the transaction was last submitted with, if it has been
+    /// submitted before.
+    fn fees(&self) -> Option<Eip1559Estimation> {
+        Some(Eip1559Estimation {
+            max_fee_per_gas: self.max_fee_per_gas?,
+            max_priority_fee_per_gas: self.max_priority_fee_per_gas?,
+        })
+    }
+}

--- a/crates/core/src/tx/types.rs
+++ b/crates/core/src/tx/types.rs
@@ -18,9 +18,9 @@ use serde::{Deserialize, Serialize};
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Transaction {
-    /// The destination of the transaction; `None` deploys a contract.
+    /// The destination of the transaction.
     pub to: Address,
-    /// The destination of the transaction; `None` deploys a contract.
+    /// The transaction value.
     pub value: U256,
     /// The transaction calldata.
     pub input: Bytes,


### PR DESCRIPTION
This PR contains the complete transaction submission queue implementation, and is provided as a reference in order to see the complete picture.

### PR Stack

1. #480 
2. #481 
3. #482 
4. #483 
5. #485 

### Decisions and Tradeoffs

- The transaction queue collapses the action queue and transaction storage from the TypeScript implementation. This allows us to be a bit smart about dropping expired actions without executing them onchain.
- The transaction queue handles reorgs, this is different from the TypeScript implementation
- We do not bump fees in case we know that our transaction is more expensive than the balance that the account has. This provides a soft blocker for runaway transaction fees (which was an observed issue in the TypeScript implementation). In particular, when the account runs out of balance we no longer have unbounded growth of fees in the transaction queue storage.

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://docs.safefoundation.org/cla).
