### PR TITLE
[E 3/6]: Add Specialized Transaction Types

### DIFF
--- a/crates/core/src/tx/mod.rs
+++ b/crates/core/src/tx/mod.rs
@@ -10,5 +10,6 @@
 
 mod fees;
 pub mod signer;
+pub mod types;
 
-pub use self::signer::Signer;
+pub use self::{signer::Signer, types::Transaction};

--- a/crates/core/src/tx/types.rs
+++ b/crates/core/src/tx/types.rs
@@ -1,0 +1,87 @@
+//! Transaction types for the queue.
+
+use crate::tx::fees;
+use alloy::{
+    consensus::TxEip1559,
+    eips::eip1559::Eip1559Estimation,
+    primitives::{Address, Bytes, TxKind, U256},
+    rpc::types::AccessList,
+};
+use serde::{Deserialize, Serialize};
+
+/// A transaction to submit onchain.
+///
+/// Analogous to alloy's [`TransactionRequest`], carrying the fields the queue
+/// requires to build an EIP-1559 transaction.
+///
+/// [`TransactionRequest`]: alloy::rpc::types::TransactionRequest
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Transaction {
+    /// The destination of the transaction.
+    pub to: Address,
+    /// The transaction value.
+    pub value: U256,
+    /// The transaction calldata.
+    pub input: Bytes,
+    /// The gas limit. Unlike alloy's transaction request, this is mandatory.
+    pub gas: u64,
+}
+
+impl Default for Transaction {
+    fn default() -> Self {
+        Self {
+            to: Address::ZERO,
+            value: U256::ZERO,
+            input: Bytes::new(),
+            gas: 21_000,
+        }
+    }
+}
+
+/// A [`Transaction`] with a nonce that is ready for submission.
+///
+/// It may contain fees from a previous submission.
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TransactionWithNonce {
+    /// The nonce assigned to the transaction by the queue.
+    pub nonce: u64,
+    /// The transaction.
+    #[serde(flatten)]
+    pub transaction: Transaction,
+    /// The maximum total fee per gas, set by the queue on submission.
+    #[serde(default, with = "alloy::serde::quantity::opt")]
+    pub max_fee_per_gas: Option<u128>,
+    /// The maximum priority fee per gas, set by the queue on submission.
+    #[serde(default, with = "alloy::serde::quantity::opt")]
+    pub max_priority_fee_per_gas: Option<u128>,
+}
+
+impl TransactionWithNonce {
+    /// Builds a concrete EIP-1559 transaction for signing, bumping `estimate`
+    /// above any fees from a previous submission so that it replaces it.
+    pub fn build(self, chain_id: u64, estimate: Eip1559Estimation) -> TxEip1559 {
+        let fees = fees::bump(estimate, self.fees());
+        TxEip1559 {
+            chain_id,
+            nonce: self.nonce,
+            gas_limit: self.transaction.gas,
+            max_fee_per_gas: fees.max_fee_per_gas,
+            max_priority_fee_per_gas: fees.max_priority_fee_per_gas,
+            to: TxKind::Call(self.transaction.to),
+            value: self.transaction.value,
+            access_list: AccessList::default(),
+            input: self.transaction.input,
+        }
+    }
+
+    /// The fees the transaction was last submitted with, if it has been
+    /// submitted before.
+    fn fees(&self) -> Option<Eip1559Estimation> {
+        Some(Eip1559Estimation {
+            max_fee_per_gas: self.max_fee_per_gas?,
+            max_priority_fee_per_gas: self.max_priority_fee_per_gas?,
+        })
+    }
+}

--- a/crates/core/src/tx/types.rs
+++ b/crates/core/src/tx/types.rs
@@ -23,7 +23,7 @@ pub struct Transaction {
     /// The transaction value.
     pub value: U256,
     /// The transaction calldata.
-    pub input: Bytes,
+    pub data: Bytes,
     /// The gas limit. Unlike alloy's transaction request, this is mandatory.
     pub gas: u64,
 }
@@ -33,18 +33,18 @@ impl Default for Transaction {
         Self {
             to: Address::ZERO,
             value: U256::ZERO,
-            input: Bytes::new(),
+            data: Bytes::new(),
             gas: 21_000,
         }
     }
 }
 
-/// A [`Transaction`] with a nonce that is ready for submission.
+/// A [`Transaction`] with a nonce allocated for submission.
 ///
 /// It may contain fees from a previous submission.
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
 #[serde(rename_all = "camelCase")]
-pub struct TransactionWithNonce {
+pub struct AllocatedTransaction {
     /// The nonce assigned to the transaction by the queue.
     pub nonce: u64,
     /// The transaction.
@@ -58,7 +58,7 @@ pub struct TransactionWithNonce {
     pub max_priority_fee_per_gas: Option<u128>,
 }
 
-impl TransactionWithNonce {
+impl AllocatedTransaction {
     /// Builds a concrete EIP-1559 transaction for signing, bumping `estimate`
     /// above any fees from a previous submission so that it replaces it.
     pub fn build(self, chain_id: u64, estimate: Eip1559Estimation) -> TxEip1559 {
@@ -72,7 +72,7 @@ impl TransactionWithNonce {
             to: TxKind::Call(self.transaction.to),
             value: self.transaction.value,
             access_list: AccessList::default(),
-            input: self.transaction.input,
+            input: self.transaction.data,
         }
     }
 


### PR DESCRIPTION
This is part of a larger stack, see https://github.com/safe-research/safenet/pull/479.

### Context and Motivation

Alloy transaction request types have a lot of `Option`s. This is because it is designed for use with an account, which would make RPC calls to fill in certain values that are missing (such as nonce, gas fees, etc.).

In our case, we don't want this - we want _very_ strict control over what fields are required as input, and what fields are not. To model this, we introduce a specialized `Transaction` type, along with an `*WithNonce` variant that can be built into an EIP-1559 transaction for signing with the `Signer`.

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://docs.safefoundation.org/cla).
