### PR TITLE
[E 6/6]: Transaction Queue Heartbeat

### DIFF
--- a/crates/core/src/tx/mod.rs
+++ b/crates/core/src/tx/mod.rs
@@ -6,8 +6,6 @@
 //! local [`signer`], and resubmitting with bumped fees when a transaction is
 //! stuck.
 
-#![allow(dead_code)]
-
 mod fees;
 pub mod signer;
 mod storage;
@@ -20,6 +18,7 @@ use self::{
     types::AllocatedTransaction,
 };
 pub use self::{signer::Signer, types::Transaction};
+use crate::index::BlockUpdate;
 use alloy::{
     eips::{BlockId, eip1559::Eip1559Estimation},
     primitives::U256,
@@ -132,6 +131,72 @@ where
         self.submit_pending().await
     }
 
+    /// Handles an indexer [`BlockUpdate`], performing the queue's per-block
+    /// housekeeping: invalidating cached chain state, marking executed
+    /// transactions, pruning finalized and expired ones, resubmitting stale
+    /// transactions and submitting newly queued ones.
+    pub async fn handle_block_update(&mut self, update: BlockUpdate) -> Result<(), Error> {
+        self.nonce_cache = None;
+        self.fee_cache = None;
+        self.balance_cache = None;
+        match update {
+            BlockUpdate::New { number, safe, .. } => {
+                if self.next_block()?.is_some_and(|next| next != number) || safe > number {
+                    return Err(Error::BadUpdate);
+                }
+                self.block = Block::Latest { block: number };
+
+                // The signer nonce is an RPC round-trip needed only to mark
+                // executed transactions and to assign nonces to queued ones;
+                // both are moot unless a transaction is still outstanding, so
+                // skip it (and the work that needs it) otherwise. Pruning needs
+                // no nonce and always runs, before submission so expired
+                // transactions are dropped rather than broadcast.
+                let outstanding = self.storage.count_outstanding(number).await? > 0;
+                if outstanding {
+                    let nonce = self.nonce().await?;
+                    self.storage
+                        .mark_executed(Status {
+                            block: number,
+                            nonce,
+                        })
+                        .await?;
+                }
+
+                self.storage.prune(safe).await?;
+                if outstanding {
+                    self.resubmit_stale(number).await?;
+                    self.submit_pending().await?;
+                }
+            }
+            BlockUpdate::Uncle { number } => {
+                if self.latest_block().is_some_and(|latest| latest < number) {
+                    return Err(Error::BadUpdate);
+                }
+                self.block = Block::Latest {
+                    block: number.checked_sub(1).ok_or(Error::BadUpdate)?,
+                };
+                self.storage.unmark_executed(number).await?;
+            }
+            BlockUpdate::Warp { from, to } => {
+                if self.next_block()?.is_some_and(|next| next != from) || to < from {
+                    return Err(Error::BadUpdate);
+                }
+
+                // We do not handle warping (it gets weird with transaction
+                // submission and getting transaction counts). It is not worth
+                // it either as warping is historic and most transactions are
+                // too far in the past to execute anyway. Put us into the state
+                // where we are waiting for the next new block update, so queued
+                // transactions do not execute right away. This ensures that
+                // transactions that are queued already expired while warping do
+                // execute.
+                self.block = Block::Warping { to };
+            }
+        }
+        Ok(())
+    }
+
     /// Submits queued transactions while fewer than
     /// `config.max_in_flight_transactions` are in flight.
     ///
@@ -237,6 +302,18 @@ where
         }
     }
 
+    /// Returns the expected next block for block updates, or `None` if no block
+    /// updates have been received.
+    fn next_block(&self) -> Result<Option<u64>, Error> {
+        match self.block {
+            Block::Latest { block } | Block::Warping { to: block } => {
+                let next = block.checked_add(1).ok_or(Error::EndOfChain)?;
+                Ok(Some(next))
+            }
+            _ => Ok(None),
+        }
+    }
+
     /// Returns the signer's onchain nonce (its transaction count), fetched from
     /// the chain on a cache miss and cached until the next block update.
     async fn nonce(&mut self) -> Result<u64, Error> {
@@ -287,5 +364,243 @@ where
                 Ok(balance)
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloy::{
+        primitives::{Address, B256, Bloom, U64, U256, address, keccak256},
+        providers::{ProviderBuilder, RootProvider},
+        rpc::types::FeeHistory,
+        signers::k256::ecdsa::SigningKey,
+        transports::mock::Asserter,
+    };
+    use sqlx::sqlite::SqlitePoolOptions;
+
+    const CHAIN_ID: u64 = 1;
+    const ENTRY_POINT: Address = address!("0x5FF137D4b0FDCD49DcA30c7CF57E578a026d2789");
+
+    /// A transaction queue backed by a mocked RPC client and an in-memory pool.
+    async fn queue(asserter: &Asserter) -> TransactionQueue<RootProvider> {
+        let provider = ProviderBuilder::default().connect_mocked_client(asserter.clone());
+        let private_key = SigningKey::from_slice(keccak256("test signer").as_slice()).unwrap();
+        let signer = Signer::new(private_key);
+        let pool = SqlitePoolOptions::new()
+            .max_connections(1)
+            .connect_with("sqlite::memory:".parse().unwrap())
+            .await
+            .unwrap();
+        TransactionQueue::new(provider, CHAIN_ID, signer, pool, Config::default())
+            .await
+            .unwrap()
+    }
+
+    /// A transaction carrying `input` as its calldata.
+    fn transaction(input: &str) -> Transaction {
+        Transaction {
+            to: ENTRY_POINT,
+            input: input.parse().unwrap(),
+            ..Default::default()
+        }
+    }
+
+    /// A new-block update at `number`, finalizing state up to `safe`.
+    fn new_block(number: u64) -> BlockUpdate {
+        BlockUpdate::New {
+            number,
+            hash: B256::ZERO,
+            logs_bloom: Bloom::ZERO,
+            safe: 0,
+        }
+    }
+
+    /// A fee-history response yielding an estimate of a 210 max fee and 10
+    /// priority fee (base fee 100, doubled, plus the 10 priority fee).
+    fn fee_history() -> FeeHistory {
+        FeeHistory {
+            base_fee_per_gas: vec![100, 100],
+            reward: Some(vec![vec![10]]),
+            ..Default::default()
+        }
+    }
+
+    #[tokio::test]
+    async fn submits_queued_transactions_with_reorg_awareness() {
+        let asserter = Asserter::new();
+        let mut queue = queue(&asserter).await;
+        queue.queue(transaction("0x01"), 1000).await.unwrap();
+
+        asserter.push_success(&U64::from(0)); // signer transaction count
+        asserter.push_success(&fee_history()); // fee estimate
+        asserter.push_success(&B256::ZERO); // transaction hash from submission
+        queue.handle_block_update(new_block(10)).await.unwrap();
+
+        // At block 11 the signer nonce has advanced to 1, so nonce 0 executed.
+        // The safe block (5) is below the execution, so it is marked but not
+        // pruned. No transaction is broadcast, so only the nonce is fetched.
+        asserter.push_success(&U64::from(1));
+        queue.handle_block_update(new_block(11)).await.unwrap();
+        assert!(asserter.read_q().is_empty());
+
+        // Block 11 is uncled, reverting the execution: the transaction is in
+        // flight again.
+        queue
+            .handle_block_update(BlockUpdate::Uncle { number: 11 })
+            .await
+            .unwrap();
+        assert!(asserter.read_q().is_empty());
+
+        // We update up to block 12, where the nonce stays the same. This means
+        // that it is not submitted and gets resubmitted (since it did not get
+        // executed on the new canonical chain since the reorg).
+        asserter.push_success(&U64::from(0)); // signer transaction count
+        queue.handle_block_update(new_block(11)).await.unwrap();
+        assert!(asserter.read_q().is_empty());
+
+        asserter.push_success(&U64::from(0)); // signer transaction count
+        asserter.push_success(&fee_history()); // fee estimate
+        asserter.push_success(&B256::ZERO); // transaction hash from submission
+        queue.handle_block_update(new_block(12)).await.unwrap();
+        assert!(asserter.read_q().is_empty());
+
+        // Now the transaction gets picked up, and since there are no remaining
+        // outstanding transactions we avoid any additional RPC requests on
+        // future blocks.
+        asserter.push_success(&U64::from(1)); // signer transaction count
+        queue.handle_block_update(new_block(13)).await.unwrap();
+        assert!(asserter.read_q().is_empty());
+
+        for block in 14..=20 {
+            queue.handle_block_update(new_block(block)).await.unwrap();
+            assert!(asserter.read_q().is_empty());
+        }
+    }
+
+    #[tokio::test]
+    async fn does_not_submit_expired_transactions() {
+        let asserter = Asserter::new();
+        let mut queue = queue(&asserter).await;
+
+        // Fill up the queue with transactions that will not execute.
+        asserter.push_success(&U64::from(0)); // signer transaction count
+        asserter.push_success(&fee_history()); // fee estimate
+        for i in 0..queue.config.max_in_flight_transactions {
+            queue
+                .queue(transaction(&format!("0x{i:02x}")), 12)
+                .await
+                .unwrap();
+            asserter.push_success(&B256::ZERO); // transaction hash from submission
+        }
+
+        // Add two more transactions that cannot be submitted because of the
+        // in-flight limit.
+        queue.queue(transaction("0xf0"), 12).await.unwrap();
+        queue.queue(transaction("0xf1"), 12).await.unwrap();
+
+        // Observe a block to submit some of the transactions.
+        queue.handle_block_update(new_block(10)).await.unwrap();
+        assert!(asserter.read_q().is_empty());
+
+        // At block 11, the nonce advances by 1, opening up one more transaction
+        // to be submitted.
+        asserter.push_success(&U64::from(1)); // signer transaction count
+        asserter.push_success(&fee_history()); // fee estimate
+        asserter.push_success(&B256::ZERO); // transaction hash from submission
+        queue.handle_block_update(new_block(11)).await.unwrap();
+        assert!(asserter.read_q().is_empty());
+
+        // At block 12, another transaction gets mined, but the outstanding
+        // transaction has already expired and is not executed. However, we
+        // do get resubmissions of the remaining original inflight transactions
+        // because of the resubmit deadline, despite being past the expiry. This
+        // is because once a transaction is in the mempool, it has to execute.
+        asserter.push_success(&U64::from(2)); // signer transaction count
+        asserter.push_success(&fee_history()); // fee estimate
+        for _ in 2..queue.config.max_in_flight_transactions {
+            asserter.push_success(&B256::ZERO); // transaction hash from submission
+        }
+        queue.handle_block_update(new_block(12)).await.unwrap();
+        assert!(asserter.read_q().is_empty());
+
+        // At block 13, all the remaining transactions get mined, the second
+        // transaction was already expired and does not resubmit.
+        asserter.push_success(&U64::from(queue.config.max_in_flight_transactions + 1)); // signer transaction count
+        queue.handle_block_update(new_block(13)).await.unwrap();
+        assert!(asserter.read_q().is_empty());
+
+        // At block 14, there are no outstanding transactions and therefore no
+        // RPC requests are made.
+        queue.handle_block_update(new_block(14)).await.unwrap();
+        assert!(asserter.read_q().is_empty());
+    }
+
+    #[tokio::test]
+    async fn expired_transactions_while_warping_are_ignored() {
+        let asserter = Asserter::new();
+        let mut queue = queue(&asserter).await;
+
+        // Observe a warp update.
+        queue
+            .handle_block_update(BlockUpdate::Warp { from: 0, to: 1000 })
+            .await
+            .unwrap();
+        assert!(asserter.read_q().is_empty());
+
+        // queue a transaction long expired.
+        queue.queue(transaction("0x01"), 42).await.unwrap();
+
+        // now queue a block update, the transaction is not submitted as it is
+        // expired and was never submitted to an RPC node.
+        queue.handle_block_update(new_block(1001)).await.unwrap();
+        assert!(asserter.read_q().is_empty());
+    }
+
+    #[tokio::test]
+    async fn retries_failed_submissions_on_the_next_block() {
+        let asserter = Asserter::new();
+        let mut queue = queue(&asserter).await;
+
+        // Queue two transactions that will both fail to submit. The first is
+        // cheap enough for the signer to afford, so its failure is treated as a
+        // general error; the second has a high gas limit the signer cannot
+        // afford, so its failure is treated as the node rejecting it.
+        queue.queue(transaction("0x01"), 1000).await.unwrap();
+        queue
+            .queue(
+                Transaction {
+                    gas: 1_000_000,
+                    ..transaction("0x02")
+                },
+                1000,
+            )
+            .await
+            .unwrap();
+
+        // At block 10 both submissions fail. The signer balance (100M) covers
+        // the cheap transaction (21000 gas * 210 max fee = ~4.4M) but not the
+        // expensive one (1M gas * 210 max fee = 210M). Only the cheap one is
+        // recorded as submitted (without a block, so it retries immediately);
+        // the expensive one is left unrecorded so its fees are not bumped.
+        asserter.push_success(&U64::from(0)); // signer transaction count
+        asserter.push_success(&fee_history()); // fee estimate
+        asserter.push_failure_msg("no connection"); // cheap submission fails
+        asserter.push_success(&U256::from(100_000_000)); // signer balance
+        asserter.push_failure_msg("insufficient funds"); // expensive submission fails
+        queue.handle_block_update(new_block(10)).await.unwrap();
+        assert!(asserter.read_q().is_empty());
+
+        // At block 11 neither transaction executed (the nonce is unchanged), so
+        // both are resubmitted regardless of how they failed: the recorded one
+        // because its submission block is unset, and the unrecorded one because
+        // its reserved nonce was never submitted. The balance is not queried as
+        // both resubmissions succeed.
+        asserter.push_success(&U64::from(0)); // signer transaction count
+        asserter.push_success(&fee_history()); // fee estimate
+        asserter.push_success(&B256::ZERO); // cheap resubmission
+        asserter.push_success(&B256::ZERO); // expensive resubmission
+        queue.handle_block_update(new_block(11)).await.unwrap();
+        assert!(asserter.read_q().is_empty());
     }
 }

--- a/crates/core/src/tx/mod.rs
+++ b/crates/core/src/tx/mod.rs
@@ -397,11 +397,11 @@ mod tests {
             .unwrap()
     }
 
-    /// A transaction carrying `input` as its calldata.
-    fn transaction(input: &str) -> Transaction {
+    /// A transaction carrying `data` as its calldata.
+    fn tx(data: &str) -> Transaction {
         Transaction {
             to: ENTRY_POINT,
-            input: input.parse().unwrap(),
+            data: data.parse().unwrap(),
             ..Default::default()
         }
     }
@@ -430,7 +430,7 @@ mod tests {
     async fn submits_queued_transactions_with_reorg_awareness() {
         let asserter = Asserter::new();
         let mut queue = queue(&asserter).await;
-        queue.queue(transaction("0x01"), 1000).await.unwrap();
+        queue.queue(tx("0x01"), 1000).await.unwrap();
 
         asserter.push_success(&U64::from(0)); // signer transaction count
         asserter.push_success(&fee_history()); // fee estimate
@@ -487,17 +487,14 @@ mod tests {
         asserter.push_success(&U64::from(0)); // signer transaction count
         asserter.push_success(&fee_history()); // fee estimate
         for i in 0..queue.config.max_in_flight_transactions {
-            queue
-                .queue(transaction(&format!("0x{i:02x}")), 12)
-                .await
-                .unwrap();
+            queue.queue(tx(&format!("0x{i:02x}")), 12).await.unwrap();
             asserter.push_success(&B256::ZERO); // transaction hash from submission
         }
 
         // Add two more transactions that cannot be submitted because of the
         // in-flight limit.
-        queue.queue(transaction("0xf0"), 12).await.unwrap();
-        queue.queue(transaction("0xf1"), 12).await.unwrap();
+        queue.queue(tx("0xf0"), 12).await.unwrap();
+        queue.queue(tx("0xf1"), 12).await.unwrap();
 
         // Observe a block to submit some of the transactions.
         queue.handle_block_update(new_block(10)).await.unwrap();
@@ -549,7 +546,7 @@ mod tests {
         assert!(asserter.read_q().is_empty());
 
         // queue a transaction long expired.
-        queue.queue(transaction("0x01"), 42).await.unwrap();
+        queue.queue(tx("0x01"), 42).await.unwrap();
 
         // now queue a block update, the transaction is not submitted as it is
         // expired and was never submitted to an RPC node.
@@ -566,12 +563,12 @@ mod tests {
         // cheap enough for the signer to afford, so its failure is treated as a
         // general error; the second has a high gas limit the signer cannot
         // afford, so its failure is treated as the node rejecting it.
-        queue.queue(transaction("0x01"), 1000).await.unwrap();
+        queue.queue(tx("0x01"), 1000).await.unwrap();
         queue
             .queue(
                 Transaction {
                     gas: 1_000_000,
-                    ..transaction("0x02")
+                    ..tx("0x02")
                 },
                 1000,
             )


### PR DESCRIPTION
This is part of a larger stack, see #479.

### Context and Motivation

This PR implements the heartbeat of the transaction queue: block updates. It processes block updates and triggers (re-)submissions of non-executed transactions as well as does some housekeeping in the DB.

### Decisions and Tradeoffs

- The transaction queue was made to be reorg aware
- We do some basic defensive block update input checks like for the state machine. In practice, this should never happen

### Testing

Some high level tests were added to check basic flows. Again, there is the issue that we cannot assert on RPC input (see #465), but the tests do still cover a lot of the behaviour of the component.

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://docs.safefoundation.org/cla).
