### PR TITLE
[G 1/2]: Driver Component

### DIFF
--- a/crates/core/src/driver.rs
+++ b/crates/core/src/driver.rs
@@ -1,0 +1,156 @@
+//! Service driver.
+//!
+//! Ties the core building blocks together into a running service: it follows
+//! the chain with an [`indexer`](crate::index), feeds block updates to the
+//! [`transaction queue`](crate::tx) for its per-block housekeeping, and feeds
+//! every update to the [`state machine`](crate::state). The actions produced by
+//! the state machine are encoded into transactions by the [`Service`] and queued
+//! for submission.
+
+use crate::{
+    index::{self, Update, Watcher, events::Events},
+    state::{self, StateMachine, StateTransition},
+    tx::{self, Transaction, TransactionQueue},
+};
+use alloy::providers::Provider;
+use serde::{Serialize, de::DeserializeOwned};
+use std::{pin::Pin, time::Duration};
+
+/// How long to wait after a failed step before retrying, to avoid spinning on a
+/// persistent failure (such as an unreachable RPC node).
+const STEP_RETRY_DELAY: Duration = Duration::from_millis(100);
+
+/// Whether the [`Driver::run`] loop should keep processing updates or stop.
+enum Loop {
+    /// Continue with the next iteration.
+    Continue,
+    /// Stop the run loop, for example after a shutdown signal.
+    Break,
+}
+
+/// Error produced by the [`Driver`].
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+    /// An indexer error.
+    #[error(transparent)]
+    Index(#[from] index::Error),
+    /// A state machine error.
+    #[error(transparent)]
+    State(#[from] state::Error),
+    /// A transaction queue error.
+    #[error(transparent)]
+    Transactions(#[from] tx::Error),
+}
+
+/// A Safenet service.
+///
+/// Implementors describe how the service observes the chain (its [`Events`]) and
+/// reacts to it (its [`State`](Service::State) and
+/// [`Transition`](Service::Transition)), and how the resulting
+/// [`Action`](Service::Action)s map onto onchain transactions.
+pub trait Service: StateTransition<Self::State> {
+    /// The service state, persisted across restarts and rolled back on reorgs.
+    type State: Serialize + DeserializeOwned;
+
+    /// Encodes state transition `actions` into transactions to submit onchain,
+    /// each paired with the block number after which it should be dropped if it
+    /// has not yet been submitted.
+    fn encode_actions(&self, actions: Vec<Self::Action>) -> Vec<(Transaction, u64)>;
+}
+
+/// Drives a [`Service`] by wiring its indexer, state machine and transaction
+/// queue together.
+pub struct Driver<P, S>
+where
+    S: Service,
+{
+    service: S,
+    watcher: Watcher<P, S::Event>,
+    state: StateMachine<S::State, S>,
+    transactions: TransactionQueue<P>,
+}
+
+impl<P, S> Driver<P, S>
+where
+    P: Provider + Clone,
+    S: Service,
+    S::Event: Events,
+{
+    /// Creates a driver from the service and the components it coordinates.
+    pub fn new(
+        service: S,
+        watcher: Watcher<P, S::Event>,
+        state: StateMachine<S::State, S>,
+        transactions: TransactionQueue<P>,
+    ) -> Self {
+        Self {
+            service,
+            watcher,
+            state,
+            transactions,
+        }
+    }
+
+    /// Runs the service, processing indexer updates until a shutdown signal
+    /// (such as Ctrl-C) is received or an unrecoverable error occurs.
+    ///
+    /// A failed step is retried on the next iteration rather than stopping the
+    /// service.
+    pub async fn run(mut self) {
+        let shutdown = async {
+            if let Err(err) = tokio::signal::ctrl_c().await {
+                tracing::error!(?err, "signal handling error; shutting down");
+            }
+        };
+        tokio::pin!(shutdown);
+
+        loop {
+            match self.step(shutdown.as_mut()).await {
+                Ok(Loop::Continue) => {}
+                Ok(Loop::Break) => {
+                    tracing::info!("received shutdown signal; stopping service");
+                    break;
+                }
+                Err(Error::State(err)) => {
+                    tracing::error!(?err, "unrecoverable state transition error; exiting");
+                    break;
+                }
+                Err(err) => {
+                    tracing::warn!(?err, "service step failed; retrying after delay");
+                    tokio::time::sleep(STEP_RETRY_DELAY).await;
+                }
+            }
+        }
+    }
+
+    /// Processes a single indexer update: feeding block updates to the
+    /// transaction queue, advancing the state machine, and queuing the
+    /// transactions its actions encode to.
+    ///
+    /// Only the wait for the next update races `shutdown`; once an update
+    /// arrives it is processed to completion so its state transition and queued
+    /// transactions are committed before the loop can stop.
+    async fn step(&mut self, shutdown: Pin<&mut impl Future<Output = ()>>) -> Result<Loop, Error> {
+        let update = tokio::select! {
+            biased;
+            _ = shutdown => return Ok(Loop::Break),
+            update = self.watcher.next() => update?,
+        };
+
+        // Block updates drive the transaction queue's per-block housekeeping
+        // (marking executed transactions, pruning, resubmitting and submitting).
+        // Do this before advancing the state machine so freshly queued
+        // transactions are submitted against the current block.
+        if let Update::Block(block) = &update {
+            self.transactions.handle_block_update(block.clone()).await?;
+        }
+
+        let actions = self.state.handle_update(update).await?;
+        if !actions.is_empty() {
+            let transactions = self.service.encode_actions(actions);
+            self.transactions.queue(transactions).await?;
+        }
+
+        Ok(Loop::Continue)
+    }
+}

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -10,7 +10,10 @@
 //!   restarts and roll back in case of reorgs.
 //! - Reliable transaction submission with all its complexities.
 
+pub mod driver;
 pub mod index;
 pub mod observability;
 pub mod state;
 pub mod tx;
+
+pub use self::driver::{Driver, Service};

--- a/crates/core/src/tx/mod.rs
+++ b/crates/core/src/tx/mod.rs
@@ -126,8 +126,11 @@ where
     /// Queues `transaction` for execution, to be dropped if it has not been
     /// submitted by block `expires_at`, then attempts to submit it (and any
     /// other queued transactions) onchain.
-    pub async fn queue(&mut self, transaction: Transaction, expires_at: u64) -> Result<(), Error> {
-        self.storage.enqueue(transaction, expires_at).await?;
+    pub async fn queue(
+        &mut self,
+        transactions: impl IntoIterator<Item = (Transaction, u64)>,
+    ) -> Result<(), Error> {
+        self.storage.enqueue(transactions).await?;
         self.submit_pending().await
     }
 
@@ -458,7 +461,7 @@ mod tests {
     async fn submits_queued_transactions_with_reorg_awareness() {
         let asserter = Asserter::new();
         let mut queue = queue(&asserter).await;
-        queue.queue(tx("0x01"), 1000).await.unwrap();
+        queue.queue([(tx("0x01"), 1000)]).await.unwrap();
 
         asserter.push_success(&U64::from(0)); // signer transaction count
         asserter.push_success(&fee_history()); // fee estimate
@@ -515,14 +518,17 @@ mod tests {
         asserter.push_success(&U64::from(0)); // signer transaction count
         asserter.push_success(&fee_history()); // fee estimate
         for i in 0..queue.config.max_in_flight_transactions {
-            queue.queue(tx(&format!("0x{i:02x}")), 12).await.unwrap();
+            queue
+                .queue([(tx(&format!("0x{i:02x}")), 12)])
+                .await
+                .unwrap();
             asserter.push_success(&B256::ZERO); // transaction hash from submission
         }
 
         // Add two more transactions that cannot be submitted because of the
         // in-flight limit.
-        queue.queue(tx("0xf0"), 12).await.unwrap();
-        queue.queue(tx("0xf1"), 12).await.unwrap();
+        queue.queue([(tx("0xf0"), 12)]).await.unwrap();
+        queue.queue([(tx("0xf1"), 12)]).await.unwrap();
 
         // Observe a block to submit some of the transactions.
         queue.handle_block_update(new_block(10)).await.unwrap();
@@ -574,7 +580,7 @@ mod tests {
         assert!(asserter.read_q().is_empty());
 
         // queue a transaction long expired.
-        queue.queue(tx("0x01"), 42).await.unwrap();
+        queue.queue([(tx("0x01"), 42)]).await.unwrap();
 
         // now queue a block update, the transaction is not submitted as it is
         // expired and was never submitted to an RPC node.
@@ -591,15 +597,15 @@ mod tests {
         // cheap enough for the signer to afford, so its failure is treated as a
         // general error; the second has a high gas limit the signer cannot
         // afford, so its failure is treated as the node rejecting it.
-        queue.queue(tx("0x01"), 1000).await.unwrap();
+        queue.queue([(tx("0x01"), 1000)]).await.unwrap();
         queue
-            .queue(
+            .queue([(
                 Transaction {
                     gas: 1_000_000,
                     ..tx("0x02")
                 },
                 1000,
-            )
+            )])
             .await
             .unwrap();
 

--- a/crates/core/src/tx/storage.rs
+++ b/crates/core/src/tx/storage.rs
@@ -81,15 +81,23 @@ impl TransactionStorage {
         Ok(Self { pool })
     }
 
-    /// Stores `transaction` as a queued transaction that expires at block
-    /// `expires_at` if it has not been submitted by then.
-    pub async fn enqueue(&self, transaction: Transaction, expires_at: u64) -> Result<(), Error> {
-        let request = serde_json::to_string(&transaction)?;
-        sqlx::query("INSERT INTO transactions (request, expires_at) VALUES (?, ?)")
-            .bind(request)
-            .bind(i64::try_from(expires_at)?)
-            .execute(&self.pool)
-            .await?;
+    /// Stores `transactions` as queued transactions, each expiring at its
+    /// `expires_at` block if it has not been submitted by then. The whole batch
+    /// is inserted atomically.
+    pub async fn enqueue(
+        &self,
+        transactions: impl IntoIterator<Item = (Transaction, u64)>,
+    ) -> Result<(), Error> {
+        let mut tx = self.pool.begin().await?;
+        for (transaction, expires_at) in transactions {
+            let request = serde_json::to_string(&transaction)?;
+            sqlx::query("INSERT INTO transactions (request, expires_at) VALUES (?, ?)")
+                .bind(request)
+                .bind(i64::try_from(expires_at)?)
+                .execute(&mut *tx)
+                .await?;
+        }
+        tx.commit().await?;
         Ok(())
     }
 
@@ -348,7 +356,7 @@ mod tests {
     #[tokio::test]
     async fn submit_assigns_the_account_nonce_and_fees() {
         let storage = storage().await;
-        storage.enqueue(tx("0x5afe"), 100).await.unwrap();
+        storage.enqueue([(tx("0x5afe"), 100)]).await.unwrap();
 
         // There are no in flight transactions to begin with.
         assert_eq!(storage.count_in_flight().await.unwrap(), 0);
@@ -376,9 +384,9 @@ mod tests {
     #[tokio::test]
     async fn submit_assigns_sequential_nonces_in_queue_order() {
         let storage = storage().await;
-        storage.enqueue(tx("0x5afe01"), 100).await.unwrap();
-        storage.enqueue(tx("0x5afe02"), 100).await.unwrap();
-        storage.enqueue(tx("0x5afe03"), 100).await.unwrap();
+        storage.enqueue([(tx("0x5afe01"), 100)]).await.unwrap();
+        storage.enqueue([(tx("0x5afe02"), 100)]).await.unwrap();
+        storage.enqueue([(tx("0x5afe03"), 100)]).await.unwrap();
 
         // Each submission picks the next free nonce above the in-flight ones, in
         // FIFO order.
@@ -396,7 +404,7 @@ mod tests {
     #[tokio::test]
     async fn record_submission_stamps_the_block_and_fees() {
         let storage = storage().await;
-        storage.enqueue(tx("0x5afe"), 100).await.unwrap();
+        storage.enqueue([(tx("0x5afe"), 100)]).await.unwrap();
         let submitted = storage
             .next_transaction(Status { nonce: 5, block: 0 })
             .await
@@ -427,7 +435,7 @@ mod tests {
     #[tokio::test]
     async fn record_submission_errors_for_an_unknown_nonce() {
         let storage = storage().await;
-        storage.enqueue(tx("0x5afe"), 100).await.unwrap();
+        storage.enqueue([(tx("0x5afe"), 100)]).await.unwrap();
         storage
             .next_transaction(Status { nonce: 5, block: 0 })
             .await
@@ -449,8 +457,8 @@ mod tests {
     #[tokio::test]
     async fn prunes_queued_transactions_past_their_expiry() {
         let storage = storage().await;
-        storage.enqueue(tx("0x5afe01"), 10).await.unwrap();
-        storage.enqueue(tx("0x5afe02"), 20).await.unwrap();
+        storage.enqueue([(tx("0x5afe01"), 10)]).await.unwrap();
+        storage.enqueue([(tx("0x5afe02"), 20)]).await.unwrap();
 
         // Pruning at a safe block of 15 removes the first transaction (expiry
         // 10); the second (expiry 20) is not yet expired.


### PR DESCRIPTION
This PR introduces a driver component to facilitate the plumbing between the shared utilities.

This phase (G) was not part of the original plan, but was introduced in order to facilitate the use of the components introduced by the shared crate.

### Context and Motivation

This is the "top level" component that is expected to be initialized by each of the services and used to drive the protocols forward.

### Decisions and Tradeoffs

For now, initialization is manual (in other words, it is expected that the caller initializes all driver components and passes them in). I plan on simplifying this (although without trying on both the sentinel and validator, it is hard to know what parts of the initialization should be automatic, and which parts should be manual.

Transaction queuing was changed to be bundle based, this ensures that all actions after a state transition are processed together and added to the transaction queue storage (in case of an untimely restart).

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://docs.safefoundation.org/cla).
