### PR TITLE
Introduce Validator Rust Crate

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ integration_logs.txt
 lcov.info
 node_modules/
 target/
+validator*.toml

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -808,6 +808,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "argh"
+version = "0.1.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "211818e820cda9ca6f167a64a5c808837366a6dfd807157c64c1304c486cd033"
+dependencies = [
+ "argh_derive",
+ "argh_shared",
+]
+
+[[package]]
+name = "argh_derive"
+version = "0.1.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c442a9d18cef5dde467405d27d461d080d68972d6d0dfd0408265b6749ec427d"
+dependencies = [
+ "argh_shared",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "argh_shared"
+version = "0.1.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5ade012bac4db278517a0132c8c10c6427025868dca16c801087c28d5a411f1"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "ark-ff"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4008,6 +4039,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
 name = "serde_with"
 version = "3.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4688,6 +4728,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml"
+version = "1.1.2+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81f3d15e84cbcd896376e6730314d59fb5a87f31e4b038454184435cd57defee"
+dependencies = [
+ "indexmap 2.14.0",
+ "serde_core",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_parser",
+ "toml_writer",
+ "winnow",
+]
+
+[[package]]
 name = "toml_datetime"
 version = "1.1.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4716,6 +4771,12 @@ checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
  "winnow",
 ]
+
+[[package]]
+name = "toml_writer"
+version = "1.1.1+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
 
 [[package]]
 name = "tower"
@@ -4961,6 +5022,19 @@ name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
+name = "validator"
+version = "0.2.0"
+dependencies = [
+ "argh",
+ "safenet-core",
+ "serde",
+ "thiserror",
+ "tokio",
+ "toml",
+ "tracing",
+]
 
 [[package]]
 name = "valuable"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,17 @@
 [workspace]
 resolver = "3"
 members = ["crates/*"]
+
+[workspace.dependencies]
+alloy = { version = "2", features = ["full"] }
+argh = "0.1"
+futures = "0.3"
+metrics = "0.24"
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+sqlx = { version = "0.9", features = ["sqlite", "runtime-tokio"] }
+thiserror = "2"
+tokio = { version = "1", features = ["full"] }
+toml = "1"
+tracing = "0.1"
+url = { version = "2", features = ["serde"] }

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -5,19 +5,19 @@ edition = "2024"
 publish = false
 
 [dependencies]
-alloy = { version = "2", features = ["full"] }
-futures = "0.3"
-metrics = "0.24"
+alloy.workspace = true
+futures.workspace = true
+metrics.workspace = true
 metrics-exporter-prometheus = "0.18"
-serde = { version = "1", features = ["derive"] }
-serde_json = "1"
-sqlx = { version = "0.9", features = ["sqlite", "runtime-tokio"] }
-thiserror = "2"
-tokio = { version = "1", features = ["full"] }
-tracing = "0.1"
+serde.workspace = true
+serde_json.workspace = true
+sqlx.workspace = true
+thiserror.workspace = true
+tokio.workspace = true
+tracing.workspace = true
 tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt", "json"] }
-url = { version = "2", features = ["serde"] }
+url.workspace = true
 
 [dev-dependencies]
-alloy = { version = "2", features = ["json-rpc"] }
-tokio = { version = "1", features = ["test-util"] }
+alloy = { workspace = true, features = ["json-rpc"] }
+tokio = { workspace = true, features = ["test-util"] }

--- a/crates/validator/Cargo.toml
+++ b/crates/validator/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "validator"
+version = "0.2.0"
+edition = "2024"
+publish = false
+
+[dependencies]
+argh.workspace = true
+safenet-core.path = "../core"
+serde.workspace = true
+thiserror.workspace = true
+tokio.workspace = true
+toml.workspace = true
+tracing.workspace = true

--- a/crates/validator/src/config.rs
+++ b/crates/validator/src/config.rs
@@ -1,0 +1,30 @@
+use safenet_core::observability;
+use serde::Deserialize;
+use std::path::Path;
+use tokio::{fs, io};
+
+/// Error produced by the block watcher.
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+    /// An IO error when interacting with the filesystem.
+    #[error(transparent)]
+    Io(#[from] io::Error),
+    /// Error when parsing the configuration.
+    #[error(transparent)]
+    Parse(#[from] toml::de::Error),
+}
+
+#[derive(Debug, Default, Deserialize)]
+#[serde(default)]
+pub struct Config {
+    pub observability: observability::Config,
+}
+
+impl Config {
+    /// Loads a configuration from a file.
+    pub async fn load(file: &Path) -> Result<Self, Error> {
+        let contents = fs::read_to_string(file).await?;
+        let config = toml::from_str(&contents)?;
+        Ok(config)
+    }
+}

--- a/crates/validator/src/main.rs
+++ b/crates/validator/src/main.rs
@@ -1,0 +1,33 @@
+mod config;
+
+use self::config::Config;
+use argh::FromArgs;
+use safenet_core::observability;
+use std::{error::Error, path::PathBuf};
+
+#[derive(Debug, FromArgs)]
+/// Safenet validator.
+struct Options {
+    /// path to the validator TOML configuration file.
+    #[argh(option, default = "PathBuf::from(\"validator.toml\")")]
+    config_file: PathBuf,
+
+    /// print version information.
+    #[argh(switch)]
+    version: bool,
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn Error>> {
+    let options: Options = argh::from_env();
+    if options.version {
+        println!("{}", env!("CARGO_PKG_VERSION"));
+        return Ok(());
+    }
+
+    let config = Config::load(&options.config_file).await?;
+    observability::init(config.observability)?;
+
+    tracing::debug!(config_file = %options.config_file.display(), "validator configuration loaded");
+    Ok(())
+}


### PR DESCRIPTION
This PR just lays some initial ground work and creates a new crate for the Rust validator binary.

### Decisions and Tradeoffs

- For now, the binary just parses CLI arguments and reads a configuration file. I decided to use configuration files instead of environment variables or command line arguments are they are (IMO) easier to deal with. In particular, in our infra services that are configured through files are generally easier to deal with (they do not involve `daemon-reload`-ing systemd unit files) and allow for more structured input (like arrays with nested objects, for example for the validator configuration). I chose TOML as I find it strikes a great balance between a simple format (unlike YAML) yet easy to edit and read (unlike JSON).
- We setup observability to see logs, just to do some tiny amount of visible work.
- We move all shared (or reasonably sharable) crates into workspace dependencies. This ensures we build one version/feature set for all our crates instead of having potentially multiple versions or crates (which can cause weird bugs or cryptic compiler errors). Note that a couple crates are intentionally not workspace dependencies, as they are the "implementation backend" choice for the shared crates:
  - `tracing-subscriber`: decides how tracing is recorded (for us, stdout) which should only be added as a dependency where the subscriber is initialized, and not where tracing is used
  - `metrics-exporter-prometheus`: similar argument to the tracing subscriber; this defines how metrics are hosted and is not required where metrics are used
- Added a Git ignore rule for validator configuration. I included an extra glob-`*` in the pattern to make it easier for multiple configuration files (like `validator.dev.toml` and `validator.local.toml`) to live at the root of the repository (making it easy to run with `cargo run -qp validator -- --config-file validator.dev.toml` for example) without the configuration files being accidentally checked into version control.

### Testing

```
$ cargo run -qp validator
2026-06-29T10:24:22.236335Z  INFO safenet_core::observability: serving prometheus metrics and health endpoint metrics_addr=127.0.0.1:46049
2026-06-29T10:24:22.236409Z DEBUG validator: validator configuration loaded config_file=validator.toml
```

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://docs.safefoundation.org/cla).
