### PR TITLE
Deny Unkonwn Fields When Deserializing Configurations

### DIFF
--- a/crates/core/src/index/blocks.rs
+++ b/crates/core/src/index/blocks.rs
@@ -28,7 +28,7 @@ pub enum BlockTime {
 
 /// Block watcher configuration.
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize)]
-#[serde(default)]
+#[serde(default, deny_unknown_fields)]
 pub struct Config {
     /// Expected time between blocks.
     pub block_time: BlockTime,

--- a/crates/core/src/index/events.rs
+++ b/crates/core/src/index/events.rs
@@ -54,7 +54,7 @@ pub struct EventUpdate<E> {
 
 /// Event watcher configuration.
 #[derive(Clone, Debug, Deserialize, PartialEq, Eq)]
-#[serde(default)]
+#[serde(default, deny_unknown_fields)]
 pub struct Config {
     /// The number of blocks to query at once while warping over a reorg-safe
     /// range. Halved on query failure (never below one) and reset on success.

--- a/crates/core/src/index/mod.rs
+++ b/crates/core/src/index/mod.rs
@@ -17,7 +17,7 @@ pub use events::EventUpdate;
 
 /// Watcher configuration, aggregating the block and event watcher configs.
 #[derive(Clone, Debug, Default, Deserialize, PartialEq, Eq)]
-#[serde(default)]
+#[serde(default, deny_unknown_fields)]
 pub struct Config {
     /// Block watcher configuration.
     #[serde(flatten)]

--- a/crates/core/src/observability/mod.rs
+++ b/crates/core/src/observability/mod.rs
@@ -16,7 +16,7 @@ pub mod metrics;
 /// Deserializes from a configuration file and fills in defaults for any omitted
 /// field, so a consumer only specifies the values it needs to override.
 #[derive(Clone, Debug, Deserialize)]
-#[serde(default)]
+#[serde(default, deny_unknown_fields)]
 pub struct Config {
     /// The `tracing` env-filter directive controlling log verbosity (see
     /// [`logging::init`]). Defaults to `info`.

--- a/crates/core/src/tx/mod.rs
+++ b/crates/core/src/tx/mod.rs
@@ -51,7 +51,7 @@ pub enum Error {
 
 /// Transaction queue configuration.
 #[derive(Clone, Debug, Deserialize, PartialEq)]
-#[serde(default)]
+#[serde(default, deny_unknown_fields)]
 pub struct Config {
     /// The maximum number of transactions that may be in flight (submitted
     /// onchain but not yet executed) at any one time. The queue only submits new

--- a/crates/validator/src/config.rs
+++ b/crates/validator/src/config.rs
@@ -15,7 +15,7 @@ pub enum Error {
 }
 
 #[derive(Debug, Default, Deserialize)]
-#[serde(default)]
+#[serde(default, deny_unknown_fields)]
 pub struct Config {
     pub observability: observability::Config,
 }


### PR DESCRIPTION
Add `deny_unknown_fields` directive to `serde` to get deserialization errors when unknown fields are encountered.

### Context and Motivation

When playing around with running the validator (see #489), I ran into an issue where I was setting a configuration parameter but not noticing the effect I was expecting. It turns out that this was because I had used the wrong configuration option name.

In order to make this user error more apparent, make the configuration types implement stricter deserialization where unknown fields are treated as errors instead of being silently ignored.

### Decisions and Tradeoffs

For now, I only applied this to configurations, because they are user-facing and this helps with user errors. I left the other deserialization implementations more permissive for now.

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://docs.safefoundation.org/cla).
