### PR TITLE
Allow to post coverage report as non privileged runner

### DIFF
--- a/.github/actions/post-comment/action.yaml
+++ b/.github/actions/post-comment/action.yaml
@@ -40,12 +40,18 @@ runs:
             ? require('fs').readFileSync(contentFile, 'utf8')
             : process.env.CONTENT;
 
+          if (!content) {
+            core.setFailed('post-comment: either content or content-file must be provided and non-empty.');
+            return;
+          }
+
           let existingComment;
           if (marker) {
-            const { data: comments } = await github.rest.issues.listComments({
+            const comments = await github.paginate(github.rest.issues.listComments, {
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: issueNumber,
+              per_page: 100,
             });
             existingComment = comments.find(c => c.body.includes(marker));
           }

--- a/.github/actions/post-comment/action.yaml
+++ b/.github/actions/post-comment/action.yaml
@@ -1,0 +1,67 @@
+name: "Post PR Comment"
+description: "Creates or updates a PR comment, identified by an optional marker string"
+inputs:
+  github-token:
+    description: "The GITHUB_TOKEN required to post comments"
+    required: true
+  issue-number:
+    description: "The PR/issue number to comment on"
+    required: true
+  content:
+    description: "The markdown content of the comment"
+    required: false
+    default: ""
+  content-file:
+    description: "Path to a file containing the comment body (takes precedence over content)"
+    required: false
+    default: ""
+  marker:
+    description: "A unique string within the comment body used to find and update an existing comment. If omitted, always creates a new comment."
+    required: false
+    default: ""
+
+runs:
+  using: "composite"
+  steps:
+    - name: Post or Update Comment
+      uses: actions/github-script@v6
+      env:
+        ISSUE_NUMBER: ${{ inputs.issue-number }}
+        CONTENT: ${{ inputs.content }}
+        CONTENT_FILE: ${{ inputs.content-file }}
+        MARKER: ${{ inputs.marker }}
+      with:
+        github-token: ${{ inputs.github-token }}
+        script: |
+          const issueNumber = parseInt(process.env.ISSUE_NUMBER);
+          const marker = process.env.MARKER;
+          const contentFile = process.env.CONTENT_FILE;
+          const content = contentFile
+            ? require('fs').readFileSync(contentFile, 'utf8')
+            : process.env.CONTENT;
+
+          let existingComment;
+          if (marker) {
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: issueNumber,
+            });
+            existingComment = comments.find(c => c.body.includes(marker));
+          }
+
+          if (existingComment) {
+            await github.rest.issues.updateComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              comment_id: existingComment.id,
+              body: content,
+            });
+          } else {
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: issueNumber,
+              body: content,
+            });
+          }

--- a/.github/actions/report-coverage/action.yaml
+++ b/.github/actions/report-coverage/action.yaml
@@ -110,45 +110,37 @@ runs:
         # Grep -v removes the "Reading tracefile" noise
         FILE_LIST=$(lcov --list lcov.info | grep -v "Reading tracefile")
 
-        # 6. Export Variables for JS Step
-
-        # Pass Total %
+        # 6. Export step outputs
         echo "TOTAL_STATS=$TOTAL_STATS" >> $GITHUB_OUTPUT
 
-        # Pass the summary
         echo "SUMMARY<<EOF" >> $GITHUB_OUTPUT
         echo -e "$REPORT_TABLE" >> $GITHUB_OUTPUT
         echo "EOF" >> $GITHUB_OUTPUT
 
-        # Pass the details
         echo "DETAILS<<EOF" >> $GITHUB_OUTPUT
         echo "$FILE_LIST" >> $GITHUB_OUTPUT
         echo "EOF" >> $GITHUB_OUTPUT
 
-    - name: Build Report
-      id: build_report
-      shell: bash
-      env:
-        TOTAL_STATS: ${{ steps.process_coverage.outputs.TOTAL_STATS }}
-        SUMMARY: ${{ steps.process_coverage.outputs.SUMMARY }}
-        DETAILS: ${{ steps.process_coverage.outputs.DETAILS }}
-      run: |
-        cat > coverage-report.md <<EOF
-        <!-- coverage-report -->
-        ### 🛡️ Test Coverage Report
-
-        **Total Line Coverage:** ${TOTAL_STATS}
-
-        ${SUMMARY}
-
-        <details>
-        <summary><strong>📄 Click to view coverage for all files</strong></summary>
-
-        \`\`\`text
-        ${DETAILS}
-        \`\`\`
-        </details>
-        EOF
+        # 7. Build report file
+        # Variables are used directly here (no ${{ }} interpolation) to avoid
+        # URL-encoding of newlines and unintended shell expansion in heredocs.
+        {
+          echo "<!-- coverage-report -->"
+          echo "### 🛡️ Test Coverage Report"
+          echo ""
+          echo "**Total Line Coverage:** ${TOTAL_STATS}"
+          echo ""
+          echo -e "$REPORT_TABLE"
+          echo ""
+          echo "<details>"
+          echo "<summary><strong>📄 Click to view coverage for all files</strong></summary>"
+          echo ""
+          echo '```text'
+          echo "${FILE_LIST}"
+          echo '```'
+          echo ""
+          echo "</details>"
+        } > coverage-report.md
 
     - name: Post Coverage Step Summary
       if: ${{ inputs.post-as-step-summary == 'true' }}
@@ -158,7 +150,13 @@ runs:
     - name: Prepare Coverage Artifact
       if: ${{ inputs.upload-artifact == 'true' }}
       shell: bash
-      run: jq -r '.pull_request.number' "$GITHUB_EVENT_PATH" > issue-number.txt
+      run: |
+        PR_NUMBER=$(jq -r '.pull_request.number' "$GITHUB_EVENT_PATH")
+        if [ "$PR_NUMBER" = "null" ] || [ -z "$PR_NUMBER" ]; then
+          echo "❌ upload-artifact requires a pull_request event context."
+          exit 1
+        fi
+        echo "$PR_NUMBER" > issue-number.txt
 
     - name: Upload Coverage Artifact
       if: ${{ inputs.upload-artifact == 'true' }}

--- a/.github/actions/report-coverage/action.yaml
+++ b/.github/actions/report-coverage/action.yaml
@@ -122,7 +122,7 @@ runs:
         echo "EOF" >> $GITHUB_OUTPUT
 
         # 7. Build report file
-        # Variables are used directly here (no ${{ }} interpolation) to avoid
+        # Variables are used directly here (no template interpolation) to avoid
         # URL-encoding of newlines and unintended shell expansion in heredocs.
         {
           echo "<!-- coverage-report -->"

--- a/.github/actions/report-coverage/action.yaml
+++ b/.github/actions/report-coverage/action.yaml
@@ -1,9 +1,14 @@
 name: "Report Coverage"
-description: "Merges reports, and comments on PR"
+description: "Merges reports, and posts coverage as a PR comment or step summary"
 inputs:
   github-token:
-    description: "The GITHUB_TOKEN required to post comments"
-    required: true
+    description: "The GITHUB_TOKEN required to post comments (not needed when post-as-step-summary is true)"
+    required: false
+    default: ""
+  post-as-step-summary:
+    description: "Post the report as a workflow step summary instead of a PR comment (safe for fork PRs)"
+    required: false
+    default: "false"
 
 runs:
   using: "composite"
@@ -120,7 +125,32 @@ runs:
         echo "$FILE_LIST" >> $GITHUB_OUTPUT
         echo "EOF" >> $GITHUB_OUTPUT
 
+    - name: Post Coverage Step Summary
+      if: inputs.post-as-step-summary == 'true'
+      shell: bash
+      env:
+        TOTAL_STATS: ${{ steps.process_coverage.outputs.TOTAL_STATS }}
+        SUMMARY: ${{ steps.process_coverage.outputs.SUMMARY }}
+        DETAILS: ${{ steps.process_coverage.outputs.DETAILS }}
+      run: |
+        cat >> "$GITHUB_STEP_SUMMARY" <<EOF
+        ### 🛡️ Test Coverage Report
+
+        **Total Line Coverage:** ${TOTAL_STATS}
+
+        ${SUMMARY}
+
+        <details>
+        <summary><strong>📄 Click to view coverage for all files</strong></summary>
+
+        \`\`\`text
+        ${DETAILS}
+        \`\`\`
+        </details>
+        EOF
+
     - name: Post Coverage Comment
+      if: inputs.post-as-step-summary != 'true'
       uses: actions/github-script@v6
       env:
         TOTAL_STATS: ${{ steps.process_coverage.outputs.TOTAL_STATS }}

--- a/.github/actions/report-coverage/action.yaml
+++ b/.github/actions/report-coverage/action.yaml
@@ -126,7 +126,7 @@ runs:
         echo "EOF" >> $GITHUB_OUTPUT
 
     - name: Post Coverage Step Summary
-      if: inputs.post-as-step-summary == 'true'
+      if: ${{ inputs.post-as-step-summary == 'true' }}
       shell: bash
       env:
         TOTAL_STATS: ${{ steps.process_coverage.outputs.TOTAL_STATS }}
@@ -150,7 +150,7 @@ runs:
         EOF
 
     - name: Post Coverage Comment
-      if: inputs.post-as-step-summary != 'true'
+      if: ${{ inputs.post-as-step-summary != 'true' }}
       uses: actions/github-script@v6
       env:
         TOTAL_STATS: ${{ steps.process_coverage.outputs.TOTAL_STATS }}

--- a/.github/actions/report-coverage/action.yaml
+++ b/.github/actions/report-coverage/action.yaml
@@ -1,12 +1,12 @@
 name: "Report Coverage"
-description: "Merges reports, and posts coverage as a PR comment or step summary"
+description: "Merges coverage reports and outputs them as a step summary or artifact for downstream comment posting"
 inputs:
-  github-token:
-    description: "The GITHUB_TOKEN required to post comments (not needed when post-as-step-summary is true)"
-    required: false
-    default: ""
   post-as-step-summary:
-    description: "Post the report as a workflow step summary instead of a PR comment (safe for fork PRs)"
+    description: "Post the report as a workflow step summary (safe for fork PRs)"
+    required: false
+    default: "false"
+  upload-artifact:
+    description: "Upload the report as an artifact so a downstream privileged workflow can post it as a PR comment"
     required: false
     default: "false"
 
@@ -15,7 +15,7 @@ runs:
   steps:
     # --- Dependencies for this action ---
     # We install lcov here so the main workflow doesn't have to know about it
-    - name: Install LCOV 
+    - name: Install LCOV
       shell: bash
       run: |
         # We clone the repository as the version via apt-get is faulty
@@ -28,10 +28,10 @@ runs:
         git checkout dfeb7505ef372f806ddb280b52a90f41cd8169cd
 
         sudo make install
-        
+
         # Verify version to be sure
         lcov --version
-        
+
         # Cleanup
         cd ..
         rm -rf /tmp/lcov
@@ -44,7 +44,7 @@ runs:
         # Initialize Markdown Table Header
         # We use \n for newlines which we will interpret later
         REPORT_TABLE="| Package | Coverage |\n| :--- | :--- |"
-        
+
         # 1. Get workspace patterns from package.json (e.g., "packages/*", "apps/web")
         # We use -r for raw output to remove quotes
         WORKSPACE_PATTERNS=$(jq -r '.workspaces[]' package.json)
@@ -56,16 +56,16 @@ runs:
 
           # Force shell expansion of the glob (e.g., packages/* -> packages/a packages/b)
           for pkg in $pattern; do
-            
+
             # Check if it is actually a directory
             if [ -d "$pkg" ]; then
-              
+
               # Standardized Location: {package}/coverage/lcov.info
               LCOV_FILE="$pkg/coverage/lcov.info"
 
               if [ -f "$LCOV_FILE" ]; then
                 echo "✅ Found coverage: $LCOV_FILE"
-                
+
                 # --- A. Fix Paths ---
                 # We need to prepend the package path ($pkg) to the source files.
                 # Example: SF:src/utils.ts -> SF:validator/src/utils.ts
@@ -75,15 +75,15 @@ runs:
                 # Run lcov summary on this specific file
                 # Extract the percentage (e.g., "85.4%")
                 PKG_STATS=$(lcov --summary "$LCOV_FILE" | grep "lines......" | cut -d ':' -f 2 | xargs)
-               
+
                 PKG_NAME=$(basename "$pkg")
-                
+
                 echo "   📊 $PKG_NAME: $PKG_STATS"
                 lcov --list "$LCOV_FILE"
 
                 # Append row to table
                 REPORT_TABLE="${REPORT_TABLE}\n| **${PKG_NAME}** | ${PKG_STATS} |"
-                
+
                 # Add to merge list
                 MERGE_ARGS+=(--add-tracefile "$LCOV_FILE")
               else
@@ -114,7 +114,7 @@ runs:
 
         # Pass Total %
         echo "TOTAL_STATS=$TOTAL_STATS" >> $GITHUB_OUTPUT
-        
+
         # Pass the summary
         echo "SUMMARY<<EOF" >> $GITHUB_OUTPUT
         echo -e "$REPORT_TABLE" >> $GITHUB_OUTPUT
@@ -125,15 +125,16 @@ runs:
         echo "$FILE_LIST" >> $GITHUB_OUTPUT
         echo "EOF" >> $GITHUB_OUTPUT
 
-    - name: Post Coverage Step Summary
-      if: ${{ inputs.post-as-step-summary == 'true' }}
+    - name: Build Report
+      id: build_report
       shell: bash
       env:
         TOTAL_STATS: ${{ steps.process_coverage.outputs.TOTAL_STATS }}
         SUMMARY: ${{ steps.process_coverage.outputs.SUMMARY }}
         DETAILS: ${{ steps.process_coverage.outputs.DETAILS }}
       run: |
-        cat >> "$GITHUB_STEP_SUMMARY" <<EOF
+        cat > coverage-report.md <<EOF
+        <!-- coverage-report -->
         ### 🛡️ Test Coverage Report
 
         **Total Line Coverage:** ${TOTAL_STATS}
@@ -149,56 +150,21 @@ runs:
         </details>
         EOF
 
-    - name: Post Coverage Comment
-      if: ${{ inputs.post-as-step-summary != 'true' }}
-      uses: actions/github-script@v6
-      env:
-        TOTAL_STATS: ${{ steps.process_coverage.outputs.TOTAL_STATS }}
-        SUMMARY: ${{ steps.process_coverage.outputs.SUMMARY }}
-        DETAILS: ${{ steps.process_coverage.outputs.DETAILS }}
+    - name: Post Coverage Step Summary
+      if: ${{ inputs.post-as-step-summary == 'true' }}
+      shell: bash
+      run: cat coverage-report.md >> "$GITHUB_STEP_SUMMARY"
+
+    - name: Prepare Coverage Artifact
+      if: ${{ inputs.upload-artifact == 'true' }}
+      shell: bash
+      run: jq -r '.pull_request.number' "$GITHUB_EVENT_PATH" > issue-number.txt
+
+    - name: Upload Coverage Artifact
+      if: ${{ inputs.upload-artifact == 'true' }}
+      uses: actions/upload-artifact@v4
       with:
-        github-token: ${{ inputs.github-token }}
-        script: |
-          const totalStats = process.env.TOTAL_STATS;
-          const summary = process.env.SUMMARY;
-          const details = process.env.DETAILS;
-          
-          const title = "### 🛡️ Test Coverage Report"
-          const formattedBody = `
-          ${title}
-          
-          **Total Line Coverage:** ${totalStats}
-          
-          ${summary}
-
-          <details>
-          <summary><strong>📄 Click to view coverage for all files</strong></summary>
-          
-          \`\`\`text
-          ${details}
-          \`\`\`
-          </details>
-          `;
-
-          const { data: comments } = await github.rest.issues.listComments({
-            owner: context.repo.owner,
-            repo: context.repo.repo,
-            issue_number: context.issue.number,
-          });
-          const botComment = comments.find(c => c.body.includes(title));
-
-          if (botComment) {
-            await github.rest.issues.updateComment({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              comment_id: botComment.id,
-              body: formattedBody
-            });
-          } else {
-            await github.rest.issues.createComment({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: context.issue.number,
-              body: formattedBody
-            });
-          }
+        name: coverage-comment
+        path: |
+          coverage-report.md
+          issue-number.txt

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,6 @@ jobs:
       
       - name: Post Coverage Report
         if: github.event_name == 'pull_request'
-        uses: ./.github/actions/report-coverage 
+        uses: ./.github/actions/report-coverage
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }} 
+          post-as-step-summary: "true"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,4 +37,4 @@ jobs:
         if: github.event_name == 'pull_request'
         uses: ./.github/actions/report-coverage
         with:
-          post-as-step-summary: "true"
+          upload-artifact: "true"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,9 +32,10 @@ jobs:
       - run: npm ci
       - run: npm run check
       - run: npm run coverage
-      
+
       - name: Post Coverage Report
         if: github.event_name == 'pull_request'
         uses: ./.github/actions/report-coverage
         with:
+          post-as-step-summary: "true"
           upload-artifact: "true"

--- a/.github/workflows/post_coverage_comment.yml
+++ b/.github/workflows/post_coverage_comment.yml
@@ -1,0 +1,40 @@
+name: Post Coverage Comment
+
+on:
+  workflow_run:
+    workflows: ["ci"]
+    types:
+      - completed
+
+permissions:
+  contents: read
+  actions: read
+  pull-requests: write
+
+jobs:
+  post-comment:
+    runs-on: ubuntu-latest
+    if: github.event.workflow_run.event == 'pull_request'
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Download Coverage Artifact
+        id: download
+        uses: actions/download-artifact@v4
+        with:
+          name: coverage-comment
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Read Issue Number
+        id: artifact
+        shell: bash
+        run: echo "issue-number=$(cat issue-number.txt)" >> $GITHUB_OUTPUT
+
+      - name: Post Coverage Comment
+        uses: ./.github/actions/post-comment
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          issue-number: ${{ steps.artifact.outputs.issue-number }}
+          content-file: coverage-report.md
+          marker: "<!-- coverage-report -->"

--- a/.github/workflows/post_coverage_comment.yml
+++ b/.github/workflows/post_coverage_comment.yml
@@ -14,7 +14,7 @@ permissions:
 jobs:
   post-comment:
     runs-on: ubuntu-latest
-    if: github.event.workflow_run.event == 'pull_request'
+    if: github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.conclusion == 'success'
     steps:
       - uses: actions/checkout@v5
 


### PR DESCRIPTION
This enables to run the coverage report with PRs from forked repositories which do not have a write access GITHUB_TOKEN.

For this the coverage posting is split into two separate workflows:
- Generate coverage (running on the non privileged runner of the PR)
- Post comment (running on the privileged runner based on main)

This approach was chosen over just posting the coverage as a step summary, to keep the functionality that the coverage is posted as a comment.

The report is also posted as a step summary (see Checks > ci):

<img width="716" height="663" alt="image" src="https://github.com/user-attachments/assets/73b0497c-b3a6-4937-8829-6966c536ce1c" />


---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://docs.safefoundation.org/cla).
