### PR TITLE
Add Serialization Helper

### DIFF
--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -13,6 +13,7 @@
 pub mod driver;
 pub mod index;
 pub mod observability;
+pub mod serialization;
 pub mod state;
 pub mod tx;
 

--- a/crates/core/src/observability/mod.rs
+++ b/crates/core/src/observability/mod.rs
@@ -1,11 +1,9 @@
 //! Observability helpers shared across Safenet services: a default `tracing`
 //! logging setup and a Prometheus metrics exporter.
 
-use serde::{Deserialize, Deserializer, de};
-use std::{
-    borrow::Cow,
-    net::{Ipv4Addr, SocketAddr},
-};
+use crate::serialization;
+use serde::Deserialize;
+use std::net::{Ipv4Addr, SocketAddr};
 use tracing_subscriber::EnvFilter;
 
 pub mod logging;
@@ -20,7 +18,7 @@ pub mod metrics;
 pub struct Config {
     /// The `tracing` env-filter directive controlling log verbosity (see
     /// [`logging::init`]). Defaults to `info`.
-    #[serde(deserialize_with = "deserialize_log_filter")]
+    #[serde(with = "serialization::from_str")]
     pub log_filter: EnvFilter,
     /// The address the Prometheus metrics HTTP listener binds to (see
     /// [`metrics::serve`]). Defaults to `127.0.0.1:0`, which picks an ephemeral
@@ -61,13 +59,6 @@ pub fn init(config: Config) -> Result<(), InitError> {
 
     tracing::info!(%metrics_addr, "serving prometheus metrics and health endpoint");
     Ok(())
-}
-
-fn deserialize_log_filter<'de, D>(deserializer: D) -> Result<EnvFilter, D::Error>
-where
-    D: Deserializer<'de>,
-{
-    EnvFilter::try_new(Cow::deserialize(deserializer)?).map_err(de::Error::custom)
 }
 
 #[cfg(test)]

--- a/crates/core/src/serialization.rs
+++ b/crates/core/src/serialization.rs
@@ -3,8 +3,17 @@
 /// Deserialization helper to use the [`std::str::FromStr`] implementation to
 /// deserialize from a string value.
 pub mod from_str {
-    use serde::{Deserialize as _, Deserializer, de};
+    use serde::{Deserialize as _, Deserializer, Serializer, de};
     use std::{borrow::Cow, fmt::Display, str::FromStr};
+
+    #[doc(hidden)]
+    pub fn serialize<S, T>(value: &T, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+        T: Display,
+    {
+        serializer.collect_str(value)
+    }
 
     #[doc(hidden)]
     pub fn deserialize<'de, D, T>(deserializer: D) -> Result<T, D::Error>

--- a/crates/core/src/serialization.rs
+++ b/crates/core/src/serialization.rs
@@ -1,0 +1,25 @@
+//! Serialization helpers.
+
+/// Deserialization helper to use the [`std::str::FromStr`] implementation to
+/// deserialize from a string value.
+pub mod from_str {
+    use serde::{Deserialize as _, Deserializer, de};
+    use std::{borrow::Cow, fmt::Display, str::FromStr};
+
+    #[doc(hidden)]
+    pub fn deserialize<'de, D, T>(deserializer: D) -> Result<T, D::Error>
+    where
+        D: Deserializer<'de>,
+        T: FromStr,
+        T::Err: Display,
+    {
+        // Note that we use `Cow<str>` instead of `&str` or `String` here; while
+        // we would want a `&str` here since we only need the string temporarily
+        // for deserialization. However, not all deserializers support this
+        // (notably the JSON deserializer because of JSON string semantics) and
+        // only support deserializing in to owned `String`s. Use `Cow` to get a
+        // reference if supported, and an owned string otherwise.
+        let str = Cow::<'de, str>::deserialize(deserializer)?;
+        T::from_str(&str).map_err(de::Error::custom)
+    }
+}


### PR DESCRIPTION
Adds a serialization helper for fields that are encoded as strings.

### Context and Motivation

It is a common pattern that fields are encoded as strings in TOML/JSON for types that also implement `FromStr` string decoding but not `Deserialize`.

Instead of manually overriding the deserialization function for each type manually, create a generic function that can be used in each of these cases.

For now, this is only used for the `log_filter`, but it will also be used for SQLite connection URL in the future.

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://docs.safefoundation.org/cla).
