### PR TITLE
Simplify Driver Initialization

### DIFF
--- a/crates/core/src/driver.rs
+++ b/crates/core/src/driver.rs
@@ -10,15 +10,27 @@
 use crate::{
     index::{self, Update, Watcher, events::Events},
     state::{self, StateMachine, StateTransition},
-    tx::{self, Transaction, TransactionQueue},
+    tx::{self, Signer, Transaction, TransactionQueue},
 };
-use alloy::providers::Provider;
-use serde::{Serialize, de::DeserializeOwned};
+use alloy::{primitives::Address, providers::Provider};
+use serde::{Deserialize, Serialize, de::DeserializeOwned};
+use sqlx::sqlite::SqlitePool;
 use std::{pin::Pin, time::Duration};
 
 /// How long to wait after a failed step before retrying, to avoid spinning on a
 /// persistent failure (such as an unreachable RPC node).
 const STEP_RETRY_DELAY: Duration = Duration::from_millis(100);
+
+/// Driver configuration, aggregating the configuration of each component the
+/// driver wires together.
+#[derive(Clone, Debug, Default, Deserialize, PartialEq)]
+#[serde(default)]
+pub struct Config {
+    /// Indexer (block and event watcher) configuration.
+    pub index: index::Config,
+    /// Transaction queue configuration.
+    pub transactions: tx::Config,
+}
 
 /// Whether the [`Driver::run`] loop should keep processing updates or stop.
 enum Loop {
@@ -76,19 +88,43 @@ where
     S: Service,
     S::Event: Events,
 {
-    /// Creates a driver from the service and the components it coordinates.
-    pub fn new(
+    /// Creates a driver that wires together the indexer, state machine and
+    /// transaction queue for `service`.
+    ///
+    /// The indexer follows the events emitted by `addresses`, and the
+    /// transaction queue signs `chain_id` transactions with `signer`; both the
+    /// state snapshots and the transaction queue persist to `pool`. The indexer
+    /// resumes from the last committed state snapshot so it stays in lock-step
+    /// with the state machine.
+    pub async fn new(
         service: S,
-        watcher: Watcher<P, S::Event>,
-        state: StateMachine<S::State, S>,
-        transactions: TransactionQueue<P>,
-    ) -> Self {
-        Self {
+        provider: P,
+        signer: Signer,
+        pool: SqlitePool,
+        addresses: Vec<Address>,
+        config: Config,
+    ) -> Result<Self, Error>
+    where
+        S: Clone,
+        S::State: Default,
+    {
+        let state = StateMachine::new(service.clone(), pool.clone()).await?;
+        let watcher = Watcher::new(
+            provider.clone(),
+            config.index,
+            addresses,
+            state.last_block().await,
+        )
+        .await?;
+        let transactions =
+            TransactionQueue::new(provider, signer, pool, config.transactions).await?;
+
+        Ok(Self {
             service,
             watcher,
             state,
             transactions,
-        }
+        })
     }
 
     /// Runs the service, processing indexer updates until a shutdown signal

--- a/crates/core/src/state/mod.rs
+++ b/crates/core/src/state/mod.rs
@@ -9,6 +9,7 @@ pub mod storage;
 use self::storage::SnapshotStore;
 use crate::index::{BlockUpdate, EventUpdate, Update};
 use serde::{Serialize, de::DeserializeOwned};
+use sqlx::SqlitePool;
 use std::{mem, range::RangeInclusive};
 use tokio::sync::Mutex;
 
@@ -78,20 +79,21 @@ where
     S: Serialize + DeserializeOwned,
 {
     /// Creates a new state machine with the given state transition.
-    pub async fn new(transition: T, snapshots: SnapshotStore<S>) -> Result<Self, Error>
+    pub async fn new(transition: T, pool: SqlitePool) -> Result<Self, Error>
     where
         S: Default,
     {
-        Self::with_init(transition, snapshots, S::default).await
+        Self::with_init(transition, pool, S::default).await
     }
 
     /// Creates a new state machine with the given state transition and an
     /// initial value constructor.
     pub async fn with_init(
         transition: T,
-        snapshots: SnapshotStore<S>,
+        pool: SqlitePool,
         init: impl FnOnce() -> S,
     ) -> Result<Self, Error> {
+        let snapshots = SnapshotStore::new(pool).await?;
         let (state, status) = snapshots
             .current()
             .await?
@@ -108,6 +110,23 @@ where
             transition,
             snapshots,
         })
+    }
+
+    /// Returns the last block that was fully processed by the state machine.
+    /// Note that this only counts fully processed blocks.
+    pub async fn last_block(&self) -> Option<u64> {
+        match self.inner.lock().await.as_ref()?.status {
+            Status::Initialized => None,
+            Status::BlockPending { pending } => pending.checked_sub(1),
+            // This is a bit counter-intuitive, but if we observed the latest
+            // block `N` and are waiting for its events, then we have only
+            // completely processed block `N-1`. This should correspond to the
+            // block returned by `snapshots.current` without round-tripping to
+            // the database. Note that the `WarpEvents` status's starting block
+            // gets updated as event updates are processed.
+            Status::BlockEvents { latest } => latest.checked_sub(1),
+            Status::WarpEvents { range } => range.start.checked_sub(1),
+        }
     }
 
     /// Handle an indexer update.
@@ -204,7 +223,6 @@ mod tests {
     use super::*;
     use crate::index::{BlockUpdate, EventUpdate, Update};
     use serde::Deserialize;
-    use sqlx::sqlite::{SqlitePool, SqlitePoolOptions};
 
     /// State that records every block and event it was transitioned with, so
     /// transitions, rollbacks and resumes are all observable.
@@ -244,16 +262,13 @@ mod tests {
     }
 
     async fn pool() -> SqlitePool {
-        SqlitePoolOptions::new()
-            .max_connections(1)
-            .connect_with("sqlite::memory:".parse().unwrap())
-            .await
-            .unwrap()
+        SqlitePool::connect("sqlite::memory:").await.unwrap()
     }
 
     async fn new_machine(pool: &SqlitePool) -> StateMachine<TestState, TestTransition> {
-        let snapshots = SnapshotStore::new(pool.clone()).await.unwrap();
-        StateMachine::new(TestTransition, snapshots).await.unwrap()
+        StateMachine::new(TestTransition, pool.clone())
+            .await
+            .unwrap()
     }
 
     /// Reads back the committed tip snapshot through a separate store over the

--- a/crates/core/src/state/storage.rs
+++ b/crates/core/src/state/storage.rs
@@ -149,7 +149,6 @@ impl From<TryFromIntError> for Error {
 mod tests {
     use super::*;
     use serde::Deserialize;
-    use sqlx::sqlite::SqlitePoolOptions;
 
     #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
     struct State {
@@ -161,11 +160,7 @@ mod tests {
     }
 
     async fn store() -> SnapshotStore<State> {
-        let pool = SqlitePoolOptions::new()
-            .max_connections(1)
-            .connect_with("sqlite::memory:".parse().unwrap())
-            .await
-            .unwrap();
+        let pool = SqlitePool::connect("sqlite::memory:").await.unwrap();
         SnapshotStore::new(pool).await.unwrap()
     }
 

--- a/crates/core/src/tx/mod.rs
+++ b/crates/core/src/tx/mod.rs
@@ -104,11 +104,11 @@ where
     /// persists its state in `pool`.
     pub async fn new(
         provider: P,
-        chain_id: u64,
         signer: Signer,
         pool: SqlitePool,
         config: Config,
     ) -> Result<Self, Error> {
+        let chain_id = provider.get_chain_id().await?;
         let storage = TransactionStorage::new(pool).await?;
         Ok(Self {
             provider,
@@ -408,7 +408,6 @@ mod tests {
         signers::k256::ecdsa::SigningKey,
         transports::mock::Asserter,
     };
-    use sqlx::sqlite::SqlitePoolOptions;
 
     const CHAIN_ID: u64 = 1;
     const ENTRY_POINT: Address = address!("0x5FF137D4b0FDCD49DcA30c7CF57E578a026d2789");
@@ -416,14 +415,11 @@ mod tests {
     /// A transaction queue backed by a mocked RPC client and an in-memory pool.
     async fn queue(asserter: &Asserter) -> TransactionQueue<RootProvider> {
         let provider = ProviderBuilder::default().connect_mocked_client(asserter.clone());
+        asserter.push_success(&U64::from(CHAIN_ID));
         let private_key = SigningKey::from_slice(keccak256("test signer").as_slice()).unwrap();
         let signer = Signer::new(private_key);
-        let pool = SqlitePoolOptions::new()
-            .max_connections(1)
-            .connect_with("sqlite::memory:".parse().unwrap())
-            .await
-            .unwrap();
-        TransactionQueue::new(provider, CHAIN_ID, signer, pool, Config::default())
+        let pool = SqlitePool::connect("sqlite://:memory:").await.unwrap();
+        TransactionQueue::new(provider, signer, pool, Config::default())
             .await
             .unwrap()
     }

--- a/crates/core/src/tx/storage.rs
+++ b/crates/core/src/tx/storage.rs
@@ -312,16 +312,11 @@ impl From<TryFromIntError> for Error {
 mod tests {
     use super::*;
     use alloy::primitives::{Address, Bytes, address};
-    use sqlx::sqlite::SqlitePoolOptions;
 
     const ENTRY_POINT: Address = address!("0x5FF137D4b0FDCD49DcA30c7CF57E578a026d2789");
 
     async fn storage() -> TransactionStorage {
-        let pool = SqlitePoolOptions::new()
-            .max_connections(1)
-            .connect_with("sqlite::memory:".parse().unwrap())
-            .await
-            .unwrap();
+        let pool = SqlitePool::connect("sqlite://:memory:").await.unwrap();
         TransactionStorage::new(pool).await.unwrap()
     }
 


### PR DESCRIPTION
Add a `new` function that initializes a `Driver` fully, instead of requiring the caller to individually initialize the sub-components. 

### Context and Motivation

Both the validator and the sentinel will initialize a `Driver` value, and initializing each subcomponent from the outside is not ideal because:

1. It adds a lot of unnecessary boilerplate to each of the services
2. It has some soundness issues where you can partially use one of the components before constructing the driver and get into states that are hard to reason about

### Decisions and Tradeoffs

I refactored some of the initialization of the sub-components to make things a little bit easier for the driver.

Additionally, I transitioned to using the `SqliteConnectionOptions` type directly instead of the pool options, as it will correctly set some parameters based on the connection string (for example, when using `:memory:`, the pool will create connections with the "shared cache" option set so that you don't get different in-memory databases from the same pool).

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://docs.safefoundation.org/cla).
