### PR TITLE
Use Workspace Dependencies for Core Crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ alloy = { version = "2", features = ["full"] }
 argh = "0.1"
 futures = "0.3"
 metrics = "0.24"
+safenet-core = { path = "crates/core" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 sqlx = { version = "0.9", features = ["sqlite", "runtime-tokio"] }

--- a/crates/sentinel/Cargo.toml
+++ b/crates/sentinel/Cargo.toml
@@ -5,9 +5,9 @@ edition = "2024"
 publish = false
 
 [dependencies]
-safenet-core.path = "../core"
 alloy.workspace = true
 argh.workspace = true
+safenet-core.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 sqlx.workspace = true

--- a/crates/validator/Cargo.toml
+++ b/crates/validator/Cargo.toml
@@ -6,7 +6,7 @@ publish = false
 
 [dependencies]
 argh.workspace = true
-safenet-core.path = "../core"
+safenet-core.workspace = true
 serde.workspace = true
 thiserror.workspace = true
 tokio.workspace = true


### PR DESCRIPTION
I did a small booboo and used the core crate as a path dependency in the binary Cargo manifests, when it can also be declared as a workspace dependency. Adjust this.

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://docs.safefoundation.org/cla).
