### PR TITLE
Add Rust Coverage to PR Comments

### DIFF
--- a/.github/actions/report-coverage/action.yaml
+++ b/.github/actions/report-coverage/action.yaml
@@ -45,6 +45,37 @@ runs:
         # We use \n for newlines which we will interpret later
         REPORT_TABLE="| Package | Coverage |\n| :--- | :--- |"
 
+        # Process a single LCOV tracefile: optionally rewrite its source paths
+        # to be relative to the repository root, collect per-package stats, add
+        # a table row and queue it for the final merge.
+        # Usage: process_lcov <lcov-file> <display-name> [path-prefix]
+        process_lcov() {
+          local lcov_file="$1"
+          local display_name="$2"
+          local path_prefix="${3:-}"
+
+          # --- A. Fix Paths ---
+          # Some tools emit source paths relative to the package directory.
+          # Prepend the package path so they resolve from the repository root.
+          # Example: SF:src/utils.ts -> SF:validator/src/utils.ts
+          if [ -n "$path_prefix" ]; then
+            sed -i "s|^SF:|SF:$path_prefix/|g" "$lcov_file"
+          fi
+
+          # --- B. Get Individual Stats ---
+          # Run lcov summary on this specific file and extract the percentage
+          # (e.g. "85.4%").
+          local stats
+          stats=$(lcov --summary "$lcov_file" | grep "lines......" | cut -d ':' -f 2 | xargs)
+
+          echo "   📊 $display_name: $stats"
+          lcov --list "$lcov_file"
+
+          # Append row to table and add to the merge list.
+          REPORT_TABLE="${REPORT_TABLE}\n| **${display_name}** | ${stats} |"
+          MERGE_ARGS+=(--add-tracefile "$lcov_file")
+        }
+
         # 1. Get workspace patterns from package.json (e.g., "packages/*", "apps/web")
         # We use -r for raw output to remove quotes
         WORKSPACE_PATTERNS=$(jq -r '.workspaces[]' package.json)
@@ -65,27 +96,7 @@ runs:
 
               if [ -f "$LCOV_FILE" ]; then
                 echo "✅ Found coverage: $LCOV_FILE"
-
-                # --- A. Fix Paths ---
-                # We need to prepend the package path ($pkg) to the source files.
-                # Example: SF:src/utils.ts -> SF:validator/src/utils.ts
-                sed -i "s|^SF:|SF:$pkg/|g" "$LCOV_FILE"
-
-                # --- B. Get Individual Stats ---
-                # Run lcov summary on this specific file
-                # Extract the percentage (e.g., "85.4%")
-                PKG_STATS=$(lcov --summary "$LCOV_FILE" | grep "lines......" | cut -d ':' -f 2 | xargs)
-
-                PKG_NAME=$(basename "$pkg")
-
-                echo "   📊 $PKG_NAME: $PKG_STATS"
-                lcov --list "$LCOV_FILE"
-
-                # Append row to table
-                REPORT_TABLE="${REPORT_TABLE}\n| **${PKG_NAME}** | ${PKG_STATS} |"
-
-                # Add to merge list
-                MERGE_ARGS+=(--add-tracefile "$LCOV_FILE")
+                process_lcov "$LCOV_FILE" "$(basename "$pkg")" "$pkg"
               else
                 echo "⚪️ No coverage found for $pkg (Skipping)"
               fi
@@ -93,7 +104,27 @@ runs:
           done
         done
 
-        # 3. Merge
+        # 3. Scan Rust crates (crates/*)
+        # Unlike the JavaScript reports, the Rust LCOV files are generated with
+        # paths already relative to the repository root, so no prefix rewrite is
+        # needed. Crates are labelled by their Cargo package name.
+        echo "🔍 Scanning Rust crates in crates/*..."
+        for manifest in crates/*/Cargo.toml; do
+          [ -f "$manifest" ] || continue
+
+          crate=$(dirname "$manifest")
+          LCOV_FILE="$crate/coverage/lcov.info"
+
+          if [ -f "$LCOV_FILE" ]; then
+            echo "✅ Found coverage: $LCOV_FILE"
+            CRATE_NAME=$(grep -m1 '^name' "$manifest" | cut -d '"' -f 2)
+            process_lcov "$LCOV_FILE" "$CRATE_NAME"
+          else
+            echo "⚪️ No coverage found for $crate (Skipping)"
+          fi
+        done
+
+        # 4. Merge
         if [ -z "$MERGE_ARGS" ]; then
            echo "❌ No coverage files found in any workspace!"
            exit 1
@@ -102,15 +133,15 @@ runs:
         echo "🔗 Merging all reports..."
         lcov "${MERGE_ARGS[@]}" --output-file lcov.info
 
-        # 4. Get Total Summary
+        # 5. Get Total Summary
         OUTPUT=$(lcov --summary lcov.info)
         TOTAL_STATS=$(echo "$OUTPUT" | grep "lines......" | cut -d ':' -f 2 | xargs)
 
-        # 5. Get File List
+        # 6. Get File List
         # Grep -v removes the "Reading tracefile" noise
         FILE_LIST=$(lcov --list lcov.info | grep -v "Reading tracefile")
 
-        # 6. Export step outputs
+        # 7. Export step outputs
         echo "TOTAL_STATS=$TOTAL_STATS" >> $GITHUB_OUTPUT
 
         echo "SUMMARY<<EOF" >> $GITHUB_OUTPUT
@@ -121,7 +152,7 @@ runs:
         echo "$FILE_LIST" >> $GITHUB_OUTPUT
         echo "EOF" >> $GITHUB_OUTPUT
 
-        # 7. Build report file
+        # 8. Build report file
         # Variables are used directly here (no template interpolation) to avoid
         # URL-encoding of newlines and unintended shell expansion in heredocs.
         {

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,9 +29,15 @@ jobs:
           # See <https://github.com/foundry-rs/foundry/issues/13362>
           version: v1.5.1
 
+      # https://github.com/taiki-e/install-action/releases/tag/v2.82.6
+      - uses: taiki-e/install-action@9bcaee1dcae34154180f412e2fa69355a7cda9f6
+        with:
+          tool: cargo-llvm-cov
+
       - run: npm ci
       - run: npm run check
       - run: npm run coverage
+      - run: scripts/rust_coverage.sh
 
       - name: Post Coverage Report
         if: github.event_name == 'pull_request'

--- a/scripts/rust_coverage.sh
+++ b/scripts/rust_coverage.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+
+# Collect coverage data for the whole workspace in a single test run.
+cargo llvm-cov --workspace --no-report
+
+# Emit a per-crate LCOV report so that each crate shows up as its own row in
+# the merged coverage report. Source paths are rewritten to be relative to the
+# repository root to match the convention used by the TypeScript and Solidity
+# reports (i.e. "SF:crates/core/src/...").
+for manifest in crates/*/Cargo.toml; do
+    crate="$(dirname "$manifest")"
+    name="$(grep -m1 '^name' "$manifest" | cut -d '"' -f2)"
+    lcov="$crate/coverage/lcov.info"
+
+    mkdir -p "$crate/coverage"
+    cargo llvm-cov report --package "$name" --lcov --output-path "$lcov"
+    sed -i "s|^SF:$ROOT/|SF:|" "$lcov"
+done


### PR DESCRIPTION
### Context and Motivation

Currently, the GitHub action comment with coverage information in the PR only contains TypeScript and Solidity coverage. This PR adds support to Rust coverage as well.

### Decisions and Tradeoffs

I (well........... Claude), opted for `taiki-e/cargo-llvm-cov` tool for automatically instrumenting tests for coverage. I did some very minor due diligence and:

- It is the [most popular coverage tool on lib.rs](https://lib.rs/search?q=coverage)
- I have used it before [in the past](https://github.com/cowprotocol/services/blob/7a8da5d6eb6a40399c258a4960677e11fcc34407/.github/workflows/pull-request.yaml#L113)

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://docs.safefoundation.org/cla).
