### PR TITLE
[B 2i]: Add State transition event handling

### DIFF
--- a/crates/sentinel/src/bindings.rs
+++ b/crates/sentinel/src/bindings.rs
@@ -5,15 +5,6 @@ pub mod oracle {
 
     sol! {
         #[derive(Debug)]
-        enum SentinelOracleRequestState {
-            PENDING,
-            FROZEN,
-            RESOLVED_APPROVED,
-            RESOLVED_DENIED,
-            TIMED_OUT
-        }
-
-        #[derive(Debug)]
         contract SentinelOracle {
             event NewRequest(
                 bytes32 indexed requestId,
@@ -34,17 +25,6 @@ pub mod oracle {
                 address indexed proposer,
                 bytes result,
                 bool approved
-            );
-            event Claimed(
-                bytes32 indexed requestId,
-                address indexed sentinel,
-                uint256 bondReturn,
-                uint256 feeReward
-            );
-            event DisputeResolved(
-                bytes32 indexed requestId,
-                SentinelOracleRequestState outcome,
-                uint256 slashed
             );
 
             function commitApprove(bytes32 requestId) external;

--- a/crates/sentinel/src/service.rs
+++ b/crates/sentinel/src/service.rs
@@ -1,18 +1,21 @@
 use crate::{
     action::{SentinelAction, SentinelActionKind},
-    bindings::oracle::{ERC20, SentinelOracle},
+    bindings::{
+        SentinelEvents,
+        consensus::Consensus,
+        oracle::{ERC20, SentinelOracle},
+    },
+    state::State,
 };
 use alloy::{
     primitives::{Address, U256},
     sol_types::SolCall,
 };
-use safenet_core::tx::Transaction;
+use safenet_core::{Service, index::EventLog, state::StateTransition, tx::Transaction};
 
-/// The sentinel service: maps actions to encoded transactions.
-///
-/// Holds the oracle and fee-token addresses needed to route each action to
-/// the correct contract. Plugs into the `Driver` once it lands (PR #486) by
-/// also implementing `StateTransition` (B2) and `Service` (D1, here).
+/// The sentinel service: drives the request FSM (`preparing -> pending ->
+/// committed -> finalized`) from `SentinelOracle`/`Consensus` events and maps
+/// its actions to encoded transactions.
 pub struct SentinelService {
     oracle: Address,
     fee_token: Address,
@@ -24,17 +27,60 @@ impl SentinelService {
         Self { oracle, fee_token }
     }
 
-    /// Maps each action to a `(Transaction, expires_at)` pair for the queue.
-    ///
-    /// The `expires_at` is the request's voting deadline, forwarded from the
-    /// action so the `TransactionQueue` can drop it if it goes unsubmitted
-    /// past that block.
-    #[cfg_attr(not(test), expect(dead_code))]
-    pub fn encode_actions(&self, actions: Vec<SentinelAction>) -> Vec<(Transaction, u64)> {
-        actions
-            .into_iter()
-            .map(|SentinelAction { kind, expires_at }| (self.encode_action(kind), expires_at))
-            .collect()
+    /// Starts tracking a newly proposed oracle transaction, deciding whether
+    /// we vote to approve or deny it.
+    fn handle_oracle_transaction_proposed(
+        &self,
+        state: State,
+        _event: Consensus::OracleTransactionProposed,
+    ) -> (State, Vec<SentinelAction>) {
+        // TODO: gate on our oracle, derive the request id, run the detector
+        // and start tracking the request as `Preparing`.
+        (state, Vec::new())
+    }
+
+    /// Casts our vote once a tracked request is opened for voting onchain.
+    fn handle_new_request(
+        &self,
+        state: State,
+        _event: SentinelOracle::NewRequest,
+    ) -> (State, Vec<SentinelAction>) {
+        // TODO: only act on a `Preparing` request; emit `ApproveToken` and
+        // the vote, and move it to `Pending`.
+        (state, Vec::new())
+    }
+
+    /// Records that our vote has been committed onchain.
+    fn handle_committed(
+        &self,
+        state: State,
+        _event: SentinelOracle::Committed,
+    ) -> (State, Vec<SentinelAction>) {
+        // TODO: gate on our own account; only move a `Pending` request to
+        // `Committed`.
+        (state, Vec::new())
+    }
+
+    /// Claims the bond for a request we committed on, once its outcome is
+    /// known.
+    fn handle_resolved(
+        &self,
+        state: State,
+        _event: SentinelOracle::OracleResult,
+    ) -> (State, Vec<SentinelAction>) {
+        // TODO: drop the request unconditionally; only emit a `Claim` when
+        // we actually committed onchain (`Committed`/`Finalized`) and either
+        // the vote won or the request timed out.
+        (state, Vec::new())
+    }
+
+    /// Finalizes committed requests and cleans up stale ones once their
+    /// voting deadline has passed.
+    fn handle_block_advance(&self, state: State, _block: u64) -> (State, Vec<SentinelAction>) {
+        // TODO: move past-deadline `Committed` requests to `Finalized` with
+        // a `Finalize` action; drop stale `Preparing`/`Pending`/`Finalized`
+        // requests.
+        (state, Vec::new())
     }
 
     fn encode_action(&self, kind: SentinelActionKind) -> Transaction {
@@ -83,6 +129,52 @@ impl SentinelService {
                 gas: 100_000,
             },
         }
+    }
+}
+
+impl StateTransition<State> for SentinelService {
+    type Event = SentinelEvents;
+    type Action = SentinelAction;
+
+    async fn new_block(&mut self, state: State, block: u64) -> (State, Vec<Self::Action>) {
+        self.handle_block_advance(state, block)
+    }
+
+    async fn event(
+        &mut self,
+        state: State,
+        event: EventLog<Self::Event>,
+    ) -> (State, Vec<Self::Action>) {
+        match event.data {
+            SentinelEvents::Consensus(Consensus::ConsensusEvents::OracleTransactionProposed(
+                event,
+            )) => self.handle_oracle_transaction_proposed(state, event),
+            SentinelEvents::Oracle(SentinelOracle::SentinelOracleEvents::NewRequest(event)) => {
+                self.handle_new_request(state, event)
+            }
+            SentinelEvents::Oracle(SentinelOracle::SentinelOracleEvents::Committed(event)) => {
+                self.handle_committed(state, event)
+            }
+            SentinelEvents::Oracle(SentinelOracle::SentinelOracleEvents::OracleResult(event)) => {
+                self.handle_resolved(state, event)
+            }
+        }
+    }
+}
+
+impl Service for SentinelService {
+    type State = State;
+
+    /// Maps each action to a `(Transaction, expires_at)` pair for the queue.
+    ///
+    /// The `expires_at` is the request's voting deadline, forwarded from the
+    /// action so the `TransactionQueue` can drop it if it goes unsubmitted
+    /// past that block.
+    fn encode_actions(&self, actions: Vec<SentinelAction>) -> Vec<(Transaction, u64)> {
+        actions
+            .into_iter()
+            .map(|SentinelAction { kind, expires_at }| (self.encode_action(kind), expires_at))
+            .collect()
     }
 }
 

--- a/crates/sentinel/src/state.rs
+++ b/crates/sentinel/src/state.rs
@@ -26,7 +26,6 @@ pub struct SentinelRequestState {
 /// Serialized per block by the `StateMachine`; `B256` keys round-trip through
 /// serde_json as their hex representation.
 #[derive(Debug, Default, Clone, Serialize, Deserialize)]
-#[cfg_attr(not(test), expect(dead_code))]
 pub struct State(pub HashMap<B256, SentinelRequestState>);
 
 #[cfg(test)]


### PR DESCRIPTION
Added the event handling for the Sentinel state transitions. The state transition function implementations are empty and will be implemented in follow up PRs.

We currently also handle event that do not trigger any state changes (e.g. Claimed and DisputeResolved) to have an exhaustive list.

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://docs.safefoundation.org/cla).
