### PR TITLE
Indexer Emits Event Logs

### DIFF
--- a/crates/core/src/index/events.rs
+++ b/crates/core/src/index/events.rs
@@ -37,6 +37,18 @@ pub trait Events: Sized {
     fn decode_log(topics: &[B256], data: &[u8]) -> Option<Self>;
 }
 
+/// An event log, adding additional log position information (block number and
+/// log index) to event data.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct EventLog<E> {
+    /// The block number the log is for.
+    pub block: u64,
+    /// The index of the log within the block.
+    pub index: u64,
+    /// The decoded event data.
+    pub data: E,
+}
+
 /// A batch of decoded event logs together with the inclusive range of blocks
 /// `from..=to` they were fetched for.
 ///
@@ -49,7 +61,7 @@ pub struct EventUpdate<E> {
     pub blocks: RangeInclusive<u64>,
     /// The decoded logs in `(block_number, log_index)` order. May be empty when
     /// no watched events occurred in the range.
-    pub logs: Vec<E>,
+    pub logs: Vec<EventLog<E>>,
 }
 
 /// Event watcher configuration.
@@ -385,7 +397,7 @@ where
 
     /// Fetches the watched logs for some blocks using the given strategy,
     /// returning them decoded and in `(block_number, log_index)` order.
-    async fn fetch_logs(&self, fetch: Fetch) -> Result<Vec<E>, Error> {
+    async fn fetch_logs(&self, fetch: Fetch) -> Result<Vec<EventLog<E>>, Error> {
         let logs = match fetch {
             Fetch::SingleQuery(blocks) => {
                 let filter = blocks
@@ -451,7 +463,7 @@ where
                     .collect()
             }
         };
-        decode_and_sort(logs)
+        decode_and_sort(&logs)
     }
 
     /// Guards against nodes that silently cap the number of returned logs: a
@@ -472,25 +484,35 @@ where
     }
 }
 
-/// Sorts logs into `(block_number, log_index)` order and decodes them into the
-/// typed event set, dropping any that are not part of the set.
-fn decode_and_sort<E>(mut logs: Vec<Log>) -> Result<Vec<E>, Error>
+/// Decodes logs into the typed event set and sorts them into
+/// `(block_number, log_index)` order.
+fn decode_and_sort<E>(logs: &[Log]) -> Result<Vec<EventLog<E>>, Error>
 where
     E: Events,
 {
-    logs.sort_unstable_by_key(|log| (log.block_number, log.log_index));
-    logs.iter()
+    let mut logs = logs
+        .iter()
         .map(|log| {
-            E::decode_log(log.topics(), &log.data().data).ok_or_else(|| Error::DecodeLog {
-                // This is an unfortunate typing quirk of `alloy`, but we
-                // should never have a log without a block hash or index set.
-                // If we do, its not the end of the world, and we would just
-                // report an error with weird data.
-                block_hash: log.block_hash.unwrap_or(B256::repeat_byte(0xff)),
-                log_index: log.log_index.unwrap_or(u64::MAX),
-            })
+            E::decode_log(log.topics(), &log.data().data)
+                .and_then(|data| {
+                    Some(EventLog {
+                        block: log.block_number?,
+                        index: log.log_index?,
+                        data,
+                    })
+                })
+                .ok_or_else(|| Error::DecodeLog {
+                    // This is an unfortunate typing quirk of `alloy`, but we
+                    // should never have a log without a block hash or index set.
+                    // If we do, it's not the end of the world, and we would just
+                    // report an error with weird data.
+                    block_hash: log.block_hash.unwrap_or(B256::repeat_byte(0xff)),
+                    log_index: log.log_index.unwrap_or(u64::MAX),
+                })
         })
-        .collect()
+        .collect::<Result<Vec<_>, _>>()?;
+    logs.sort_unstable_by_key(|log| (log.block, log.index));
+    Ok(logs)
 }
 
 /// Utility to convert between a `std::ops::RangeInclusive` and the more modern
@@ -629,6 +651,10 @@ mod tests {
         }
     }
 
+    fn event_log<E>((block, index): (u64, u64), data: E) -> EventLog<E> {
+        EventLog { block, index, data }
+    }
+
     fn watcher(
         asserter: &Asserter,
         config: Config,
@@ -639,7 +665,7 @@ mod tests {
 
     #[test]
     fn decodes_and_sorts_logs() {
-        let events = decode_and_sort::<Erc20::Erc20Events>(vec![
+        let events = decode_and_sort::<Erc20::Erc20Events>(&[
             log(
                 (2, 0),
                 Erc20::Transfer {
@@ -667,18 +693,27 @@ mod tests {
         assert_eq!(
             events,
             [
-                Erc20::Erc20Events::Transfer(Erc20::Transfer {
-                    amount: uint!(3_U256),
-                    ..Default::default()
-                }),
-                Erc20::Erc20Events::Transfer(Erc20::Transfer {
-                    amount: uint!(1_U256),
-                    ..Default::default()
-                }),
-                Erc20::Erc20Events::Approval(Erc20::Approval {
-                    amount: uint!(2_U256),
-                    ..Default::default()
-                }),
+                event_log(
+                    (1, 1),
+                    Erc20::Erc20Events::Transfer(Erc20::Transfer {
+                        amount: uint!(3_U256),
+                        ..Default::default()
+                    })
+                ),
+                event_log(
+                    (2, 0),
+                    Erc20::Erc20Events::Transfer(Erc20::Transfer {
+                        amount: uint!(1_U256),
+                        ..Default::default()
+                    })
+                ),
+                event_log(
+                    (2, 5),
+                    Erc20::Erc20Events::Approval(Erc20::Approval {
+                        amount: uint!(2_U256),
+                        ..Default::default()
+                    })
+                ),
             ]
         );
     }
@@ -710,26 +745,35 @@ mod tests {
         ];
 
         assert_matches!(
-            decode_and_sort::<Erc20::Erc20Events>(logs.clone()),
+            decode_and_sort::<Erc20::Erc20Events>(&logs),
             Err(Error::DecodeLog { log_index, .. }) if log_index == 1
         );
 
-        let events = decode_and_sort::<TokenEvents>(logs).unwrap();
+        let events = decode_and_sort::<TokenEvents>(&logs).unwrap();
         assert_eq!(
             events,
             [
-                TokenEvents::Erc721(Erc721::Erc721Events::Transfer(Erc721::Transfer {
-                    tokenId: uint!(3_U256),
-                    ..Default::default()
-                })),
-                TokenEvents::Erc20(Erc20::Erc20Events::Transfer(Erc20::Transfer {
-                    amount: uint!(1_U256),
-                    ..Default::default()
-                })),
-                TokenEvents::Erc20(Erc20::Erc20Events::Approval(Erc20::Approval {
-                    amount: uint!(2_U256),
-                    ..Default::default()
-                })),
+                event_log(
+                    (1, 1),
+                    TokenEvents::Erc721(Erc721::Erc721Events::Transfer(Erc721::Transfer {
+                        tokenId: uint!(3_U256),
+                        ..Default::default()
+                    }))
+                ),
+                event_log(
+                    (2, 0),
+                    TokenEvents::Erc20(Erc20::Erc20Events::Transfer(Erc20::Transfer {
+                        amount: uint!(1_U256),
+                        ..Default::default()
+                    }))
+                ),
+                event_log(
+                    (2, 5),
+                    TokenEvents::Erc20(Erc20::Erc20Events::Approval(Erc20::Approval {
+                        amount: uint!(2_U256),
+                        ..Default::default()
+                    }))
+                ),
             ]
         );
     }
@@ -764,14 +808,20 @@ mod tests {
         assert_eq!(
             logs,
             [
-                Erc20::Erc20Events::Approval(Erc20::Approval {
-                    amount: uint!(2_U256),
-                    ..Default::default()
-                }),
-                Erc20::Erc20Events::Transfer(Erc20::Transfer {
-                    amount: uint!(1_U256),
-                    ..Default::default()
-                }),
+                event_log(
+                    (1, 1),
+                    Erc20::Erc20Events::Approval(Erc20::Approval {
+                        amount: uint!(2_U256),
+                        ..Default::default()
+                    })
+                ),
+                event_log(
+                    (2, 0),
+                    Erc20::Erc20Events::Transfer(Erc20::Transfer {
+                        amount: uint!(1_U256),
+                        ..Default::default()
+                    })
+                ),
             ]
         );
         assert!(asserter.read_q().is_empty());
@@ -809,14 +859,20 @@ mod tests {
         assert_eq!(
             logs,
             [
-                Erc20::Erc20Events::Approval(Erc20::Approval {
-                    amount: uint!(2_U256),
-                    ..Default::default()
-                }),
-                Erc20::Erc20Events::Transfer(Erc20::Transfer {
-                    amount: uint!(1_U256),
-                    ..Default::default()
-                }),
+                event_log(
+                    (1, 1),
+                    Erc20::Erc20Events::Approval(Erc20::Approval {
+                        amount: uint!(2_U256),
+                        ..Default::default()
+                    })
+                ),
+                event_log(
+                    (2, 0),
+                    Erc20::Erc20Events::Transfer(Erc20::Transfer {
+                        amount: uint!(1_U256),
+                        ..Default::default()
+                    })
+                ),
             ]
         );
         assert!(asserter.read_q().is_empty());
@@ -878,14 +934,20 @@ mod tests {
         assert_eq!(
             logs,
             [
-                Erc20::Erc20Events::Transfer(Erc20::Transfer {
-                    amount: uint!(1_U256),
-                    ..Default::default()
-                }),
-                Erc20::Erc20Events::Approval(Erc20::Approval {
-                    amount: uint!(4_U256),
-                    ..Default::default()
-                }),
+                event_log(
+                    (1, 0),
+                    Erc20::Erc20Events::Transfer(Erc20::Transfer {
+                        amount: uint!(1_U256),
+                        ..Default::default()
+                    })
+                ),
+                event_log(
+                    (1, 3),
+                    Erc20::Erc20Events::Approval(Erc20::Approval {
+                        amount: uint!(4_U256),
+                        ..Default::default()
+                    })
+                ),
             ]
         );
         assert!(asserter.read_q().is_empty());
@@ -1024,10 +1086,13 @@ mod tests {
         // The failed `Transfer` query is dropped, leaving only the `Approval`.
         assert_eq!(
             logs,
-            [Erc20::Erc20Events::Approval(Erc20::Approval {
-                amount: uint!(7_U256),
-                ..Default::default()
-            })]
+            [event_log(
+                (1, 0),
+                Erc20::Erc20Events::Approval(Erc20::Approval {
+                    amount: uint!(7_U256),
+                    ..Default::default()
+                })
+            )]
         );
         assert!(asserter.read_q().is_empty());
     }
@@ -1084,10 +1149,13 @@ mod tests {
             events.next().await.unwrap(),
             Some(EventUpdate {
                 blocks: range(1..=5),
-                logs: vec![Erc20::Erc20Events::Transfer(Erc20::Transfer {
-                    amount: uint!(1_U256),
-                    ..Default::default()
-                })],
+                logs: vec![event_log(
+                    (3, 0),
+                    Erc20::Erc20Events::Transfer(Erc20::Transfer {
+                        amount: uint!(1_U256),
+                        ..Default::default()
+                    })
+                )],
             })
         );
         assert_eq!(
@@ -1190,14 +1258,20 @@ mod tests {
             Some(EventUpdate {
                 blocks: range(5..=5),
                 logs: vec![
-                    Erc20::Erc20Events::Transfer(Erc20::Transfer {
-                        amount: uint!(1_U256),
-                        ..Default::default()
-                    }),
-                    Erc20::Erc20Events::Approval(Erc20::Approval {
-                        amount: uint!(2_U256),
-                        ..Default::default()
-                    }),
+                    event_log(
+                        (5, 0),
+                        Erc20::Erc20Events::Transfer(Erc20::Transfer {
+                            amount: uint!(1_U256),
+                            ..Default::default()
+                        })
+                    ),
+                    event_log(
+                        (5, 1),
+                        Erc20::Erc20Events::Approval(Erc20::Approval {
+                            amount: uint!(2_U256),
+                            ..Default::default()
+                        })
+                    ),
                 ],
             })
         );
@@ -1231,10 +1305,13 @@ mod tests {
             events.next().await.unwrap(),
             Some(EventUpdate {
                 blocks: range(1337..=1337),
-                logs: vec![Erc20::Erc20Events::Transfer(Erc20::Transfer {
-                    amount: uint!(1_U256),
-                    ..Default::default()
-                })],
+                logs: vec![event_log(
+                    (1337, 0),
+                    Erc20::Erc20Events::Transfer(Erc20::Transfer {
+                        amount: uint!(1_U256),
+                        ..Default::default()
+                    })
+                )],
             })
         );
         assert_eq!(events.next().await.unwrap(), None);
@@ -1290,10 +1367,13 @@ mod tests {
             events.next().await.unwrap(),
             Some(EventUpdate {
                 blocks: range(1337..=1337),
-                logs: vec![Erc20::Erc20Events::Transfer(Erc20::Transfer {
-                    amount: uint!(1_U256),
-                    ..Default::default()
-                })],
+                logs: vec![event_log(
+                    (1337, 0),
+                    Erc20::Erc20Events::Transfer(Erc20::Transfer {
+                        amount: uint!(1_U256),
+                        ..Default::default()
+                    })
+                )],
             })
         );
         assert_eq!(events.next().await.unwrap(), None);
@@ -1346,14 +1426,20 @@ mod tests {
             Some(EventUpdate {
                 blocks: range(1337..=1337),
                 logs: vec![
-                    Erc20::Erc20Events::Transfer(Erc20::Transfer {
-                        amount: uint!(1_U256),
-                        ..Default::default()
-                    }),
-                    Erc20::Erc20Events::Approval(Erc20::Approval {
-                        amount: uint!(2_U256),
-                        ..Default::default()
-                    })
+                    event_log(
+                        (1337, 0),
+                        Erc20::Erc20Events::Transfer(Erc20::Transfer {
+                            amount: uint!(1_U256),
+                            ..Default::default()
+                        })
+                    ),
+                    event_log(
+                        (1337, 1),
+                        Erc20::Erc20Events::Approval(Erc20::Approval {
+                            amount: uint!(2_U256),
+                            ..Default::default()
+                        })
+                    )
                 ],
             })
         );

--- a/crates/core/src/index/mod.rs
+++ b/crates/core/src/index/mod.rs
@@ -13,7 +13,7 @@ use events::{EventWatcher, Events};
 use serde::Deserialize;
 
 pub use blocks::BlockUpdate;
-pub use events::EventUpdate;
+pub use events::{EventLog, EventUpdate};
 
 /// Watcher configuration, aggregating the block and event watcher configs.
 #[derive(Clone, Debug, Default, Deserialize, PartialEq, Eq)]
@@ -260,14 +260,14 @@ mod tests {
         );
 
         // Log query from range 848..=947
-        asserter.push_success(&vec![log(weth_deposit(1))]);
+        asserter.push_success(&vec![log((848, 0), weth_deposit(1))]);
         assert_eq!(
             watcher.next().await.unwrap(),
             logs_update(848..=947, [weth_deposit(1)])
         );
 
         // Log query from range 948..=997
-        asserter.push_success(&vec![log(weth_deposit(2))]);
+        asserter.push_success(&vec![log((948, 0), weth_deposit(2))]);
         assert_eq!(
             watcher.next().await.unwrap(),
             logs_update(948..=997, [weth_deposit(2)])
@@ -275,7 +275,7 @@ mod tests {
 
         assert_eq!(watcher.next().await.unwrap(), new_block_update(998, 997));
 
-        asserter.push_success(&vec![log(weth_deposit(3))]);
+        asserter.push_success(&vec![log((998, 0), weth_deposit(3))]);
         assert_eq!(
             watcher.next().await.unwrap(),
             logs_update(998..=998, [weth_deposit(3)])
@@ -283,7 +283,7 @@ mod tests {
 
         assert_eq!(watcher.next().await.unwrap(), new_block_update(999, 997));
 
-        asserter.push_success(&vec![log(weth_deposit(4))]);
+        asserter.push_success(&vec![log((999, 0), weth_deposit(4))]);
         assert_eq!(
             watcher.next().await.unwrap(),
             logs_update(999..=999, [weth_deposit(4)])
@@ -291,7 +291,7 @@ mod tests {
 
         assert_eq!(watcher.next().await.unwrap(), new_block_update(1000, 997));
 
-        asserter.push_success(&vec![log(weth_deposit(5))]);
+        asserter.push_success(&vec![log((1000, 0), weth_deposit(5))]);
         assert_eq!(
             watcher.next().await.unwrap(),
             logs_update(1000..=1000, [weth_deposit(5)])
@@ -301,7 +301,7 @@ mod tests {
         asserter.push_success(&block(1001));
         assert_eq!(watcher.next().await.unwrap(), new_block_update(1001, 998));
 
-        asserter.push_success(&vec![log(weth_deposit(6))]);
+        asserter.push_success(&vec![log((1001, 0), weth_deposit(6))]);
         assert_eq!(
             watcher.next().await.unwrap(),
             logs_update(1001..=1001, [weth_deposit(6)])
@@ -393,12 +393,14 @@ mod tests {
         })
     }
 
-    fn log(event: impl SolEvent) -> Log {
+    fn log((block_number, log_index): (u64, u64), event: impl SolEvent) -> Log {
         Log {
             inner: alloy::primitives::Log {
                 address: WATCHED,
                 data: event.encode_log_data(),
             },
+            block_number: Some(block_number),
+            log_index: Some(log_index),
             ..Default::default()
         }
     }
@@ -414,9 +416,18 @@ mod tests {
         blocks: std::ops::RangeInclusive<u64>,
         logs: impl IntoIterator<Item = Weth::Deposit>,
     ) -> Update<Weth::WethEvents> {
+        let block = *blocks.start();
         Update::Logs(EventUpdate {
             blocks: blocks.into(),
-            logs: logs.into_iter().map(Weth::WethEvents::Deposit).collect(),
+            logs: logs
+                .into_iter()
+                .enumerate()
+                .map(|(index, data)| EventLog {
+                    block,
+                    index: index.try_into().expect("test log index fits in u64"),
+                    data: Weth::WethEvents::Deposit(data),
+                })
+                .collect(),
         })
     }
 }

--- a/crates/core/src/state/mod.rs
+++ b/crates/core/src/state/mod.rs
@@ -7,7 +7,7 @@
 pub mod storage;
 
 use self::storage::SnapshotStore;
-use crate::index::{BlockUpdate, EventUpdate, Update};
+use crate::index::{BlockUpdate, EventLog, EventUpdate, Update};
 use serde::{Serialize, de::DeserializeOwned};
 use sqlx::SqlitePool;
 use std::{mem, range::RangeInclusive};
@@ -46,11 +46,11 @@ where
     /// Perform the state transition for when a new block is observed.
     fn new_block(&mut self, state: S, block: u64) -> impl Future<Output = (S, Vec<Self::Action>)>;
 
-    /// Perform the state transition when a new event is observed.
+    /// Perform the state transition when a new event log is observed.
     fn event(
         &mut self,
         state: S,
-        event: Self::Event,
+        event: EventLog<Self::Event>,
     ) -> impl Future<Output = (S, Vec<Self::Action>)>;
 }
 
@@ -167,6 +167,15 @@ where
                 if matches!(status, Status::BlockEvents { latest } if is_next_in_range(latest..=latest, blocks))
                     || matches!(status, Status::WarpEvents { range } if is_next_in_range(range, blocks)) =>
             {
+                // We are extra defensive with the updates that we pass to the
+                // state machine, so ensure that the logs are in strictly sorted
+                // and in the update's block range.
+                if !logs.is_sorted_by(|a, b| (a.block, a.index) < (b.block, b.index))
+                    || logs.iter().any(|log| !blocks.contains(&log.block))
+                {
+                    return Err(Error::BadUpdate);
+                }
+
                 let mut state = state;
                 let mut actions = vec![];
                 for log in logs {
@@ -255,9 +264,13 @@ mod tests {
             (state, vec![Action::Block(block)])
         }
 
-        async fn event(&mut self, mut state: TestState, event: u64) -> (TestState, Vec<Action>) {
-            state.events.push(event);
-            (state, vec![Action::Event(event)])
+        async fn event(
+            &mut self,
+            mut state: TestState,
+            event: EventLog<u64>,
+        ) -> (TestState, Vec<Action>) {
+            state.events.push(event.data);
+            (state, vec![Action::Event(event.data)])
         }
     }
 
@@ -311,9 +324,18 @@ mod tests {
         blocks: std::ops::RangeInclusive<u64>,
         logs: impl IntoIterator<Item = u64>,
     ) -> Update<u64> {
+        let block = *blocks.start();
         Update::Logs(EventUpdate {
             blocks: blocks.into(),
-            logs: logs.into_iter().collect(),
+            logs: logs
+                .into_iter()
+                .enumerate()
+                .map(|(index, data)| EventLog {
+                    block,
+                    index: index.try_into().expect("test log index fits in u64"),
+                    data,
+                })
+                .collect(),
         })
     }
 

--- a/crates/validator/src/service.rs
+++ b/crates/validator/src/service.rs
@@ -2,7 +2,9 @@
 //! validator service is implemented.
 
 use alloy::sol;
-use safenet_core::{Service, state::StateTransition, tx::Transaction, watcher_events};
+use safenet_core::{
+    Service, index::EventLog, state::StateTransition, tx::Transaction, watcher_events,
+};
 
 sol! {
     #[derive(Debug)]
@@ -26,7 +28,7 @@ impl StateTransition<()> for DummyService {
         (state, Vec::new())
     }
 
-    async fn event(&mut self, state: (), _event: Self::Event) -> ((), Vec<Self::Action>) {
+    async fn event(&mut self, state: (), _event: EventLog<Self::Event>) -> ((), Vec<Self::Action>) {
         (state, Vec::new())
     }
 }


### PR DESCRIPTION
Extend the events update to include additional log metadata along with the decoded event data.

### Context and Motivation

Both the validator and the sentinel benefit from knowing the block number of the event in the state transition. It is used for various things, including setting deadlines for particular actions to be executed onchain.

### Decisions and Tradeoffs

Since this is needed by all our services, I opted to make all event updates include the block number and log index. 

Note that we add an additional update value check to the `StateMachine` defensively, to ensure that we do not process invalid information into the state machine. This should never happen, but we want to be extra safe.

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://docs.safefoundation.org/cla).
