### PR TITLE
Add Checkout Step to Post Coverage Comment Workflow

### DIFF
--- a/.github/workflows/post_coverage_comment.yml
+++ b/.github/workflows/post_coverage_comment.yml
@@ -16,6 +16,8 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.conclusion == 'success'
     steps:
+      - uses: actions/checkout@v5
+
       - name: Download Coverage Artifact
         id: download
         uses: actions/download-artifact@v4


### PR DESCRIPTION
In refactoring the coverage flows in #502, I accidentally removed the checkout action which is required in order to use the `post-comment` action included in our `.github` directory.

This adds it back in.

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://docs.safefoundation.org/cla).
