### PR TITLE
Pure State Transition Functions

### DIFF
--- a/crates/core/src/driver.rs
+++ b/crates/core/src/driver.rs
@@ -75,7 +75,7 @@ pub trait Service {
     type Actions: ActionEncoder<<Self::Transition as StateTransition<Self::State>>::Action>;
 
     /// Constructs the service components used by the driver.
-    fn components(&self) -> (Self::Transition, Self::Effects, Self::Actions);
+    fn components(self) -> (Self::Transition, Self::Effects, Self::Actions);
 }
 
 /// Drives a [`Service`] by wiring its indexer, state machine and transaction

--- a/crates/core/src/driver.rs
+++ b/crates/core/src/driver.rs
@@ -9,7 +9,7 @@
 
 use crate::{
     index::{self, Update, Watcher, events::Events},
-    state::{self, StateMachine, StateTransition},
+    state::{self, EffectHandler, StateMachine, StateTransition},
     tx::{self, Signer, Transaction, TransactionQueue},
 };
 use alloy::{primitives::Address, providers::Provider};
@@ -54,20 +54,28 @@ pub enum Error {
     Transactions(#[from] tx::Error),
 }
 
-/// A Safenet service.
-///
-/// Implementors describe how the service observes the chain (its [`Events`]) and
-/// reacts to it (its [`State`](Service::State) and
-/// [`Transition`](Service::Transition)), and how the resulting
-/// [`Action`](Service::Action)s map onto onchain transactions.
-pub trait Service: StateTransition<Self::State> {
-    /// The service state, persisted across restarts and rolled back on reorgs.
-    type State: Serialize + DeserializeOwned;
-
-    /// Encodes state transition `actions` into transactions to submit onchain,
+/// An action encoder.
+pub trait ActionEncoder<Action> {
+    /// Encodes state transition `action` into a transaction to submit onchain,
     /// each paired with the block number after which it should be dropped if it
     /// has not yet been submitted.
-    fn encode_actions(&self, actions: Vec<Self::Action>) -> Vec<(Transaction, u64)>;
+    fn encode_action(&self, action: Action) -> (Transaction, u64);
+}
+
+/// A Safenet service definition.
+pub trait Service {
+    type State: Default + DeserializeOwned + Serialize;
+    type Event: Debug + Events;
+
+    type Transition: StateTransition<Self::State, Event = Self::Event>;
+    type Effects: EffectHandler<
+            <Self::Transition as StateTransition<Self::State>>::Effect,
+            <Self::Transition as StateTransition<Self::State>>::Resume,
+        >;
+    type Actions: ActionEncoder<<Self::Transition as StateTransition<Self::State>>::Action>;
+
+    /// Constructs the service components used by the driver.
+    fn components(&self) -> (Self::Transition, Self::Effects, Self::Actions);
 }
 
 /// Drives a [`Service`] by wiring its indexer, state machine and transaction
@@ -76,9 +84,9 @@ pub struct Driver<P, S>
 where
     S: Service,
 {
-    service: S,
     watcher: Watcher<P, S::Event>,
-    state: StateMachine<S::State, S>,
+    state: StateMachine<S::State, S::Transition, S::Effects>,
+    actions: S::Actions,
     transactions: TransactionQueue<P>,
 }
 
@@ -86,7 +94,6 @@ impl<P, S> Driver<P, S>
 where
     P: Provider + Clone,
     S: Service,
-    S::Event: Events + Debug,
 {
     /// Creates a driver that wires together the indexer, state machine and
     /// transaction queue for `service`.
@@ -103,12 +110,9 @@ where
         pool: SqlitePool,
         addresses: Vec<Address>,
         config: Config,
-    ) -> Result<Self, Error>
-    where
-        S: Clone,
-        S::State: Default,
-    {
-        let state = StateMachine::new(service.clone(), pool.clone()).await?;
+    ) -> Result<Self, Error> {
+        let (transition, effects, actions) = service.components();
+        let state = StateMachine::new(transition, effects, pool.clone()).await?;
         let watcher = Watcher::new(
             provider.clone(),
             config.index,
@@ -120,9 +124,9 @@ where
             TransactionQueue::new(provider, signer, pool, config.transactions).await?;
 
         Ok(Self {
-            service,
             watcher,
             state,
+            actions,
             transactions,
         })
     }
@@ -182,9 +186,14 @@ where
             self.transactions.handle_block_update(block.clone()).await?;
         }
 
+        // Perform a state transition for the next update.
         let actions = self.state.handle_update(update).await?;
+
+        // Submit transactions for execution onchain.
         if !actions.is_empty() {
-            let transactions = self.service.encode_actions(actions);
+            let transactions = actions
+                .into_iter()
+                .map(|action| self.actions.encode_action(action));
             self.transactions.queue(transactions).await?;
         }
 

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -17,4 +17,4 @@ pub mod serialization;
 pub mod state;
 pub mod tx;
 
-pub use self::driver::{Driver, Service};
+pub use self::driver::Driver;

--- a/crates/core/src/state/mod.rs
+++ b/crates/core/src/state/mod.rs
@@ -10,7 +10,7 @@ use self::storage::SnapshotStore;
 use crate::index::{BlockUpdate, EventLog, EventUpdate, Update};
 use serde::{Serialize, de::DeserializeOwned};
 use sqlx::SqlitePool;
-use std::{mem, range::RangeInclusive};
+use std::{collections::VecDeque, convert::Infallible, mem, range::RangeInclusive};
 use tokio::sync::Mutex;
 
 /// Error produced by the [`StateMachine`].
@@ -32,6 +32,46 @@ pub enum Error {
     Poisoned,
 }
 
+/// A state transition message.
+///
+/// This describes any of the inputs that cause the state machine to progress.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum Message<Event, Resume> {
+    /// A new block.
+    NewBlock(u64),
+    /// A new event.
+    Event(EventLog<Event>),
+    /// Resume from an effect.
+    ///
+    /// Effects are returned from state transition functions and represent some
+    /// impure computation that needs to be performed, in which case a resume
+    /// transition will be applied to the state machine once completed. The
+    /// order in which effects resume is not well-defined and subject to change;
+    /// implementations MUST NOT rely on effect resume ordering.
+    Resume(Resume),
+}
+
+/// A state transition command.
+///
+/// Commands are returned from state machine transitions and are either actions
+/// that need to be executed onchain, or effects that need to be performed and
+/// resumed back into the state machine.
+///
+/// Effects may be performed more than once for the same chain message, for
+/// example after a crash or reorg replay. Transitions that emit effects must be
+/// prepared for the replayed effect to resume with a different result.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum Command<Action, Effect> {
+    /// An onchain action.
+    Action(Action),
+    /// An effect to perform.
+    ///
+    /// Effects are external observations or operations. They are not part of
+    /// the pure transition function and may be replayed even when a previous
+    /// execution already changed external state.
+    Effect(Effect),
+}
+
 /// Describes the state transition function for the state machine.
 ///
 /// Note that **all state transitions are non-fallible**, this means that in
@@ -42,28 +82,43 @@ where
 {
     type Event;
     type Action;
+    type Effect;
+    type Resume;
 
-    /// Perform the state transition for when a new block is observed.
-    fn new_block(&mut self, state: S, block: u64) -> impl Future<Output = (S, Vec<Self::Action>)>;
-
-    /// Perform the state transition when a new event log is observed.
-    fn event(
-        &mut self,
+    /// Apply the state transition for the given message.
+    fn apply_transition(
+        &self,
         state: S,
-        event: EventLog<Self::Event>,
-    ) -> impl Future<Output = (S, Vec<Self::Action>)>;
+        message: Message<Self::Event, Self::Resume>,
+    ) -> (S, Commands<S, Self>);
 }
+
+/// An effect handler that can be used for handling effects for a state
+/// transition.
+pub trait EffectHandler<Effect, Resume> {
+    /// Performs an effect and returns its result to resume a state machine.
+    ///
+    /// Note that this method explicitly does not fail, and is expected to return
+    /// some result that indicates an error so the state machine can handle the
+    /// effect error internally.
+    ///
+    /// The same effect may be performed more than once for the same chain
+    /// message. For consumptive resources such as pre-committed nonces, handlers
+    /// should encode outcomes like "already used" in `Resume`; state transitions
+    /// remain pure because they consume only the resume value.
+    fn perform_effect(&mut self, effect: Effect) -> impl Future<Output = Resume>;
+}
+
+/// A utility type for a vector of commands for some state and its transition.
+pub type Commands<S, T> =
+    Vec<Command<<T as StateTransition<S>>::Action, <T as StateTransition<S>>::Effect>>;
 
 /// A service state machine.
-pub struct StateMachine<S, T> {
-    inner: Mutex<Option<Inner<S>>>,
-    transition: T,
+pub struct StateMachine<S, T, E> {
+    inner: Mutex<Option<(S, Status)>>,
     snapshots: SnapshotStore<S>,
-}
-
-struct Inner<S> {
-    state: S,
-    status: Status,
+    transition: T,
+    effects: E,
 }
 
 enum Status {
@@ -73,23 +128,25 @@ enum Status {
     WarpEvents { range: RangeInclusive<u64> },
 }
 
-impl<S, T, E> StateMachine<S, T>
+impl<S, T, E> StateMachine<S, T, E>
 where
-    T: StateTransition<S, Event = E>,
     S: Serialize + DeserializeOwned,
+    T: StateTransition<S>,
+    E: EffectHandler<T::Effect, T::Resume>,
 {
     /// Creates a new state machine with the given state transition.
-    pub async fn new(transition: T, pool: SqlitePool) -> Result<Self, Error>
+    pub async fn new(transition: T, effects: E, pool: SqlitePool) -> Result<Self, Error>
     where
         S: Default,
     {
-        Self::with_init(transition, pool, S::default).await
+        Self::with_init(transition, effects, pool, S::default).await
     }
 
     /// Creates a new state machine with the given state transition and an
     /// initial value constructor.
     pub async fn with_init(
         transition: T,
+        effects: E,
         pool: SqlitePool,
         init: impl FnOnce() -> S,
     ) -> Result<Self, Error> {
@@ -103,19 +160,22 @@ where
             })
             .transpose()?
             .unwrap_or_else(|| (init(), Status::Initialized));
-        let inner = Mutex::new(Some(Inner { state, status }));
+        let inner = Mutex::new(Some((state, status)));
 
         Ok(Self {
             inner,
-            transition,
             snapshots,
+            transition,
+            effects,
         })
     }
 
     /// Returns the last block that was fully processed by the state machine.
     /// Note that this only counts fully processed blocks.
     pub async fn last_block(&self) -> Option<u64> {
-        match self.inner.lock().await.as_ref()?.status {
+        let lock = self.inner.lock().await;
+        let (_, status) = lock.as_ref()?;
+        match status {
             Status::Initialized => None,
             Status::BlockPending { pending } => pending.checked_sub(1),
             // This is a bit counter-intuitive, but if we observed the latest
@@ -133,9 +193,12 @@ where
     ///
     /// The state machine halts if it returns an error, as it can no longer
     /// correctly progress.
-    pub async fn handle_update(&mut self, update: Update<E>) -> Result<Vec<T::Action>, Error> {
+    pub async fn handle_update(
+        &mut self,
+        update: Update<T::Event>,
+    ) -> Result<Vec<T::Action>, Error> {
         let mut lock = self.inner.lock().await;
-        let Inner { state, status } = mem::take(&mut *lock).ok_or(Error::Poisoned)?;
+        let (state, status) = mem::take(&mut *lock).ok_or(Error::Poisoned)?;
         let (state, status, actions) = match update {
             Update::Block(BlockUpdate::Warp { from, to })
                 if matches!(status, Status::Initialized)
@@ -150,15 +213,19 @@ where
                 if matches!(status, Status::BlockPending { pending } if number < pending)
                     || matches!(status, Status::BlockEvents { latest } if number <= latest) =>
             {
-                let (_, snapshot) = self.snapshots.reorg(number).await?;
+                let (_, state) = self.snapshots.reorg(number).await?;
                 let status = Status::BlockPending { pending: number };
-                (snapshot, status, vec![])
+                (state, status, vec![])
             }
             Update::Block(BlockUpdate::New { number, safe, .. })
                 if matches!(status, Status::Initialized)
                     || matches!(status, Status::BlockPending { pending } if pending == number) =>
             {
-                let (state, actions) = self.transition.new_block(state, number).await;
+                let (state, actions) =
+                    TransitionBatch::new(&self.transition, &mut self.effects, state)
+                        .apply(Message::NewBlock(number))
+                        .await
+                        .finish();
                 let status = Status::BlockEvents { latest: number };
                 self.snapshots.prune(safe).await?;
                 (state, status, actions)
@@ -176,13 +243,12 @@ where
                     return Err(Error::BadUpdate);
                 }
 
-                let mut state = state;
-                let mut actions = vec![];
+                let mut batch = TransitionBatch::new(&self.transition, &mut self.effects, state);
                 for log in logs {
-                    let (new_state, new_actions) = self.transition.event(state, log).await;
-                    state = new_state;
-                    actions.extend(new_actions);
+                    batch = batch.apply(Message::Event(log)).await;
                 }
+                let (state, actions) = batch.finish();
+
                 // In case we are warping, we can prune intermediate state from
                 // storage for the event pages.
                 let should_prune = matches!(status, Status::WarpEvents { .. });
@@ -206,8 +272,59 @@ where
             }
             _ => return Err(Error::BadUpdate),
         };
-        *lock = Some(Inner { state, status });
+        *lock = Some((state, status));
         Ok(actions)
+    }
+}
+
+struct TransitionBatch<'a, S, T, E>
+where
+    T: StateTransition<S>,
+{
+    transition: &'a T,
+    effects: E,
+    state: S,
+    actions: Vec<T::Action>,
+}
+
+impl<'a, S, T, E> TransitionBatch<'a, S, T, E>
+where
+    T: StateTransition<S>,
+    E: EffectHandler<T::Effect, T::Resume>,
+{
+    fn new(transition: &'a T, effects: E, state: S) -> Self {
+        Self {
+            transition,
+            effects,
+            state,
+            actions: vec![],
+        }
+    }
+
+    async fn apply(mut self, message: Message<T::Event, T::Resume>) -> Self {
+        let (state, commands) = self.transition.apply_transition(self.state, message);
+        self.state = state;
+        self.actions.reserve(commands.len());
+
+        let mut commands = VecDeque::from(commands);
+        while let Some(command) = commands.pop_front() {
+            match command {
+                Command::Action(action) => self.actions.push(action),
+                Command::Effect(effect) => {
+                    let result = self.effects.perform_effect(effect).await;
+                    let (new_state, new_commands) = self
+                        .transition
+                        .apply_transition(self.state, Message::Resume(result));
+                    self.state = new_state;
+                    commands.extend(new_commands);
+                }
+            }
+        }
+        self
+    }
+
+    fn finish(self) -> (S, Vec<T::Action>) {
+        (self.state, self.actions)
     }
 }
 
@@ -227,11 +344,30 @@ fn is_next_in_range(range: impl Into<RangeInclusive<u64>>, sub: RangeInclusive<u
     range.start == sub.start && range.contains(&sub.last)
 }
 
+/// An effect handler for pure state machines without any side-effects.
+pub struct Pure;
+
+impl<Resume> EffectHandler<Infallible, Resume> for Pure {
+    async fn perform_effect(&mut self, effect: Infallible) -> Resume {
+        match effect {}
+    }
+}
+
+impl<E, R, H> EffectHandler<E, R> for &mut H
+where
+    H: EffectHandler<E, R>,
+{
+    fn perform_effect(&mut self, effect: E) -> impl Future<Output = R> {
+        (*self).perform_effect(effect)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::index::{BlockUpdate, EventUpdate, Update};
     use serde::Deserialize;
+    use std::convert::Infallible;
 
     /// State that records every block and event it was transitioned with, so
     /// transitions, rollbacks and resumes are all observable.
@@ -253,24 +389,26 @@ mod tests {
 
     impl StateTransition<TestState> for TestTransition {
         type Event = u64;
+        type Resume = Infallible;
         type Action = Action;
+        type Effect = Infallible;
 
-        async fn new_block(
-            &mut self,
+        fn apply_transition(
+            &self,
             mut state: TestState,
-            block: u64,
-        ) -> (TestState, Vec<Action>) {
-            state.blocks.push(block);
-            (state, vec![Action::Block(block)])
-        }
-
-        async fn event(
-            &mut self,
-            mut state: TestState,
-            event: EventLog<u64>,
-        ) -> (TestState, Vec<Action>) {
-            state.events.push(event.data);
-            (state, vec![Action::Event(event.data)])
+            message: Message<Self::Event, Self::Resume>,
+        ) -> (TestState, Commands<TestState, Self>) {
+            match message {
+                Message::NewBlock(block) => {
+                    state.blocks.push(block);
+                    (state, vec![Command::Action(Action::Block(block))])
+                }
+                Message::Event(event) => {
+                    state.events.push(event.data);
+                    (state, vec![Command::Action(Action::Event(event.data))])
+                }
+                Message::Resume(result) => match result {},
+            }
         }
     }
 
@@ -278,8 +416,8 @@ mod tests {
         SqlitePool::connect("sqlite::memory:").await.unwrap()
     }
 
-    async fn new_machine(pool: &SqlitePool) -> StateMachine<TestState, TestTransition> {
-        StateMachine::new(TestTransition, pool.clone())
+    async fn new_machine(pool: &SqlitePool) -> StateMachine<TestState, TestTransition, Pure> {
+        StateMachine::new(TestTransition, Pure, pool.clone())
             .await
             .unwrap()
     }

--- a/crates/core/src/state/mod.rs
+++ b/crates/core/src/state/mod.rs
@@ -282,7 +282,7 @@ where
     T: StateTransition<S>,
 {
     transition: &'a T,
-    effects: E,
+    effects: &'a mut E,
     state: S,
     actions: Vec<T::Action>,
 }
@@ -292,7 +292,7 @@ where
     T: StateTransition<S>,
     E: EffectHandler<T::Effect, T::Resume>,
 {
-    fn new(transition: &'a T, effects: E, state: S) -> Self {
+    fn new(transition: &'a T, effects: &'a mut E, state: S) -> Self {
         Self {
             transition,
             effects,
@@ -304,6 +304,12 @@ where
     async fn apply(mut self, message: Message<T::Event, T::Resume>) -> Self {
         let (state, commands) = self.transition.apply_transition(self.state, message);
         self.state = state;
+
+        // We assume that most commands are actions, and that effect transitions
+        // will generally produce a single command. This allows us to pre-
+        // allocate some space for the final actions. If we are off, then we
+        // either just reserved some additional extra space or need to grow the
+        // vector an additional time while handling new actions.
         self.actions.reserve(commands.len());
 
         let mut commands = VecDeque::from(commands);
@@ -350,15 +356,6 @@ pub struct Pure;
 impl<Resume> EffectHandler<Infallible, Resume> for Pure {
     async fn perform_effect(&mut self, effect: Infallible) -> Resume {
         match effect {}
-    }
-}
-
-impl<E, R, H> EffectHandler<E, R> for &mut H
-where
-    H: EffectHandler<E, R>,
-{
-    fn perform_effect(&mut self, effect: E) -> impl Future<Output = R> {
-        (*self).perform_effect(effect)
     }
 }
 

--- a/crates/sentinel/src/service.rs
+++ b/crates/sentinel/src/service.rs
@@ -1,3 +1,5 @@
+use std::{convert::Infallible, sync::Arc};
+
 use crate::{
     action::{SentinelAction, SentinelActionKind},
     bindings::{
@@ -13,11 +15,16 @@ use alloy::{
     primitives::{Address, U256},
     sol_types::{SolCall, SolValue},
 };
-use safenet_core::{Service, index::EventLog, state::StateTransition, tx::Transaction};
+use safenet_core::{
+    driver::{ActionEncoder, Service},
+    state::{Command, Commands, Message, Pure, StateTransition},
+    tx::Transaction,
+};
 
 /// The sentinel service: drives the request FSM (`preparing -> pending ->
 /// committed -> finalized`) from `SentinelOracle`/`Consensus` events and maps
 /// its actions to encoded transactions.
+#[derive(Clone)]
 pub struct SentinelService {
     oracle: Address,
     fee_token: Address,
@@ -31,7 +38,7 @@ pub struct SentinelService {
     /// The number of blocks a `Preparing` request is kept alive for before
     /// being cleaned up.
     voting_window: u64,
-    detector: Detector,
+    detector: Arc<Detector>,
 }
 
 impl SentinelService {
@@ -52,7 +59,7 @@ impl SentinelService {
             account,
             chain_id,
             voting_window,
-            detector,
+            detector: Arc::new(detector),
         }
     }
 
@@ -225,7 +232,7 @@ impl SentinelService {
         (state, actions)
     }
 
-    fn encode_action(&self, kind: SentinelActionKind) -> Transaction {
+    fn encode_action_kind(&self, kind: SentinelActionKind) -> Transaction {
         match kind {
             SentinelActionKind::ApproveToken { bond } => Transaction {
                 to: self.fee_token,
@@ -277,47 +284,56 @@ impl SentinelService {
 impl StateTransition<State> for SentinelService {
     type Event = SentinelEvents;
     type Action = SentinelAction;
+    type Effect = Infallible;
+    type Resume = Infallible;
 
-    async fn new_block(&mut self, state: State, block: u64) -> (State, Vec<Self::Action>) {
-        self.handle_block_advance(state, block)
-    }
-
-    async fn event(
-        &mut self,
+    fn apply_transition(
+        &self,
         state: State,
-        event: EventLog<Self::Event>,
-    ) -> (State, Vec<Self::Action>) {
-        let block = event.block;
-        match event.data {
-            SentinelEvents::Consensus(Consensus::ConsensusEvents::OracleTransactionProposed(
-                event,
-            )) => self.handle_oracle_transaction_proposed(state, block, event),
-            SentinelEvents::Oracle(SentinelOracle::SentinelOracleEvents::NewRequest(event)) => {
-                self.handle_new_request(state, block, event)
+        message: Message<Self::Event, Self::Resume>,
+    ) -> (State, Commands<State, Self>) {
+        let (state, actions) = match message {
+            Message::NewBlock(block) => self.handle_block_advance(state, block),
+            Message::Event(event) => {
+                let block = event.block;
+                match event.data {
+                    SentinelEvents::Consensus(
+                        Consensus::ConsensusEvents::OracleTransactionProposed(event),
+                    ) => self.handle_oracle_transaction_proposed(state, block, event),
+                    SentinelEvents::Oracle(SentinelOracle::SentinelOracleEvents::NewRequest(
+                        event,
+                    )) => self.handle_new_request(state, block, event),
+                    SentinelEvents::Oracle(SentinelOracle::SentinelOracleEvents::Committed(
+                        event,
+                    )) => self.handle_committed(state, event),
+                    SentinelEvents::Oracle(SentinelOracle::SentinelOracleEvents::OracleResult(
+                        event,
+                    )) => self.handle_resolved(state, event),
+                }
             }
-            SentinelEvents::Oracle(SentinelOracle::SentinelOracleEvents::Committed(event)) => {
-                self.handle_committed(state, event)
-            }
-            SentinelEvents::Oracle(SentinelOracle::SentinelOracleEvents::OracleResult(event)) => {
-                self.handle_resolved(state, event)
-            }
-        }
+            Message::Resume(result) => match result {},
+        };
+        let commands = actions.into_iter().map(Command::Action).collect();
+        (state, commands)
+    }
+}
+
+impl ActionEncoder<SentinelAction> for SentinelService {
+    fn encode_action(&self, action: SentinelAction) -> (Transaction, u64) {
+        (self.encode_action_kind(action.kind), action.expires_at)
     }
 }
 
 impl Service for SentinelService {
     type State = State;
+    type Event = SentinelEvents;
 
-    /// Maps each action to a `(Transaction, expires_at)` pair for the queue.
-    ///
-    /// The `expires_at` is the request's voting deadline, forwarded from the
-    /// action so the `TransactionQueue` can drop it if it goes unsubmitted
-    /// past that block.
-    fn encode_actions(&self, actions: Vec<SentinelAction>) -> Vec<(Transaction, u64)> {
-        actions
-            .into_iter()
-            .map(|SentinelAction { kind, expires_at }| (self.encode_action(kind), expires_at))
-            .collect()
+    type Transition = Self;
+    type Effects = Pure;
+    type Actions = Self;
+
+    fn components(self) -> (Self::Transition, Self::Effects, Self::Actions) {
+        (self.clone(), Pure, self)
     }
 }
 
@@ -326,6 +342,7 @@ mod tests {
     use super::*;
     use crate::bindings::consensus::{Operation, SafeTransaction};
     use alloy::primitives::{B256, address, uint};
+    use safenet_core::index::EventLog;
 
     const ORACLE: Address = address!("1111111111111111111111111111111111111111");
     const FEE_TOKEN: Address = address!("2222222222222222222222222222222222222222");
@@ -422,7 +439,7 @@ mod tests {
 
     #[tokio::test]
     async fn oracle_transaction_proposed_tracks_a_preparing_request() {
-        let mut svc = service();
+        let svc = service();
         let safe_tx_hash = B256::repeat_byte(0x01);
         let id = request_id(safe_tx_hash, 7, ORACLE);
         let event =
@@ -430,9 +447,10 @@ mod tests {
                 proposed_event(ORACLE, safe_tx_hash),
             ));
 
-        let (state, actions) = svc.event(State::default(), log(5, event)).await;
+        let (state, commands) =
+            svc.apply_transition(State::default(), Message::Event(log(5, event)));
 
-        assert!(actions.is_empty());
+        assert!(commands.is_empty());
         let request = &state.0[&id];
         assert_eq!(request.status, RequestStatus::Preparing);
         assert!(request.approve);
@@ -441,7 +459,7 @@ mod tests {
 
     #[tokio::test]
     async fn oracle_transaction_proposed_denies_blocklisted_destination() {
-        let mut svc = service_with_blocklist(vec![TO]);
+        let svc = service_with_blocklist(vec![TO]);
         let safe_tx_hash = B256::repeat_byte(0x02);
         let id = request_id(safe_tx_hash, 7, ORACLE);
         let event =
@@ -449,29 +467,30 @@ mod tests {
                 proposed_event(ORACLE, safe_tx_hash),
             ));
 
-        let (state, _) = svc.event(State::default(), log(5, event)).await;
+        let (state, _) = svc.apply_transition(State::default(), Message::Event(log(5, event)));
 
         assert!(!state.0[&id].approve);
     }
 
     #[tokio::test]
     async fn oracle_transaction_proposed_ignores_other_oracles() {
-        let mut svc = service();
+        let svc = service();
         let other_oracle = address!("6666666666666666666666666666666666666666");
         let event =
             SentinelEvents::Consensus(Consensus::ConsensusEvents::OracleTransactionProposed(
                 proposed_event(other_oracle, B256::repeat_byte(0x03)),
             ));
 
-        let (state, actions) = svc.event(State::default(), log(5, event)).await;
+        let (state, commands) =
+            svc.apply_transition(State::default(), Message::Event(log(5, event)));
 
         assert!(state.0.is_empty());
-        assert!(actions.is_empty());
+        assert!(commands.is_empty());
     }
 
     #[tokio::test]
     async fn oracle_transaction_proposed_ignores_a_duplicate_for_an_existing_request() {
-        let mut svc = service();
+        let svc = service();
         let safe_tx_hash = B256::repeat_byte(0x0f);
         let id = request_id(safe_tx_hash, 7, ORACLE);
         let mut committed = request_state(RequestStatus::Preparing, 50, true);
@@ -482,15 +501,15 @@ mod tests {
                 proposed_event(ORACLE, safe_tx_hash),
             ));
 
-        let (state, actions) = svc.event(state, log(5, event)).await;
+        let (state, commands) = svc.apply_transition(state, Message::Event(log(5, event)));
 
         assert_eq!(state.0[&id], committed);
-        assert!(actions.is_empty());
+        assert!(commands.is_empty());
     }
 
     #[tokio::test]
     async fn new_request_commits_approve_vote_for_a_preparing_request() {
-        let mut svc = service();
+        let svc = service();
         let id = B256::repeat_byte(0x04);
         let state = with_request(id, request_state(RequestStatus::Preparing, 1, true));
         let event = SentinelEvents::Oracle(SentinelOracle::SentinelOracleEvents::NewRequest(
@@ -503,31 +522,31 @@ mod tests {
             },
         ));
 
-        let (state, actions) = svc.event(state, log(40, event)).await;
+        let (state, commands) = svc.apply_transition(state, Message::Event(log(40, event)));
 
         let request = &state.0[&id];
         assert_eq!(request.status, RequestStatus::Pending);
         assert_eq!(request.deadline, 50);
         assert_eq!(
-            actions,
+            commands,
             vec![
-                SentinelAction {
+                Command::Action(SentinelAction {
                     kind: SentinelActionKind::ApproveToken {
                         bond: U256::from(1_000u64)
                     },
                     expires_at: 50,
-                },
-                SentinelAction {
+                }),
+                Command::Action(SentinelAction {
                     kind: SentinelActionKind::CommitApprove { id },
                     expires_at: 50,
-                },
+                }),
             ]
         );
     }
 
     #[tokio::test]
     async fn new_request_commits_deny_vote_when_denied() {
-        let mut svc = service();
+        let svc = service();
         let id = B256::repeat_byte(0x05);
         let state = with_request(id, request_state(RequestStatus::Preparing, 1, false));
         let event = SentinelEvents::Oracle(SentinelOracle::SentinelOracleEvents::NewRequest(
@@ -540,31 +559,31 @@ mod tests {
             },
         ));
 
-        let (state, actions) = svc.event(state, log(40, event)).await;
+        let (state, commands) = svc.apply_transition(state, Message::Event(log(40, event)));
 
         let request = &state.0[&id];
         assert_eq!(request.status, RequestStatus::Pending);
         assert_eq!(request.deadline, 50);
         assert_eq!(
-            actions,
+            commands,
             vec![
-                SentinelAction {
+                Command::Action(SentinelAction {
                     kind: SentinelActionKind::ApproveToken {
                         bond: U256::from(1_000u64)
                     },
                     expires_at: 50,
-                },
-                SentinelAction {
+                }),
+                Command::Action(SentinelAction {
                     kind: SentinelActionKind::CommitDeny { id },
                     expires_at: 50,
-                },
+                }),
             ]
         );
     }
 
     #[tokio::test]
     async fn new_request_ignores_unknown_or_non_preparing_requests() {
-        let mut svc = service();
+        let svc = service();
         let id = B256::repeat_byte(0x06);
         let event = || {
             SentinelEvents::Oracle(SentinelOracle::SentinelOracleEvents::NewRequest(
@@ -578,161 +597,163 @@ mod tests {
             ))
         };
 
-        let (state, actions) = svc.event(State::default(), log(1, event())).await;
+        let (state, commands) =
+            svc.apply_transition(State::default(), Message::Event(log(1, event())));
         assert!(state.0.is_empty());
-        assert!(actions.is_empty());
+        assert!(commands.is_empty());
 
         let mut pending = with_request(id, request_state(RequestStatus::Preparing, 1, true));
         pending.0.get_mut(&id).unwrap().status = RequestStatus::Pending;
-        let (state, actions) = svc.event(pending, log(1, event())).await;
+        let (state, commands) = svc.apply_transition(pending, Message::Event(log(1, event())));
         assert_eq!(state.0[&id].status, RequestStatus::Pending);
-        assert!(actions.is_empty());
+        assert!(commands.is_empty());
     }
 
     #[tokio::test]
     async fn committed_moves_a_pending_request_to_committed_for_our_account() {
-        let mut svc = service();
+        let svc = service();
         let id = B256::repeat_byte(0x07);
         let state = with_request(id, request_state(RequestStatus::Pending, 50, true));
 
-        let (state, actions) = svc
-            .event(state, log(10, committed_event(id, ACCOUNT)))
-            .await;
+        let (state, commands) =
+            svc.apply_transition(state, Message::Event(log(10, committed_event(id, ACCOUNT))));
 
         assert_eq!(state.0[&id].status, RequestStatus::Committed);
-        assert!(actions.is_empty());
+        assert!(commands.is_empty());
     }
 
     #[tokio::test]
     async fn committed_ignores_other_sentinels() {
-        let mut svc = service();
+        let svc = service();
         let id = B256::repeat_byte(0x08);
         let other = address!("8888888888888888888888888888888888888888");
         let state = with_request(id, request_state(RequestStatus::Pending, 50, true));
 
-        let (state, actions) = svc.event(state, log(10, committed_event(id, other))).await;
+        let (state, commands) =
+            svc.apply_transition(state, Message::Event(log(10, committed_event(id, other))));
 
         assert_eq!(state.0[&id].status, RequestStatus::Pending);
-        assert!(actions.is_empty());
+        assert!(commands.is_empty());
     }
 
     #[tokio::test]
     async fn committed_ignores_unknown_or_non_pending_requests() {
-        let mut svc = service();
+        let svc = service();
         let id = B256::repeat_byte(0x09);
 
-        let (state, actions) = svc
-            .event(State::default(), log(10, committed_event(id, ACCOUNT)))
-            .await;
+        let (state, commands) = svc.apply_transition(
+            State::default(),
+            Message::Event(log(10, committed_event(id, ACCOUNT))),
+        );
         assert!(state.0.is_empty());
-        assert!(actions.is_empty());
+        assert!(commands.is_empty());
 
         let state = with_request(id, request_state(RequestStatus::Preparing, 50, true));
-        let (state, actions) = svc
-            .event(state, log(10, committed_event(id, ACCOUNT)))
-            .await;
+        let (state, commands) =
+            svc.apply_transition(state, Message::Event(log(10, committed_event(id, ACCOUNT))));
         assert_eq!(state.0[&id].status, RequestStatus::Preparing);
-        assert!(actions.is_empty());
+        assert!(commands.is_empty());
     }
 
     #[tokio::test]
     async fn resolved_claims_and_drops_a_committed_request_when_our_vote_won() {
-        let mut svc = service();
+        let svc = service();
         let id = B256::repeat_byte(0x0a);
         let state = with_request(id, request_state(RequestStatus::Committed, 50, true));
         let event = resolved_event(id, true, ResolveReason::UNANIMOUS_APPROVE);
 
-        let (state, actions) = svc.event(state, log(10, event)).await;
+        let (state, commands) = svc.apply_transition(state, Message::Event(log(10, event)));
 
         assert!(!state.0.contains_key(&id));
         assert_eq!(
-            actions,
-            vec![SentinelAction {
+            commands,
+            vec![Command::Action(SentinelAction {
                 kind: SentinelActionKind::Claim { id },
                 expires_at: u64::MAX,
-            }]
+            })]
         );
     }
 
     #[tokio::test]
     async fn resolved_claims_and_drops_a_finalized_request_when_our_vote_won() {
-        let mut svc = service();
+        let svc = service();
         let id = B256::repeat_byte(0x0b);
         let state = with_request(id, request_state(RequestStatus::Finalized, 60, false));
         let event = resolved_event(id, false, ResolveReason::UNANIMOUS_DENY);
 
-        let (state, actions) = svc.event(state, log(10, event)).await;
+        let (state, commands) = svc.apply_transition(state, Message::Event(log(10, event)));
 
         assert!(!state.0.contains_key(&id));
         assert_eq!(
-            actions,
-            vec![SentinelAction {
+            commands,
+            vec![Command::Action(SentinelAction {
                 kind: SentinelActionKind::Claim { id },
                 expires_at: u64::MAX,
-            }]
+            })]
         );
     }
 
     #[tokio::test]
     async fn resolved_claims_on_timeout_even_when_our_vote_lost() {
-        let mut svc = service();
+        let svc = service();
         let id = B256::repeat_byte(0x0c);
         let state = with_request(id, request_state(RequestStatus::Committed, 50, false));
         let event = resolved_event(id, true, ResolveReason::TIMEOUT);
 
-        let (state, actions) = svc.event(state, log(10, event)).await;
+        let (state, commands) = svc.apply_transition(state, Message::Event(log(10, event)));
 
         assert!(!state.0.contains_key(&id));
         assert_eq!(
-            actions,
-            vec![SentinelAction {
+            commands,
+            vec![Command::Action(SentinelAction {
                 kind: SentinelActionKind::Claim { id },
                 expires_at: u64::MAX,
-            }]
+            })]
         );
     }
 
     #[tokio::test]
     async fn resolved_drops_without_claiming_when_our_vote_lost() {
-        let mut svc = service();
+        let svc = service();
         let id = B256::repeat_byte(0x0d);
         let state = with_request(id, request_state(RequestStatus::Committed, 50, true));
         let event = resolved_event(id, false, ResolveReason::UNANIMOUS_DENY);
 
-        let (state, actions) = svc.event(state, log(10, event)).await;
+        let (state, commands) = svc.apply_transition(state, Message::Event(log(10, event)));
 
         assert!(!state.0.contains_key(&id));
-        assert!(actions.is_empty());
+        assert!(commands.is_empty());
     }
 
     #[tokio::test]
     async fn resolved_drops_without_claiming_a_request_we_never_committed_onchain() {
-        let mut svc = service();
+        let svc = service();
         let id = B256::repeat_byte(0x0e);
         let state = with_request(id, request_state(RequestStatus::Pending, 50, true));
         let event = resolved_event(id, true, ResolveReason::UNANIMOUS_APPROVE);
 
-        let (state, actions) = svc.event(state, log(10, event)).await;
+        let (state, commands) = svc.apply_transition(state, Message::Event(log(10, event)));
 
         assert!(!state.0.contains_key(&id));
-        assert!(actions.is_empty());
+        assert!(commands.is_empty());
     }
 
     #[tokio::test]
     async fn resolved_ignores_an_unknown_request() {
-        let mut svc = service();
+        let svc = service();
         let id = B256::repeat_byte(0x0f);
         let event = resolved_event(id, true, ResolveReason::UNANIMOUS_APPROVE);
 
-        let (state, actions) = svc.event(State::default(), log(10, event)).await;
+        let (state, commands) =
+            svc.apply_transition(State::default(), Message::Event(log(10, event)));
 
         assert!(state.0.is_empty());
-        assert!(actions.is_empty());
+        assert!(commands.is_empty());
     }
 
     #[tokio::test]
     async fn resolved_drops_without_panicking_on_a_malformed_result() {
-        let mut svc = service();
+        let svc = service();
         let id = B256::repeat_byte(0x10);
         let state = with_request(id, request_state(RequestStatus::Committed, 50, true));
         let event = SentinelEvents::Oracle(SentinelOracle::SentinelOracleEvents::OracleResult(
@@ -744,35 +765,35 @@ mod tests {
             },
         ));
 
-        let (state, actions) = svc.event(state, log(10, event)).await;
+        let (state, commands) = svc.apply_transition(state, Message::Event(log(10, event)));
 
         assert!(!state.0.contains_key(&id));
-        assert!(actions.is_empty());
+        assert!(commands.is_empty());
     }
 
     #[tokio::test]
     async fn block_advance_finalizes_a_past_deadline_committed_request() {
-        let mut svc = service();
+        let svc = service();
         let id = B256::repeat_byte(0x10);
         let state = with_request(id, request_state(RequestStatus::Committed, 50, true));
 
-        let (state, actions) = svc.new_block(state, 51).await;
+        let (state, commands) = svc.apply_transition(state, Message::NewBlock(51));
 
         let request = &state.0[&id];
         assert_eq!(request.status, RequestStatus::Finalized);
         assert_eq!(request.deadline, 51 + VOTING_WINDOW);
         assert_eq!(
-            actions,
-            vec![SentinelAction {
+            commands,
+            vec![Command::Action(SentinelAction {
                 kind: SentinelActionKind::Finalize { id },
                 expires_at: 51 + VOTING_WINDOW,
-            }]
+            })]
         );
     }
 
     #[tokio::test]
     async fn block_advance_drops_stale_requests() {
-        let mut svc = service();
+        let svc = service();
         let preparing_id = B256::repeat_byte(0x12);
         let pending_id = B256::repeat_byte(0x13);
         let finalized_id = B256::repeat_byte(0x16);
@@ -788,17 +809,17 @@ mod tests {
             request_state(RequestStatus::Finalized, 50, true),
         );
 
-        let (state, actions) = svc.new_block(state, 51).await;
+        let (state, commands) = svc.apply_transition(state, Message::NewBlock(51));
 
         assert!(!state.0.contains_key(&preparing_id));
         assert!(!state.0.contains_key(&pending_id));
         assert!(!state.0.contains_key(&finalized_id));
-        assert!(actions.is_empty());
+        assert!(commands.is_empty());
     }
 
     #[tokio::test]
     async fn block_advance_keeps_requests_before_their_deadline() {
-        let mut svc = service();
+        let svc = service();
         let comitted_id = B256::repeat_byte(0x11);
         let preparing_id = B256::repeat_byte(0x14);
         let pending_id = B256::repeat_byte(0x15);
@@ -819,19 +840,19 @@ mod tests {
             request_state(RequestStatus::Finalized, 50, true),
         );
 
-        let (state, actions) = svc.new_block(state, 50).await;
+        let (state, commands) = svc.apply_transition(state, Message::NewBlock(50));
 
         assert!(state.0.contains_key(&comitted_id));
         assert!(state.0.contains_key(&preparing_id));
         assert!(state.0.contains_key(&pending_id));
         assert!(state.0.contains_key(&finalized_id));
-        assert!(actions.is_empty());
+        assert!(commands.is_empty());
     }
 
     #[test]
     fn encodes_approve_token() {
         let bond = uint!(1_000_U256);
-        let tx = service().encode_action(SentinelActionKind::ApproveToken { bond });
+        let tx = service().encode_action_kind(SentinelActionKind::ApproveToken { bond });
 
         assert_eq!(tx.to, FEE_TOKEN);
         assert_eq!(tx.value, U256::ZERO);
@@ -849,7 +870,7 @@ mod tests {
     #[test]
     fn encodes_commit_approve() {
         let id = B256::repeat_byte(0x01);
-        let tx = service().encode_action(SentinelActionKind::CommitApprove { id });
+        let tx = service().encode_action_kind(SentinelActionKind::CommitApprove { id });
 
         assert_eq!(tx.to, ORACLE);
         assert_eq!(tx.value, U256::ZERO);
@@ -863,7 +884,7 @@ mod tests {
     #[test]
     fn encodes_commit_deny() {
         let id = B256::repeat_byte(0x02);
-        let tx = service().encode_action(SentinelActionKind::CommitDeny { id });
+        let tx = service().encode_action_kind(SentinelActionKind::CommitDeny { id });
 
         assert_eq!(tx.to, ORACLE);
         assert_eq!(tx.value, U256::ZERO);
@@ -877,7 +898,7 @@ mod tests {
     #[test]
     fn encodes_finalize() {
         let id = B256::repeat_byte(0x03);
-        let tx = service().encode_action(SentinelActionKind::Finalize { id });
+        let tx = service().encode_action_kind(SentinelActionKind::Finalize { id });
 
         assert_eq!(tx.to, ORACLE);
         assert_eq!(tx.value, U256::ZERO);
@@ -891,7 +912,7 @@ mod tests {
     #[test]
     fn encodes_claim() {
         let id = B256::repeat_byte(0x04);
-        let tx = service().encode_action(SentinelActionKind::Claim { id });
+        let tx = service().encode_action_kind(SentinelActionKind::Claim { id });
 
         assert_eq!(tx.to, ORACLE);
         assert_eq!(tx.value, U256::ZERO);
@@ -907,7 +928,7 @@ mod tests {
         let bond = uint!(500_U256);
         let id = B256::repeat_byte(0xab);
         let deadline = 999u64;
-        let encoded = service().encode_actions(vec![
+        for action in [
             SentinelAction {
                 kind: SentinelActionKind::ApproveToken { bond },
                 expires_at: deadline,
@@ -916,12 +937,9 @@ mod tests {
                 kind: SentinelActionKind::CommitApprove { id },
                 expires_at: deadline,
             },
-        ]);
-
-        assert_eq!(encoded.len(), 2);
-        assert_eq!(encoded[0].0.to, FEE_TOKEN);
-        assert_eq!(encoded[1].0.to, ORACLE);
-        assert_eq!(encoded[0].1, deadline);
-        assert_eq!(encoded[1].1, deadline);
+        ] {
+            let (_, encoded_deadline) = service().encode_action(action);
+            assert_eq!(encoded_deadline, deadline);
+        }
     }
 }

--- a/crates/validator/src/service.rs
+++ b/crates/validator/src/service.rs
@@ -3,8 +3,12 @@
 
 use alloy::sol;
 use safenet_core::{
-    Service, index::EventLog, state::StateTransition, tx::Transaction, watcher_events,
+    driver::{ActionEncoder, Service},
+    state::{Commands, Message, Pure, StateTransition},
+    tx::Transaction,
+    watcher_events,
 };
+use std::convert::Infallible;
 
 sol! {
     #[derive(Debug)]
@@ -22,21 +26,37 @@ pub struct DummyService;
 
 impl StateTransition<()> for DummyService {
     type Event = Dummy::DummyEvents;
-    type Action = ();
+    type Action = Infallible;
+    type Effect = Infallible;
+    type Resume = Infallible;
 
-    async fn new_block(&mut self, state: (), _block: u64) -> ((), Vec<Self::Action>) {
-        (state, Vec::new())
+    fn apply_transition(
+        &self,
+        state: (),
+        message: Message<Self::Event, Self::Resume>,
+    ) -> ((), Commands<(), Self>) {
+        match message {
+            Message::NewBlock(_) | Message::Event(_) => (state, Vec::new()),
+            Message::Resume(result) => match result {},
+        }
     }
+}
 
-    async fn event(&mut self, state: (), _event: EventLog<Self::Event>) -> ((), Vec<Self::Action>) {
-        (state, Vec::new())
+impl ActionEncoder<Infallible> for DummyService {
+    fn encode_action(&self, action: Infallible) -> (Transaction, u64) {
+        match action {}
     }
 }
 
 impl Service for DummyService {
     type State = ();
+    type Event = Dummy::DummyEvents;
 
-    fn encode_actions(&self, _actions: Vec<Self::Action>) -> Vec<(Transaction, u64)> {
-        Vec::new()
+    type Transition = Self;
+    type Effects = Pure;
+    type Actions = Self;
+
+    fn components(&self) -> (Self::Transition, Self::Effects, Self::Actions) {
+        (Self, Pure, Self)
     }
 }

--- a/crates/validator/src/service.rs
+++ b/crates/validator/src/service.rs
@@ -56,7 +56,7 @@ impl Service for DummyService {
     type Effects = Pure;
     type Actions = Self;
 
-    fn components(&self) -> (Self::Transition, Self::Effects, Self::Actions) {
+    fn components(self) -> (Self::Transition, Self::Effects, Self::Actions) {
         (Self, Pure, Self)
     }
 }


### PR DESCRIPTION
This PR is an attempt at implementing pure state transition functions with an effect handling system. This allows the state transition function to no longer take a `&mut self` and no longer be async. Processes that require side-effects must be done through the effect system.

### Context and Motivation

When we introduced the state machine component, we originally made the state transition function be an `async fn(&mut self)`. While state transition functions are _generally_ side-effect free, this is not generally true for all cases in the validator:

1. Nonce generation and use is impure, if we use a nonce once, and then we reorg and require the same nonce again, **we cannot reuse it**
2. Random coefficients during DKG is impure, if we reorg we cannot generate new ones because the action with their commitment may already have been submitted making them non-adjustable for a given DKG ceremony

### Design and Tradeoffs

The implementation changes the state transition function to be pure (`fn(&self)`) and adds an effect system where the impure operations can be modeled.

- Nomenclature for the inputs and output were inspired by [Elm](https://guide.elm-lang.org/) which was a pioneer in the FRP model that we apply here:
  - `Message`s are inputs to the state transition (or "update") function; previously there were `new_block` and `event` and they are now `NewBlock`, `Event` and `Resume`. `Resume` is a message that provides a result from performing an effect
  - `Command`s are the outputs to the state transition beside the new state; previously they were `Action`s, and now they are `Action`s and `Effect`s. `Effect`s are the new system which allow for some internal impure computation to happen which must produce some result (error results must be provided back to the state machine), while actions are dedicated for onchain transacions.
- As previously discussed, the `Service` is now broken up into different components that implement the different parts required by the `Driver`. This allows clearer isolation between the pure and impure parts (not to mention things like contract addresses are not generally needed for state transitions and only used for transaction encoding).

#### Porting Sentinel Service

To avoid making this PR too big, I just ported the Sentinel service 1:1. Now that we split the service into its components, it would make sense for the service to split up into parts, but as a separate PR. The Sentinel specific changes were kept in a separate commit to make reviewing easier: https://github.com/safe-research/safenet/pull/512/commits/f2f4a94170318a5a722764a8d6710f54b52741c6.

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://docs.safefoundation.org/cla).
