### PR TITLE
Make expires_at optional

### DIFF
--- a/crates/core/src/driver.rs
+++ b/crates/core/src/driver.rs
@@ -58,8 +58,8 @@ pub enum Error {
 pub trait ActionEncoder<Action> {
     /// Encodes state transition `action` into a transaction to submit onchain,
     /// each paired with the block number after which it should be dropped if it
-    /// has not yet been submitted.
-    fn encode_action(&self, action: Action) -> (Transaction, u64);
+    /// has not yet been submitted, or `None` if it should never be dropped.
+    fn encode_action(&self, action: Action) -> (Transaction, Option<u64>);
 }
 
 /// A Safenet service definition.

--- a/crates/core/src/tx/mod.rs
+++ b/crates/core/src/tx/mod.rs
@@ -124,11 +124,12 @@ where
     }
 
     /// Queues `transaction` for execution, to be dropped if it has not been
-    /// submitted by block `expires_at`, then attempts to submit it (and any
-    /// other queued transactions) onchain.
+    /// submitted by block `expires_at`, or never dropped if `expires_at` is
+    /// `None`, then attempts to submit it (and any other queued transactions)
+    /// onchain.
     pub async fn queue(
         &mut self,
-        transactions: impl IntoIterator<Item = (Transaction, u64)>,
+        transactions: impl IntoIterator<Item = (Transaction, Option<u64>)>,
     ) -> Result<(), Error> {
         self.storage.enqueue(transactions).await?;
         self.submit_pending().await
@@ -457,7 +458,7 @@ mod tests {
     async fn submits_queued_transactions_with_reorg_awareness() {
         let asserter = Asserter::new();
         let mut queue = queue(&asserter).await;
-        queue.queue([(tx("0x01"), 1000)]).await.unwrap();
+        queue.queue([(tx("0x01"), Some(1000))]).await.unwrap();
 
         asserter.push_success(&U64::from(0)); // signer transaction count
         asserter.push_success(&fee_history()); // fee estimate
@@ -515,7 +516,7 @@ mod tests {
         asserter.push_success(&fee_history()); // fee estimate
         for i in 0..queue.config.max_in_flight_transactions {
             queue
-                .queue([(tx(&format!("0x{i:02x}")), 12)])
+                .queue([(tx(&format!("0x{i:02x}")), Some(12))])
                 .await
                 .unwrap();
             asserter.push_success(&B256::ZERO); // transaction hash from submission
@@ -523,8 +524,8 @@ mod tests {
 
         // Add two more transactions that cannot be submitted because of the
         // in-flight limit.
-        queue.queue([(tx("0xf0"), 12)]).await.unwrap();
-        queue.queue([(tx("0xf1"), 12)]).await.unwrap();
+        queue.queue([(tx("0xf0"), Some(12))]).await.unwrap();
+        queue.queue([(tx("0xf1"), Some(12))]).await.unwrap();
 
         // Observe a block to submit some of the transactions.
         queue.handle_block_update(new_block(10)).await.unwrap();
@@ -576,7 +577,7 @@ mod tests {
         assert!(asserter.read_q().is_empty());
 
         // queue a transaction long expired.
-        queue.queue([(tx("0x01"), 42)]).await.unwrap();
+        queue.queue([(tx("0x01"), Some(42))]).await.unwrap();
 
         // now queue a block update, the transaction is not submitted as it is
         // expired and was never submitted to an RPC node.
@@ -593,14 +594,14 @@ mod tests {
         // cheap enough for the signer to afford, so its failure is treated as a
         // general error; the second has a high gas limit the signer cannot
         // afford, so its failure is treated as the node rejecting it.
-        queue.queue([(tx("0x01"), 1000)]).await.unwrap();
+        queue.queue([(tx("0x01"), Some(1000))]).await.unwrap();
         queue
             .queue([(
                 Transaction {
                     gas: 1_000_000,
                     ..tx("0x02")
                 },
-                1000,
+                Some(1000),
             )])
             .await
             .unwrap();

--- a/crates/core/src/tx/storage.rs
+++ b/crates/core/src/tx/storage.rs
@@ -69,7 +69,7 @@ impl TransactionStorage {
             "CREATE TABLE IF NOT EXISTS transactions (
                  id           INTEGER PRIMARY KEY,
                  request      TEXT    NOT NULL,
-                 expires_at   INTEGER NOT NULL,
+                 expires_at   INTEGER DEFAULT NULL,
                  nonce        INTEGER DEFAULT NULL,
                  submitted_at INTEGER DEFAULT NULL,
                  executed_at  INTEGER DEFAULT NULL
@@ -82,18 +82,19 @@ impl TransactionStorage {
     }
 
     /// Stores `transactions` as queued transactions, each expiring at its
-    /// `expires_at` block if it has not been submitted by then. The whole batch
-    /// is inserted atomically.
+    /// `expires_at` block if it has not been submitted by then, or never
+    /// expiring if `expires_at` is `None`. The whole batch is inserted
+    /// atomically.
     pub async fn enqueue(
         &self,
-        transactions: impl IntoIterator<Item = (Transaction, u64)>,
+        transactions: impl IntoIterator<Item = (Transaction, Option<u64>)>,
     ) -> Result<(), Error> {
         let mut tx = self.pool.begin().await?;
         for (transaction, expires_at) in transactions {
             let request = serde_json::to_string(&transaction)?;
             sqlx::query("INSERT INTO transactions (request, expires_at) VALUES (?, ?)")
                 .bind(request)
-                .bind(i64::try_from(expires_at)?)
+                .bind(expires_at.map(i64::try_from).transpose()?)
                 .execute(&mut *tx)
                 .await?;
         }
@@ -147,7 +148,7 @@ impl TransactionStorage {
                  ))
              WHERE id = (
                  SELECT id FROM transactions
-                 WHERE nonce IS NULL AND expires_at > ?
+                 WHERE nonce IS NULL AND (expires_at IS NULL OR expires_at > ?)
                  ORDER BY id ASC
                  LIMIT 1
              )
@@ -207,7 +208,8 @@ impl TransactionStorage {
     pub async fn count_outstanding(&self, block: u64) -> Result<usize, Error> {
         let count = sqlx::query_scalar::<_, i64>(
             "SELECT COUNT(*) FROM transactions
-             WHERE executed_at IS NULL AND (nonce IS NOT NULL OR expires_at > ?)",
+             WHERE executed_at IS NULL
+               AND (nonce IS NOT NULL OR expires_at IS NULL OR expires_at > ?)",
         )
         .bind(i64::try_from(block)?)
         .fetch_one(&self.pool)
@@ -249,11 +251,16 @@ impl TransactionStorage {
             .await?;
 
         // Remove queued (not-yet-submitted) transactions that expired at or
-        // before the reorg-safe block.
-        sqlx::query("DELETE FROM transactions WHERE nonce IS NULL AND expires_at <= ?")
-            .bind(safe)
-            .execute(&mut *tx)
-            .await?;
+        // before the reorg-safe block. Never-expiring transactions have a
+        // `NULL` `expires_at` and are excluded explicitly rather than relying
+        // on the fact that SQL comparisons against `NULL` are never true.
+        sqlx::query(
+            "DELETE FROM transactions
+             WHERE nonce IS NULL AND expires_at IS NOT NULL AND expires_at <= ?",
+        )
+        .bind(safe)
+        .execute(&mut *tx)
+        .await?;
 
         tx.commit().await?;
         Ok(())
@@ -351,7 +358,7 @@ mod tests {
     #[tokio::test]
     async fn submit_assigns_the_account_nonce_and_fees() {
         let storage = storage().await;
-        storage.enqueue([(tx("0x5afe"), 100)]).await.unwrap();
+        storage.enqueue([(tx("0x5afe"), Some(100))]).await.unwrap();
 
         // There are no in flight transactions to begin with.
         assert_eq!(storage.count_in_flight().await.unwrap(), 0);
@@ -379,9 +386,18 @@ mod tests {
     #[tokio::test]
     async fn submit_assigns_sequential_nonces_in_queue_order() {
         let storage = storage().await;
-        storage.enqueue([(tx("0x5afe01"), 100)]).await.unwrap();
-        storage.enqueue([(tx("0x5afe02"), 100)]).await.unwrap();
-        storage.enqueue([(tx("0x5afe03"), 100)]).await.unwrap();
+        storage
+            .enqueue([(tx("0x5afe01"), Some(100))])
+            .await
+            .unwrap();
+        storage
+            .enqueue([(tx("0x5afe02"), Some(100))])
+            .await
+            .unwrap();
+        storage
+            .enqueue([(tx("0x5afe03"), Some(100))])
+            .await
+            .unwrap();
 
         // Each submission picks the next free nonce above the in-flight ones, in
         // FIFO order.
@@ -399,7 +415,7 @@ mod tests {
     #[tokio::test]
     async fn record_submission_stamps_the_block_and_fees() {
         let storage = storage().await;
-        storage.enqueue([(tx("0x5afe"), 100)]).await.unwrap();
+        storage.enqueue([(tx("0x5afe"), Some(100))]).await.unwrap();
         let submitted = storage
             .next_transaction(Status { nonce: 5, block: 0 })
             .await
@@ -430,7 +446,7 @@ mod tests {
     #[tokio::test]
     async fn record_submission_errors_for_an_unknown_nonce() {
         let storage = storage().await;
-        storage.enqueue([(tx("0x5afe"), 100)]).await.unwrap();
+        storage.enqueue([(tx("0x5afe"), Some(100))]).await.unwrap();
         storage
             .next_transaction(Status { nonce: 5, block: 0 })
             .await
@@ -452,8 +468,8 @@ mod tests {
     #[tokio::test]
     async fn prunes_queued_transactions_past_their_expiry() {
         let storage = storage().await;
-        storage.enqueue([(tx("0x5afe01"), 10)]).await.unwrap();
-        storage.enqueue([(tx("0x5afe02"), 20)]).await.unwrap();
+        storage.enqueue([(tx("0x5afe01"), Some(10))]).await.unwrap();
+        storage.enqueue([(tx("0x5afe02"), Some(20))]).await.unwrap();
 
         // Pruning at a safe block of 15 removes the first transaction (expiry
         // 10); the second (expiry 20) is not yet expired.
@@ -465,5 +481,25 @@ mod tests {
             .unwrap()
             .unwrap();
         assert_eq!(next.transaction.data, tx("0x5afe02").data);
+    }
+
+    #[tokio::test]
+    async fn never_expiring_transactions_are_always_selectable_and_never_pruned() {
+        let storage = storage().await;
+        storage.enqueue([(tx("0x5afe"), None)]).await.unwrap();
+
+        // Pruning at any safe block does not remove a never-expiring queued
+        // transaction.
+        storage.prune(1_000_000).await.unwrap();
+
+        let next = storage
+            .next_transaction(Status {
+                nonce: 0,
+                block: 1_000_000,
+            })
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(next.transaction.data, tx("0x5afe").data);
     }
 }

--- a/crates/sentinel/src/action.rs
+++ b/crates/sentinel/src/action.rs
@@ -19,9 +19,10 @@ pub enum SentinelActionKind {
 /// no longer useful.
 ///
 /// The deadline is forwarded to the `TransactionQueue` as the per-tx expiry
-/// so the queue can drop it if it goes unsubmitted past that block.
+/// so the queue can drop it if it goes unsubmitted past that block. `None`
+/// means the action must never expire.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SentinelAction {
     pub kind: SentinelActionKind,
-    pub expires_at: u64,
+    pub expires_at: Option<u64>,
 }

--- a/crates/sentinel/src/service.rs
+++ b/crates/sentinel/src/service.rs
@@ -151,11 +151,11 @@ impl SentinelTransition {
                 kind: SentinelActionKind::ApproveToken {
                     bond: event.bondTarget,
                 },
-                expires_at: deadline,
+                expires_at: Some(deadline),
             },
             SentinelAction {
                 kind: vote,
-                expires_at: deadline,
+                expires_at: Some(deadline),
             },
         ];
         (state, actions)
@@ -214,7 +214,7 @@ impl SentinelTransition {
                 },
                 // Claiming has no onchain deadline, so the action must never
                 // expire in the `TransactionQueue`.
-                expires_at: u64::MAX,
+                expires_at: None,
             }]
         } else {
             Vec::new()
@@ -242,7 +242,7 @@ impl SentinelTransition {
                     request.deadline = block.saturating_add(self.voting_window);
                     actions.push(SentinelAction {
                         kind: SentinelActionKind::Finalize { id },
-                        expires_at: request.deadline,
+                        expires_at: Some(request.deadline),
                     });
                     true
                 }
@@ -342,7 +342,7 @@ impl StateTransition<State> for SentinelTransition {
 }
 
 impl ActionEncoder<SentinelAction> for SentinelEncoder {
-    fn encode_action(&self, action: SentinelAction) -> (Transaction, u64) {
+    fn encode_action(&self, action: SentinelAction) -> (Transaction, Option<u64>) {
         (self.encode_action_kind(action.kind), action.expires_at)
     }
 }
@@ -585,11 +585,11 @@ mod tests {
                     kind: SentinelActionKind::ApproveToken {
                         bond: U256::from(1_000u64)
                     },
-                    expires_at: 50,
+                    expires_at: Some(50),
                 }),
                 Command::Action(SentinelAction {
                     kind: SentinelActionKind::CommitApprove { id },
-                    expires_at: 50,
+                    expires_at: Some(50),
                 }),
             ]
         );
@@ -622,11 +622,11 @@ mod tests {
                     kind: SentinelActionKind::ApproveToken {
                         bond: U256::from(1_000u64)
                     },
-                    expires_at: 50,
+                    expires_at: Some(50),
                 }),
                 Command::Action(SentinelAction {
                     kind: SentinelActionKind::CommitDeny { id },
-                    expires_at: 50,
+                    expires_at: Some(50),
                 }),
             ]
         );
@@ -720,7 +720,7 @@ mod tests {
             commands,
             vec![Command::Action(SentinelAction {
                 kind: SentinelActionKind::Claim { id },
-                expires_at: u64::MAX,
+                expires_at: None,
             })]
         );
     }
@@ -739,7 +739,7 @@ mod tests {
             commands,
             vec![Command::Action(SentinelAction {
                 kind: SentinelActionKind::Claim { id },
-                expires_at: u64::MAX,
+                expires_at: None,
             })]
         );
     }
@@ -758,7 +758,7 @@ mod tests {
             commands,
             vec![Command::Action(SentinelAction {
                 kind: SentinelActionKind::Claim { id },
-                expires_at: u64::MAX,
+                expires_at: None,
             })]
         );
     }
@@ -837,7 +837,7 @@ mod tests {
             commands,
             vec![Command::Action(SentinelAction {
                 kind: SentinelActionKind::Finalize { id },
-                expires_at: 51 + VOTING_WINDOW,
+                expires_at: Some(51 + VOTING_WINDOW),
             })]
         );
     }
@@ -982,15 +982,15 @@ mod tests {
         for action in [
             SentinelAction {
                 kind: SentinelActionKind::ApproveToken { bond },
-                expires_at: deadline,
+                expires_at: Some(deadline),
             },
             SentinelAction {
                 kind: SentinelActionKind::CommitApprove { id },
-                expires_at: deadline,
+                expires_at: Some(deadline),
             },
         ] {
             let (_, encoded_deadline) = encoder().encode_action(action);
-            assert_eq!(encoded_deadline, deadline);
+            assert_eq!(encoded_deadline, Some(deadline));
         }
     }
 }

--- a/crates/validator/src/service.rs
+++ b/crates/validator/src/service.rs
@@ -43,7 +43,7 @@ impl StateTransition<()> for DummyService {
 }
 
 impl ActionEncoder<Infallible> for DummyService {
-    fn encode_action(&self, action: Infallible) -> (Transaction, u64) {
+    fn encode_action(&self, action: Infallible) -> (Transaction, Option<u64>) {
         match action {}
     }
 }


### PR DESCRIPTION
Some actions never expire (i.e. claiming rewards from the Sentinel oracle) and therefore should not expire. Changing epires_at to an Option avoids the workaround using i64::max.

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://docs.safefoundation.org/cla).
