### PR TITLE
[B 1]: Implement ECDH

### DIFF
--- a/crates/validator/src/bindings.rs
+++ b/crates/validator/src/bindings.rs
@@ -21,7 +21,7 @@ sol! {
     /// `r` and the scalar component `z`. Onchain attestations and completed
     /// signatures share this shape.
     #[derive(Debug, Default)]
-    struct Attestation {
+    struct Signature {
         Point r;
         uint256 z;
     }
@@ -119,7 +119,7 @@ sol! {
             bytes32 groupId,
             Point groupKey,
             bytes32 signatureId,
-            Attestation attestation
+            Signature attestation
         );
         event TransactionProposed(
             bytes32 indexed safeTxHash,
@@ -134,7 +134,7 @@ sol! {
             address indexed safe,
             uint64 epoch,
             bytes32 signatureId,
-            Attestation attestation
+            Signature attestation
         );
         event OracleTransactionProposed(
             bytes32 indexed safeTxHash,
@@ -151,7 +151,7 @@ sol! {
             uint64 epoch,
             address oracle,
             bytes32 signatureId,
-            Attestation attestation
+            Signature attestation
         );
         event ValidatorStakerSet(address indexed validator, address staker);
 
@@ -220,7 +220,7 @@ sol! {
         );
         event SignRevealedNonces(bytes32 indexed sid, address participant, SignNonces nonces);
         event SignShared(bytes32 indexed sid, bytes32 indexed selectionRoot, address participant, uint256 z);
-        event SignCompleted(bytes32 indexed sid, bytes32 indexed selectionRoot, Attestation signature);
+        event SignCompleted(bytes32 indexed sid, bytes32 indexed selectionRoot, Signature signature);
 
         function keyGenAndCommit(
             bytes32 participants,

--- a/crates/validator/src/frost/ecdh.rs
+++ b/crates/validator/src/frost/ecdh.rs
@@ -1,0 +1,146 @@
+//! ECDH-XOR encryption of FROST secret shares for the onchain publishing
+//! channel.
+
+use crate::bindings;
+
+use super::{error::Error, marshal};
+use alloy::primitives::B256;
+use k256::{
+    NonZeroScalar, ProjectivePoint, Scalar,
+    elliptic_curve::{
+        hash2curve::{self, ExpandMsgXmd},
+        point::AffineCoordinates as _,
+        zeroize::{Zeroize, ZeroizeOnDrop},
+    },
+    sha2::Sha256,
+};
+use rand::{CryptoRng, RngCore};
+use serde::{Deserialize, Serialize};
+
+/// A locally-generated ECDH encryption key. The secret scalar is sampled by the
+/// effect handler and never leaves the secret store; only [`public_key`] is
+/// published onchain.
+///
+/// [`public_key`]: EncryptionKey::public_key
+#[derive(Clone, Deserialize, Serialize)]
+pub struct EncryptionKey(NonZeroScalar);
+
+impl EncryptionKey {
+    /// Samples a fresh encryption key from `rng`.
+    pub fn generate<R>(mut rng: R) -> Self
+    where
+        R: CryptoRng + RngCore,
+    {
+        let mut entropy = [0; 32];
+        rng.fill_bytes(&mut entropy);
+        Self(hash_to_scalar(b"enc", &entropy))
+    }
+
+    /// The public key `q` published onchain for peers to encrypt shares to.
+    pub fn public_key(&self) -> bindings::Point {
+        let public_key = ProjectivePoint::GENERATOR * *self.0;
+        marshal::solidity_point(&public_key)
+    }
+
+    /// Encrypts or decrypts a 32-byte secret-share `msg` against a peer's
+    /// encryption public key. See [`ecdh`].
+    pub fn ecdh(&self, public_key: &bindings::Point, msg: B256) -> Result<B256, Error> {
+        let public_key = marshal::frost_point(public_key)?;
+        let encrypted = ecdh(&self.0, &public_key, msg.0)?;
+        Ok(encrypted.into())
+    }
+}
+
+impl Drop for EncryptionKey {
+    fn drop(&mut self) {
+        self.0.zeroize();
+    }
+}
+
+impl ZeroizeOnDrop for EncryptionKey {}
+
+/// Encrypts or decrypts `msg` via ECDH: `msg XOR (receiver_pubkey * sender_privkey).x`.
+///
+/// XOR is its own inverse, so this serves both directions. `receiver_pubkey`
+/// must be a valid non-identity point and `sender_privkey` must be non-zero.
+fn ecdh(
+    sender_privkey: &NonZeroScalar,
+    receiver_pubkey: &ProjectivePoint,
+    msg: [u8; 32],
+) -> Result<[u8; 32], Error> {
+    if *receiver_pubkey == ProjectivePoint::IDENTITY {
+        return Err(Error::malformed_element());
+    }
+
+    let shared_secret = (*receiver_pubkey * **sender_privkey).to_affine().x();
+    let mut result = msg;
+    for (byte, secret) in result.iter_mut().zip(shared_secret) {
+        *byte ^= secret;
+    }
+    Ok(result)
+}
+
+fn hash_to_scalar(discriminant: &[u8], msg: &[u8]) -> NonZeroScalar {
+    let mut u = [Scalar::ZERO];
+    hash2curve::hash_to_field::<ExpandMsgXmd<Sha256>, Scalar>(
+        &[msg],
+        &[b"FROST-secp256k1-SHA256-v1", discriminant],
+        &mut u,
+    )
+    .expect("hash to secp256k1 scalar never fails for a single output");
+    NonZeroScalar::new(u[0]).expect("hashing to zero is cryptographically impossible")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn key(pk: u64) -> EncryptionKey {
+        EncryptionKey(NonZeroScalar::new(Scalar::from(pk)).unwrap())
+    }
+
+    fn m(msg: [u8; 32]) -> B256 {
+        msg.into()
+    }
+
+    #[test]
+    fn roundtrip_encrypt_decrypt() {
+        let mut rng = rand::thread_rng();
+        let key = EncryptionKey::generate(&mut rng);
+        let peer = EncryptionKey::generate(&mut rng);
+        let msg = m([0x5a; 32]);
+
+        let enc = key.ecdh(&peer.public_key(), msg).unwrap();
+        let dec = peer.ecdh(&key.public_key(), enc).unwrap();
+        assert_eq!(dec, msg);
+    }
+
+    #[test]
+    fn ecdh_is_commutative() {
+        let alice = key(2);
+        let bob = key(3);
+        let msg = m([0x42; 32]);
+        assert_eq!(
+            alice.ecdh(&bob.public_key(), msg).unwrap(),
+            bob.ecdh(&alice.public_key(), msg).unwrap(),
+        );
+    }
+
+    #[test]
+    fn different_recipient_different_ciphertext() {
+        let alice = key(2);
+        let bob = key(3);
+        let charlie = key(4);
+        let msg = m([0x42; 32]);
+        assert_ne!(
+            alice.ecdh(&bob.public_key(), msg).unwrap(),
+            alice.ecdh(&charlie.public_key(), msg).unwrap(),
+        );
+    }
+
+    #[test]
+    fn ecdh_rejects_degenerate_inputs() {
+        let alice = key(2);
+        assert!(alice.ecdh(&bindings::Point::default(), B256::ZERO).is_err());
+    }
+}

--- a/crates/validator/src/frost/error.rs
+++ b/crates/validator/src/frost/error.rs
@@ -1,0 +1,23 @@
+/// A Safenet FROST error.
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+    /// The underlying FROST ciphersuite error.
+    #[error(transparent)]
+    Frost(#[from] frost_secp256k1::Error),
+}
+
+impl Error {
+    /// An error indicating a malformed scalar.
+    pub const fn malformed_scalar() -> Self {
+        Self::Frost(frost_core::Error::FieldError(
+            frost_core::FieldError::MalformedScalar,
+        ))
+    }
+
+    /// An error indicating a malformed group element (point).
+    pub const fn malformed_element() -> Self {
+        Self::Frost(frost_core::Error::GroupError(
+            frost_core::GroupError::MalformedElement,
+        ))
+    }
+}

--- a/crates/validator/src/frost/marshal.rs
+++ b/crates/validator/src/frost/marshal.rs
@@ -1,0 +1,74 @@
+//! Marshalling between secp256k1 primitives and their Solidity types.
+
+use super::error::Error;
+use crate::bindings;
+use alloy::primitives::U256;
+use k256::{
+    Scalar,
+    elliptic_curve::{
+        Group, PrimeField as _,
+        sec1::{FromEncodedPoint as _, ToEncodedPoint as _},
+    },
+};
+
+/// Converts a secp256k1 point to the ABI `Point { uint256 x; uint256 y }`.
+pub fn solidity_point(point: &k256::ProjectivePoint) -> bindings::Point {
+    if point.is_identity().into() {
+        return bindings::Point {
+            x: U256::ZERO,
+            y: U256::ZERO,
+        };
+    }
+
+    let encoded = point.to_encoded_point(false);
+    let (chunks, _) = encoded.as_bytes()[1..].as_chunks::<32>();
+    bindings::Point {
+        x: U256::from_be_bytes(chunks[0]),
+        y: U256::from_be_bytes(chunks[1]),
+    }
+}
+
+/// Converts a secp256k1 scalar to a `U256`.
+pub fn solidity_scalar(scalar: &k256::Scalar) -> U256 {
+    U256::from_be_bytes(scalar.to_bytes().into())
+}
+
+/// Converts a FROST signature to the ABI `(Point r, uint256 z)` pair.
+pub fn solidity_signature(signature: &frost_secp256k1::Signature) -> bindings::Signature {
+    bindings::Signature {
+        r: solidity_point(signature.R()),
+        z: solidity_scalar(signature.z()),
+    }
+}
+
+/// Converts a `U256` to a canonical secp256k1 scalar.
+pub fn frost_scalar(scalar: &U256) -> Result<k256::Scalar, Error> {
+    Scalar::from_repr(scalar.to_be_bytes().into())
+        .into_option()
+        .ok_or_else(Error::malformed_element)
+}
+
+/// Converts an ABI `Point { uint256 x; uint256 y }` to a secp256k1 point. The
+/// zero point decodes to the identity.
+pub fn frost_point(point: &bindings::Point) -> Result<k256::ProjectivePoint, Error> {
+    if point.x.is_zero() && point.y.is_zero() {
+        return Ok(k256::ProjectivePoint::IDENTITY);
+    }
+
+    let mut buffer = [0; 65];
+    buffer[0] = 0x04;
+    buffer[1..33].copy_from_slice(&point.x.to_be_bytes::<32>());
+    buffer[33..65].copy_from_slice(&point.y.to_be_bytes::<32>());
+    let encoded = k256::EncodedPoint::from_bytes(buffer).map_err(|_| Error::malformed_element())?;
+    k256::ProjectivePoint::from_encoded_point(&encoded)
+        .into_option()
+        .ok_or_else(Error::malformed_element)
+}
+
+/// Converts an ABI Schnorr signature `(Point r, uint256 z)` to a FROST signature.
+pub fn frost_signature(r: &bindings::Point, z: &U256) -> Result<frost_secp256k1::Signature, Error> {
+    Ok(frost_secp256k1::Signature::new(
+        frost_point(r)?,
+        frost_scalar(z)?,
+    ))
+}

--- a/crates/validator/src/frost/mod.rs
+++ b/crates/validator/src/frost/mod.rs
@@ -1,0 +1,13 @@
+//! A thin Safenet-specific layer over the ZCash Foundation FROST crates.
+//!
+//! Safenet uses the standard RFC 9591 FROST(secp256k1, SHA-256) ciphersuite.
+//!
+//! This module provides an interface that is compatible with the onchain
+//! FROST coordinator contract, internally managing the marshalling between
+//! [`frost-secp256k1`] values and their Solidity ABI representations.
+
+#![expect(dead_code)]
+
+pub mod ecdh;
+pub mod error;
+pub mod marshal;

--- a/crates/validator/src/main.rs
+++ b/crates/validator/src/main.rs
@@ -1,5 +1,6 @@
 mod bindings;
 mod config;
+mod frost;
 mod service;
 
 use self::{config::Config, service::DummyService};


### PR DESCRIPTION
This PR introduces a FROST module to the validator and implements the ECDH protocol used for secret share encryption.

> [!IMPORTANT]
> The order of the phase B sub-phases is different from what was specified in the epic; I chose a slightly different order to implement things that made more sense to me.

### Decisions and Tradeoffs

The `frost` module in the validator is designed to provide an interface that works with the Solidity interface of the FROST coordinator contracts. That is, it handles marshaling to and from Solidity ABI structs to internal `frost-secp256k1` and `k256` representations internally.

The `EncryptionKey` implements serialization traits so that it can read and write to an SQLite store.

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://docs.safefoundation.org/cla).
