### PR TITLE
[B 2]: Implement Key Generation

### DIFF
--- a/crates/validator/src/frost/ecdh.rs
+++ b/crates/validator/src/frost/ecdh.rs
@@ -1,10 +1,7 @@
 //! ECDH-XOR encryption of FROST secret shares for the onchain publishing
 //! channel.
 
-use crate::bindings;
-
-use super::{error::Error, marshal};
-use alloy::primitives::B256;
+use super::error::Error;
 use k256::{
     NonZeroScalar, ProjectivePoint, Scalar,
     elliptic_curve::{
@@ -37,17 +34,19 @@ impl EncryptionKey {
     }
 
     /// The public key `q` published onchain for peers to encrypt shares to.
-    pub fn public_key(&self) -> bindings::Point {
-        let public_key = ProjectivePoint::GENERATOR * *self.0;
-        marshal::solidity_point(&public_key)
+    pub(super) fn public_key(&self) -> ProjectivePoint {
+        ProjectivePoint::GENERATOR * *self.0
     }
 
     /// Encrypts or decrypts a 32-byte secret-share `msg` against a peer's
     /// encryption public key. See [`ecdh`].
-    pub fn ecdh(&self, public_key: &bindings::Point, msg: B256) -> Result<B256, Error> {
-        let public_key = marshal::frost_point(public_key)?;
-        let encrypted = ecdh(&self.0, &public_key, msg.0)?;
-        Ok(encrypted.into())
+    pub(super) fn ecdh(
+        &self,
+        public_key: &ProjectivePoint,
+        msg: [u8; 32],
+    ) -> Result<[u8; 32], Error> {
+        let encrypted = ecdh(&self.0, public_key, msg)?;
+        Ok(encrypted)
     }
 }
 
@@ -99,16 +98,12 @@ mod tests {
         EncryptionKey(NonZeroScalar::new(Scalar::from(pk)).unwrap())
     }
 
-    fn m(msg: [u8; 32]) -> B256 {
-        msg.into()
-    }
-
     #[test]
     fn roundtrip_encrypt_decrypt() {
         let mut rng = rand::thread_rng();
         let key = EncryptionKey::generate(&mut rng);
         let peer = EncryptionKey::generate(&mut rng);
-        let msg = m([0x5a; 32]);
+        let msg = [0x5a; 32];
 
         let enc = key.ecdh(&peer.public_key(), msg).unwrap();
         let dec = peer.ecdh(&key.public_key(), enc).unwrap();
@@ -119,7 +114,7 @@ mod tests {
     fn ecdh_is_commutative() {
         let alice = key(2);
         let bob = key(3);
-        let msg = m([0x42; 32]);
+        let msg = [0x00; 32];
         assert_eq!(
             alice.ecdh(&bob.public_key(), msg).unwrap(),
             bob.ecdh(&alice.public_key(), msg).unwrap(),
@@ -131,7 +126,7 @@ mod tests {
         let alice = key(2);
         let bob = key(3);
         let charlie = key(4);
-        let msg = m([0x42; 32]);
+        let msg = [0xff; 32];
         assert_ne!(
             alice.ecdh(&bob.public_key(), msg).unwrap(),
             alice.ecdh(&charlie.public_key(), msg).unwrap(),
@@ -141,6 +136,6 @@ mod tests {
     #[test]
     fn ecdh_rejects_degenerate_inputs() {
         let alice = key(2);
-        assert!(alice.ecdh(&bindings::Point::default(), B256::ZERO).is_err());
+        assert!(alice.ecdh(&ProjectivePoint::IDENTITY, [0xff; 32]).is_err());
     }
 }

--- a/crates/validator/src/frost/keygen.rs
+++ b/crates/validator/src/frost/keygen.rs
@@ -1,0 +1,175 @@
+//! Distributed key generation, driving the FROST `keys::dkg::part{1,2,3}`
+//! rounds with address-derived identifiers and ECDH-encrypted secret shares.
+
+use super::{ecdh::EncryptionKey, error::Error, marshal, participants};
+use crate::bindings;
+use alloy::primitives::Address;
+use frost_secp256k1::{
+    Identifier,
+    keys::{
+        self, PublicKeyPackage,
+        dkg::{self, round1, round2},
+    },
+};
+use k256::{ProjectivePoint, elliptic_curve::PrimeField as _};
+use std::collections::BTreeMap;
+
+/// The output of DKG round 1: the secret polynomial (persisted to the secret
+/// store) and the onchain commitment to publish.
+pub struct Round1 {
+    pub encryption_key: EncryptionKey,
+    pub secret_package: round1::SecretPackage,
+    pub commitment: bindings::KeyGenCommitment,
+}
+
+/// Runs DKG round 1 for `me`, producing the round 1 secret package and the
+/// onchain [`KeyGenCommitment`](bindings::KeyGenCommitment). The `encryption_key`
+/// and `rng` are supplied (and the secrets persisted) by the caller.
+pub fn generate_round1<R>(
+    rng: &mut R,
+    me: Address,
+    max_signers: u16,
+    min_signers: u16,
+) -> Result<Round1, Error>
+where
+    R: rand::RngCore + rand::CryptoRng,
+{
+    let identifier = participants::identifier(me);
+    let encryption_key = EncryptionKey::generate(&mut *rng);
+    let (secret_package, package) = dkg::part1(identifier, max_signers, min_signers, &mut *rng)?;
+    let commitment = marshal::solidity_commitment(&encryption_key.public_key(), &package);
+    Ok(Round1 {
+        encryption_key,
+        secret_package,
+        commitment,
+    })
+}
+
+/// The output of DKG round 2: the secret package (persisted) and the onchain
+/// secret share to publish.
+pub struct Round2 {
+    pub secret_package: round2::SecretPackage,
+    pub share: bindings::KeyGenSecretShare,
+}
+
+/// Runs DKG round 2 for `me` given every participant's round 1 commitment
+/// (including `me`'s own). Produces the round 2 secret package and the ECDH
+/// encrypted secret shares for the peers, ordered by ascending peer address.
+pub fn generate_round2(
+    me: Address,
+    encryption_key: &EncryptionKey,
+    secret_package: &round1::SecretPackage,
+    commitments: &BTreeMap<Address, bindings::KeyGenCommitment>,
+) -> Result<Round2, Error> {
+    let (encryption_keys, round1_packages) = decode_peer_commitments(me, commitments)?;
+    let (secret_package, round2_packages) = dkg::part2(secret_package.clone(), &round1_packages)?;
+
+    let public_key_package = PublicKeyPackage::from_dkg_commitments(
+        &round1_packages
+            .iter()
+            .map(|(identifier, package)| (*identifier, package.commitment()))
+            .chain(std::iter::once((
+                *secret_package.identifier(),
+                secret_package.commitment(),
+            )))
+            .collect(),
+    )?;
+    let verifying_share = public_key_package
+        .verifying_shares()
+        .get(secret_package.identifier())
+        .ok_or(frost_secp256k1::Error::IncorrectNumberOfPackages)?;
+
+    let encrypted_shares = encryption_keys
+        .iter()
+        .map(|(peer, encryption_key_peer)| {
+            let package = round2_packages
+                .get(&participants::identifier(*peer))
+                .ok_or(frost_secp256k1::Error::UnknownIdentifier)?;
+            let signing_share = package.signing_share().to_scalar().to_bytes().into();
+            encryption_key.ecdh(encryption_key_peer, signing_share)
+        })
+        .collect::<Result<Vec<_>, Error>>()?;
+    let share = marshal::solidity_secret_share(verifying_share, &encrypted_shares);
+
+    Ok(Round2 {
+        secret_package,
+        share,
+    })
+}
+
+/// The output of DKG round 3: the finalized key material.
+pub struct Round3 {
+    pub key_package: keys::KeyPackage,
+    pub public_key_package: PublicKeyPackage,
+}
+
+/// Runs DKG round 3 for `me`, decrypting the peers' secret shares (indexed by
+/// `me`'s position in each publisher's address-ordered participant set) and
+/// finalizing the group key material.
+pub fn generate_round3(
+    me: Address,
+    encryption_key: &EncryptionKey,
+    secret_package: &round2::SecretPackage,
+    commitments: &BTreeMap<Address, bindings::KeyGenCommitment>,
+    shares: &BTreeMap<Address, bindings::KeyGenSecretShare>,
+) -> Result<Round3, Error> {
+    let (encryption_keys, round1_packages) = decode_peer_commitments(me, commitments)?;
+    let round2_packages = shares
+        .iter()
+        .filter(|(publisher, _)| **publisher != me)
+        .map(|(publisher, share)| {
+            let index = shares
+                .keys()
+                .filter(|address| *address != publisher)
+                .position(|address| *address == me)
+                .ok_or(frost_secp256k1::Error::UnknownIdentifier)?;
+            let encrypted = share
+                .f
+                .get(index)
+                .ok_or(frost_core::Error::IncorrectNumberOfShares)?;
+            let encryption_key_peer = encryption_keys
+                .get(publisher)
+                .ok_or(frost_secp256k1::Error::UnknownIdentifier)?;
+            let secret_share = encryption_key.ecdh(encryption_key_peer, encrypted.to_be_bytes())?;
+            let signing_share = keys::SigningShare::new(
+                k256::Scalar::from_repr(secret_share.into())
+                    .into_option()
+                    .ok_or_else(Error::malformed_scalar)?,
+            );
+            Ok((
+                participants::identifier(*publisher),
+                round2::Package::new(signing_share),
+            ))
+        })
+        .collect::<Result<BTreeMap<_, _>, Error>>()?;
+
+    let (key_package, public_key_package) =
+        dkg::part3(secret_package, &round1_packages, &round2_packages)?;
+    Ok(Round3 {
+        key_package,
+        public_key_package,
+    })
+}
+
+type PeerCommitments = (
+    BTreeMap<Address, ProjectivePoint>,
+    BTreeMap<Identifier, round1::Package>,
+);
+
+fn decode_peer_commitments(
+    me: Address,
+    commitments: &BTreeMap<Address, bindings::KeyGenCommitment>,
+) -> Result<PeerCommitments, Error> {
+    let mut encryption_keys = BTreeMap::new();
+    let mut round1_packages = BTreeMap::new();
+    for (address, commitment) in commitments {
+        if *address == me {
+            continue;
+        }
+
+        let (encryption_key, package) = marshal::frost_commitment(commitment)?;
+        encryption_keys.insert(*address, encryption_key);
+        round1_packages.insert(participants::identifier(*address), package);
+    }
+    Ok((encryption_keys, round1_packages))
+}

--- a/crates/validator/src/frost/marshal.rs
+++ b/crates/validator/src/frost/marshal.rs
@@ -3,6 +3,7 @@
 use super::error::Error;
 use crate::bindings;
 use alloy::primitives::U256;
+use frost_secp256k1::keys::{self, dkg};
 use k256::{
     Scalar,
     elliptic_curve::{
@@ -10,6 +11,48 @@ use k256::{
         sec1::{FromEncodedPoint as _, ToEncodedPoint as _},
     },
 };
+
+/// Converts a DKG round 1 [`Package`](dkg::round1::Package) and an encryption
+/// public key to the ABI [`KeyGenCommitment`](bindings::KeyGenCommitment):
+///
+/// - `q`  the encryption public key for ECDH-encrypted secret shares,
+/// - `c`  all coefficient commitments `[g^a₀, …, g^a_{t-1}]`,
+/// - `r`  the proof-of-knowledge nonce commitment `R`,
+/// - `mu` the proof-of-knowledge scalar `μ`.
+pub fn solidity_commitment(
+    encryption_public_key: &k256::ProjectivePoint,
+    package: &dkg::round1::Package,
+) -> bindings::KeyGenCommitment {
+    let q = solidity_point(encryption_public_key);
+    let c = package
+        .commitment()
+        .coefficients()
+        .iter()
+        .map(|coefficient| solidity_point(&coefficient.value()))
+        .collect();
+    let bindings::Signature { r, z } = solidity_signature(package.proof_of_knowledge());
+    bindings::KeyGenCommitment { q, c, r, mu: z }
+}
+
+/// Converts a verifying share and the peer-encrypted secret shares to the ABI
+/// [`KeyGenSecretShare`](bindings::KeyGenSecretShare).
+///
+/// `encrypted_secret_shares` must already be in the canonical publishing order
+/// (ascending participant address, excluding self), matching the TypeScript
+/// `KeyGenClient.createSecretShares`; the contract and peers index `f` by this
+/// order.
+pub fn solidity_secret_share(
+    verifying_share: &keys::VerifyingShare,
+    encrypted_secret_shares: &[[u8; 32]],
+) -> bindings::KeyGenSecretShare {
+    let y = solidity_point(&verifying_share.to_element());
+    let f = encrypted_secret_shares
+        .iter()
+        .copied()
+        .map(U256::from_be_bytes)
+        .collect();
+    bindings::KeyGenSecretShare { y, f }
+}
 
 /// Converts a secp256k1 point to the ABI `Point { uint256 x; uint256 y }`.
 pub fn solidity_point(point: &k256::ProjectivePoint) -> bindings::Point {
@@ -39,6 +82,27 @@ pub fn solidity_signature(signature: &frost_secp256k1::Signature) -> bindings::S
         r: solidity_point(signature.R()),
         z: solidity_scalar(signature.z()),
     }
+}
+
+/// Converts an ABI [`KeyGenCommitment`](bindings::KeyGenCommitment) back to the
+/// peer's encryption public key and DKG round 1 package.
+pub fn frost_commitment(
+    commitment: &bindings::KeyGenCommitment,
+) -> Result<(k256::ProjectivePoint, dkg::round1::Package), Error> {
+    let encryption_public_key = frost_point(&commitment.q)?;
+    let coefficients = keys::VerifiableSecretSharingCommitment::new(
+        commitment
+            .c
+            .iter()
+            .map(|coefficient| {
+                let coefficient = frost_point(coefficient)?;
+                Ok(frost_core::keys::CoefficientCommitment::new(coefficient))
+            })
+            .collect::<Result<_, Error>>()?,
+    );
+    let proof_of_knowledge = frost_signature(&commitment.r, &commitment.mu)?;
+    let package = dkg::round1::Package::new(coefficients, proof_of_knowledge);
+    Ok((encryption_public_key, package))
 }
 
 /// Converts a `U256` to a canonical secp256k1 scalar.

--- a/crates/validator/src/frost/mod.rs
+++ b/crates/validator/src/frost/mod.rs
@@ -10,4 +10,79 @@
 
 pub mod ecdh;
 pub mod error;
-pub mod marshal;
+pub mod keygen;
+mod marshal;
+mod participants;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloy::primitives::address;
+    use std::collections::BTreeMap;
+
+    #[test]
+    fn ceremony() {
+        let mut rng = rand::thread_rng();
+        let participants = [
+            address!("f39Fd6e51aad88F6F4ce6aB8827279cffFb92266"),
+            address!("70997970C51812dc3A010C7d01b50e0d17dc79C8"),
+            address!("3C44CdDdB6a900fa2b585dd299e03d12FA4293BC"),
+        ];
+        let count = participants.len() as u16;
+        let threshold = 2;
+
+        let mut round1 = BTreeMap::new();
+        for participant in participants {
+            let r1 = keygen::generate_round1(&mut rng, participant, count, threshold).unwrap();
+            round1.insert(participant, r1);
+        }
+
+        let commitments = participants
+            .into_iter()
+            .map(|participant| (participant, round1[&participant].commitment.clone()))
+            .collect();
+
+        let mut round2 = BTreeMap::new();
+        for participant in participants {
+            let r1 = &round1[&participant];
+            let r2 = keygen::generate_round2(
+                participant,
+                &r1.encryption_key,
+                &r1.secret_package,
+                &commitments,
+            )
+            .unwrap();
+            round2.insert(participant, r2);
+        }
+
+        let shares = participants
+            .into_iter()
+            .map(|participant| (participant, round2[&participant].share.clone()))
+            .collect();
+
+        let mut round3 = BTreeMap::new();
+        for participant in participants {
+            let r1 = &round1[&participant];
+            let r2 = &round2[&participant];
+            let r3 = keygen::generate_round3(
+                participant,
+                &r1.encryption_key,
+                &r2.secret_package,
+                &commitments,
+                &shares,
+            )
+            .unwrap();
+            round3.insert(participant, r3);
+        }
+
+        let group_key = round3
+            .values()
+            .next()
+            .unwrap()
+            .public_key_package
+            .verifying_key();
+        for r3 in round3.values() {
+            assert_eq!(group_key, r3.public_key_package.verifying_key());
+        }
+    }
+}

--- a/crates/validator/src/frost/participants.rs
+++ b/crates/validator/src/frost/participants.rs
@@ -1,0 +1,33 @@
+//! Address-derived FROST participant identifiers.
+//!
+//! Safenet keys participants by their Ethereum address rather than FROST's
+//! default sequential identifiers. The identifier is derived with the
+//! ciphersuite's `HID` hash (`hash_to_field` over the domain
+//! `"FROST-secp256k1-SHA256-v1id"`), which is exactly what the TypeScript
+//! `deriveParticipantId` (`hid(address)`) and the onchain
+//! `FROST.identifier(address)` compute, so the three agree by construction.
+
+use alloy::primitives::Address;
+use frost_secp256k1::Identifier;
+
+/// Derives the FROST [`Identifier`] for an Ethereum address.
+///
+/// Port of `deriveParticipantId` in `validator/src/frost/identifier.ts`.
+pub fn identifier(address: Address) -> Identifier {
+    Identifier::derive(address.as_slice())
+        .expect("FROST(secp256k1, SHA-256) always supports identifier derivation")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloy::primitives::address;
+
+    #[test]
+    fn identifier_is_deterministic_and_distinct() {
+        let a = address!("70997970C51812dc3A010C7d01b50e0d17dc79C8");
+        let b = address!("f39Fd6e51aad88F6F4ce6aB8827279cffFb92266");
+        assert_eq!(identifier(a), identifier(a));
+        assert_ne!(identifier(a), identifier(b));
+    }
+}


### PR DESCRIPTION
This PR adds the logic require for performing DKG in a way that is compatible with the TypeScript implementation.

### Design and Tradeoffs

It wraps the `frost-secp256k1` crate in a pretty straight forward way and adds some basic marshalling methods that are required for going to and from the Solidity representation of the FROST primitives.

Note that I made some small changes to the ECDH implementation, and made it be completely internal to the `frost` module; this is because I do not want external callers to be performing low-level cryptography.

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://docs.safefoundation.org/cla).
