### PR TITLE
[B 3i]: Make Encryption Infallible

### DIFF
--- a/crates/validator/src/frost/ecdh.rs
+++ b/crates/validator/src/frost/ecdh.rs
@@ -1,18 +1,19 @@
 //! ECDH-XOR encryption of FROST secret shares for the onchain publishing
 //! channel.
 
-use super::error::Error;
 use k256::{
-    NonZeroScalar, ProjectivePoint, Scalar,
+    EncodedPoint, NonZeroScalar, ProjectivePoint, Scalar,
     elliptic_curve::{
+        Group,
         hash2curve::{self, ExpandMsgXmd},
         point::AffineCoordinates as _,
+        sec1::{FromEncodedPoint, ToEncodedPoint},
         zeroize::{Zeroize, ZeroizeOnDrop},
     },
     sha2::Sha256,
 };
 use rand::{CryptoRng, RngCore};
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Deserializer, Serialize, Serializer, de};
 
 /// A locally-generated ECDH encryption key. The secret scalar is sampled by the
 /// effect handler and never leaves the secret store; only [`public_key`] is
@@ -34,19 +35,14 @@ impl EncryptionKey {
     }
 
     /// The public key `q` published onchain for peers to encrypt shares to.
-    pub(super) fn public_key(&self) -> ProjectivePoint {
-        ProjectivePoint::GENERATOR * *self.0
+    pub(super) fn public_key(&self) -> EncryptionPublicKey {
+        EncryptionPublicKey(ProjectivePoint::GENERATOR * *self.0)
     }
 
     /// Encrypts or decrypts a 32-byte secret-share `msg` against a peer's
     /// encryption public key. See [`ecdh`].
-    pub(super) fn ecdh(
-        &self,
-        public_key: &ProjectivePoint,
-        msg: [u8; 32],
-    ) -> Result<[u8; 32], Error> {
-        let encrypted = ecdh(&self.0, public_key, msg)?;
-        Ok(encrypted)
+    pub(super) fn ecdh(&self, public_key: &EncryptionPublicKey, msg: [u8; 32]) -> [u8; 32] {
+        ecdh(&self.0, public_key, msg)
     }
 }
 
@@ -58,25 +54,66 @@ impl Drop for EncryptionKey {
 
 impl ZeroizeOnDrop for EncryptionKey {}
 
+/// An encryption public key that can be serialized.
+#[derive(Clone)]
+pub struct EncryptionPublicKey(ProjectivePoint);
+
+impl EncryptionPublicKey {
+    /// Returns the public key as a point.
+    pub fn as_point(&self) -> &ProjectivePoint {
+        &self.0
+    }
+}
+
+impl TryFrom<ProjectivePoint> for EncryptionPublicKey {
+    type Error = frost_secp256k1::Error;
+
+    fn try_from(point: ProjectivePoint) -> Result<Self, Self::Error> {
+        if point.is_identity().into() {
+            return Err(frost_secp256k1::GroupError::InvalidIdentityElement.into());
+        }
+        Ok(Self(point))
+    }
+}
+
+impl<'de> Deserialize<'de> for EncryptionPublicKey {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let encoded = EncodedPoint::deserialize(deserializer)?;
+        ProjectivePoint::from_encoded_point(&encoded)
+            .into_option()
+            .ok_or_else(|| de::Error::custom("invalid encryption public key encoding"))?
+            .try_into()
+            .map_err(de::Error::custom)
+    }
+}
+
+impl Serialize for EncryptionPublicKey {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        self.0.to_encoded_point(true).serialize(serializer)
+    }
+}
+
 /// Encrypts or decrypts `msg` via ECDH: `msg XOR (receiver_pubkey * sender_privkey).x`.
 ///
 /// XOR is its own inverse, so this serves both directions. `receiver_pubkey`
 /// must be a valid non-identity point and `sender_privkey` must be non-zero.
 fn ecdh(
     sender_privkey: &NonZeroScalar,
-    receiver_pubkey: &ProjectivePoint,
+    receiver_pubkey: &EncryptionPublicKey,
     msg: [u8; 32],
-) -> Result<[u8; 32], Error> {
-    if *receiver_pubkey == ProjectivePoint::IDENTITY {
-        return Err(Error::malformed_element());
-    }
-
-    let shared_secret = (*receiver_pubkey * **sender_privkey).to_affine().x();
+) -> [u8; 32] {
+    let shared_secret = (receiver_pubkey.0 * **sender_privkey).to_affine().x();
     let mut result = msg;
     for (byte, secret) in result.iter_mut().zip(shared_secret) {
         *byte ^= secret;
     }
-    Ok(result)
+    result
 }
 
 fn hash_to_scalar(discriminant: &[u8], msg: &[u8]) -> NonZeroScalar {
@@ -105,8 +142,8 @@ mod tests {
         let peer = EncryptionKey::generate(&mut rng);
         let msg = [0x5a; 32];
 
-        let enc = key.ecdh(&peer.public_key(), msg).unwrap();
-        let dec = peer.ecdh(&key.public_key(), enc).unwrap();
+        let enc = key.ecdh(&peer.public_key(), msg);
+        let dec = peer.ecdh(&key.public_key(), enc);
         assert_eq!(dec, msg);
     }
 
@@ -116,8 +153,8 @@ mod tests {
         let bob = key(3);
         let msg = [0x00; 32];
         assert_eq!(
-            alice.ecdh(&bob.public_key(), msg).unwrap(),
-            bob.ecdh(&alice.public_key(), msg).unwrap(),
+            alice.ecdh(&bob.public_key(), msg),
+            bob.ecdh(&alice.public_key(), msg),
         );
     }
 
@@ -128,14 +165,13 @@ mod tests {
         let charlie = key(4);
         let msg = [0xff; 32];
         assert_ne!(
-            alice.ecdh(&bob.public_key(), msg).unwrap(),
-            alice.ecdh(&charlie.public_key(), msg).unwrap(),
+            alice.ecdh(&bob.public_key(), msg),
+            alice.ecdh(&charlie.public_key(), msg),
         );
     }
 
     #[test]
-    fn ecdh_rejects_degenerate_inputs() {
-        let alice = key(2);
-        assert!(alice.ecdh(&ProjectivePoint::IDENTITY, [0xff; 32]).is_err());
+    fn ecdh_rejects_degenerate_public_keys_at_infinity() {
+        assert!(EncryptionPublicKey::try_from(ProjectivePoint::IDENTITY).is_err());
     }
 }

--- a/crates/validator/src/frost/keygen.rs
+++ b/crates/validator/src/frost/keygen.rs
@@ -2,7 +2,7 @@
 //! rounds with address-derived identifiers and ECDH-encrypted secret shares.
 
 use super::{ecdh::EncryptionKey, error::Error, marshal, participants};
-use crate::bindings;
+use crate::{bindings, frost::ecdh::EncryptionPublicKey};
 use alloy::primitives::Address;
 use frost_secp256k1::{
     Identifier,
@@ -11,7 +11,7 @@ use frost_secp256k1::{
         dkg::{self, round1, round2},
     },
 };
-use k256::{ProjectivePoint, elliptic_curve::PrimeField as _};
+use k256::elliptic_curve::PrimeField as _;
 use std::collections::BTreeMap;
 
 /// The output of DKG round 1: the secret polynomial (persisted to the secret
@@ -28,15 +28,15 @@ pub struct Round1 {
 pub fn generate_round1<R>(
     rng: &mut R,
     me: Address,
-    max_signers: u16,
-    min_signers: u16,
+    count: u16,
+    threshold: u16,
 ) -> Result<Round1, Error>
 where
     R: rand::RngCore + rand::CryptoRng,
 {
     let identifier = participants::identifier(me);
     let encryption_key = EncryptionKey::generate(&mut *rng);
-    let (secret_package, package) = dkg::part1(identifier, max_signers, min_signers, &mut *rng)?;
+    let (secret_package, package) = dkg::part1(identifier, count, threshold, &mut *rng)?;
     let commitment = marshal::solidity_commitment(&encryption_key.public_key(), &package);
     Ok(Round1 {
         encryption_key,
@@ -86,7 +86,7 @@ pub fn generate_round2(
                 .get(&participants::identifier(*peer))
                 .ok_or(frost_secp256k1::Error::UnknownIdentifier)?;
             let signing_share = package.signing_share().to_scalar().to_bytes().into();
-            encryption_key.ecdh(encryption_key_peer, signing_share)
+            Ok(encryption_key.ecdh(encryption_key_peer, signing_share))
         })
         .collect::<Result<Vec<_>, Error>>()?;
     let share = marshal::solidity_secret_share(verifying_share, &encrypted_shares);
@@ -130,7 +130,7 @@ pub fn generate_round3(
             let encryption_key_peer = encryption_keys
                 .get(publisher)
                 .ok_or(frost_secp256k1::Error::UnknownIdentifier)?;
-            let secret_share = encryption_key.ecdh(encryption_key_peer, encrypted.to_be_bytes())?;
+            let secret_share = encryption_key.ecdh(encryption_key_peer, encrypted.to_be_bytes());
             let signing_share = keys::SigningShare::new(
                 k256::Scalar::from_repr(secret_share.into())
                     .into_option()
@@ -152,7 +152,7 @@ pub fn generate_round3(
 }
 
 type PeerCommitments = (
-    BTreeMap<Address, ProjectivePoint>,
+    BTreeMap<Address, EncryptionPublicKey>,
     BTreeMap<Identifier, round1::Package>,
 );
 

--- a/crates/validator/src/frost/marshal.rs
+++ b/crates/validator/src/frost/marshal.rs
@@ -1,7 +1,7 @@
 //! Marshalling between secp256k1 primitives and their Solidity types.
 
 use super::error::Error;
-use crate::bindings;
+use crate::{bindings, frost::ecdh::EncryptionPublicKey};
 use alloy::primitives::U256;
 use frost_secp256k1::keys::{self, dkg};
 use k256::{
@@ -20,10 +20,10 @@ use k256::{
 /// - `r`  the proof-of-knowledge nonce commitment `R`,
 /// - `mu` the proof-of-knowledge scalar `μ`.
 pub fn solidity_commitment(
-    encryption_public_key: &k256::ProjectivePoint,
+    encryption_public_key: &EncryptionPublicKey,
     package: &dkg::round1::Package,
 ) -> bindings::KeyGenCommitment {
-    let q = solidity_point(encryption_public_key);
+    let q = solidity_point(encryption_public_key.as_point());
     let c = package
         .commitment()
         .coefficients()
@@ -88,8 +88,8 @@ pub fn solidity_signature(signature: &frost_secp256k1::Signature) -> bindings::S
 /// peer's encryption public key and DKG round 1 package.
 pub fn frost_commitment(
     commitment: &bindings::KeyGenCommitment,
-) -> Result<(k256::ProjectivePoint, dkg::round1::Package), Error> {
-    let encryption_public_key = frost_point(&commitment.q)?;
+) -> Result<(EncryptionPublicKey, dkg::round1::Package), Error> {
+    let encryption_public_key = frost_point(&commitment.q)?.try_into()?;
     let coefficients = keys::VerifiableSecretSharingCommitment::new(
         commitment
             .c


### PR DESCRIPTION
### Context and Motivation

#524 implemented key generation, but was done in a way that consumers of the code cannot determine the source of the error (did a participant misbehave?). This causes issues for consensus as it means that validators do not know which participant should be kicked out for the next key generation ceremony.

As a first small step, this PR makes encryption infallible: once you have an `EncryptionKey` and `EncryptionPublicKey`, all encryption operations are valid. This allows us to check for `EncryptionPublicKey` validity at marshaling time and attribute an issue with the public key to a misbehaving validator.

### Decisions and Tradeoffs

We manually implement `serde` on the public key type (since only `EncodedPoint` implements serialization, but we want a projective point for ECDH operations).

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://docs.safefoundation.org/cla).
