### PR TITLE
[B 3ii]: Verified Commitments and Shares

### DIFF
--- a/crates/validator/src/frost/keygen.rs
+++ b/crates/validator/src/frost/keygen.rs
@@ -3,15 +3,15 @@
 
 use super::{ecdh::EncryptionKey, error::Error, marshal, participants};
 use crate::{bindings, frost::ecdh::EncryptionPublicKey};
-use alloy::primitives::Address;
+use alloy::primitives::{Address, U256};
 use frost_secp256k1::{
     Identifier,
     keys::{
-        self, PublicKeyPackage,
+        self,
         dkg::{self, round1, round2},
     },
 };
-use k256::elliptic_curve::PrimeField as _;
+use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 
 /// The output of DKG round 1: the secret polynomial (persisted to the secret
@@ -45,131 +45,207 @@ where
     })
 }
 
+/// A validated round 1 public commitment from a participant.
+#[derive(Clone, Deserialize, Serialize)]
+pub struct Round1Commitment {
+    encryption_public_key: EncryptionPublicKey,
+    package: round1::Package,
+}
+
+/// Verifies a round 1 public commitment.
+///
+/// These are applied to _both_ `me`, the validator itself, and all peers that
+/// publish key generation commitments onchain.
+pub fn verify_round1_commitment(
+    min_signers: u16,
+    participant: Address,
+    commitment: &bindings::KeyGenCommitment,
+) -> Result<Round1Commitment, Error> {
+    let identifier = participants::identifier(participant);
+    let (encryption_public_key, package) = marshal::frost_commitment(commitment)?;
+    if package.commitment().coefficients().len() as u16 != min_signers {
+        return Err(frost_secp256k1::Error::IncorrectNumberOfCommitments.into());
+    }
+    frost_core::keys::dkg::verify_proof_of_knowledge(
+        identifier,
+        package.commitment(),
+        package.proof_of_knowledge(),
+    )?;
+    Ok(Round1Commitment {
+        encryption_public_key,
+        package,
+    })
+}
+
 /// The output of DKG round 2: the secret package (persisted) and the onchain
 /// secret share to publish.
 pub struct Round2 {
     pub secret_package: round2::SecretPackage,
+    pub public_key_package: keys::PublicKeyPackage,
     pub share: bindings::KeyGenSecretShare,
 }
 
-/// Runs DKG round 2 for `me` given every participant's round 1 commitment
-/// (including `me`'s own). Produces the round 2 secret package and the ECDH
-/// encrypted secret shares for the peers, ordered by ascending peer address.
+/// Runs DKG round 2 given every participant's round 1 commitment. Produces the
+/// round 2 secret package and the ECDH encrypted secret shares for the peers,
+/// ordered by ascending peer address.
 pub fn generate_round2(
-    me: Address,
     encryption_key: &EncryptionKey,
     secret_package: &round1::SecretPackage,
-    commitments: &BTreeMap<Address, bindings::KeyGenCommitment>,
+    commitments: &BTreeMap<Address, Round1Commitment>,
 ) -> Result<Round2, Error> {
-    let (encryption_keys, round1_packages) = decode_peer_commitments(me, commitments)?;
-    let (secret_package, round2_packages) = dkg::part2(secret_package.clone(), &round1_packages)?;
+    let round1_peer_packages =
+        peer_packages(secret_package.identifier(), commitments, |commitment| {
+            commitment.package.clone()
+        });
 
-    let public_key_package = PublicKeyPackage::from_dkg_commitments(
-        &round1_packages
-            .iter()
-            .map(|(identifier, package)| (*identifier, package.commitment()))
-            .chain(std::iter::once((
-                *secret_package.identifier(),
-                secret_package.commitment(),
-            )))
-            .collect(),
-    )?;
+    let (secret_package, round2_packages) =
+        dkg::part2(secret_package.clone(), &round1_peer_packages)?;
+
+    let round1_commitments = round1_peer_packages
+        .iter()
+        .map(|(identifier, package)| (*identifier, package.commitment()))
+        .chain(std::iter::once((
+            *secret_package.identifier(),
+            secret_package.commitment(),
+        )))
+        .collect();
+    let public_key_package = keys::PublicKeyPackage::from_dkg_commitments(&round1_commitments)?;
     let verifying_share = public_key_package
         .verifying_shares()
         .get(secret_package.identifier())
-        .ok_or(frost_secp256k1::Error::IncorrectNumberOfPackages)?;
+        .ok_or(frost_secp256k1::Error::UnknownIdentifier)?;
 
-    let encrypted_shares = encryption_keys
+    let encrypted_shares = commitments
         .iter()
-        .map(|(peer, encryption_key_peer)| {
+        .map(|(participant, commitment)| {
+            (
+                participants::identifier(*participant),
+                &commitment.encryption_public_key,
+            )
+        })
+        .filter(|(participant, _)| participant != secret_package.identifier())
+        .map(|(peer, encryption_public_key)| {
             let package = round2_packages
-                .get(&participants::identifier(*peer))
+                .get(&peer)
                 .ok_or(frost_secp256k1::Error::UnknownIdentifier)?;
             let signing_share = package.signing_share().to_scalar().to_bytes().into();
-            Ok(encryption_key.ecdh(encryption_key_peer, signing_share))
+            Ok(encryption_key.ecdh(encryption_public_key, signing_share))
         })
         .collect::<Result<Vec<_>, Error>>()?;
     let share = marshal::solidity_secret_share(verifying_share, &encrypted_shares);
 
     Ok(Round2 {
         secret_package,
+        public_key_package,
         share,
     })
+}
+
+/// A validated round 2 signing share from a peer.
+#[derive(Clone, Deserialize, Serialize)]
+pub struct Round2Share {
+    package: round2::Package,
+}
+
+/// Verifies a round 2 secret signing share received from a peer.
+pub fn verify_round2_share(
+    encryption_key: &EncryptionKey,
+    secret_package: &round2::SecretPackage,
+    public_key_package: &keys::PublicKeyPackage,
+    commitments: &BTreeMap<Address, Round1Commitment>,
+    peer: Address,
+    share: &bindings::KeyGenSecretShare,
+) -> Result<Round2Share, Error> {
+    if share.f.len() as u16 != secret_package.max_signers() - 1 {
+        return Err(frost_secp256k1::Error::IncorrectNumberOfShares.into());
+    }
+
+    let identifier = participants::identifier(peer);
+    if identifier == *secret_package.identifier() {
+        return Err(frost_secp256k1::Error::IncorrectPackage.into());
+    }
+
+    let round1 = &commitments
+        .get(&peer)
+        .ok_or(frost_secp256k1::Error::UnknownIdentifier)?;
+    let encryption_public_key = &round1.encryption_public_key;
+    let commitment = round1.package.commitment().clone();
+
+    let verifying_share = public_key_package
+        .verifying_shares()
+        .get(&identifier)
+        .ok_or(frost_secp256k1::Error::UnknownIdentifier)?;
+
+    let index = commitments
+        .keys()
+        .filter(|address| **address != peer)
+        .position(|address| participants::identifier(*address) == *secret_package.identifier())
+        .ok_or(frost_secp256k1::Error::UnknownIdentifier)?;
+    let encrypted_share = share
+        .f
+        .get(index)
+        .ok_or(frost_core::Error::IncorrectNumberOfShares)?;
+    let secret_share = encryption_key.ecdh(encryption_public_key, encrypted_share.to_be_bytes());
+
+    let y = marshal::frost_point(&share.y)?;
+    if y != verifying_share.to_element() {
+        return Err(frost_secp256k1::Error::MalformedVerifyingKey.into());
+    }
+
+    let signing_share =
+        keys::SigningShare::new(marshal::frost_scalar(&U256::from_be_bytes(secret_share))?);
+
+    // Pre-verify the share to make sure it matches the commitment from
+    // the peer; this allows us to complain right away in case an
+    // invalid share was provided.
+    let _ =
+        keys::SecretShare::new(*secret_package.identifier(), signing_share, commitment).verify()?;
+
+    let package = round2::Package::new(signing_share);
+    Ok(Round2Share { package })
 }
 
 /// The output of DKG round 3: the finalized key material.
 pub struct Round3 {
     pub key_package: keys::KeyPackage,
-    pub public_key_package: PublicKeyPackage,
+    pub public_key_package: keys::PublicKeyPackage,
 }
 
 /// Runs DKG round 3 for `me`, decrypting the peers' secret shares (indexed by
 /// `me`'s position in each publisher's address-ordered participant set) and
 /// finalizing the group key material.
 pub fn generate_round3(
-    me: Address,
-    encryption_key: &EncryptionKey,
     secret_package: &round2::SecretPackage,
-    commitments: &BTreeMap<Address, bindings::KeyGenCommitment>,
-    shares: &BTreeMap<Address, bindings::KeyGenSecretShare>,
+    commitments: &BTreeMap<Address, Round1Commitment>,
+    shares: &BTreeMap<Address, Round2Share>,
 ) -> Result<Round3, Error> {
-    let (encryption_keys, round1_packages) = decode_peer_commitments(me, commitments)?;
-    let round2_packages = shares
-        .iter()
-        .filter(|(publisher, _)| **publisher != me)
-        .map(|(publisher, share)| {
-            let index = shares
-                .keys()
-                .filter(|address| *address != publisher)
-                .position(|address| *address == me)
-                .ok_or(frost_secp256k1::Error::UnknownIdentifier)?;
-            let encrypted = share
-                .f
-                .get(index)
-                .ok_or(frost_core::Error::IncorrectNumberOfShares)?;
-            let encryption_key_peer = encryption_keys
-                .get(publisher)
-                .ok_or(frost_secp256k1::Error::UnknownIdentifier)?;
-            let secret_share = encryption_key.ecdh(encryption_key_peer, encrypted.to_be_bytes());
-            let signing_share = keys::SigningShare::new(
-                k256::Scalar::from_repr(secret_share.into())
-                    .into_option()
-                    .ok_or_else(Error::malformed_scalar)?,
-            );
-            Ok((
-                participants::identifier(*publisher),
-                round2::Package::new(signing_share),
-            ))
-        })
-        .collect::<Result<BTreeMap<_, _>, Error>>()?;
+    let round1_peer_packages =
+        peer_packages(secret_package.identifier(), commitments, |commitment| {
+            commitment.package.clone()
+        });
+    let round2_peer_packages = peer_packages(secret_package.identifier(), shares, |share| {
+        share.package.clone()
+    });
 
     let (key_package, public_key_package) =
-        dkg::part3(secret_package, &round1_packages, &round2_packages)?;
+        dkg::part3(secret_package, &round1_peer_packages, &round2_peer_packages)?;
     Ok(Round3 {
         key_package,
         public_key_package,
     })
 }
 
-type PeerCommitments = (
-    BTreeMap<Address, EncryptionPublicKey>,
-    BTreeMap<Identifier, round1::Package>,
-);
-
-fn decode_peer_commitments(
-    me: Address,
-    commitments: &BTreeMap<Address, bindings::KeyGenCommitment>,
-) -> Result<PeerCommitments, Error> {
-    let mut encryption_keys = BTreeMap::new();
-    let mut round1_packages = BTreeMap::new();
-    for (address, commitment) in commitments {
-        if *address == me {
-            continue;
-        }
-
-        let (encryption_key, package) = marshal::frost_commitment(commitment)?;
-        encryption_keys.insert(*address, encryption_key);
-        round1_packages.insert(participants::identifier(*address), package);
-    }
-    Ok((encryption_keys, round1_packages))
+fn peer_packages<T, P, F>(
+    me: &Identifier,
+    items: &BTreeMap<Address, T>,
+    select: F,
+) -> BTreeMap<Identifier, P>
+where
+    F: Fn(&T) -> P,
+{
+    items
+        .iter()
+        .map(|(participant, item)| (participants::identifier(*participant), select(item)))
+        .filter(|(participant, _)| participant != me)
+        .collect()
 }

--- a/crates/validator/src/frost/mod.rs
+++ b/crates/validator/src/frost/mod.rs
@@ -39,39 +39,57 @@ mod tests {
 
         let commitments = participants
             .into_iter()
-            .map(|participant| (participant, round1[&participant].commitment.clone()))
+            .map(|participant| {
+                let commitment = keygen::verify_round1_commitment(
+                    threshold,
+                    participant,
+                    &round1[&participant].commitment,
+                )
+                .unwrap();
+                (participant, commitment)
+            })
             .collect();
 
         let mut round2 = BTreeMap::new();
         for participant in participants {
             let r1 = &round1[&participant];
-            let r2 = keygen::generate_round2(
-                participant,
-                &r1.encryption_key,
-                &r1.secret_package,
-                &commitments,
-            )
-            .unwrap();
+            let r2 = keygen::generate_round2(&r1.encryption_key, &r1.secret_package, &commitments)
+                .unwrap();
             round2.insert(participant, r2);
         }
 
         let shares = participants
             .into_iter()
-            .map(|participant| (participant, round2[&participant].share.clone()))
-            .collect();
+            .map(|me| {
+                let r1 = &round1[&me];
+                let r2 = &round2[&me];
+                let shares = participants
+                    .into_iter()
+                    .filter(|peer| *peer != me)
+                    .map(|peer| {
+                        let share = &round2[&peer].share;
+                        let share = keygen::verify_round2_share(
+                            &r1.encryption_key,
+                            &r2.secret_package,
+                            &r2.public_key_package,
+                            &commitments,
+                            peer,
+                            share,
+                        )
+                        .unwrap();
+                        (peer, share)
+                    })
+                    .collect();
+                (me, shares)
+            })
+            .collect::<BTreeMap<_, _>>();
 
         let mut round3 = BTreeMap::new();
         for participant in participants {
-            let r1 = &round1[&participant];
             let r2 = &round2[&participant];
-            let r3 = keygen::generate_round3(
-                participant,
-                &r1.encryption_key,
-                &r2.secret_package,
-                &commitments,
-                &shares,
-            )
-            .unwrap();
+            let r3 =
+                keygen::generate_round3(&r2.secret_package, &commitments, &shares[&participant])
+                    .unwrap();
             round3.insert(participant, r3);
         }
 


### PR DESCRIPTION
... using the power of types!

### Context and Motivation

As a follow up to #526, where we want to start assigning attribution to cryptographic errors (in order to react to malicious validators and kick them out of consensus). As a next step, we define new `Round1Commitment` and `Round2Share` types which represent _validated_ commitments and shares from other participants.

### Decisions and Tradeoffs

When a Solidity `KeyGenCommitment` or `KeyGenShare` is received from onchain, we do additional validation in order to construct verified types (in the spirit of [_Parse, don't Validate_](https://lexi-lambda.github.io/blog/2019/11/05/parse-don-t-validate/)). This allows us to, with more certainty, know that the DKG rounds will not fail when we do them (unless the caller did not correctly use the inputs).

This does have the downside of doing additional work (as the `frost_secp256k1::keys::dkg` will **also** do this work internally), but it is important in order be able to reliably determine culpability in face of DKG protocol failures.

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://docs.safefoundation.org/cla).
