### PR TITLE
[B 3iii]: Error With Culpability

### DIFF
--- a/crates/validator/src/frost/error.rs
+++ b/crates/validator/src/frost/error.rs
@@ -1,23 +1,46 @@
+use alloy::primitives::Address;
+
 /// A Safenet FROST error.
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
-    /// The underlying FROST ciphersuite error.
-    #[error(transparent)]
-    Frost(#[from] frost_secp256k1::Error),
+    /// An unexpected FROST error.
+    ///
+    /// This occurs the FROST implementation is called with unexpected inputs
+    /// (such as invalid threshold or incorrect participants for a round).
+    #[error("unexpected FROST error: {0}")]
+    Unexpected(frost_secp256k1::Error),
+    /// A participant misbehaved and provided invalid inputs.
+    ///
+    /// This occurs if an invalid commitment or secret share is provided by
+    /// another participant; they should be removed from the participant group.
+    #[error("misbehaving participant {culprit}: {cause}")]
+    Participant {
+        cause: frost_secp256k1::Error,
+        culprit: Address,
+    },
 }
 
-impl Error {
-    /// An error indicating a malformed scalar.
-    pub const fn malformed_scalar() -> Self {
-        Self::Frost(frost_core::Error::FieldError(
-            frost_core::FieldError::MalformedScalar,
-        ))
+pub(super) trait Culprit<T> {
+    fn err_unexpected(self) -> Result<T, Error>;
+    fn err_with_culprit(self, participant: Address) -> Result<T, Error>;
+}
+
+impl<T> Culprit<T> for Result<T, frost_secp256k1::Error> {
+    fn err_unexpected(self) -> Result<T, Error> {
+        self.map_err(Error::Unexpected)
     }
 
-    /// An error indicating a malformed group element (point).
-    pub const fn malformed_element() -> Self {
-        Self::Frost(frost_core::Error::GroupError(
-            frost_core::GroupError::MalformedElement,
-        ))
+    fn err_with_culprit(self, culprit: Address) -> Result<T, Error> {
+        self.map_err(|cause| Error::Participant { cause, culprit })
     }
+}
+
+/// An error indicating a malformed scalar.
+pub(super) const fn malformed_scalar() -> frost_secp256k1::Error {
+    frost_secp256k1::Error::FieldError(frost_secp256k1::FieldError::MalformedScalar)
+}
+
+/// An error indicating a malformed group element (point).
+pub(super) const fn malformed_element() -> frost_secp256k1::Error {
+    frost_secp256k1::Error::GroupError(frost_secp256k1::GroupError::MalformedElement)
 }

--- a/crates/validator/src/frost/keygen.rs
+++ b/crates/validator/src/frost/keygen.rs
@@ -1,7 +1,11 @@
 //! Distributed key generation, driving the FROST `keys::dkg::part{1,2,3}`
 //! rounds with address-derived identifiers and ECDH-encrypted secret shares.
 
-use super::{ecdh::EncryptionKey, error::Error, marshal, participants};
+use super::{
+    ecdh::EncryptionKey,
+    error::{Culprit as _, Error},
+    marshal, participants,
+};
 use crate::{bindings, frost::ecdh::EncryptionPublicKey};
 use alloy::primitives::{Address, U256};
 use frost_secp256k1::{
@@ -36,7 +40,8 @@ where
 {
     let identifier = participants::identifier(me);
     let encryption_key = EncryptionKey::generate(&mut *rng);
-    let (secret_package, package) = dkg::part1(identifier, count, threshold, &mut *rng)?;
+    let (secret_package, package) =
+        dkg::part1(identifier, count, threshold, &mut *rng).err_unexpected()?;
     let commitment = marshal::solidity_commitment(&encryption_key.public_key(), &package);
     Ok(Round1 {
         encryption_key,
@@ -62,19 +67,22 @@ pub fn verify_round1_commitment(
     commitment: &bindings::KeyGenCommitment,
 ) -> Result<Round1Commitment, Error> {
     let identifier = participants::identifier(participant);
-    let (encryption_public_key, package) = marshal::frost_commitment(commitment)?;
-    if package.commitment().coefficients().len() as u16 != min_signers {
-        return Err(frost_secp256k1::Error::IncorrectNumberOfCommitments.into());
-    }
-    frost_core::keys::dkg::verify_proof_of_knowledge(
-        identifier,
-        package.commitment(),
-        package.proof_of_knowledge(),
-    )?;
-    Ok(Round1Commitment {
-        encryption_public_key,
-        package,
-    })
+    marshal::frost_commitment(commitment)
+        .and_then(|(encryption_public_key, package)| {
+            if package.commitment().coefficients().len() as u16 != min_signers {
+                return Err(frost_secp256k1::Error::IncorrectNumberOfCommitments);
+            }
+            frost_core::keys::dkg::verify_proof_of_knowledge(
+                identifier,
+                package.commitment(),
+                package.proof_of_knowledge(),
+            )?;
+            Ok(Round1Commitment {
+                encryption_public_key,
+                package,
+            })
+        })
+        .err_with_culprit(participant)
 }
 
 /// The output of DKG round 2: the secret package (persisted) and the onchain
@@ -98,47 +106,54 @@ pub fn generate_round2(
             commitment.package.clone()
         });
 
-    let (secret_package, round2_packages) =
-        dkg::part2(secret_package.clone(), &round1_peer_packages)?;
-
-    let round1_commitments = round1_peer_packages
-        .iter()
-        .map(|(identifier, package)| (*identifier, package.commitment()))
-        .chain(std::iter::once((
-            *secret_package.identifier(),
-            secret_package.commitment(),
-        )))
-        .collect();
-    let public_key_package = keys::PublicKeyPackage::from_dkg_commitments(&round1_commitments)?;
-    let verifying_share = public_key_package
-        .verifying_shares()
-        .get(secret_package.identifier())
-        .ok_or(frost_secp256k1::Error::UnknownIdentifier)?;
-
-    let encrypted_shares = commitments
-        .iter()
-        .map(|(participant, commitment)| {
-            (
-                participants::identifier(*participant),
-                &commitment.encryption_public_key,
-            )
-        })
-        .filter(|(participant, _)| participant != secret_package.identifier())
-        .map(|(peer, encryption_public_key)| {
-            let package = round2_packages
-                .get(&peer)
+    // By construction, the second round of DKG should have no participant
+    // culprits (as the `commitments` have already verified the length of the
+    // commitments and the proof of knowledge). The only way we encounter an
+    // error here is if the caller were to mix secrets and commitments from
+    // different DKG ceremonies.
+    dkg::part2(secret_package.clone(), &round1_peer_packages)
+        .and_then(|(secret_package, round2_packages)| {
+            let round1_commitments = round1_peer_packages
+                .iter()
+                .map(|(identifier, package)| (*identifier, package.commitment()))
+                .chain(std::iter::once((
+                    *secret_package.identifier(),
+                    secret_package.commitment(),
+                )))
+                .collect();
+            let public_key_package =
+                keys::PublicKeyPackage::from_dkg_commitments(&round1_commitments)?;
+            let verifying_share = public_key_package
+                .verifying_shares()
+                .get(secret_package.identifier())
                 .ok_or(frost_secp256k1::Error::UnknownIdentifier)?;
-            let signing_share = package.signing_share().to_scalar().to_bytes().into();
-            Ok(encryption_key.ecdh(encryption_public_key, signing_share))
-        })
-        .collect::<Result<Vec<_>, Error>>()?;
-    let share = marshal::solidity_secret_share(verifying_share, &encrypted_shares);
 
-    Ok(Round2 {
-        secret_package,
-        public_key_package,
-        share,
-    })
+            let encrypted_shares = commitments
+                .iter()
+                .map(|(participant, commitment)| {
+                    (
+                        participants::identifier(*participant),
+                        &commitment.encryption_public_key,
+                    )
+                })
+                .filter(|(participant, _)| participant != secret_package.identifier())
+                .map(|(peer, encryption_public_key)| {
+                    let package = round2_packages
+                        .get(&peer)
+                        .ok_or(frost_secp256k1::Error::UnknownIdentifier)?;
+                    let signing_share = package.signing_share().to_scalar().to_bytes().into();
+                    Ok(encryption_key.ecdh(encryption_public_key, signing_share))
+                })
+                .collect::<Result<Vec<_>, frost_secp256k1::Error>>()?;
+            let share = marshal::solidity_secret_share(verifying_share, &encrypted_shares);
+
+            Ok(Round2 {
+                secret_package,
+                public_key_package,
+                share,
+            })
+        })
+        .err_unexpected()
 }
 
 /// A validated round 2 signing share from a peer.
@@ -157,51 +172,63 @@ pub fn verify_round2_share(
     share: &bindings::KeyGenSecretShare,
 ) -> Result<Round2Share, Error> {
     if share.f.len() as u16 != secret_package.max_signers() - 1 {
-        return Err(frost_secp256k1::Error::IncorrectNumberOfShares.into());
+        return Err(frost_secp256k1::Error::IncorrectNumberOfShares).err_with_culprit(peer);
     }
 
     let identifier = participants::identifier(peer);
     if identifier == *secret_package.identifier() {
-        return Err(frost_secp256k1::Error::IncorrectPackage.into());
+        return Err(frost_secp256k1::Error::IncorrectPackage).err_unexpected();
     }
 
-    let round1 = &commitments
+    let (commitment, verifying_share, secret_share) = commitments
         .get(&peer)
-        .ok_or(frost_secp256k1::Error::UnknownIdentifier)?;
-    let encryption_public_key = &round1.encryption_public_key;
-    let commitment = round1.package.commitment().clone();
+        .ok_or(frost_secp256k1::Error::UnknownIdentifier)
+        .and_then(|round1| {
+            let encryption_public_key = &round1.encryption_public_key;
+            let commitment = round1.package.commitment().clone();
 
-    let verifying_share = public_key_package
-        .verifying_shares()
-        .get(&identifier)
-        .ok_or(frost_secp256k1::Error::UnknownIdentifier)?;
+            let verifying_share = public_key_package
+                .verifying_shares()
+                .get(&identifier)
+                .ok_or(frost_secp256k1::Error::UnknownIdentifier)?;
 
-    let index = commitments
-        .keys()
-        .filter(|address| **address != peer)
-        .position(|address| participants::identifier(*address) == *secret_package.identifier())
-        .ok_or(frost_secp256k1::Error::UnknownIdentifier)?;
-    let encrypted_share = share
-        .f
-        .get(index)
-        .ok_or(frost_core::Error::IncorrectNumberOfShares)?;
-    let secret_share = encryption_key.ecdh(encryption_public_key, encrypted_share.to_be_bytes());
+            let index = commitments
+                .keys()
+                .filter(|address| **address != peer)
+                .position(|address| {
+                    participants::identifier(*address) == *secret_package.identifier()
+                })
+                .ok_or(frost_secp256k1::Error::UnknownIdentifier)?;
+            let encrypted_share = share
+                .f
+                .get(index)
+                .ok_or(frost_secp256k1::Error::IncorrectNumberOfShares)?;
+            let secret_share =
+                encryption_key.ecdh(encryption_public_key, encrypted_share.to_be_bytes());
 
-    let y = marshal::frost_point(&share.y)?;
-    if y != verifying_share.to_element() {
-        return Err(frost_secp256k1::Error::MalformedVerifyingKey.into());
-    }
+            Ok((commitment, verifying_share, secret_share))
+        })
+        .err_unexpected()?;
 
-    let signing_share =
-        keys::SigningShare::new(marshal::frost_scalar(&U256::from_be_bytes(secret_share))?);
+    let package = marshal::frost_point(&share.y)
+        .and_then(|y| {
+            if y != verifying_share.to_element() {
+                return Err(frost_secp256k1::Error::MalformedVerifyingKey);
+            }
 
-    // Pre-verify the share to make sure it matches the commitment from
-    // the peer; this allows us to complain right away in case an
-    // invalid share was provided.
-    let _ =
-        keys::SecretShare::new(*secret_package.identifier(), signing_share, commitment).verify()?;
+            let signing_share =
+                keys::SigningShare::new(marshal::frost_scalar(&U256::from_be_bytes(secret_share))?);
 
-    let package = round2::Package::new(signing_share);
+            // Pre-verify the share to make sure it matches the commitment from
+            // the peer; this allows us to complain right away in case an
+            // invalid share was provided.
+            let _ = keys::SecretShare::new(*secret_package.identifier(), signing_share, commitment)
+                .verify()?;
+
+            Ok(round2::Package::new(signing_share))
+        })
+        .err_with_culprit(peer)?;
+
     Ok(Round2Share { package })
 }
 
@@ -227,8 +254,13 @@ pub fn generate_round3(
         share.package.clone()
     });
 
+    // By construction, the third round of DKG should have no participant
+    // culprits (as the `commitments` and `shares` have already been verified).
+    // The only way we encounter an error here is if the caller were to mix
+    // secrets and commitments and shares from different DKG ceremonies.
     let (key_package, public_key_package) =
-        dkg::part3(secret_package, &round1_peer_packages, &round2_peer_packages)?;
+        dkg::part3(secret_package, &round1_peer_packages, &round2_peer_packages)
+            .err_unexpected()?;
     Ok(Round3 {
         key_package,
         public_key_package,

--- a/crates/validator/src/frost/marshal.rs
+++ b/crates/validator/src/frost/marshal.rs
@@ -1,6 +1,6 @@
 //! Marshalling between secp256k1 primitives and their Solidity types.
 
-use super::error::Error;
+use super::error;
 use crate::{bindings, frost::ecdh::EncryptionPublicKey};
 use alloy::primitives::U256;
 use frost_secp256k1::keys::{self, dkg};
@@ -88,7 +88,7 @@ pub fn solidity_signature(signature: &frost_secp256k1::Signature) -> bindings::S
 /// peer's encryption public key and DKG round 1 package.
 pub fn frost_commitment(
     commitment: &bindings::KeyGenCommitment,
-) -> Result<(EncryptionPublicKey, dkg::round1::Package), Error> {
+) -> Result<(EncryptionPublicKey, dkg::round1::Package), frost_secp256k1::Error> {
     let encryption_public_key = frost_point(&commitment.q)?.try_into()?;
     let coefficients = keys::VerifiableSecretSharingCommitment::new(
         commitment
@@ -98,7 +98,7 @@ pub fn frost_commitment(
                 let coefficient = frost_point(coefficient)?;
                 Ok(frost_core::keys::CoefficientCommitment::new(coefficient))
             })
-            .collect::<Result<_, Error>>()?,
+            .collect::<Result<_, frost_secp256k1::Error>>()?,
     );
     let proof_of_knowledge = frost_signature(&commitment.r, &commitment.mu)?;
     let package = dkg::round1::Package::new(coefficients, proof_of_knowledge);
@@ -106,15 +106,17 @@ pub fn frost_commitment(
 }
 
 /// Converts a `U256` to a canonical secp256k1 scalar.
-pub fn frost_scalar(scalar: &U256) -> Result<k256::Scalar, Error> {
+pub fn frost_scalar(scalar: &U256) -> Result<k256::Scalar, frost_secp256k1::Error> {
     Scalar::from_repr(scalar.to_be_bytes().into())
         .into_option()
-        .ok_or_else(Error::malformed_element)
+        .ok_or_else(error::malformed_scalar)
 }
 
 /// Converts an ABI `Point { uint256 x; uint256 y }` to a secp256k1 point. The
 /// zero point decodes to the identity.
-pub fn frost_point(point: &bindings::Point) -> Result<k256::ProjectivePoint, Error> {
+pub fn frost_point(
+    point: &bindings::Point,
+) -> Result<k256::ProjectivePoint, frost_secp256k1::Error> {
     if point.x.is_zero() && point.y.is_zero() {
         return Ok(k256::ProjectivePoint::IDENTITY);
     }
@@ -123,14 +125,17 @@ pub fn frost_point(point: &bindings::Point) -> Result<k256::ProjectivePoint, Err
     buffer[0] = 0x04;
     buffer[1..33].copy_from_slice(&point.x.to_be_bytes::<32>());
     buffer[33..65].copy_from_slice(&point.y.to_be_bytes::<32>());
-    let encoded = k256::EncodedPoint::from_bytes(buffer).map_err(|_| Error::malformed_element())?;
+    let encoded = k256::EncodedPoint::from_bytes(buffer).map_err(|_| error::malformed_element())?;
     k256::ProjectivePoint::from_encoded_point(&encoded)
         .into_option()
-        .ok_or_else(Error::malformed_element)
+        .ok_or_else(error::malformed_element)
 }
 
 /// Converts an ABI Schnorr signature `(Point r, uint256 z)` to a FROST signature.
-pub fn frost_signature(r: &bindings::Point, z: &U256) -> Result<frost_secp256k1::Signature, Error> {
+pub fn frost_signature(
+    r: &bindings::Point,
+    z: &U256,
+) -> Result<frost_secp256k1::Signature, frost_secp256k1::Error> {
     Ok(frost_secp256k1::Signature::new(
         frost_point(r)?,
         frost_scalar(z)?,


### PR DESCRIPTION
### Context and Motivation

The third and final step for assigning culpability to FROST operations: we change the error type to clearly differentiate between an unexpected cryptographic FROST error, and one that was caused by a misbehaving participant.

This is important for consensus to function correctly and remove misbehaving peers from the set of participants in order to continue with consensus.

### Decisions and Tradeoffs

We changed the internals to all produce `frost_secp256k1::Error`s, with **no manual conversion** to the `Error` type. This forces code to explicitly consider what type of error it is and assign culpability where appropriate.

We will be able to reuse this error type for the signing ceremony as well.

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://docs.safefoundation.org/cla).
