### PR TITLE
[B 0]: Implement Hmac on Signer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1412,6 +1412,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
+name = "const-oid"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
+
+[[package]]
 name = "const_format"
 version = "0.2.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1621,7 +1627,7 @@ version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
 dependencies = [
- "const-oid",
+ "const-oid 0.9.6",
  "zeroize",
 ]
 
@@ -1685,7 +1691,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer 0.10.4",
- "const-oid",
+ "const-oid 0.9.6",
  "crypto-common 0.1.6",
  "subtle",
 ]
@@ -1697,6 +1703,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
 dependencies = [
  "block-buffer 0.12.0",
+ "const-oid 0.10.2",
  "crypto-common 0.2.2",
  "ctutils",
 ]
@@ -3820,10 +3827,12 @@ version = "0.2.0"
 dependencies = [
  "alloy",
  "futures",
+ "hkdf",
  "metrics",
  "metrics-exporter-prometheus",
  "serde",
  "serde_json",
+ "sha2 0.11.0",
  "sqlx",
  "thiserror",
  "tokio",

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -7,10 +7,12 @@ publish = false
 [dependencies]
 alloy.workspace = true
 futures.workspace = true
+hkdf = "0.13"
 metrics.workspace = true
 metrics-exporter-prometheus = "0.18"
 serde.workspace = true
 serde_json.workspace = true
+sha2 = "0.11"
 sqlx.workspace = true
 thiserror.workspace = true
 tokio.workspace = true

--- a/crates/core/src/kdf.rs
+++ b/crates/core/src/kdf.rs
@@ -1,0 +1,81 @@
+//! Key-derivation primitives shared across the crate.
+
+use alloy::primitives::B256;
+use hkdf::Hkdf;
+use sha2::Sha256;
+
+/// Deterministically derives a 32-byte value from `ikm` (input keying material) using
+/// HKDF-SHA256 (RFC 5869), scoped to `domain` and bound to `message`.
+///
+/// `domain` is used as the HKDF salt (RFC 5869 §3.1: salt lets multiple independent
+/// pseudorandom keys be derived from a single `ikm`), so derivations for different use cases
+/// over the same `ikm` can never collide with one another. `message` is passed as HKDF's
+/// `info` parts (RFC 5869 §3.2), fed to the underlying HMAC incrementally rather than
+/// concatenated upfront.
+///
+/// # Panics
+///
+/// Panics if `domain` is empty, since an empty domain provides no separation.
+pub fn derive_key(ikm: &[u8], domain: &[u8], message: &[&[u8]]) -> B256 {
+    assert!(!domain.is_empty(), "HKDF domain must not be empty");
+
+    let hkdf = Hkdf::<Sha256>::new(Some(domain), ikm);
+    let mut okm = [0u8; 32];
+    hkdf.expand_multi_info(message, &mut okm)
+        .expect("32 bytes is far below HKDF-SHA256's maximum output length");
+    B256::from(okm)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Independently computed (Python `hmac`/`hashlib`, mirroring RFC 5869 §2.2/§2.3), since
+    /// the RFC's own published vectors use different salt/IKM/info lengths than we exercise
+    /// here.
+    #[test]
+    fn derive_key_matches_reference_vector() {
+        let ikm = b"top secret key material";
+        let domain = b"safenet-sentinel-reveal-salt";
+        let message = b"request-1";
+        let expected: B256 = "de66ad87d39718318f7ec36177e9e2286b5c0ade3dc0de22b65e9ee55ccaab0d"
+            .parse()
+            .unwrap();
+
+        assert_eq!(derive_key(ikm, domain, &[message]), expected);
+    }
+
+    #[test]
+    fn derive_key_is_deterministic_and_bound_to_domain_and_message() {
+        let ikm = b"top secret key material";
+
+        assert_eq!(
+            derive_key(ikm, b"domain-a", &[b"message-1"]),
+            derive_key(ikm, b"domain-a", &[b"message-1"]),
+        );
+        assert_ne!(
+            derive_key(ikm, b"domain-a", &[b"message-1"]),
+            derive_key(ikm, b"domain-b", &[b"message-1"]),
+        );
+        assert_ne!(
+            derive_key(ikm, b"domain-a", &[b"message-1"]),
+            derive_key(ikm, b"domain-a", &[b"message-2"]),
+        );
+    }
+
+    #[test]
+    fn derive_key_treats_multi_part_message_as_its_concatenation() {
+        let ikm = b"top secret key material";
+
+        assert_eq!(
+            derive_key(ikm, b"domain-a", &[b"foo", b"bar"]),
+            derive_key(ikm, b"domain-a", &[b"foobar"]),
+        );
+    }
+
+    #[test]
+    #[should_panic(expected = "HKDF domain must not be empty")]
+    fn derive_key_rejects_empty_domain() {
+        derive_key(b"ikm", b"", &[b"message"]);
+    }
+}

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -12,6 +12,7 @@
 
 pub mod driver;
 pub mod index;
+pub mod kdf;
 pub mod observability;
 pub mod serialization;
 pub mod state;

--- a/crates/core/src/tx/signer.rs
+++ b/crates/core/src/tx/signer.rs
@@ -1,5 +1,6 @@
 //! The local account used to sign transactions for submitting onchain.
 
+use crate::kdf;
 use alloy::{
     consensus::{SignableTransaction as _, TxEip1559},
     eips::Encodable2718 as _,
@@ -45,6 +46,22 @@ impl Signer {
             .map_err(|_| SigningError)?;
         let raw_tx = tx.into_signed(signature).encoded_2718();
         Ok(SignedTransaction(raw_tx))
+    }
+
+    /// Deterministically derives a 32-byte value from this account's private key using
+    /// HKDF-SHA256, bound to the caller-supplied `domain` and `message`.
+    ///
+    /// `domain` must be a non-empty, caller-chosen constant identifying the specific use case
+    /// (e.g. `"safenet-sentinel-reveal-salt"`), so that derivations for unrelated purposes over
+    /// the same private key can never collide. See [`kdf::derive_key`] for details.
+    ///
+    /// Since the output is keyed by the account's own private key, it is
+    /// reproducible without persisting anything beyond `domain` and `message`.
+    pub fn derive_key(&self, domain: &[u8], message: &[u8]) -> B256 {
+        let mut key = self.0.to_bytes();
+        let derived = kdf::derive_key(key.as_slice(), domain, &[message]);
+        key.0.zeroize();
+        derived
     }
 }
 


### PR DESCRIPTION
Allow to generate deterministic hashes that are derived from the signer private key. This uses hmac and sha2 to follow a well defined standard.

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://docs.safefoundation.org/cla).
