### PR TITLE
[A 1]: Implement Commit Reveal Lib

### DIFF
--- a/contracts/src/libraries/SentinelOracleCommitmentsV2.sol
+++ b/contracts/src/libraries/SentinelOracleCommitmentsV2.sol
@@ -1,0 +1,116 @@
+// SPDX-License-Identifier: GPL-3.0-only
+pragma solidity ^0.8.30;
+
+library SentinelOracleCommitment {
+    // ============================================================
+    // ENUMS
+    // ============================================================
+
+    enum Vote {
+        NONE, // never committed
+        PENDING, // committed, not yet revealed
+        APPROVED,
+        DENIED
+    }
+
+    // ============================================================
+    // STRUCTS
+    // ============================================================
+
+    struct Commitment {
+        bytes32 commitHash;
+        uint256 bondAmount;
+        Vote vote;
+        bool claimed;
+    }
+
+    // ============================================================
+    // ERRORS
+    // ============================================================
+
+    error NothingToClaim();
+    error AlreadyClaimed();
+    error NotRevealed();
+
+    // ============================================================
+    // INTERNAL FUNCTIONS
+    // ============================================================
+
+    function markClaimed(Commitment storage self) internal returns (Commitment memory) {
+        require(self.vote != Vote.PENDING, NotRevealed());
+        require(self.bondAmount > 0, NothingToClaim());
+        require(!self.claimed, AlreadyClaimed());
+        self.claimed = true;
+        Commitment memory snapshot = self;
+        return snapshot;
+    }
+
+    function computeHash(address sentinel, bytes32 requestId, bool approve, bytes32 salt)
+        internal
+        pure
+        returns (bytes32)
+    {
+        // forge-lint: disable-next-line(asm-keccak256)
+        return keccak256(abi.encodePacked(approve, salt, sentinel, requestId));
+    }
+}
+
+library SentinelOracleCommitmentMap {
+    // ============================================================
+    // STRUCTS
+    // ============================================================
+
+    struct T {
+        mapping(bytes32 requestId => mapping(address sentinel => SentinelOracleCommitment.Commitment)) commitments;
+    }
+
+    // ============================================================
+    // EVENTS
+    // ============================================================
+
+    event Committed(bytes32 indexed requestId, address indexed sentinel, uint256 bondAmount);
+    event Revealed(bytes32 indexed requestId, address indexed sentinel, bool approved, uint256 bondAmount);
+
+    // ============================================================
+    // ERRORS
+    // ============================================================
+
+    error AlreadyCommitted();
+    error AlreadyRevealed();
+    error InvalidReveal();
+    error NotCommitted();
+
+    // ============================================================
+    // INTERNAL FUNCTIONS
+    // ============================================================
+
+    function checkNotCommitted(T storage self, bytes32 requestId, address sentinel) internal view {
+        require(self.commitments[requestId][sentinel].commitHash == 0, AlreadyCommitted());
+    }
+
+    function add(T storage self, bytes32 requestId, address sentinel, bytes32 commitHash, uint256 bondAmount) internal {
+        self.commitments[requestId][sentinel] = SentinelOracleCommitment.Commitment({
+            commitHash: commitHash, bondAmount: bondAmount, vote: SentinelOracleCommitment.Vote.PENDING, claimed: false
+        });
+        emit Committed(requestId, sentinel, bondAmount);
+    }
+
+    function reveal(T storage self, bytes32 requestId, address sentinel, bool approve, bytes32 salt) internal {
+        SentinelOracleCommitment.Commitment storage c = self.commitments[requestId][sentinel];
+        require(c.vote != SentinelOracleCommitment.Vote.NONE, NotCommitted());
+        require(c.vote == SentinelOracleCommitment.Vote.PENDING, AlreadyRevealed());
+        require(
+            SentinelOracleCommitment.computeHash(sentinel, requestId, approve, salt) == c.commitHash, InvalidReveal()
+        );
+        c.vote = approve ? SentinelOracleCommitment.Vote.APPROVED : SentinelOracleCommitment.Vote.DENIED;
+        emit Revealed(requestId, sentinel, approve, c.bondAmount);
+    }
+
+    function get(T storage self, bytes32 requestId, address sentinel)
+        internal
+        view
+        returns (SentinelOracleCommitment.Commitment storage)
+    {
+        return self.commitments[requestId][sentinel];
+    }
+}


### PR DESCRIPTION
Adjust the commitments Solidity library to handle the commit/ reveal flow.

- Design Decisions:
  - Verify the hash in the reveal method. This requires to provide the salt to the lib.
  - The code does not include tests, these will be added once the implementation is stable
  - To avoid breaking tests the changes are implemented in a copied library. Once the implementation is completed the original will be removed.


## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://docs.safefoundation.org/cla).
