### PR TITLE
[B 4]: Implement Signing Nonces Chunking

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1527,6 +1527,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
 
 [[package]]
+name = "crossbeam-deque"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5181e0de7b61eb03a81e347d6dd8797bae9da5146707b51077e2d71a54ec0ceb"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-epoch"
 version = "0.9.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3683,6 +3693,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "rayon"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "recvmsg"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5214,6 +5244,8 @@ dependencies = [
  "frost-secp256k1",
  "k256",
  "rand 0.8.6",
+ "rand_chacha 0.3.1",
+ "rayon",
  "safenet-core",
  "serde",
  "sqlx",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ futures = "0.3"
 k256 = { version = "0.13", features = ["hash2curve", "serde"] }
 metrics = "0.24"
 rand = "0.8"
+rand_chacha = "0.3"
 safenet-core = { path = "crates/core" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/crates/validator/Cargo.toml
+++ b/crates/validator/Cargo.toml
@@ -11,6 +11,8 @@ frost-core = { version = "3", features = ["internals"] }
 frost-secp256k1 = "3"
 k256.workspace = true
 rand.workspace = true
+rand_chacha.workspace = true
+rayon = "1"
 safenet-core.workspace = true
 serde.workspace = true
 sqlx.workspace = true

--- a/crates/validator/src/frost/marshal.rs
+++ b/crates/validator/src/frost/marshal.rs
@@ -3,7 +3,10 @@
 use super::error;
 use crate::{bindings, frost::ecdh::EncryptionPublicKey};
 use alloy::primitives::U256;
-use frost_secp256k1::keys::{self, dkg};
+use frost_secp256k1::{
+    keys::{self, dkg},
+    round1,
+};
 use k256::{
     Scalar,
     elliptic_curve::{
@@ -52,6 +55,14 @@ pub fn solidity_secret_share(
         .map(U256::from_be_bytes)
         .collect();
     bindings::KeyGenSecretShare { y, f }
+}
+
+/// The marshaled hiding (`d`) and binding (`e`) commitment points for a
+/// signing nonce pair.
+pub fn solidity_sign_nonces(commitments: &round1::SigningCommitments) -> bindings::SignNonces {
+    let d = solidity_point(&commitments.hiding().value());
+    let e = solidity_point(&commitments.binding().value());
+    bindings::SignNonces { d, e }
 }
 
 /// Converts a secp256k1 point to the ABI `Point { uint256 x; uint256 y }`.

--- a/crates/validator/src/frost/mod.rs
+++ b/crates/validator/src/frost/mod.rs
@@ -12,6 +12,7 @@ pub mod ecdh;
 pub mod error;
 pub mod keygen;
 mod marshal;
+pub mod nonces;
 mod participants;
 
 #[cfg(test)]

--- a/crates/validator/src/frost/nonces.rs
+++ b/crates/validator/src/frost/nonces.rs
@@ -1,0 +1,132 @@
+//! The 1024-nonce preprocessing scheme layered over standard FROST nonces.
+//!
+//! Each nonces' merkle proof is **precomputed at generation time** (when the
+//! tree is built once anyway) and stored alongside it in a [`Nonces`], so
+//! revealing a single nonce needs only that one entry rather than the whole
+//! chunk resident in memory.
+
+use super::marshal;
+use crate::{
+    bindings,
+    merkle::{MerkleRoot, MerkleTree},
+};
+use alloy::primitives::{B256, keccak256};
+use frost_secp256k1::{keys::SigningShare, round1};
+use rand::{CryptoRng, RngCore, SeedableRng as _};
+use rand_chacha::ChaCha12Rng;
+use rayon::iter::{IntoParallelIterator as _, ParallelIterator as _};
+
+/// The number of nonces committed to per `preprocess`, matching the onchain
+/// `FROSTNonceCommitmentSet` sequence chunk size.
+pub const SEQUENCE_CHUNK_SIZE: u64 = 1024;
+
+/// A single preprocessing nonce pair and its precomputed inclusion proof in the
+/// chunk's merkle tree. Because the proof is stored with the nonce, a nonce can
+/// be revealed in isolation without the rest of the chunk.
+pub struct Nonces {
+    signing_nonces: round1::SigningNonces,
+    proof: Vec<B256>,
+}
+
+impl Nonces {
+    /// Compute the signature nonces reveal parameters the FROST sining nonce
+    /// pair.
+    pub fn reveal(&self) -> (bindings::SignNonces, &[B256]) {
+        (
+            marshal::solidity_sign_nonces(self.signing_nonces.commitments()),
+            &self.proof,
+        )
+    }
+}
+
+/// A freshly generated chunk of preprocessing nonces: the per-offset secrets
+/// (each carrying its own proof) to persist and the merkle `commitment` to
+/// publish onchain.
+pub struct NonceChunk {
+    /// The `SEQUENCE_CHUNK_SIZE` nonces, indexed by offset. Secret; persisted to
+    /// the secret store and never rolled back.
+    pub nonces: Vec<Nonces>,
+    /// The merkle root over the nonce commitments, published by `preprocess`.
+    pub commitment: MerkleRoot,
+}
+
+impl NonceChunk {
+    /// Generates a fresh chunk of `SEQUENCE_CHUNK_SIZE` nonces for
+    /// `signing_share`, the merkle root committing to them, and each nonce's
+    /// inclusion proof. The RNG is supplied by the caller.
+    pub fn generate<R>(signing_share: &SigningShare, rng: &mut R) -> Result<NonceChunk, rand::Error>
+    where
+        R: RngCore + CryptoRng,
+    {
+        // Parallelize nonce generation to speed up the process. Note that this
+        // requires us to seed one RNG per nonce pair, as the `R` passed in
+        // cannot be shared across threads. The choice of [`ChaCha12Rng`] is
+        // based on the fact that it is the standard RNG used by [`rand`] (both
+        // the `ThreadRng` and `StdRng`), it is a cryptographically secure RNG,
+        // and it allows unique random streams per nonce generation.
+        let rngs = (0..SEQUENCE_CHUNK_SIZE)
+            .map({
+                let seed = ChaCha12Rng::from_rng(&mut *rng)?;
+                move |offset| {
+                    let mut rng = seed.clone();
+                    rng.set_stream(offset.checked_add(1).expect("chunk too large"));
+                    Ok((offset, rng))
+                }
+            })
+            .collect::<Result<Vec<_>, rand::Error>>()?;
+        let (signing_nonces, leaves) = rngs
+            .into_par_iter()
+            .map(|(offset, mut rng)| {
+                let signing_nonces = round1::SigningNonces::new(signing_share, &mut rng);
+                let marshaled = marshal::solidity_sign_nonces(signing_nonces.commitments());
+                let leaf = nonces_leaf(offset, &marshaled);
+                (signing_nonces, leaf)
+            })
+            .unzip::<_, _, Vec<_>, Vec<_>>();
+
+        let tree = MerkleTree::build(leaves);
+        let nonces = signing_nonces
+            .into_iter()
+            .enumerate()
+            .map(|(i, signing_nonces)| Nonces {
+                signing_nonces,
+                proof: tree.proof(i),
+            })
+            .collect();
+
+        Ok(NonceChunk {
+            nonces,
+            commitment: tree.root(),
+        })
+    }
+}
+
+/// The leaf hash for a nonce commitment at `offset` in the nonce tree. Defined
+/// as `keccak256(abi.encode(offset, d.x, d.y, e.x, e.y))`.
+fn nonces_leaf(offset: u64, nonces: &bindings::SignNonces) -> B256 {
+    let mut buf = [0u8; 160];
+    buf[24..32].copy_from_slice(&offset.to_be_bytes());
+    buf[32..64].copy_from_slice(&nonces.d.x.to_be_bytes::<32>());
+    buf[64..96].copy_from_slice(&nonces.d.y.to_be_bytes::<32>());
+    buf[96..128].copy_from_slice(&nonces.e.x.to_be_bytes::<32>());
+    buf[128..160].copy_from_slice(&nonces.e.y.to_be_bytes::<32>());
+    keccak256(buf)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn nonces_commitment_inclusion_proofs() {
+        let signing_share = SigningShare::new(k256::Scalar::ONE);
+        let chunk = NonceChunk::generate(&signing_share, &mut rand::thread_rng()).unwrap();
+        assert_eq!(chunk.nonces.len(), SEQUENCE_CHUNK_SIZE as usize);
+
+        for offset in [0, 1, 42, 777, (SEQUENCE_CHUNK_SIZE - 1) as usize] {
+            let (nonces, proof) = &chunk.nonces[offset].reveal();
+            let leaf = nonces_leaf(offset as _, nonces);
+            assert!(chunk.commitment.verify(leaf, proof));
+        }
+    }
+}

--- a/crates/validator/src/main.rs
+++ b/crates/validator/src/main.rs
@@ -1,6 +1,7 @@
 mod bindings;
 mod config;
 mod frost;
+mod merkle;
 mod service;
 
 use self::{config::Config, service::DummyService};

--- a/crates/validator/src/merkle.rs
+++ b/crates/validator/src/merkle.rs
@@ -1,0 +1,143 @@
+//! Sorted-pair Keccak-256 Merkle trees.
+
+#![cfg_attr(not(test), allow(dead_code))]
+
+use alloy::primitives::{B256, keccak256};
+use serde::{Deserialize, Serialize};
+
+/// A Merkle tree.
+pub struct MerkleTree(Vec<Vec<B256>>);
+
+impl MerkleTree {
+    /// Builds a Merkle tree from a vector of leaves.
+    ///
+    /// It is the callers responsibility to define how the leaves are computed.
+    pub fn build(leaves: Vec<B256>) -> Self {
+        let mut tree = vec![leaves];
+        while let Some(level) = tree.last()
+            && level.len() > 1
+        {
+            let pairs = level.len().div_ceil(2);
+            let next = (0..pairs)
+                .map(|i| {
+                    let a = level.get(i * 2).copied().unwrap_or(B256::ZERO);
+                    let b = level.get(i * 2 + 1).copied().unwrap_or(B256::ZERO);
+                    hash_pair(a, b)
+                })
+                .collect();
+            tree.push(next);
+        }
+        Self(tree)
+    }
+
+    /// Returns the height of the Merkle tree.
+    pub fn height(&self) -> usize {
+        self.0.len()
+    }
+
+    /// Returns the root of the Merkle tree.
+    pub fn root(&self) -> MerkleRoot {
+        let digest = self
+            .0
+            .last()
+            .and_then(|level| level.first())
+            .copied()
+            .unwrap_or_default();
+        MerkleRoot(digest)
+    }
+
+    /// Generates a Merkle inclusion proof for the leaf at `index`: the sibling
+    /// hashes from the leaf up to (but excluding) the root.
+    pub fn proof(&self, index: usize) -> Vec<B256> {
+        let len = self.height().saturating_sub(1);
+        let mut current = index;
+        let mut proof = Vec::with_capacity(len);
+        for level in self.0.iter().take(len) {
+            let sibling = current ^ 1;
+            proof.push(level.get(sibling).copied().unwrap_or(B256::ZERO));
+            current >>= 1;
+        }
+        proof
+    }
+}
+
+/// A Merkle root that can be used to verify a proof.
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(transparent)]
+pub struct MerkleRoot(B256);
+
+impl MerkleRoot {
+    /// Verifies a Merkle proof for a leaf.
+    pub fn verify(&self, leaf: B256, proof: &[B256]) -> bool {
+        let mut node = leaf;
+        for &sibling in proof {
+            node = hash_pair(node, sibling);
+        }
+        self.0 == node
+    }
+}
+
+impl PartialEq<B256> for MerkleRoot {
+    fn eq(&self, other: &B256) -> bool {
+        self.0 == *other
+    }
+}
+
+/// Hashes a pair of nodes with canonical (ascending) ordering, matching
+/// OpenZeppelin's commutative `MerkleProof` hashing.
+fn hash_pair(a: B256, b: B256) -> B256 {
+    let (left, right) = if a <= b { (a, b) } else { (b, a) };
+    let mut data = [0u8; 64];
+    data[..32].copy_from_slice(left.as_slice());
+    data[32..].copy_from_slice(right.as_slice());
+    keccak256(data)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloy::primitives::b256;
+
+    #[test]
+    fn merkle_root_empty_returns_zero() {
+        assert_eq!(MerkleTree::build(vec![]).root(), B256::ZERO);
+    }
+
+    #[test]
+    fn merkle_root_single_leaf() {
+        let leaf = B256::from([1u8; 32]);
+        assert_eq!(MerkleTree::build(vec![leaf]).root(), leaf);
+    }
+
+    #[test]
+    fn verifies_a_proof() {
+        let leaves = (1..=13).map(|i| B256::from([i; 32])).collect::<Vec<_>>();
+        let tree = MerkleTree::build(leaves.clone());
+        let root = tree.root();
+
+        for (i, leaf) in leaves.into_iter().enumerate() {
+            let proof = tree.proof(i);
+            assert!(root.verify(leaf, &proof))
+        }
+    }
+
+    #[test]
+    fn generates_the_expected_merkle_root() {
+        let root = MerkleTree::build(vec![
+            b256!("0000000000000000000000000000000000000000000000000000000000000001"),
+            b256!("0000000000000000000000000000000000000000000000000000000000000002"),
+            b256!("0000000000000000000000000000000000000000000000000000000000000003"),
+            b256!("0000000000000000000000000000000000000000000000000000000000000004"),
+            b256!("0000000000000000000000000000000000000000000000000000000000000005"),
+            B256::ZERO,
+            B256::ZERO,
+            B256::ZERO,
+        ])
+        .root();
+
+        assert_eq!(
+            root,
+            b256!("37e58bc84afff4e1afade4140135583af3d6d3523a435e60cec5dc75ae3d7e8b")
+        );
+    }
+}


### PR DESCRIPTION
### Context and Motivation

This PR implements the 1024 nonces chunks which need to be committed to (in the `FROSTCoordinator.preprocess` phase).

### Decisions and Tradeoffs

We use `rayon` in order to compute the chunk in parallel on all cores. This, along side the nonces pair specific seeded RNG, gives us performance gains linear to the number of cores on the system (on my system with 8 cores, it takes ~290ms instead of 2.4s; in `release` builds, nonce generation takes less than 20ms).

Note that we also chose to store proofs with each of the nonces - this allows the `Nonces` to be written to an SQLite database individually, and have the proof be read per nonce instead of requiring the whole tree to be loaded into memory.

### Testing

For now, we test on some internal details of the `Nonces` type (in particular, we need to compute the leaf hash for the nonce pair). I decided to keep it this way, as the validator never needs to verify nonce inclusion proofs (so there is no public API to use for testing).

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://docs.safefoundation.org/cla).
