### PR TITLE
[B 1]: Update bindings and add hashing functions

### DIFF
--- a/crates/sentinel/src/bindings.rs
+++ b/crates/sentinel/src/bindings.rs
@@ -45,6 +45,40 @@ pub mod oracle {
         }
 
         #[derive(Debug)]
+        contract SentinelOracleV2 {
+            event NewRequest(
+                bytes32 indexed requestId,
+                address indexed proposer,
+                uint256 fee,
+                uint256 bondTarget,
+                uint256 commitDeadline,
+                uint256 revealDeadline
+            );
+            event Committed(bytes32 indexed requestId, address indexed sentinel, uint256 bondAmount);
+            event Revealed(
+                bytes32 indexed requestId,
+                address indexed sentinel,
+                bool approved,
+                uint256 bondAmount
+            );
+            event OracleResult(
+                bytes32 indexed requestId,
+                address indexed proposer,
+                bytes result,
+                bool approved
+            );
+
+            function commit(bytes32 requestId, bytes32 commitHash) external;
+            function reveal(bytes32 requestId, bool approve, bytes32 salt) external;
+            function hashCommitment(address sentinel, bytes32 requestId, bool approve, bytes32 salt)
+                external
+                pure
+                returns (bytes32);
+            function finalize(bytes32 requestId) external;
+            function claim(bytes32 requestId) external;
+        }
+
+        #[derive(Debug)]
         contract ERC20 {
             function approve(address spender, uint256 amount) external returns (bool);
             function allowance(address owner, address spender) external view returns (uint256);

--- a/crates/sentinel/src/hashing.rs
+++ b/crates/sentinel/src/hashing.rs
@@ -3,9 +3,47 @@ use crate::bindings::{
     safe::{Operation as SafeOperation, SafeTx},
 };
 use alloy::{
-    primitives::{Address, B256, U256},
+    primitives::{Address, B256, U256, keccak256},
     sol_types::{Eip712Domain, SolStruct},
 };
+use safenet_core::tx::Signer;
+
+/// Domain separator for deriving a sentinel's reveal salt from its account key. Passed as the
+/// HKDF salt in [`Signer::derive_key`]; see `Signer::derive_key`'s own docs for why this alone
+/// (not a hard security requirement) is enough separation from other uses of the same key.
+const REVEAL_SALT_DOMAIN: &[u8] = b"safenet-sentinel-reveal-salt";
+
+/// Computes the blind commit-hash preimage for the sentinel game's commit-reveal vote, mirroring
+/// `SentinelOracleCommitment.computeHash` (`contracts/src/libraries/SentinelOracleCommitmentsV2.sol`):
+/// `keccak256(abi.encodePacked(approve, salt, sentinel, requestId))`. Binding `sentinel` and
+/// `requestId` into the preimage (not just `approve`/`salt`) is load-bearing, not
+/// defense-in-depth — see the epic's Architecture Decision for why.
+#[must_use]
+#[cfg_attr(not(test), expect(dead_code))]
+pub fn commit_hash(sentinel: Address, request_id: B256, approve: bool, salt: B256) -> B256 {
+    let mut preimage = [0u8; 85];
+    preimage[0] = u8::from(approve);
+    preimage[1..33].copy_from_slice(salt.as_slice());
+    preimage[33..53].copy_from_slice(sentinel.as_slice());
+    preimage[53..85].copy_from_slice(request_id.as_slice());
+    keccak256(preimage)
+}
+
+/// Extends [`Signer`] with the sentinel game's reveal-salt derivation, so callers can write
+/// `signer.reveal_salt(request_id)` alongside its other account operations.
+#[cfg_attr(not(test), expect(dead_code))]
+pub trait RevealSalt {
+    /// Deterministically derives this account's reveal salt for `request_id`, so nothing needs
+    /// to be persisted between `commit` and `reveal` (see the epic's Architecture Decision:
+    /// "Deterministic salt derivation via HMAC-SHA256").
+    fn reveal_salt(&self, request_id: B256) -> B256;
+}
+
+impl RevealSalt for Signer {
+    fn reveal_salt(&self, request_id: B256) -> B256 {
+        self.derive_key(REVEAL_SALT_DOMAIN, request_id.as_slice())
+    }
+}
 
 /// Computes the EIP-712 signing hash for a Safe transaction.
 #[must_use]
@@ -58,7 +96,10 @@ pub fn oracle_tx_proposal_hash(
 mod tests {
     use super::*;
     use crate::bindings::consensus::Operation;
-    use alloy::primitives::{Bytes, address, b256};
+    use alloy::{
+        primitives::{Bytes, address, b256},
+        signers::k256::ecdsa::SigningKey,
+    };
 
     fn zero_tx(chain_id: u64, safe: Address, to: Address) -> SafeTransaction {
         SafeTransaction {
@@ -104,6 +145,54 @@ mod tests {
         assert_eq!(
             id,
             b256!("2a29f463bfd18f87230f795b09f22d8d126f0fcedab6149ce430777c827115b0"),
+        );
+    }
+
+    /// Parity vector: `SentinelOracleCommitment.computeHash` from
+    /// `contracts/src/libraries/SentinelOracleCommitmentsV2.sol`, obtained by exercising that
+    /// library directly with `forge test`.
+    /// Inputs: sentinel=0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045, requestId=1, approve=true,
+    /// salt=keccak256("test-salt").
+    #[test]
+    fn commit_hash_parity() {
+        let sentinel = address!("d8dA6BF26964aF9D7eEd9e03E53415D37aA96045");
+        let request_id = b256!("0000000000000000000000000000000000000000000000000000000000000001");
+        let salt = b256!("8bcfa1e0aed22543ed44d41a95e315383294a18f9fb6e67ee082afcd585a6ff1");
+
+        assert_eq!(
+            commit_hash(sentinel, request_id, true, salt),
+            b256!("9f44e900e6915367390f6c4cd429c13649a332a97f99330ae9d3770b0bcaab76"),
+        );
+    }
+
+    /// Independently computed (Python `hmac`/`hashlib` HKDF-SHA256 per RFC 5869 §2.2/§2.3,
+    /// mirroring `kdf::derive_key`'s own reference-vector test), since `reveal_salt` has no
+    /// onchain/TS counterpart to cross-check against.
+    /// Inputs: private key = keccak256("top secret key"), requestId=1.
+    #[test]
+    fn reveal_salt_parity() {
+        let key = SigningKey::from_bytes(&keccak256("top secret key").0.into()).unwrap();
+        let signer = Signer::new(key);
+        let request_id = b256!("0000000000000000000000000000000000000000000000000000000000000001");
+
+        assert_eq!(
+            signer.reveal_salt(request_id),
+            b256!("40b40e386211784e67ff361d1c7be5ffaf17b1b59eb91d176cfe0f02f28d7461"),
+        );
+    }
+
+    #[test]
+    fn reveal_salt_is_bound_to_request_id() {
+        let key = SigningKey::from_bytes(&keccak256("top secret key").0.into()).unwrap();
+        let signer = Signer::new(key);
+
+        assert_ne!(
+            signer.reveal_salt(b256!(
+                "0000000000000000000000000000000000000000000000000000000000000001"
+            )),
+            signer.reveal_salt(b256!(
+                "0000000000000000000000000000000000000000000000000000000000000002"
+            )),
         );
     }
 }


### PR DESCRIPTION
Add the SentinelOracleV2 to the bindings and implement the require hashing functions to derive the salt and calculate the commit hash.

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://docs.safefoundation.org/cla).
