### PR TITLE
[B 6]: Add Signing Ceremony Test

### DIFF
--- a/crates/validator/src/frost/mod.rs
+++ b/crates/validator/src/frost/mod.rs
@@ -6,7 +6,7 @@
 //! FROST coordinator contract, internally managing the marshalling between
 //! [`frost-secp256k1`] values and their Solidity ABI representations.
 
-#![expect(dead_code)]
+#![cfg_attr(not(test), expect(dead_code))]
 
 pub mod ecdh;
 pub mod error;
@@ -19,7 +19,8 @@ pub mod signing;
 #[cfg(test)]
 mod tests {
     use super::*;
-    use alloy::primitives::address;
+    use crate::merkle::MerkleRoot;
+    use alloy::primitives::{address, keccak256};
     use std::collections::BTreeMap;
 
     #[test]
@@ -103,6 +104,150 @@ mod tests {
             .verifying_key();
         for r3 in round3.values() {
             assert_eq!(group_key, r3.public_key_package.verifying_key());
+        }
+
+        // Signing ceremony: a threshold set of signers jointly signs a message,
+        // each contributing a signature share and the signer-set selection.
+        let message = keccak256("Hello, Safenet!");
+        let signers = [participants[0], participants[2]];
+
+        // Every signer preprocesses a nonce chunk, reveals its first nonce and
+        // verifies each signer's revealed commitment.
+        let mut secret_nonces = BTreeMap::new();
+        let mut revealed_nonces = BTreeMap::new();
+        for signer in signers {
+            let key_package = &round3[&signer].key_package;
+            let chunk =
+                nonces::NonceChunk::with_size(1, key_package.signing_share(), &mut rng).unwrap();
+            let nonces = chunk.nonces.into_iter().next().unwrap();
+            let (sign_nonces, proof) = nonces.reveal();
+
+            // Verify the Merkle proof as is done on the smart contract. This
+            // is not expected to be enfoced by the clients, but added here for
+            // testing.
+            assert!(
+                chunk
+                    .commitment
+                    .verify(nonces::nonces_leaf(0, &sign_nonces), proof)
+            );
+
+            secret_nonces.insert(signer, nonces);
+            revealed_nonces.insert(signer, sign_nonces);
+        }
+
+        // Each signer independently produces its signature share.
+        let revealed = revealed_nonces
+            .iter()
+            .map(|(participant, nonces)| {
+                let commitment = signing::verify_revealed_nonces(*participant, nonces).unwrap();
+                (*participant, commitment)
+            })
+            .collect();
+        let signatures = signers
+            .into_iter()
+            .map(|signer| {
+                let signature = signing::signature_share(
+                    &round3[&signer].key_package,
+                    &secret_nonces[&signer],
+                    &revealed,
+                    &message,
+                )
+                .unwrap();
+                (signer, signature)
+            })
+            .collect::<BTreeMap<_, _>>();
+
+        // Every signer reconstructs the identical selection: the same group
+        // commitment `r` and signer-set root.
+        let selection = &signatures[&signers[0]].selection;
+        for (address, signature) in &signatures {
+            assert_eq!(signature.selection.root, selection.root);
+            assert_eq!(signature.selection.r.x, selection.r.x);
+            assert_eq!(signature.selection.r.y, selection.r.y);
+
+            // Verify the Merkle proof as is done on the smart contract. This
+            // is not expected to be enforced by the clients, but added here for
+            // testing.
+            assert!(MerkleRoot::from(selection.root).verify(
+                signing::signer_leaf(
+                    address,
+                    &signature.share.r,
+                    &signature.share.l,
+                    &signature.selection.r
+                ),
+                &signature.proof,
+            ));
+        }
+
+        // Aggregate the shares to verify the constructed signature using only
+        // data that is available onchain.
+        {
+            let signing_commitments = revealed_nonces
+                .iter()
+                .map(|(address, nonces)| {
+                    (
+                        participants::identifier(*address),
+                        marshal::frost_signing_commitments(nonces).unwrap(),
+                    )
+                })
+                .collect();
+            let signing_package =
+                frost_secp256k1::SigningPackage::new(signing_commitments, message.as_slice());
+            let signature_shares = signatures
+                .iter()
+                .map(|(address, signature)| {
+                    (
+                        participants::identifier(*address),
+                        frost_secp256k1::round2::SignatureShare::deserialize(
+                            &signature.share.z.to_be_bytes::<32>(),
+                        )
+                        .unwrap(),
+                    )
+                })
+                .collect();
+            let verifying_shares = round3
+                .iter()
+                .map(|(address, r3)| {
+                    (
+                        participants::identifier(*address),
+                        *r3.key_package.verifying_share(),
+                    )
+                })
+                .collect();
+            let public_key_package = frost_secp256k1::keys::PublicKeyPackage::new(
+                verifying_shares,
+                *group_key,
+                Some(threshold),
+            );
+
+            let signature = frost_secp256k1::aggregate(
+                &signing_package,
+                &signature_shares,
+                &public_key_package,
+            )
+            .unwrap();
+
+            // Check that the FROST signature is valid for the group.
+            public_key_package
+                .verifying_key()
+                .verify(message.as_slice(), &signature)
+                .unwrap();
+
+            // Check that the selection's group commitment is the sum of the
+            // commitment shares, and that it matches the aggregate signature's
+            // calculated group commitment; this is specific to Safenet's FROST
+            // setup and is not checked as part of regular FROST operations.
+            for group_commitment in [
+                // group commitment from the sum of commitment shares.
+                signatures
+                    .values()
+                    .map(|signature| marshal::frost_point(&signature.share.r).unwrap())
+                    .sum::<k256::ProjectivePoint>(),
+                // group commitment from the signer selection.
+                marshal::frost_point(&selection.r).unwrap(),
+            ] {
+                assert_eq!(group_commitment, *signature.R());
+            }
         }
     }
 }

--- a/crates/validator/src/frost/nonces.rs
+++ b/crates/validator/src/frost/nonces.rs
@@ -64,13 +64,27 @@ impl NonceChunk {
     where
         R: RngCore + CryptoRng,
     {
+        Self::with_size(SEQUENCE_CHUNK_SIZE, signing_share, rng)
+    }
+
+    /// Same as [`generate`] but with a user-specified size in chunks.
+    ///
+    /// This allows for smaller nonce chunks for testing.
+    pub fn with_size<R>(
+        size: u64,
+        signing_share: &SigningShare,
+        rng: &mut R,
+    ) -> Result<NonceChunk, rand::Error>
+    where
+        R: RngCore + CryptoRng,
+    {
         // Parallelize nonce generation to speed up the process. Note that this
         // requires us to seed one RNG per nonce pair, as the `R` passed in
         // cannot be shared across threads. The choice of [`ChaCha12Rng`] is
         // based on the fact that it is the standard RNG used by [`rand`] (both
         // the `ThreadRng` and `StdRng`), it is a cryptographically secure RNG,
         // and it allows unique random streams per nonce generation.
-        let rngs = (0..SEQUENCE_CHUNK_SIZE)
+        let rngs = (0..size)
             .map({
                 let seed = ChaCha12Rng::from_rng(&mut *rng)?;
                 move |offset| {
@@ -109,7 +123,7 @@ impl NonceChunk {
 
 /// The leaf hash for a nonce commitment at `offset` in the nonce tree. Defined
 /// as `keccak256(abi.encode(offset, d.x, d.y, e.x, e.y))`.
-fn nonces_leaf(offset: u64, nonces: &bindings::SignNonces) -> B256 {
+pub(super) fn nonces_leaf(offset: u64, nonces: &bindings::SignNonces) -> B256 {
     let mut buf = [0u8; 160];
     buf[24..32].copy_from_slice(&offset.to_be_bytes());
     buf[32..64].copy_from_slice(&nonces.d.x.to_be_bytes::<32>());

--- a/crates/validator/src/frost/signing.rs
+++ b/crates/validator/src/frost/signing.rs
@@ -161,7 +161,7 @@ fn binding_factor_to_scalar(
 /// The leaf hash for a participant in the signer-set selection tree. Defined as
 /// `keccak256(participant, r.x, r.y, l, group_r.x, group_r.y)`, matching
 /// `FROSTSignatureShares._hash` (the participant occupies a full 32-byte slot).
-fn signer_leaf(
+pub(super) fn signer_leaf(
     participant: &Address,
     r: &bindings::Point,
     l: &U256,

--- a/crates/validator/src/merkle.rs
+++ b/crates/validator/src/merkle.rs
@@ -83,6 +83,12 @@ impl PartialEq<B256> for MerkleRoot {
     }
 }
 
+impl From<B256> for MerkleRoot {
+    fn from(root: B256) -> Self {
+        Self(root)
+    }
+}
+
 impl From<MerkleRoot> for B256 {
     fn from(root: MerkleRoot) -> Self {
         root.0


### PR DESCRIPTION
### Context and Motivation

We now test the FROST signing ceremony logic as well!

### Decisions and Tradeoffs

I made some internal functions (namely the leaf computations) `pub(super)`, so they can be accessed by the module level tests. The abstractions shouldn't leak outside of the `frost` module, so I think this is OK.

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://docs.safefoundation.org/cla).
