### PR TITLE
[B 7/7]: Refactor Public FROST API

### DIFF
--- a/crates/validator/src/frost/ecdh.rs
+++ b/crates/validator/src/frost/ecdh.rs
@@ -55,24 +55,21 @@ impl Drop for EncryptionKey {
 impl ZeroizeOnDrop for EncryptionKey {}
 
 /// An encryption public key that can be serialized.
-#[derive(Clone)]
+#[derive(Clone, Eq, PartialEq)]
 pub struct EncryptionPublicKey(ProjectivePoint);
 
 impl EncryptionPublicKey {
-    /// Returns the public key as a point.
-    pub fn as_point(&self) -> &ProjectivePoint {
-        &self.0
-    }
-}
-
-impl TryFrom<ProjectivePoint> for EncryptionPublicKey {
-    type Error = frost_secp256k1::Error;
-
-    fn try_from(point: ProjectivePoint) -> Result<Self, Self::Error> {
+    /// Tries to construct an encryption public key from a projective point.
+    pub(super) fn from_point(point: ProjectivePoint) -> Result<Self, frost_secp256k1::Error> {
         if point.is_identity().into() {
             return Err(frost_secp256k1::GroupError::InvalidIdentityElement.into());
         }
         Ok(Self(point))
+    }
+
+    /// Returns the public key as a point.
+    pub(super) fn as_point(&self) -> &ProjectivePoint {
+        &self.0
     }
 }
 
@@ -84,8 +81,8 @@ impl<'de> Deserialize<'de> for EncryptionPublicKey {
         let encoded = EncodedPoint::deserialize(deserializer)?;
         ProjectivePoint::from_encoded_point(&encoded)
             .into_option()
+            .map(EncryptionPublicKey::from_point)
             .ok_or_else(|| de::Error::custom("invalid encryption public key encoding"))?
-            .try_into()
             .map_err(de::Error::custom)
     }
 }
@@ -172,6 +169,6 @@ mod tests {
 
     #[test]
     fn ecdh_rejects_degenerate_public_keys_at_infinity() {
-        assert!(EncryptionPublicKey::try_from(ProjectivePoint::IDENTITY).is_err());
+        assert!(EncryptionPublicKey::from_point(ProjectivePoint::IDENTITY).is_err());
     }
 }

--- a/crates/validator/src/frost/keygen.rs
+++ b/crates/validator/src/frost/keygen.rs
@@ -18,23 +18,30 @@ use frost_secp256k1::{
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 
-/// The output of DKG round 1: the secret polynomial (persisted to the secret
-/// store) and the onchain commitment to publish.
-pub struct Round1 {
-    pub encryption_key: EncryptionKey,
-    pub secret_package: round1::SecretPackage,
+/// A participant's generated secrets created at [`setup`] and required by
+/// [`verify_commitment`] and [`generate_secret_shares`]. Persisted to the
+/// secret store between rounds.
+#[derive(Clone, Deserialize, Serialize)]
+pub struct Secrets {
+    encryption_key: EncryptionKey,
+    secret_package: round1::SecretPackage,
+}
+
+/// The result of [`setup`]: the secrets to persist across rounds and the
+/// onchain commitment to publish.
+///
+/// Note that the secrets are generated with randomness, meaning that they must
+/// be persisted in a reorg-resistant way.
+pub struct Setup {
+    pub secrets: Secrets,
     pub commitment: bindings::KeyGenCommitment,
 }
 
-/// Runs DKG round 1 for `me`, producing the round 1 secret package and the
-/// onchain [`KeyGenCommitment`](bindings::KeyGenCommitment). The `encryption_key`
-/// and `rng` are supplied (and the secrets persisted) by the caller.
-pub fn generate_round1<R>(
-    rng: &mut R,
-    me: Address,
-    count: u16,
-    threshold: u16,
-) -> Result<Round1, Error>
+/// Sets up key generation for `me`: samples the ECDH encryption key and the
+/// secret polynomial (to persist to the secret store) alongside the onchain
+/// [`KeyGenCommitment`](bindings::KeyGenCommitment) to publish. The `rng` is
+/// supplied by the caller.
+pub fn setup<R>(rng: &mut R, me: Address, count: u16, threshold: u16) -> Result<Setup, Error>
 where
     R: rand::RngCore + rand::CryptoRng,
 {
@@ -43,33 +50,38 @@ where
     let (secret_package, package) =
         dkg::part1(identifier, count, threshold, &mut *rng).err_unexpected()?;
     let commitment = marshal::solidity_commitment(&encryption_key.public_key(), &package);
-    Ok(Round1 {
-        encryption_key,
-        secret_package,
+
+    Ok(Setup {
+        secrets: Secrets {
+            encryption_key,
+            secret_package,
+        },
         commitment,
     })
 }
 
-/// A validated round 1 public commitment from a participant.
+/// A validated public commitment from a participant.
 #[derive(Clone, Deserialize, Serialize)]
-pub struct Round1Commitment {
+pub struct VerifiedCommitment {
     encryption_public_key: EncryptionPublicKey,
     package: round1::Package,
 }
 
-/// Verifies a round 1 public commitment.
+/// Verifies a participant's public commitment.
 ///
 /// These are applied to _both_ `me`, the validator itself, and all peers that
 /// publish key generation commitments onchain.
-pub fn verify_round1_commitment(
-    min_signers: u16,
+pub fn verify_commitment(
+    secrets: &Secrets,
     participant: Address,
     commitment: &bindings::KeyGenCommitment,
-) -> Result<Round1Commitment, Error> {
+) -> Result<VerifiedCommitment, Error> {
     let identifier = participants::identifier(participant);
     marshal::frost_commitment(commitment)
         .and_then(|(encryption_public_key, package)| {
-            if package.commitment().coefficients().len() as u16 != min_signers {
+            if package.commitment().coefficients().len() as u16
+                != *secrets.secret_package.min_signers()
+            {
                 return Err(frost_secp256k1::Error::IncorrectNumberOfCommitments);
             }
             frost_core::keys::dkg::verify_proof_of_knowledge(
@@ -77,7 +89,7 @@ pub fn verify_round1_commitment(
                 package.commitment(),
                 package.proof_of_knowledge(),
             )?;
-            Ok(Round1Commitment {
+            Ok(VerifiedCommitment {
                 encryption_public_key,
                 package,
             })
@@ -85,49 +97,68 @@ pub fn verify_round1_commitment(
         .err_with_culprit(participant)
 }
 
-/// The output of DKG round 2: the secret package (persisted) and the onchain
+/// A participant's own secret key-generation state after sharing. Persisted to
+/// the secret store and consumed by [`finalize`].
+///
+/// Unlike [`Secrets`], this can be reconstructed using the generated secrets
+/// from [`setup`] and onchain state, and therefore can be stored in the state
+/// machine (and does not require a reorg-resistant storage).
+#[derive(Clone, Deserialize, Serialize)]
+pub struct SharingState {
+    encryption_key: EncryptionKey,
+    secret_package: round2::SecretPackage,
+    group_commitment: keys::VerifiableSecretSharingCommitment,
+    commitments: BTreeMap<Address, VerifiedCommitment>,
+}
+
+/// The result of [`generate_secret_shares`]: the sharing state and the onchain
 /// secret share to publish.
-pub struct Round2 {
-    pub secret_package: round2::SecretPackage,
-    pub public_key_package: keys::PublicKeyPackage,
+pub struct SecretShares {
+    pub sharing_state: SharingState,
     pub share: bindings::KeyGenSecretShare,
 }
 
-/// Runs DKG round 2 given every participant's round 1 commitment. Produces the
-/// round 2 secret package and the ECDH encrypted secret shares for the peers,
-/// ordered by ascending peer address.
-pub fn generate_round2(
-    encryption_key: &EncryptionKey,
-    secret_package: &round1::SecretPackage,
-    commitments: &BTreeMap<Address, Round1Commitment>,
-) -> Result<Round2, Error> {
-    let round1_peer_packages =
-        peer_packages(secret_package.identifier(), commitments, |commitment| {
-            commitment.package.clone()
-        });
+/// Given every participant's verified commitment, produces the sharing state
+/// to persist and the ECDH-encrypted secret shares for the peers, ordered by
+/// ascending peer address.
+pub fn generate_secret_shares(
+    secrets: Secrets,
+    commitments: BTreeMap<Address, VerifiedCommitment>,
+) -> Result<SecretShares, Error> {
+    let (round1_peer_packages, round1_me_package) = peer_packages(
+        secrets.secret_package.identifier(),
+        &commitments,
+        |commitment| commitment.package.clone(),
+    )?;
 
     // By construction, the second round of DKG should have no participant
     // culprits (as the `commitments` have already verified the length of the
     // commitments and the proof of knowledge). The only way we encounter an
     // error here is if the caller were to mix secrets and commitments from
     // different DKG ceremonies.
-    dkg::part2(secret_package.clone(), &round1_peer_packages)
+    dkg::part2(secrets.secret_package.clone(), &round1_peer_packages)
         .and_then(|(secret_package, round2_packages)| {
-            let round1_commitments = round1_peer_packages
-                .iter()
-                .map(|(identifier, package)| (*identifier, package.commitment()))
-                .chain(std::iter::once((
-                    *secret_package.identifier(),
-                    secret_package.commitment(),
-                )))
-                .collect();
-            let public_key_package =
-                keys::PublicKeyPackage::from_dkg_commitments(&round1_commitments)?;
-            let verifying_share = public_key_package
-                .verifying_shares()
-                .get(secret_package.identifier())
-                .ok_or(frost_secp256k1::Error::UnknownIdentifier)?;
+            // Ensure that the `me` commitment is also valid, the FROST library
+            // doesn't check this by default.
+            if round1_me_package.commitment() != secret_package.commitment() {
+                return Err(frost_secp256k1::Error::IncorrectCommitment);
+            }
 
+            // Build the verifying share (i.e. the participant's "public key")
+            // from the commitments.
+            let group_commitment = frost_core::keys::sum_commitments(
+                &commitments
+                    .values()
+                    .map(|verified| verified.package.commitment())
+                    .collect::<Vec<_>>(),
+            )?;
+            let verifying_share = keys::VerifyingShare::from_commitment(
+                *secrets.secret_package.identifier(),
+                &group_commitment,
+            );
+
+            // Encrypt each of the other shares for the other participants,
+            // using their publicly broadcasted public encryption keys.
             let encrypted_shares = commitments
                 .iter()
                 .map(|(participant, commitment)| {
@@ -142,142 +173,188 @@ pub fn generate_round2(
                         .get(&peer)
                         .ok_or(frost_secp256k1::Error::UnknownIdentifier)?;
                     let signing_share = package.signing_share().to_scalar().to_bytes().into();
-                    Ok(encryption_key.ecdh(encryption_public_key, signing_share))
+                    Ok(secrets
+                        .encryption_key
+                        .ecdh(encryption_public_key, signing_share))
                 })
                 .collect::<Result<Vec<_>, frost_secp256k1::Error>>()?;
-            let share = marshal::solidity_secret_share(verifying_share, &encrypted_shares);
+            let share = marshal::solidity_secret_share(&verifying_share, &encrypted_shares);
 
-            Ok(Round2 {
-                secret_package,
-                public_key_package,
+            Ok(SecretShares {
+                sharing_state: SharingState {
+                    encryption_key: secrets.encryption_key,
+                    secret_package,
+                    group_commitment,
+                    commitments,
+                },
                 share,
             })
         })
         .err_unexpected()
 }
 
-/// A validated round 2 signing share from a peer.
+/// A validated signing share from a peer.
 #[derive(Clone, Deserialize, Serialize)]
-pub struct Round2Share {
+pub struct VerifiedShare {
     package: round2::Package,
 }
 
-/// Verifies a round 2 secret signing share received from a peer.
-pub fn verify_round2_share(
-    encryption_key: &EncryptionKey,
-    secret_package: &round2::SecretPackage,
-    public_key_package: &keys::PublicKeyPackage,
-    commitments: &BTreeMap<Address, Round1Commitment>,
-    peer: Address,
+/// Verifies a participant's secret signing share.
+///
+/// These are applied to _both_ `me`, the validator itself, and all peers that
+/// publish key generation secret shares onchain.
+pub fn verify_secret_share(
+    sharing_state: &SharingState,
+    participant: Address,
     share: &bindings::KeyGenSecretShare,
-) -> Result<Round2Share, Error> {
-    if share.f.len() as u16 != secret_package.max_signers() - 1 {
-        return Err(frost_secp256k1::Error::IncorrectNumberOfShares).err_with_culprit(peer);
+) -> Result<VerifiedShare, Error> {
+    if share.f.len() as u16 != sharing_state.secret_package.max_signers() - 1 {
+        return Err(frost_secp256k1::Error::IncorrectNumberOfShares).err_with_culprit(participant);
     }
 
-    let identifier = participants::identifier(peer);
-    if identifier == *secret_package.identifier() {
-        return Err(frost_secp256k1::Error::IncorrectPackage).err_unexpected();
-    }
+    let identifier = participants::identifier(participant);
+    let (commitment, secret_share) = if identifier == *sharing_state.secret_package.identifier() {
+        (
+            sharing_state.secret_package.commitment().clone(),
+            sharing_state
+                .secret_package
+                .secret_share()
+                .to_bytes()
+                .into(),
+        )
+    } else {
+        sharing_state
+            .commitments
+            .get(&participant)
+            .ok_or(frost_secp256k1::Error::UnknownIdentifier)
+            .and_then(|round1| {
+                let encryption_public_key = &round1.encryption_public_key;
+                let commitment = round1.package.commitment().clone();
 
-    let (commitment, verifying_share, secret_share) = commitments
-        .get(&peer)
-        .ok_or(frost_secp256k1::Error::UnknownIdentifier)
-        .and_then(|round1| {
-            let encryption_public_key = &round1.encryption_public_key;
-            let commitment = round1.package.commitment().clone();
+                // Compute the index of encrypted secret share for _me_ and
+                // decrypt it so that we can verify it against the peer's
+                // commitments.
+                let index = sharing_state
+                    .commitments
+                    .keys()
+                    .filter(|address| **address != participant)
+                    .position(|address| {
+                        participants::identifier(*address)
+                            == *sharing_state.secret_package.identifier()
+                    })
+                    .ok_or(frost_secp256k1::Error::UnknownIdentifier)?;
+                let encrypted_share = share
+                    .f
+                    .get(index)
+                    .ok_or(frost_core::Error::IncorrectNumberOfShares)?;
+                let secret_share = sharing_state
+                    .encryption_key
+                    .ecdh(encryption_public_key, encrypted_share.to_be_bytes());
 
-            let verifying_share = public_key_package
-                .verifying_shares()
-                .get(&identifier)
-                .ok_or(frost_secp256k1::Error::UnknownIdentifier)?;
-
-            let index = commitments
-                .keys()
-                .filter(|address| **address != peer)
-                .position(|address| {
-                    participants::identifier(*address) == *secret_package.identifier()
-                })
-                .ok_or(frost_secp256k1::Error::UnknownIdentifier)?;
-            let encrypted_share = share
-                .f
-                .get(index)
-                .ok_or(frost_secp256k1::Error::IncorrectNumberOfShares)?;
-            let secret_share =
-                encryption_key.ecdh(encryption_public_key, encrypted_share.to_be_bytes());
-
-            Ok((commitment, verifying_share, secret_share))
-        })
-        .err_unexpected()?;
+                Ok((commitment, secret_share))
+            })
+            .err_unexpected()?
+    };
 
     let package = marshal::frost_point(&share.y)
         .and_then(|y| {
+            let verifying_share =
+                keys::VerifyingShare::from_commitment(identifier, &sharing_state.group_commitment);
             if y != verifying_share.to_element() {
                 return Err(frost_secp256k1::Error::MalformedVerifyingKey);
             }
 
-            let signing_share =
-                keys::SigningShare::new(marshal::frost_scalar(&U256::from_be_bytes(secret_share))?);
-
             // Pre-verify the share to make sure it matches the commitment from
             // the peer; this allows us to complain right away in case an
             // invalid share was provided.
-            let _ = keys::SecretShare::new(*secret_package.identifier(), signing_share, commitment)
-                .verify()?;
+            let signing_share =
+                keys::SigningShare::new(marshal::frost_scalar(&U256::from_be_bytes(secret_share))?);
+            let _ = keys::SecretShare::new(
+                *sharing_state.secret_package.identifier(),
+                signing_share,
+                commitment,
+            )
+            .verify()?;
 
             Ok(round2::Package::new(signing_share))
         })
-        .err_with_culprit(peer)?;
+        .err_with_culprit(participant)?;
 
-    Ok(Round2Share { package })
+    Ok(VerifiedShare { package })
 }
 
-/// The output of DKG round 3: the finalized key material.
-pub struct Round3 {
-    pub key_package: keys::KeyPackage,
-    pub public_key_package: keys::PublicKeyPackage,
+/// A participant's share of the group signing key: its secret signing share,
+/// verifying share, and the group verifying key. The final result of DKG,
+/// persisted to the secret store and used to sign.
+#[derive(Clone, Deserialize, Serialize)]
+#[serde(transparent)]
+pub struct KeyShare(keys::KeyPackage);
+
+impl KeyShare {
+    /// Creates a key share from its underlying key package.
+    pub(super) fn from_key_package(key_package: keys::KeyPackage) -> KeyShare {
+        Self(key_package)
+    }
+
+    /// The underlying FROST key package, used to produce signature shares.
+    pub(super) fn as_key_package(&self) -> &keys::KeyPackage {
+        &self.0
+    }
 }
 
-/// Runs DKG round 3 for `me`, decrypting the peers' secret shares (indexed by
-/// `me`'s position in each publisher's address-ordered participant set) and
-/// finalizing the group key material.
-pub fn generate_round3(
-    secret_package: &round2::SecretPackage,
-    commitments: &BTreeMap<Address, Round1Commitment>,
-    shares: &BTreeMap<Address, Round2Share>,
-) -> Result<Round3, Error> {
-    let round1_peer_packages =
-        peer_packages(secret_package.identifier(), commitments, |commitment| {
-            commitment.package.clone()
-        });
-    let round2_peer_packages = peer_packages(secret_package.identifier(), shares, |share| {
-        share.package.clone()
-    });
+/// Finalizes key generation given all participant's verified secret shares
+/// and derives the participant's [`KeyShare`].
+pub fn finalize(
+    sharing_state: SharingState,
+    shares: BTreeMap<Address, VerifiedShare>,
+) -> Result<KeyShare, Error> {
+    let (round1_peer_packages, _) = peer_packages(
+        sharing_state.secret_package.identifier(),
+        &sharing_state.commitments,
+        |commitment| commitment.package.clone(),
+    )?;
+    let (round2_peer_packages, round2_me_package) = peer_packages(
+        sharing_state.secret_package.identifier(),
+        &shares,
+        |share| share.package.clone(),
+    )?;
+
+    // Verify that the me package matches the secret state. This is otherwise
+    // not checked by the FROST library.
+    if round2_me_package.signing_share().to_scalar() != sharing_state.secret_package.secret_share()
+    {
+        return Err(frost_secp256k1::Error::IncorrectPackage).err_unexpected();
+    }
 
     // By construction, the third round of DKG should have no participant
     // culprits (as the `commitments` and `shares` have already been verified).
     // The only way we encounter an error here is if the caller were to mix
     // secrets and commitments and shares from different DKG ceremonies.
-    let (key_package, public_key_package) =
-        dkg::part3(secret_package, &round1_peer_packages, &round2_peer_packages)
-            .err_unexpected()?;
-    Ok(Round3 {
-        key_package,
-        public_key_package,
-    })
+    let (key_package, _) = dkg::part3(
+        &sharing_state.secret_package,
+        &round1_peer_packages,
+        &round2_peer_packages,
+    )
+    .err_unexpected()?;
+
+    Ok(KeyShare::from_key_package(key_package))
 }
 
 fn peer_packages<T, P, F>(
     me: &Identifier,
     items: &BTreeMap<Address, T>,
     select: F,
-) -> BTreeMap<Identifier, P>
+) -> Result<(BTreeMap<Identifier, P>, P), Error>
 where
     F: Fn(&T) -> P,
 {
-    items
+    let mut peers = items
         .iter()
         .map(|(participant, item)| (participants::identifier(*participant), select(item)))
-        .filter(|(participant, _)| participant != me)
-        .collect()
+        .collect::<BTreeMap<_, _>>();
+    let me = peers
+        .remove(me)
+        .ok_or(frost_secp256k1::Error::UnknownIdentifier)
+        .err_unexpected()?;
+    Ok((peers, me))
 }

--- a/crates/validator/src/frost/marshal.rs
+++ b/crates/validator/src/frost/marshal.rs
@@ -105,7 +105,7 @@ pub fn solidity_signature(signature: &frost_secp256k1::Signature) -> bindings::S
 pub fn frost_commitment(
     commitment: &bindings::KeyGenCommitment,
 ) -> Result<(EncryptionPublicKey, dkg::round1::Package), frost_secp256k1::Error> {
-    let encryption_public_key = frost_point(&commitment.q)?.try_into()?;
+    let encryption_public_key = EncryptionPublicKey::from_point(frost_point(&commitment.q)?)?;
     let coefficients = keys::VerifiableSecretSharingCommitment::new(
         commitment
             .c

--- a/crates/validator/src/frost/mod.rs
+++ b/crates/validator/src/frost/mod.rs
@@ -4,7 +4,7 @@
 //!
 //! This module provides an interface that is compatible with the onchain
 //! FROST coordinator contract, internally managing the marshalling between
-//! [`frost-secp256k1`] values and their Solidity ABI representations.
+//! [`frost_secp256k1`] values and their Solidity ABI representations.
 
 #![cfg_attr(not(test), expect(dead_code))]
 
@@ -12,9 +12,9 @@ pub mod ecdh;
 pub mod error;
 pub mod keygen;
 mod marshal;
-pub mod nonces;
 mod participants;
-pub mod signing;
+pub mod preprocess;
+pub mod sign;
 
 #[cfg(test)]
 mod tests {
@@ -34,80 +34,81 @@ mod tests {
         let count = participants.len() as u16;
         let threshold = 2;
 
-        let mut round1 = BTreeMap::new();
+        // --- KEY GENERATION ---
+
+        // First do the key generation setup, which generates some random
+        // secrets that need to be persisted, as well as some public commitments
+        // that are submitted onchain.
+        let mut secrets = BTreeMap::new();
+        let mut commitments = BTreeMap::new();
         for participant in participants {
-            let r1 = keygen::generate_round1(&mut rng, participant, count, threshold).unwrap();
-            round1.insert(participant, r1);
+            let setup = keygen::setup(&mut rng, participant, count, threshold).unwrap();
+            secrets.insert(participant, setup.secrets);
+            commitments.insert(participant, setup.commitment);
         }
 
-        let commitments = participants
-            .into_iter()
-            .map(|participant| {
-                let commitment = keygen::verify_round1_commitment(
-                    threshold,
-                    participant,
-                    &round1[&participant].commitment,
-                )
-                .unwrap();
-                (participant, commitment)
-            })
-            .collect();
-
-        let mut round2 = BTreeMap::new();
-        for participant in participants {
-            let r1 = &round1[&participant];
-            let r2 = keygen::generate_round2(&r1.encryption_key, &r1.secret_package, &commitments)
-                .unwrap();
-            round2.insert(participant, r2);
-        }
-
-        let shares = participants
-            .into_iter()
-            .map(|me| {
-                let r1 = &round1[&me];
-                let r2 = &round2[&me];
-                let shares = participants
-                    .into_iter()
-                    .filter(|peer| *peer != me)
-                    .map(|peer| {
-                        let share = &round2[&peer].share;
-                        let share = keygen::verify_round2_share(
-                            &r1.encryption_key,
-                            &r2.secret_package,
-                            &r2.public_key_package,
-                            &commitments,
-                            peer,
-                            share,
-                        )
-                        .unwrap();
-                        (peer, share)
-                    })
-                    .collect();
-                (me, shares)
-            })
-            .collect::<BTreeMap<_, _>>();
-
-        let mut round3 = BTreeMap::new();
-        for participant in participants {
-            let r2 = &round2[&participant];
-            let r3 =
-                keygen::generate_round3(&r2.secret_package, &commitments, &shares[&participant])
+        // Each participant uses their random secrets to proceed to the next
+        // stage and generate encrypted secret shares that published onchain.
+        let mut sharing_states = BTreeMap::new();
+        let mut shares = BTreeMap::new();
+        for (participant, secrets) in secrets {
+            let verified_commitments = participants
+                .into_iter()
+                .map(|participant| {
+                    let commitment = keygen::verify_commitment(
+                        &secrets,
+                        participant,
+                        &commitments[&participant],
+                    )
                     .unwrap();
-            round3.insert(participant, r3);
+                    (participant, commitment)
+                })
+                .collect();
+            let share = keygen::generate_secret_shares(secrets, verified_commitments).unwrap();
+            sharing_states.insert(participant, share.sharing_state);
+            shares.insert(participant, share.share);
         }
 
-        let group_key = round3
+        // Once the secret sharing is complete, the key generation process can
+        // finalize, producing a key share for the group.
+        let mut key_shares = BTreeMap::new();
+        for (participant, sharing_state) in sharing_states {
+            let verified_shares = shares
+                .iter()
+                .map(|(peer, share)| {
+                    let verified_share =
+                        keygen::verify_secret_share(&sharing_state, *peer, share).unwrap();
+                    (*peer, verified_share)
+                })
+                .collect();
+            let key_share = keygen::finalize(sharing_state, verified_shares).unwrap();
+            key_shares.insert(participant, key_share);
+        }
+
+        // Here, all participants should share the same group verifying key.
+        // Additionally, the group key should equal to the sum of all the
+        // publicly posted commitments C_0.
+        let group_key = key_shares
             .values()
             .next()
             .unwrap()
-            .public_key_package
+            .as_key_package()
             .verifying_key();
-        for r3 in round3.values() {
-            assert_eq!(group_key, r3.public_key_package.verifying_key());
+        for key_share in key_shares.values() {
+            assert_eq!(group_key, key_share.as_key_package().verifying_key());
         }
+        assert_eq!(
+            group_key.to_element(),
+            commitments
+                .values()
+                .map(|commitments| marshal::frost_point(&commitments.c[0]).unwrap())
+                .sum::<k256::ProjectivePoint>()
+        );
 
-        // Signing ceremony: a threshold set of signers jointly signs a message,
-        // each contributing a signature share and the signer-set selection.
+        // --- SIGNING CEREMONY ---
+
+        // A threshold set of signers jointly signs a message, each contributing
+        // a signature share and the signer-set selection.
         let message = keccak256("Hello, Safenet!");
         let signers = [participants[0], participants[2]];
 
@@ -116,19 +117,18 @@ mod tests {
         let mut secret_nonces = BTreeMap::new();
         let mut revealed_nonces = BTreeMap::new();
         for signer in signers {
-            let key_package = &round3[&signer].key_package;
-            let chunk =
-                nonces::NonceChunk::with_size(1, key_package.signing_share(), &mut rng).unwrap();
+            let key_share = &key_shares[&signer];
+            let chunk = preprocess::NonceChunk::with_size(1, key_share, &mut rng).unwrap();
             let nonces = chunk.nonces.into_iter().next().unwrap();
             let (sign_nonces, proof) = nonces.reveal();
 
             // Verify the Merkle proof as is done on the smart contract. This
-            // is not expected to be enfoced by the clients, but added here for
+            // is not expected to be enforced by the clients, but added here for
             // testing.
             assert!(
                 chunk
                     .commitment
-                    .verify(nonces::nonces_leaf(0, &sign_nonces), proof)
+                    .verify(preprocess::nonces_leaf(0, &sign_nonces), proof)
             );
 
             secret_nonces.insert(signer, nonces);
@@ -136,26 +136,24 @@ mod tests {
         }
 
         // Each signer independently produces its signature share.
-        let revealed = revealed_nonces
-            .iter()
-            .map(|(participant, nonces)| {
-                let commitment = signing::verify_revealed_nonces(*participant, nonces).unwrap();
-                (*participant, commitment)
-            })
-            .collect();
-        let signatures = signers
-            .into_iter()
-            .map(|signer| {
-                let signature = signing::signature_share(
-                    &round3[&signer].key_package,
-                    &secret_nonces[&signer],
-                    &revealed,
-                    &message,
-                )
-                .unwrap();
-                (signer, signature)
-            })
-            .collect::<BTreeMap<_, _>>();
+        let mut signatures = BTreeMap::new();
+        for signer in signers {
+            let revealed = revealed_nonces
+                .iter()
+                .map(|(participant, nonces)| {
+                    let commitment = sign::verify_revealed_nonces(*participant, nonces).unwrap();
+                    (*participant, commitment)
+                })
+                .collect();
+            let signature = sign::signature_share(
+                &key_shares[&signer],
+                secret_nonces.remove(&signer).unwrap(),
+                &revealed,
+                &message,
+            )
+            .unwrap();
+            signatures.insert(signer, signature);
+        }
 
         // Every signer reconstructs the identical selection: the same group
         // commitment `r` and signer-set root.
@@ -168,8 +166,8 @@ mod tests {
             // Verify the Merkle proof as is done on the smart contract. This
             // is not expected to be enforced by the clients, but added here for
             // testing.
-            assert!(MerkleRoot::from(selection.root).verify(
-                signing::signer_leaf(
+            assert!(MerkleRoot(selection.root).verify(
+                sign::signer_leaf(
                     address,
                     &signature.share.r,
                     &signature.share.l,
@@ -205,12 +203,12 @@ mod tests {
                     )
                 })
                 .collect();
-            let verifying_shares = round3
+            let verifying_shares = key_shares
                 .iter()
-                .map(|(address, r3)| {
+                .map(|(address, key_share)| {
                     (
                         participants::identifier(*address),
-                        *r3.key_package.verifying_share(),
+                        *key_share.as_key_package().verifying_share(),
                     )
                 })
                 .collect();

--- a/crates/validator/src/frost/preprocess.rs
+++ b/crates/validator/src/frost/preprocess.rs
@@ -5,13 +5,13 @@
 //! revealing a single nonce needs only that one entry rather than the whole
 //! chunk resident in memory.
 
-use super::marshal;
+use super::{keygen::KeyShare, marshal};
 use crate::{
     bindings,
     merkle::{MerkleRoot, MerkleTree},
 };
 use alloy::primitives::{B256, keccak256};
-use frost_secp256k1::{keys::SigningShare, round1};
+use frost_secp256k1::round1;
 use rand::{CryptoRng, RngCore, SeedableRng as _};
 use rand_chacha::ChaCha12Rng;
 use rayon::iter::{IntoParallelIterator as _, ParallelIterator as _};
@@ -29,7 +29,7 @@ pub struct Nonces {
 }
 
 impl Nonces {
-    /// Compute the signature nonces reveal parameters the FROST sining nonce
+    /// Compute the signature nonces reveal parameters the FROST signing nonce
     /// pair.
     pub fn reveal(&self) -> (bindings::SignNonces, &[B256]) {
         (
@@ -57,22 +57,22 @@ pub struct NonceChunk {
 }
 
 impl NonceChunk {
-    /// Generates a fresh chunk of `SEQUENCE_CHUNK_SIZE` nonces for
-    /// `signing_share`, the merkle root committing to them, and each nonce's
-    /// inclusion proof. The RNG is supplied by the caller.
-    pub fn generate<R>(signing_share: &SigningShare, rng: &mut R) -> Result<NonceChunk, rand::Error>
+    /// Generates a fresh chunk of `SEQUENCE_CHUNK_SIZE` nonces for `key_share`,
+    /// the merkle root committing to them, and each nonce's inclusion proof. The
+    /// RNG is supplied by the caller.
+    pub fn generate<R>(key_share: &KeyShare, rng: &mut R) -> Result<NonceChunk, rand::Error>
     where
         R: RngCore + CryptoRng,
     {
-        Self::with_size(SEQUENCE_CHUNK_SIZE, signing_share, rng)
+        Self::with_size(SEQUENCE_CHUNK_SIZE, key_share, rng)
     }
 
-    /// Same as [`generate`] but with a user-specified size in chunks.
+    /// Same as [`Self::generate`] but with a user-specified chunk size.
     ///
     /// This allows for smaller nonce chunks for testing.
     pub fn with_size<R>(
         size: u64,
-        signing_share: &SigningShare,
+        key_share: &KeyShare,
         rng: &mut R,
     ) -> Result<NonceChunk, rand::Error>
     where
@@ -94,6 +94,7 @@ impl NonceChunk {
                 }
             })
             .collect::<Result<Vec<_>, rand::Error>>()?;
+        let signing_share = key_share.as_key_package().signing_share();
         let (signing_nonces, leaves) = rngs
             .into_par_iter()
             .map(|(offset, mut rng)| {
@@ -137,10 +138,19 @@ pub(super) fn nonces_leaf(offset: u64, nonces: &bindings::SignNonces) -> B256 {
 mod tests {
     use super::*;
 
+    fn dummy_key_share() -> KeyShare {
+        KeyShare::from_key_package(frost_secp256k1::keys::KeyPackage::new(
+            frost_secp256k1::Identifier::try_from(1).unwrap(),
+            frost_secp256k1::keys::SigningShare::new(k256::Scalar::ONE),
+            frost_secp256k1::keys::VerifyingShare::new(k256::ProjectivePoint::GENERATOR),
+            frost_secp256k1::VerifyingKey::new(k256::ProjectivePoint::GENERATOR),
+            1,
+        ))
+    }
+
     #[test]
     fn nonces_commitment_inclusion_proofs() {
-        let signing_share = SigningShare::new(k256::Scalar::ONE);
-        let chunk = NonceChunk::generate(&signing_share, &mut rand::thread_rng()).unwrap();
+        let chunk = NonceChunk::generate(&dummy_key_share(), &mut rand::thread_rng()).unwrap();
         assert_eq!(chunk.nonces.len(), SEQUENCE_CHUNK_SIZE as usize);
 
         for offset in [0, 1, 42, 777, (SEQUENCE_CHUNK_SIZE - 1) as usize] {

--- a/crates/validator/src/frost/sign.rs
+++ b/crates/validator/src/frost/sign.rs
@@ -5,13 +5,13 @@
 
 use super::{
     error::{Culprit as _, Error},
-    marshal,
-    nonces::Nonces,
-    participants,
+    keygen::KeyShare,
+    marshal, participants,
+    preprocess::Nonces,
 };
-use crate::{bindings, frost::marshal::frost_signing_commitments, merkle::MerkleTree};
+use crate::{bindings, merkle::MerkleTree};
 use alloy::primitives::{Address, B256, U256, keccak256};
-use frost_secp256k1::{Secp256K1Sha256, SigningPackage, keys, round1, round2};
+use frost_secp256k1::{Secp256K1Sha256, SigningPackage, round1, round2};
 use k256::elliptic_curve::PrimeField as _;
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
@@ -38,7 +38,7 @@ pub fn verify_revealed_nonces(
     participant: Address,
     nonces: &bindings::SignNonces,
 ) -> Result<RevealedNonces, Error> {
-    let commitments = frost_signing_commitments(nonces).err_with_culprit(participant)?;
+    let commitments = marshal::frost_signing_commitments(nonces).err_with_culprit(participant)?;
     Ok(RevealedNonces { commitments })
 }
 
@@ -58,11 +58,12 @@ pub struct SignatureShare {
 /// commitments then consumes the secret signing nonce to produce a signature
 /// share for the specified key package.
 pub fn signature_share(
-    key_package: &keys::KeyPackage,
-    nonces: &Nonces,
+    key_share: &KeyShare,
+    nonces: Nonces,
     revealed: &BTreeMap<Address, RevealedNonces>,
     message: &B256,
 ) -> Result<SignatureShare, Error> {
+    let key_package = key_share.as_key_package();
     let group_public_key = key_package.verifying_key();
 
     let commitments = revealed
@@ -120,7 +121,7 @@ pub fn signature_share(
             let tree = MerkleTree::build(leaves);
             let selection = bindings::SignSelection {
                 r: group_r,
-                root: tree.root().into(),
+                root: tree.root().0,
             };
 
             // Extract the signature share values that are needed onchain along

--- a/crates/validator/src/merkle.rs
+++ b/crates/validator/src/merkle.rs
@@ -64,7 +64,7 @@ impl MerkleTree {
 /// A Merkle root that can be used to verify a proof.
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq, Deserialize, Serialize)]
 #[serde(transparent)]
-pub struct MerkleRoot(B256);
+pub struct MerkleRoot(pub B256);
 
 impl MerkleRoot {
     /// Verifies a Merkle proof for a leaf.
@@ -80,18 +80,6 @@ impl MerkleRoot {
 impl PartialEq<B256> for MerkleRoot {
     fn eq(&self, other: &B256) -> bool {
         self.0 == *other
-    }
-}
-
-impl From<B256> for MerkleRoot {
-    fn from(root: B256) -> Self {
-        Self(root)
-    }
-}
-
-impl From<MerkleRoot> for B256 {
-    fn from(root: MerkleRoot) -> Self {
-        root.0
     }
 }
 


### PR DESCRIPTION
This PR refactors the public FROST API to make it harder to use incorrectly, make errors more consistent across different validators, and not leak any of the `frost_secp256k1` types in the public API.

This should address the naming complaints from the `keygen` module from previous PRs, and be the final piece in the validator's FROST library.

### Context and Motivation

There were a few rough edges to using the FROST API:

- The naming (round N is not very descriptive)
- Error proneness of use
- Inconsistent error states across different validators

While the nonces and signing API, this was already the case, this did cause some larger changes in the key generation API:

| Before | After |
| --- | --- |
| `generate_round1 -> Round1` | `setup -> Setup` |
| `verify_round1_commitment -> Round1Commitment` | `verify_commitment -> VerifiedCommitment` |
| `generate_round2 -> Round2` | `generate_secret_shares` |
| `verify_round2_share -> Round2Share` | `verify_secret_share -> VerifiedSecretShare` |
| `generate_round3 -> Round3` | `finalize -> KeyShare` |

### Decisions and Tradeoffs

We encapsulate all of the required forward-needed values into structs returned by each of the steps. This no only decreases the arity of the function, it also makes it harder to mix values from different DKG ceremonies to catch bugs easier.

Furthermore, we now check the `me`'s commitments and shares for correctness in the different DKG rounds (something that was not done before); this is to keep consistent error states across different validators (otherwise a `me` with a bad commitment would not be caught by `me` but tagged as misbehaving by all other validators). This was done to ensure consensus remains consistent under reorgs (although is more of a theoretical risk than a real one).

For more consistent naming with the contracts, we renamed `nonces` to `preprocess` and `signing` to `sign`.

Additional comments were added to the DKG process as requested in https://github.com/safe-research/safenet/pull/524#discussion_r3520326496.

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://docs.safefoundation.org/cla).
