### PR TITLE
[B3e]: Return funds to original parties on timeout

### DIFF
--- a/contracts/src/SentinelOracleV2.sol
+++ b/contracts/src/SentinelOracleV2.sol
@@ -65,6 +65,7 @@ contract SentinelOracleV2 is IOracle {
     error ZeroFee();
     error ZeroWindow();
     error SentinelNotActive();
+    error NotRevealed();
 
     // ============================================================
     // MODIFIERS
@@ -182,11 +183,16 @@ contract SentinelOracleV2 is IOracle {
 
     function claim(bytes32 requestId) external {
         SentinelOracleRequest.Request storage req = $requests.get(requestId);
-        req.requireResolved();
+        SentinelOracleRequest.State state = req.requireResolved();
         SentinelOracleCommitment.Commitment memory c = $commitments.get(requestId, msg.sender).markClaimed();
-        bool approved = c.vote == SentinelOracleCommitment.Vote.APPROVED;
-        uint256 feeReward = req.calcFeeReward(approved);
-        uint256 bondReturn = req.isBondSlashed(approved) ? 0 : c.bondAmount;
+        // Only allow claiming of pending votes in case of a timeout
+        require(
+            c.vote == SentinelOracleCommitment.Vote.APPROVED || c.vote == SentinelOracleCommitment.Vote.DENIED
+                || state == SentinelOracleRequest.State.TIMED_OUT,
+            NotRevealed()
+        );
+        uint256 feeReward = req.calcFeeReward(c.vote);
+        uint256 bondReturn = req.isBondSlashed(c.vote) ? 0 : c.bondAmount;
         uint256 totalClaim = bondReturn + feeReward;
         if (totalClaim > 0) {
             FEE_TOKEN.safeTransfer(msg.sender, totalClaim);

--- a/contracts/src/libraries/SentinelOracleCommitmentsV2.sol
+++ b/contracts/src/libraries/SentinelOracleCommitmentsV2.sol
@@ -30,14 +30,12 @@ library SentinelOracleCommitment {
 
     error NothingToClaim();
     error AlreadyClaimed();
-    error NotRevealed();
 
     // ============================================================
     // INTERNAL FUNCTIONS
     // ============================================================
 
     function markClaimed(Commitment storage self) internal returns (Commitment memory) {
-        require(self.vote != Vote.PENDING, NotRevealed());
         require(self.bondAmount > 0, NothingToClaim());
         require(!self.claimed, AlreadyClaimed());
         self.claimed = true;

--- a/contracts/src/libraries/SentinelOracleRequestsV2.sol
+++ b/contracts/src/libraries/SentinelOracleRequestsV2.sol
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: GPL-3.0-only
 pragma solidity ^0.8.30;
 
+import {SentinelOracleCommitment} from "@/libraries/SentinelOracleCommitmentsV2.sol";
+
 library SentinelOracleRequest {
     // ============================================================
     // ENUMS
@@ -84,27 +86,31 @@ library SentinelOracleRequest {
         bool nothingToReveal = self.committedCount == 0 && block.number > self.commitDeadline;
         require(block.number > self.revealDeadline || everyoneRevealed || nothingToReveal, FinalizeTooEarly());
 
-        unrevealedBond = (self.committedCount - self.revealedCount) * self.bondTarget;
-
         bool approveMet = self.approveSentinelCount > 0;
         bool denyMet = self.denySentinelCount > 0;
 
-        if (approveMet && denyMet) {
-            self.state = State.FROZEN;
-            return (State.FROZEN, 0, unrevealedBond);
+        if (approveMet || denyMet) {
+            if (approveMet && denyMet) {
+                newState = State.FROZEN;
+            } else if (approveMet) {
+                newState = State.RESOLVED_APPROVED;
+            } else {
+                newState = State.RESOLVED_DENIED;
+            }
+            // An established side exists, so a non-revealer's silence can only be griefing (stalling
+            // a request whose outcome their own commit already contributed to) -- slash their bond to
+            // `ARBITRATOR`.
+            unrevealedBond = (self.committedCount - self.revealedCount) * self.bondTarget;
+        } else {
+            // Nobody revealed (or nobody even committed): there is no established side, so no
+            // misbehavior can be proven against any committer -- bonds are returned in full via
+            // `claim()` instead of slashed.
+            newState = State.TIMED_OUT;
+            refundFee = self.fee;
+            self.fee = 0;
         }
-        if (approveMet) {
-            self.state = State.RESOLVED_APPROVED;
-            return (State.RESOLVED_APPROVED, 0, unrevealedBond);
-        }
-        if (denyMet) {
-            self.state = State.RESOLVED_DENIED;
-            return (State.RESOLVED_DENIED, 0, unrevealedBond);
-        }
-        self.state = State.TIMED_OUT;
-        refundFee = self.fee;
-        self.fee = 0;
-        return (State.TIMED_OUT, refundFee, unrevealedBond);
+
+        self.state = newState;
     }
 
     function requireResolved(Request storage self) internal view returns (State) {
@@ -116,20 +122,28 @@ library SentinelOracleRequest {
         return state;
     }
 
-    function calcFeeReward(Request storage self, bool approved) internal view returns (uint256) {
+    function calcFeeReward(Request storage self, SentinelOracleCommitment.Vote vote) internal view returns (uint256) {
+        if (vote != SentinelOracleCommitment.Vote.APPROVED && vote != SentinelOracleCommitment.Vote.DENIED) return 0;
         State state = self.state;
         if (state != State.RESOLVED_APPROVED && state != State.RESOLVED_DENIED) return 0;
+        bool approved = vote == SentinelOracleCommitment.Vote.APPROVED;
         bool isEligibleForFee = approved == (state == State.RESOLVED_APPROVED);
         if (!isEligibleForFee) return 0;
         uint256 winningSideCount = state == State.RESOLVED_APPROVED ? self.approveSentinelCount : self.denySentinelCount;
         return self.fee / winningSideCount;
     }
 
-    function isBondSlashed(Request storage self, bool approved) internal view returns (bool) {
+    function isBondSlashed(Request storage self, SentinelOracleCommitment.Vote vote) internal view returns (bool) {
         State state = requireResolved(self);
         if (state == State.TIMED_OUT) return false;
+        // A pending (never revealed) vote in a resolved request is unrevealed griefing -- slash it
+        // regardless of which side won.
+        if (vote != SentinelOracleCommitment.Vote.APPROVED && vote != SentinelOracleCommitment.Vote.DENIED) {
+            return true;
+        }
         // Slashing only applies to requests resolved via arbitration (both sides had votes).
         if (self.approveSentinelCount == 0 || self.denySentinelCount == 0) return false;
+        bool approved = vote == SentinelOracleCommitment.Vote.APPROVED;
         return approved != (state == State.RESOLVED_APPROVED);
     }
 

--- a/contracts/test/SentinelOracleV2.t.sol
+++ b/contracts/test/SentinelOracleV2.t.sol
@@ -401,8 +401,67 @@ contract SentinelOracleV2Test is Test {
         assertEq(token.balanceOf(sentinel2), s2Before + BOND_TARGET + REQUEST_FEE / 2, "sentinel2 claim incorrect");
 
         // sentinel3 never revealed — its commitment is still PENDING, so claim must revert.
-        vm.expectRevert(SentinelOracleCommitment.NotRevealed.selector);
+        vm.expectRevert(SentinelOracleV2.NotRevealed.selector);
         vm.prank(sentinel3);
+        oracle.claim(REQUEST_ID);
+    }
+
+    // ============================================================
+    // PURE TIMEOUT (NOBODY REVEALS) — BONDS REFUNDED, NOT SLASHED
+    // ============================================================
+
+    function test_NoReveals_BondsAndFeeRefundedInFull() public {
+        uint256 proposerBalBefore = token.balanceOf(proposer);
+        _postRequest();
+
+        // Both commit, but neither ever reveals.
+        _commit(sentinel1, true, SALT_1);
+        _commit(sentinel2, false, SALT_2);
+
+        _advancePastCommitDeadline();
+
+        // Nobody revealed, so there's no early-finalize signal (revealedCount never reaches
+        // committedCount) — finalize must wait for the full reveal window.
+        vm.expectRevert(SentinelOracleRequest.FinalizeTooEarly.selector);
+        oracle.finalize(REQUEST_ID);
+
+        _advancePastRevealDeadline();
+
+        uint256 arbitratorBalBefore = token.balanceOf(arbitrator);
+        oracle.finalize(REQUEST_ID);
+
+        SentinelOracleRequest.Request memory req = oracle.getRequest(REQUEST_ID);
+        assertEq(uint256(req.state), uint256(SentinelOracleRequest.State.TIMED_OUT));
+        assertEq(token.balanceOf(proposer), proposerBalBefore, "proposer fee refunded");
+
+        // No established side exists, so no misbehavior can be proven against either committer —
+        // nothing is slashed to the arbitrator.
+        assertEq(token.balanceOf(arbitrator), arbitratorBalBefore, "no bonds slashed on a pure timeout");
+
+        // Both commitments are still `Vote.PENDING`, but `claim()` succeeds anyway on `TIMED_OUT`.
+        uint256 s1Before = token.balanceOf(sentinel1);
+        vm.prank(sentinel1);
+        oracle.claim(REQUEST_ID);
+        assertEq(token.balanceOf(sentinel1), s1Before + BOND_TARGET, "sentinel1 bond refunded in full");
+
+        uint256 s2Before = token.balanceOf(sentinel2);
+        vm.prank(sentinel2);
+        oracle.claim(REQUEST_ID);
+        assertEq(token.balanceOf(sentinel2), s2Before + BOND_TARGET, "sentinel2 bond refunded in full");
+    }
+
+    function test_NoReveals_DoubleClaimReverts() public {
+        _postRequest();
+        _commit(sentinel1, true, SALT_1);
+        _advancePastCommitDeadline();
+        _advancePastRevealDeadline();
+        oracle.finalize(REQUEST_ID);
+
+        vm.prank(sentinel1);
+        oracle.claim(REQUEST_ID);
+
+        vm.expectRevert(SentinelOracleCommitment.AlreadyClaimed.selector);
+        vm.prank(sentinel1);
         oracle.claim(REQUEST_ID);
     }
 }

--- a/crates/sentinel/src/servicev2.rs
+++ b/crates/sentinel/src/servicev2.rs
@@ -314,15 +314,13 @@ impl SentinelTransition {
     /// [`Self::handle_block_advance`]; always exits `CollectingVotes` in
     /// this same step, so a request's finalize step can only ever run once.
     ///
-    /// `Finalize` is emitted whenever we stand to gain from it -- a dispute
-    /// or claim we have a vote riding on -- plus one liveness exception:
-    /// when nobody revealed at all, no node has an open vote to trigger the
-    /// non-reveal slash either, so we finalize anyway even though we gain
-    /// nothing, since otherwise nobody ever would. Outside that exception,
-    /// a node with no stake in the outcome leaves finalizing to a node that
-    /// has one. `Claim` stays conditional on our own reveal having landed,
-    /// since a `claim()` without a matching revealed commitment reverts
-    /// with `NotRevealed`.
+    /// There are the following cases when the `Finalize` action is emitted:
+    /// - no one voted: a genuine timeout, where the bonds can be re-claimed
+    /// - unanimous vote: it is possible to claim the bond and reward
+    /// - a disbute: there is still a possibility to receive a reward
+    ///
+    /// In other cases it doesn't make sense to trigger the finalization for
+    /// this sentinel.
     fn finalize(
         &self,
         state: &RequestState,
@@ -343,22 +341,19 @@ impl SentinelTransition {
         let dispute = *approve_count > 0 && *deny_count > 0;
         let timed_out = *revealed_count == 0;
 
+        // If this sentinel did not participate and it was not a timeout
+        // then no actions should be taken and the request should be dropped
         if !*self_revealed && !timed_out {
             return (None, Vec::new());
         }
 
-        // Neither action has an onchain deadline past which it stops being
-        // valid to submit, so both are kept alive indefinitely in the
-        // `TransactionQueue`.
         let mut actions = vec![SentinelAction {
             kind: SentinelActionKind::Finalize { id: request_id },
             expires_at: None,
         }];
 
-        if !*self_revealed {
-            return (None, actions);
-        }
-
+        // In case of a disbute it is not a timeout, so this sentinal participated.
+        // Finalize the request and wait for a disbute resolution by the arbitrator.
         if dispute {
             return (
                 Some(RequestState::WaitingForDisputeResolution { approve }),
@@ -366,7 +361,7 @@ impl SentinelTransition {
             );
         }
 
-        // Unanimity plus our own counted vote guarantees we're on the
+        // Unanimity plus our own counted vote guarantees this sentinal is on the
         // sole, winning side; no `OracleResult` round trip needed.
         actions.push(SentinelAction {
             kind: SentinelActionKind::Claim { id: request_id },

--- a/epics/2026_07_02_sentinel_commit_reveal_voting.md
+++ b/epics/2026_07_02_sentinel_commit_reveal_voting.md
@@ -141,27 +141,33 @@ this derivation's input space clearly distinct from any other use of the same ke
 RFC 6979 draft it is not a hard safety requirement, since HMAC's security doesn't degrade under
 reuse the way ECDSA nonce reuse does (see [Open Questions](#open-questions-and-assumptions)).
 
-### Non-reveal slashing: one uniform step in `finalize()`
+### Non-reveal slashing: only when an established side exists to prove it against
 
-Per spec §5.2, a checker who commits but never reveals gets slashed (otherwise a griefer can hit the
-bond target and then withhold their reveal to stall the request indefinitely). The chosen mechanics:
+Per spec §5.2, a checker who commits but never reveals gets slashed **if doing so is provably
+griefing** — otherwise a griefer could hit the bond target and then withhold their reveal to stall
+the request indefinitely. Slashing requires an *established side* to grief against: if
+`approveSentinelCount > 0 || denySentinelCount > 0`, a committer who never revealed had a chance to
+help resolve the request (their own commit already contributed to the outcome) and chose not to —
+that's the griefing case. But if **nobody** reveals at all (`TIMED_OUT`), there is no established
+side and no way to distinguish an honest reveal-infrastructure failure from malice; slashing
+everyone's bond in that case punishes committers for something that isn't provably misbehavior. The
+chosen mechanics:
 
 - `finalize()` computes `unrevealedBond = totalCommittedBond - totalApproveBond - totalDenyBond`
-  once revealed totals are final (see the early-finalize rule below), **regardless of which of the
-  three outcomes follows**, and transfers it to `ARBITRATOR` — mirroring the existing
-  `resolveDispute()` pattern where the arbitration loser's slashed bond goes to `ARBITRATOR`. No new
-  distribution logic is introduced. This transfer must happen **before** V1's existing
-  `if (newState == State.FROZEN) { return; }` early exit in `SentinelOracle.finalize()` (see Tech
-  Specs) — a conflicted, disputed request can still have non-revealing committers on either side, and
-  that early return must not skip slashing them.
+  once revealed totals are final (see the early-finalize rule below), **for the `FROZEN`/
+  `RESOLVED_APPROVED`/`RESOLVED_DENIED` outcomes only**, and transfers it to `ARBITRATOR` —
+  mirroring the existing `resolveDispute()` pattern where the arbitration loser's slashed bond goes
+  to `ARBITRATOR`. No new distribution logic is introduced. This transfer must happen **before**
+  V1's existing `if (newState == State.FROZEN) { return; }` early exit in `SentinelOracle.finalize()`
+  (see Tech Specs) — a conflicted, disputed request can still have non-revealing committers on either
+  side, and that early return must not skip slashing them. On `TIMED_OUT`, `unrevealedBond` is zero:
+  nobody's bond is slashed, so every committer can reclaim it in full via `claim()`.
 - The proposer's fee refund is unaffected: it already only happens on `TIMED_OUT`, funded from the
   separate `fee` balance the proposer paid — not from checker bonds. There's nothing to "top up"
   from the slashed pool in the `RESOLVED_*` branches, since the fee there is paid out to the winning
   side exactly as in V1.
-- `claim()` must reject any commitment still at `Vote.PENDING` (new `NotRevealed` error). Without
-  this guard a non-revealer could still call `claim()` after their bond was already swept out by the
-  `finalize()` slash step above, incorrectly minting a second payout from the contract's remaining
-  balance.
+- `claim()` must require a resolved outcome. For every other resolved outcome, the fee and bonds to
+  return should be calculated. In case of a `TIMED_OUT` all funds return to the original parties.
 
 ### Early finalization when everyone has revealed
 
@@ -443,8 +449,10 @@ on the winning side, so only the winning side's count is needed (see `calcFeeRew
     deadline branch in `handle_block_advance`, always leaving `CollectingVotes` in the same step so
     it cannot run twice for one request):
     - `self_revealed == false`, `revealed_count == 0` (genuine timeout, no revealer's FSM exists to
-      finalize instead) → emit `Finalize`, drop, no `Claim` (a `claim()` without our own revealed
-      commitment reverts with `NotRevealed`).
+      finalize instead) → emit `Finalize` **and** `Claim` and drop. Unlike every other
+      `self_revealed == false` case, `claim()` succeeds here: a `TIMED_OUT` outcome never slashes
+      unrevealed bonds (see the Non-reveal slashing decision above), so our own still-`PENDING`
+      commitment is claimable for its full bond.
     - `self_revealed == false`, `revealed_count > 0` → drop without emitting anything; whichever
       sentinel did reveal finalizes from its own FSM instead.
     - `self_revealed == true`, `approve_count > 0 && deny_count > 0` (dispute) → emit `Finalize`,
@@ -455,8 +463,8 @@ on the winning side, so only the winning side's count is needed (see `calcFeeRew
   - `handle_resolved` (our own `OracleResult`, `WaitingForDisputeResolution` only): decode the
     `ResolveReason`, emit `Claim` iff `event.approved == approve`, and drop the request either way.
 - Unit tests mirror the existing style in `service.rs`/`state.rs`/`hashing.rs`/`action.rs` for every
-  new branch above, plus the early-finalization path and the unconditional-`Finalize`-without-
-  `self_revealed` liveness case.
+  new branch above, plus the early-finalization path and the timeout-only `Finalize`-plus-`Claim`
+  liveness case.
 
 ### Testing
 
@@ -464,14 +472,16 @@ on the winning side, so only the winning side's count is needed (see `calcFeeRew
   no-commitments timeout, conflict → dispute) to go through `commit`+`reveal`, and add: reveal before
   `commitDeadline` reverts, reveal after `revealDeadline` reverts, wrong hash/salt reverts,
   double-commit/double-reveal reverts, early `finalize` once all committers revealed, partial-reveal
-  (some committed, fewer revealed) still resolves correctly, and a non-revealer's bond is slashed to
-  `ARBITRATOR` while their own `claim()` reverts with `NotRevealed`.
+  (some committed, fewer revealed) still resolves correctly with a non-revealer's bond slashed to
+  `ARBITRATOR` while their own `claim()` reverts with `NotRevealed`, and a pure timeout (some or all
+  committed, nobody revealed) refunding every committer's bond in full via `claim()` (no slash, no
+  `NotRevealed`) alongside the proposer's fee refund.
 - `crates/sentinel`/`safenet-core`: unit tests for the new FSM transitions (including that a request
   can only reach its finalize step once — via either the early-finalize check in `handle_revealed` or
   the deadline branch in `handle_block_advance`, never both), the tally bookkeeping
   (`committed_count`/`revealed_count`/`approve_count`/`deny_count` incrementing for *any* sentinel,
-  not just our own), the timeout-only `Finalize`-without-`self_revealed` liveness branch (and that a
-  non-revealer emits nothing once someone else's reveal has landed), the
+  not just our own), the timeout-only `Finalize`-plus-`Claim` liveness branch (and that a non-revealer
+  emits nothing once someone else's reveal has landed), the
   dispute-vs-immediate-claim split out of `CollectingVotes`, the `Signer`'s HMAC-SHA256 salt
   derivation (including RFC 4231 test vectors, not just self-consistency), the resulting
   `commit_hash`/`reveal_salt`, and `encode_actions` for `Commit`/`Reveal`.
@@ -535,8 +545,9 @@ the same small library set)
   - **B3d** — `handle_block_advance` (the `WaitingForRequest` timeout, the `CollectingCommitments`
     deadline branch emitting `Reveal`, and the `CollectingVotes` deadline branch running the finalize
     step).
-  - **B3e** — `handle_resolved` for `WaitingForDisputeResolution`.
-  - **B3f** — Flow test. Instead of individual unit tests for each transition function, tests for complete flow (triggering multiple state transitions) will be implemented for the service.
+  - **B3e** — Fix Oracle behavior to return funds to all parties in case of a timeout.
+  - **B3f** — `handle_resolved` for `WaitingForDisputeResolution`.
+  - **B3g** — Flow test. Instead of individual unit tests for each transition function, tests for complete flow (triggering multiple state transitions) will be implemented for the service.
 
 ### Phase C — Fix the integration suite & wrap up
 
@@ -596,18 +607,22 @@ be decisions rather than open ones, and are folded into the assumptions below.
   matching V1's fixed `VOTING_WINDOW`.
 - Bonds stay symmetric (`bondTarget = fee * bondMultiplier` for both sides); no new protocol-wide
   bond cap.
-- Non-reveal slashing always sends the full unrevealed pool to `ARBITRATOR`; the proposer's existing
-  `TIMED_OUT` fee refund is unaffected and unrelated to that pool.
+- Non-reveal slashing only sends the unrevealed pool to `ARBITRATOR` when an established side exists
+  to grief against (`FROZEN`/`RESOLVED_*`); a pure `TIMED_OUT` (nobody revealed) can't distinguish
+  griefing from an honest reveal-infrastructure failure, so nothing is slashed and every committer
+  reclaims their bond in full via `claim()`. The proposer's existing `TIMED_OUT` fee refund is
+  unaffected and unrelated to that pool either way.
 - Reward for winning revealers is an equal split of `fee` (no position/bond weighting); this is a
   deliberate behavior change from V1, chosen for simplicity in this first version.
 - The Rust client calls `finalize()` once its local tally says doing so is valid (either
   `revealed_count == committed_count` or past `revealDeadline`), even for a request where it never
   itself revealed, but only when `revealed_count == 0` too (nobody revealed at all). That's the one
   case with no other sentinel's FSM to rely on for liveness — otherwise no client in the fleet would
-  ever call `finalize()`, and the non-reveal slash performed inside it would never run. If someone
-  else did reveal, their own FSM finalizes instead, so a non-revealer skips it rather than
-  redundantly spending gas on a call it gets nothing from. `Claim` stays conditional on the client's
-  own reveal having landed.
+  ever call `finalize()`. If someone else did reveal, their own FSM finalizes instead, so a
+  non-revealer skips it rather than redundantly spending gas on a call it gets nothing from. `Claim`
+  stays conditional on the client's own reveal having landed **or** the request having timed out —
+  a `TIMED_OUT` outcome never slashes unrevealed bonds (see the Non-reveal slashing decision), so a
+  still-`PENDING` commitment is claimable there, unlike every other outcome.
 - The Rust sentinel derives its reveal salt deterministically via HMAC-SHA256 from the account's
   existing signing key and a domain-separated message containing `requestId` — no new secret is
   generated or configured, and no salt is persisted in the snapshot store.


### PR DESCRIPTION
The initial implementation slashed bond when not revealing even in the case when noone revealed and a timeout was triggered. With this there is no economic incentive to finalize the request for any sentinel. Also there was no conclusive result. Therefore the behavior has been changed to return all funds to the original parties in this case.

With this change there are three cases where the sentinel has economic incensive to finalize a request:
- no one voted: a genuine timeout, where the bonds can be re-claimed
- unanimous vote: it is possible to claim the bond and reward
- a disbute: there is still a possibility to receive a reward


---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://docs.safefoundation.org/cla).
