### PR TITLE
[B3f]: Handle disbute resolution

### DIFF
--- a/contracts/src/SentinelOracleV2.sol
+++ b/contracts/src/SentinelOracleV2.sol
@@ -184,15 +184,17 @@ contract SentinelOracleV2 is IOracle {
     function claim(bytes32 requestId) external {
         SentinelOracleRequest.Request storage req = $requests.get(requestId);
         SentinelOracleRequest.State state = req.requireResolved();
-        SentinelOracleCommitment.Commitment memory c = $commitments.get(requestId, msg.sender).markClaimed();
+        SentinelOracleCommitment.Commitment storage commitment = $commitments.get(requestId, msg.sender);
+        SentinelOracleCommitment.Vote vote = commitment.vote;
         // Only allow claiming of pending votes in case of a timeout
         require(
-            c.vote == SentinelOracleCommitment.Vote.APPROVED || c.vote == SentinelOracleCommitment.Vote.DENIED
+            vote == SentinelOracleCommitment.Vote.APPROVED || vote == SentinelOracleCommitment.Vote.DENIED
                 || state == SentinelOracleRequest.State.TIMED_OUT,
             NotRevealed()
         );
-        uint256 feeReward = req.calcFeeReward(c.vote);
-        uint256 bondReturn = req.isBondSlashed(c.vote) ? 0 : c.bondAmount;
+        commitment.markClaimed();
+        uint256 feeReward = req.calcFeeReward(vote);
+        uint256 bondReturn = req.isBondSlashed(vote) ? 0 : commitment.bondAmount;
         uint256 totalClaim = bondReturn + feeReward;
         if (totalClaim > 0) {
             FEE_TOKEN.safeTransfer(msg.sender, totalClaim);

--- a/contracts/src/libraries/SentinelOracleCommitmentsV2.sol
+++ b/contracts/src/libraries/SentinelOracleCommitmentsV2.sol
@@ -35,12 +35,10 @@ library SentinelOracleCommitment {
     // INTERNAL FUNCTIONS
     // ============================================================
 
-    function markClaimed(Commitment storage self) internal returns (Commitment memory) {
+    function markClaimed(Commitment storage self) internal {
         require(self.bondAmount > 0, NothingToClaim());
         require(!self.claimed, AlreadyClaimed());
         self.claimed = true;
-        Commitment memory snapshot = self;
-        return snapshot;
     }
 
     function computeHash(address sentinel, bytes32 requestId, bool approve, bytes32 salt)

--- a/crates/sentinel/src/bindings.rs
+++ b/crates/sentinel/src/bindings.rs
@@ -44,6 +44,18 @@ pub mod oracle {
             function claim(bytes32 requestId) external;
         }
 
+        // Mirrors `SentinelOracleRequest.State` in
+        // `contracts/src/libraries/SentinelOracleRequestsV2.sol`; `DisputeResolved.outcome` is
+        // this type.
+        #[derive(Debug, PartialEq, Eq)]
+        enum RequestState {
+            PENDING,
+            FROZEN,
+            RESOLVED_APPROVED,
+            RESOLVED_DENIED,
+            TIMED_OUT
+        }
+
         #[derive(Debug)]
         contract SentinelOracleV2 {
             event NewRequest(
@@ -61,12 +73,7 @@ pub mod oracle {
                 bool approved,
                 uint256 bondAmount
             );
-            event OracleResult(
-                bytes32 indexed requestId,
-                address indexed proposer,
-                bytes result,
-                bool approved
-            );
+            event DisputeResolved(bytes32 indexed requestId, RequestState outcome, uint256 slashed);
 
             function commit(bytes32 requestId, bytes32 commitHash) external;
             function reveal(bytes32 requestId, bool approve, bytes32 salt) external;

--- a/crates/sentinel/src/servicev2.rs
+++ b/crates/sentinel/src/servicev2.rs
@@ -3,7 +3,7 @@ use crate::{
     bindings::{
         SentinelEventsV2 as SentinelEvents,
         consensus::Consensus,
-        oracle::{ERC20, SentinelOracleV2 as SentinelOracle},
+        oracle::{ERC20, RequestState as OnchainRequestState, SentinelOracleV2 as SentinelOracle},
     },
     detector::Detector,
     hashing::{RevealSalt as _, commit_hash, oracle_tx_proposal_hash},
@@ -298,15 +298,34 @@ impl SentinelTransition {
         (state, actions)
     }
 
-    // TODO(sentinel commit-reveal, service FSM sub-task B3e): claims iff
-    // our own revealed vote matches the oracle's outcome, dropping the
-    // request either way.
+    /// Resolves a genuine dispute — `DisputeResolved` is only ever emitted by
+    /// `resolveDispute`, i.e. only for a request that reached
+    /// `WaitingForDisputeResolution` — by claiming iff our own revealed vote
+    /// matches the arbitrator's outcome; drops the request either way.
     fn handle_resolved(
         &self,
-        _state: State,
-        _event: SentinelOracle::OracleResult,
+        mut state: State,
+        event: SentinelOracle::DisputeResolved,
     ) -> (State, Vec<SentinelAction>) {
-        todo!("service FSM sub-task B3e")
+        let Some(RequestState::WaitingForDisputeResolution { approve }) =
+            state.0.get(&event.requestId)
+        else {
+            return (state, Vec::new());
+        };
+        let approve = *approve;
+        state.0.remove(&event.requestId);
+        let approved = event.outcome == OnchainRequestState::RESOLVED_APPROVED;
+        let actions = if approved == approve {
+            vec![SentinelAction {
+                kind: SentinelActionKind::Claim {
+                    id: event.requestId,
+                },
+                expires_at: None,
+            }]
+        } else {
+            Vec::new()
+        };
+        (state, actions)
     }
 
     /// Shared finalize step, reached from either the early-finalize check
@@ -362,7 +381,7 @@ impl SentinelTransition {
         }
 
         // Unanimity plus our own counted vote guarantees this sentinal is on the
-        // sole, winning side; no `OracleResult` round trip needed.
+        // sole, winning side; no `DisputeResolved` round trip needed.
         actions.push(SentinelAction {
             kind: SentinelActionKind::Claim { id: request_id },
             expires_at: None,
@@ -462,7 +481,7 @@ impl StateTransition<State> for SentinelTransition {
                         event,
                     )) => self.handle_revealed(state, event),
                     SentinelEvents::Oracle(
-                        SentinelOracle::SentinelOracleV2Events::OracleResult(event),
+                        SentinelOracle::SentinelOracleV2Events::DisputeResolved(event),
                     ) => self.handle_resolved(state, event),
                 }
             }

--- a/epics/2026_07_02_sentinel_commit_reveal_voting.md
+++ b/epics/2026_07_02_sentinel_commit_reveal_voting.md
@@ -329,7 +329,6 @@ out the otherwise-representable, meaningless state of `approved` holding a stale
   No `position` — reward is an equal split among winning revealers (see Architecture Decision), so
   nothing needs to be assigned at reveal time beyond which side the vote landed on.
 - `checkNotCommitted` unchanged in spirit, now checks `commitHash == 0`.
-- `markClaimed` gains `require(self.vote != Vote.PENDING, NotRevealed())` before its existing checks.
 
 ### `SentinelOracleRequests.sol`
 


### PR DESCRIPTION
Implemented handling of dispute resolution. If the dispute was resolved in favor of the sentinel then it will claim the reward.

### Design Decision
- Switch from OracleResult to DisputeResolved, as this is a more targeted event.

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://docs.safefoundation.org/cla).
