### PR TITLE
[B3g]: Flow test

### DIFF
--- a/crates/sentinel/src/servicev2.rs
+++ b/crates/sentinel/src/servicev2.rs
@@ -63,7 +63,7 @@ pub struct SentinelEncoder {
     fee_token: Address,
 }
 
-#[expect(dead_code)]
+#[cfg_attr(not(test), expect(dead_code))]
 impl SentinelService {
     pub fn new(
         oracle: Address,
@@ -528,5 +528,474 @@ impl Service for SentinelService {
             Pure,
             SentinelEncoder { oracle, fee_token },
         )
+    }
+}
+
+/// Flow tests drive `apply_transition` through a whole request lifecycle —
+/// proposal, commit, reveal, finalize, claim/dispute — rather than exercising
+/// each handler in isolation, since the interesting behavior (early
+/// finalization, the timeout-only liveness branch, dispute vs. immediate
+/// claim) only shows up across a sequence of transitions.
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::bindings::consensus::{Operation, SafeTransaction};
+    use alloy::{
+        primitives::{address, keccak256},
+        signers::k256::ecdsa::SigningKey,
+    };
+    use safenet_core::index::EventLog;
+
+    const ORACLE: Address = address!("1111111111111111111111111111111111111111");
+    const FEE_TOKEN: Address = address!("2222222222222222222222222222222222222222");
+    const CONSENSUS: Address = address!("3333333333333333333333333333333333333333");
+    const SAFE: Address = address!("4444444444444444444444444444444444444444");
+    const TO: Address = address!("5555555555555555555555555555555555555555");
+    const OTHER: Address = address!("8888888888888888888888888888888888888888");
+    const CHAIN_ID: u64 = 1;
+    const VOTING_WINDOW: u64 = 10;
+
+    fn self_signer() -> Signer {
+        Signer::new(
+            SigningKey::from_bytes(&keccak256("sentinel-v2-flow-test-key").0.into()).unwrap(),
+        )
+    }
+
+    fn self_address() -> Address {
+        self_signer().address()
+    }
+
+    fn service_with_blocklist(blocklist: Vec<Address>) -> SentinelService {
+        SentinelService::new(
+            ORACLE,
+            FEE_TOKEN,
+            CONSENSUS,
+            self_signer(),
+            U256::from(CHAIN_ID),
+            VOTING_WINDOW,
+            Detector::new(blocklist),
+        )
+    }
+
+    fn transition_with_blocklist(blocklist: Vec<Address>) -> SentinelTransition {
+        service_with_blocklist(blocklist).components().0
+    }
+
+    fn transition() -> SentinelTransition {
+        transition_with_blocklist(vec![])
+    }
+
+    fn safe_tx(to: Address) -> SafeTransaction {
+        SafeTransaction {
+            to,
+            operation: Operation::CALL,
+            ..Default::default()
+        }
+    }
+
+    fn request_id(safe_tx_hash: B256, epoch: u64, oracle: Address) -> B256 {
+        oracle_tx_proposal_hash(U256::from(CHAIN_ID), CONSENSUS, epoch, oracle, safe_tx_hash)
+    }
+
+    fn proposed_event(oracle: Address, safe_tx_hash: B256, to: Address) -> SentinelEvents {
+        SentinelEvents::Consensus(Consensus::ConsensusEvents::OracleTransactionProposed(
+            Consensus::OracleTransactionProposed {
+                safeTxHash: safe_tx_hash,
+                chainId: U256::from(CHAIN_ID),
+                safe: SAFE,
+                epoch: 7,
+                oracle,
+                transaction: safe_tx(to),
+            },
+        ))
+    }
+
+    fn new_request_event(
+        id: B256,
+        fee: U256,
+        bond_target: U256,
+        commit_deadline: u64,
+        reveal_deadline: u64,
+    ) -> SentinelEvents {
+        SentinelEvents::Oracle(SentinelOracle::SentinelOracleV2Events::NewRequest(
+            SentinelOracle::NewRequest {
+                requestId: id,
+                proposer: SAFE,
+                fee,
+                bondTarget: bond_target,
+                commitDeadline: U256::from(commit_deadline),
+                revealDeadline: U256::from(reveal_deadline),
+            },
+        ))
+    }
+
+    fn committed_event(id: B256, sentinel: Address, bond: U256) -> SentinelEvents {
+        SentinelEvents::Oracle(SentinelOracle::SentinelOracleV2Events::Committed(
+            SentinelOracle::Committed {
+                requestId: id,
+                sentinel,
+                bondAmount: bond,
+            },
+        ))
+    }
+
+    fn revealed_event(id: B256, sentinel: Address, approved: bool, bond: U256) -> SentinelEvents {
+        SentinelEvents::Oracle(SentinelOracle::SentinelOracleV2Events::Revealed(
+            SentinelOracle::Revealed {
+                requestId: id,
+                sentinel,
+                approved,
+                bondAmount: bond,
+            },
+        ))
+    }
+
+    fn dispute_resolved_event(
+        id: B256,
+        outcome: OnchainRequestState,
+        slashed: U256,
+    ) -> SentinelEvents {
+        SentinelEvents::Oracle(SentinelOracle::SentinelOracleV2Events::DisputeResolved(
+            SentinelOracle::DisputeResolved {
+                requestId: id,
+                outcome,
+                slashed,
+            },
+        ))
+    }
+
+    fn log(block: u64, data: SentinelEvents) -> EventLog<SentinelEvents> {
+        EventLog {
+            block,
+            index: 0,
+            data,
+        }
+    }
+
+    /// Full happy path: propose, commit (from two sentinels), reveal (from
+    /// two sentinels) — unanimously in favor — and finalize/claim as soon as
+    /// the last reveal lands, without waiting out the reveal window.
+    #[test]
+    fn flow_unanimous_approve_finalizes_via_early_reveal_and_claims() {
+        let svc = transition();
+        let safe_tx_hash = B256::repeat_byte(0x01);
+        let id = request_id(safe_tx_hash, 7, ORACLE);
+
+        // The transaction is proposed onchain; we decide to approve it and
+        // start tracking the request.
+        let (state, commands) = svc.apply_transition(
+            State::default(),
+            Message::Event(log(1, proposed_event(ORACLE, safe_tx_hash, TO))),
+        );
+        assert!(commands.is_empty());
+        assert_eq!(
+            state.0[&id],
+            RequestState::WaitingForRequest {
+                approve: true,
+                deadline: 1 + VOTING_WINDOW,
+            },
+        );
+
+        // A duplicate/re-delivered proposal for the same request must not
+        // reset progress.
+        let (state, commands) = svc.apply_transition(
+            state,
+            Message::Event(log(2, proposed_event(ORACLE, safe_tx_hash, TO))),
+        );
+        assert!(commands.is_empty());
+        assert_eq!(
+            state.0[&id],
+            RequestState::WaitingForRequest {
+                approve: true,
+                deadline: 1 + VOTING_WINDOW,
+            },
+        );
+
+        // The request is opened onchain: we lock a bond behind a blind
+        // commitment hash.
+        let (state, commands) = svc.apply_transition(
+            state,
+            Message::Event(log(
+                5,
+                new_request_event(id, U256::from(1_000u64), U256::from(500u64), 20, 40),
+            )),
+        );
+        let salt = self_signer().reveal_salt(id);
+        let hash = commit_hash(self_address(), id, true, salt);
+        assert_eq!(
+            state.0[&id],
+            RequestState::CollectingCommitments {
+                approve: true,
+                commit_deadline: 20,
+                reveal_deadline: 40,
+                committed_count: 0,
+                self_committed: false,
+            },
+        );
+        assert_eq!(
+            commands,
+            vec![
+                Command::Action(SentinelAction {
+                    kind: SentinelActionKind::ApproveToken {
+                        bond: U256::from(500u64)
+                    },
+                    expires_at: Some(20),
+                }),
+                Command::Action(SentinelAction {
+                    kind: SentinelActionKind::Commit { id, hash },
+                    expires_at: Some(20),
+                }),
+            ],
+        );
+
+        // Our own commit lands onchain, followed by the other sentinel's.
+        let (state, commands) = svc.apply_transition(
+            state,
+            Message::Event(log(
+                6,
+                committed_event(id, self_address(), U256::from(500u64)),
+            )),
+        );
+        assert!(commands.is_empty());
+        let (state, commands) = svc.apply_transition(
+            state,
+            Message::Event(log(7, committed_event(id, OTHER, U256::from(500u64)))),
+        );
+        assert!(commands.is_empty());
+        assert_eq!(
+            state.0[&id],
+            RequestState::CollectingCommitments {
+                approve: true,
+                commit_deadline: 20,
+                reveal_deadline: 40,
+                committed_count: 2,
+                self_committed: true,
+            },
+        );
+
+        // Past the commit deadline, our own commit landed, so we reveal.
+        let (state, commands) = svc.apply_transition(state, Message::NewBlock(21));
+        assert_eq!(
+            commands,
+            vec![Command::Action(SentinelAction {
+                kind: SentinelActionKind::Reveal {
+                    id,
+                    approve: true,
+                    salt
+                },
+                expires_at: Some(40),
+            })],
+        );
+        assert_eq!(
+            state.0[&id],
+            RequestState::CollectingVotes {
+                approve: true,
+                reveal_deadline: 40,
+                committed_count: 2,
+                revealed_count: 0,
+                approve_count: 0,
+                deny_count: 0,
+                self_revealed: false,
+            },
+        );
+
+        // The other sentinel reveals first; not enough to finalize yet.
+        let (state, commands) = svc.apply_transition(
+            state,
+            Message::Event(log(22, revealed_event(id, OTHER, true, U256::from(500u64)))),
+        );
+        assert!(commands.is_empty());
+        assert_eq!(
+            state.0[&id],
+            RequestState::CollectingVotes {
+                approve: true,
+                reveal_deadline: 40,
+                committed_count: 2,
+                revealed_count: 1,
+                approve_count: 1,
+                deny_count: 0,
+                self_revealed: false,
+            },
+        );
+
+        // Our own reveal lands; every commit is now revealed, unanimously in
+        // favor, so we finalize and claim immediately instead of waiting out
+        // the reveal window.
+        let (state, commands) = svc.apply_transition(
+            state,
+            Message::Event(log(
+                23,
+                revealed_event(id, self_address(), true, U256::from(500u64)),
+            )),
+        );
+        assert!(!state.0.contains_key(&id));
+        assert_eq!(
+            commands,
+            vec![
+                Command::Action(SentinelAction {
+                    kind: SentinelActionKind::Finalize { id },
+                    expires_at: None,
+                }),
+                Command::Action(SentinelAction {
+                    kind: SentinelActionKind::Claim { id },
+                    expires_at: None,
+                }),
+            ],
+        );
+    }
+
+    /// Drives a request to `WaitingForDisputeResolution`: both sides
+    /// revealed, so the local tally can't resolve it — an external
+    /// `DisputeResolved` is needed. Shared by the two arbitration-outcome
+    /// tests below.
+    fn setup_dispute() -> (SentinelTransition, B256, State) {
+        let svc = transition();
+        let safe_tx_hash = B256::repeat_byte(0x03);
+        let id = request_id(safe_tx_hash, 7, ORACLE);
+
+        let (state, _) = svc.apply_transition(
+            State::default(),
+            Message::Event(log(1, proposed_event(ORACLE, safe_tx_hash, TO))),
+        );
+        let (state, _) = svc.apply_transition(
+            state,
+            Message::Event(log(
+                5,
+                new_request_event(id, U256::from(1_000u64), U256::from(500u64), 20, 40),
+            )),
+        );
+        let (state, _) = svc.apply_transition(
+            state,
+            Message::Event(log(
+                6,
+                committed_event(id, self_address(), U256::from(500u64)),
+            )),
+        );
+        let (state, _) = svc.apply_transition(
+            state,
+            Message::Event(log(7, committed_event(id, OTHER, U256::from(500u64)))),
+        );
+        let (state, _) = svc.apply_transition(state, Message::NewBlock(21));
+
+        // The other sentinel reveals the opposite vote, and our own reveal
+        // lands last: unanimity fails, so this is a genuine dispute.
+        let (state, _) = svc.apply_transition(
+            state,
+            Message::Event(log(
+                22,
+                revealed_event(id, OTHER, false, U256::from(500u64)),
+            )),
+        );
+        let (state, commands) = svc.apply_transition(
+            state,
+            Message::Event(log(
+                23,
+                revealed_event(id, self_address(), true, U256::from(500u64)),
+            )),
+        );
+
+        assert_eq!(
+            commands,
+            vec![Command::Action(SentinelAction {
+                kind: SentinelActionKind::Finalize { id },
+                expires_at: None,
+            })],
+        );
+        assert_eq!(
+            state.0[&id],
+            RequestState::WaitingForDisputeResolution { approve: true },
+        );
+
+        (svc, id, state)
+    }
+
+    #[test]
+    fn flow_dispute_claims_when_arbitration_matches_our_vote() {
+        let (svc, id, state) = setup_dispute();
+        let event = dispute_resolved_event(id, OnchainRequestState::RESOLVED_APPROVED, U256::ZERO);
+
+        let (state, commands) = svc.apply_transition(state, Message::Event(log(50, event)));
+
+        assert!(!state.0.contains_key(&id));
+        assert_eq!(
+            commands,
+            vec![Command::Action(SentinelAction {
+                kind: SentinelActionKind::Claim { id },
+                expires_at: None,
+            })],
+        );
+    }
+
+    #[test]
+    fn flow_dispute_drops_without_claim_when_arbitration_contradicts_our_vote() {
+        let (svc, id, state) = setup_dispute();
+        let event = dispute_resolved_event(id, OnchainRequestState::RESOLVED_DENIED, U256::ZERO);
+
+        let (state, commands) = svc.apply_transition(state, Message::Event(log(50, event)));
+
+        assert!(!state.0.contains_key(&id));
+        assert!(commands.is_empty());
+    }
+
+    /// Nobody reveals at all — a genuine timeout with no other sentinel's
+    /// FSM around to finalize instead — so we finalize and claim our own
+    /// still-`PENDING` (unslashed) commitment ourselves.
+    #[test]
+    fn flow_finalizes_and_claims_on_genuine_reveal_timeout() {
+        let svc = transition();
+        let safe_tx_hash = B256::repeat_byte(0x05);
+        let id = request_id(safe_tx_hash, 7, ORACLE);
+
+        let (state, _) = svc.apply_transition(
+            State::default(),
+            Message::Event(log(1, proposed_event(ORACLE, safe_tx_hash, TO))),
+        );
+        let (state, _) = svc.apply_transition(
+            state,
+            Message::Event(log(
+                5,
+                new_request_event(id, U256::from(1_000u64), U256::from(500u64), 20, 40),
+            )),
+        );
+        let (state, _) = svc.apply_transition(
+            state,
+            Message::Event(log(
+                6,
+                committed_event(id, self_address(), U256::from(500u64)),
+            )),
+        );
+
+        let salt = self_signer().reveal_salt(id);
+        let (state, commands) = svc.apply_transition(state, Message::NewBlock(21));
+        assert_eq!(
+            commands,
+            vec![Command::Action(SentinelAction {
+                kind: SentinelActionKind::Reveal {
+                    id,
+                    approve: true,
+                    salt
+                },
+                expires_at: Some(40),
+            })],
+        );
+
+        // Our own reveal transaction never confirms onchain, and neither
+        // does anyone else's.
+        let (state, commands) = svc.apply_transition(state, Message::NewBlock(41));
+
+        assert!(!state.0.contains_key(&id));
+        assert_eq!(
+            commands,
+            vec![
+                Command::Action(SentinelAction {
+                    kind: SentinelActionKind::Finalize { id },
+                    expires_at: None,
+                }),
+                Command::Action(SentinelAction {
+                    kind: SentinelActionKind::Claim { id },
+                    expires_at: None,
+                }),
+            ],
+        );
     }
 }


### PR DESCRIPTION
Implement flow tests for the transitions of the sentinel service to check that the triggered actions are as expected. The flows tested are:
- Commit and Reveal without dispute
- Dispute win and loss
- Timeout (non reveal of all parties)

### Design Decision
- The implemented tests are limited to the most common flows to avoid overtesting in an early state, but still provide confidence in the implementation

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://docs.safefoundation.org/cla).
