### PR TITLE
[D 1ii]: Handle Genesis Key Generation

### DIFF
--- a/crates/validator/src/config.rs
+++ b/crates/validator/src/config.rs
@@ -70,7 +70,8 @@ pub struct ValidatorConfig {
     #[serde(default)]
     pub oracles: Vec<Address>,
     /// The salt mixed into the genesis group's key generation context.
-    pub genesis_salt: Option<B256>,
+    #[serde(default)]
+    pub genesis_salt: B256,
     /// The number of blocks in an epoch, controlling epoch rollover timing.
     #[serde(default = "ValidatorConfig::default_blocks_per_epoch")]
     pub blocks_per_epoch: NonZeroU64,
@@ -199,7 +200,7 @@ mod tests {
             address!("0x3333333333333333333333333333333333333333")
         );
         assert_eq!(
-            validator.genesis_salt.unwrap(),
+            validator.genesis_salt,
             b256!("0x00000000000000000000000000000000000000000000000000000000000000ab")
         );
         assert_eq!(validator.blocks_per_epoch.get(), 100);

--- a/crates/validator/src/consensus/epoch.rs
+++ b/crates/validator/src/consensus/epoch.rs
@@ -1,0 +1,35 @@
+use serde::{Deserialize, Serialize};
+use std::{cmp::Ordering, num::NonZeroU64};
+
+/// An epoch ID.
+#[derive(Copy, Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
+pub enum EpochId {
+    /// The genesis epoch.
+    #[default]
+    Genesis,
+    /// A regular epoch established after genesis.
+    Number { number: NonZeroU64 },
+}
+
+impl EpochId {
+    /// Returns the epoch ID as a raw numerical value. Genesis is represented
+    /// by the value 0.
+    pub fn raw_value(self) -> u64 {
+        match self {
+            EpochId::Genesis => 0,
+            EpochId::Number { number } => number.get(),
+        }
+    }
+}
+
+impl PartialOrd for EpochId {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for EpochId {
+    fn cmp(&self, other: &Self) -> Ordering {
+        u64::cmp(&self.raw_value(), &other.raw_value())
+    }
+}

--- a/crates/validator/src/consensus/mod.rs
+++ b/crates/validator/src/consensus/mod.rs
@@ -1,3 +1,4 @@
 //! Safenet consensus rules.
 
+pub mod epoch;
 pub mod group;

--- a/crates/validator/src/main.rs
+++ b/crates/validator/src/main.rs
@@ -51,8 +51,16 @@ async fn main() -> Result<(), Box<dyn Error>> {
     let mut watched = vec![consensus, coordinator];
     watched.extend(config.validator.oracles.iter().copied());
 
+    let service = ValidatorService::new(
+        config.signer.address(),
+        pool.clone(),
+        coordinator,
+        config.validator,
+    )
+    .await?;
+
     let driver = Driver::new(
-        ValidatorService,
+        service,
         provider,
         config.signer,
         pool,

--- a/crates/validator/src/service/action.rs
+++ b/crates/validator/src/service/action.rs
@@ -1,16 +1,64 @@
 //! Validator actions and their encoding into transactions.
 
+use crate::{
+    bindings::{self, Coordinator},
+    merkle::MerkleRoot,
+};
+use alloy::{
+    primitives::{Address, B256, U256},
+    sol_types::SolCall,
+};
 use safenet_core::{driver::ActionEncoder, tx::Transaction};
 
 /// An onchain action the validator emits during a state transition.
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub enum Action {}
+pub enum Action {
+    /// An action to publish key generation commitments onchain.
+    KeyGenAndCommit {
+        participants: MerkleRoot,
+        count: u16,
+        threshold: u16,
+        context: B256,
+        poap: Vec<B256>,
+        commitment: bindings::KeyGenCommitment,
+        expires_at: Option<u64>,
+    },
+}
 
-/// Encodes [`ValidatorAction`]s into the transactions the queue submits.
-pub struct Encoder;
+/// Encodes [`Action`]s into the transactions the queue submits.
+pub struct Encoder {
+    pub coordinator: Address,
+}
 
 impl ActionEncoder<Action> for Encoder {
     fn encode_action(&self, action: Action) -> (Transaction, Option<u64>) {
-        match action {}
+        match action {
+            Action::KeyGenAndCommit {
+                participants,
+                count,
+                threshold,
+                context,
+                poap,
+                commitment,
+                expires_at,
+            } => (
+                Transaction {
+                    to: self.coordinator,
+                    value: U256::ZERO,
+                    data: Coordinator::keyGenAndCommitCall {
+                        participants: participants.0,
+                        count,
+                        threshold,
+                        context,
+                        poap,
+                        commitment,
+                    }
+                    .abi_encode()
+                    .into(),
+                    gas: 250_000,
+                },
+                expires_at,
+            ),
+        }
     }
 }

--- a/crates/validator/src/service/effect.rs
+++ b/crates/validator/src/service/effect.rs
@@ -1,20 +1,110 @@
 //! The validator effect system and its handler.
 
+use crate::{frost, merkle::MerkleRoot, secrets::SecretStore, service::Action};
+use alloy::primitives::{Address, B256};
 use safenet_core::state::EffectHandler;
+use std::{
+    error::Error,
+    fmt::{self, Display, Formatter},
+};
 
 /// An impure operation the state transition asks the handler to perform.
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub enum Effect {}
+pub enum Effect {
+    /// Build a key gen commitment action.
+    BuildKeyGenCommitment {
+        id: B256,
+        participants: MerkleRoot,
+        count: u16,
+        threshold: u16,
+        context: B256,
+        poap: Vec<B256>,
+        expires_at: Option<u64>,
+    },
+}
 
 /// The result of performing an [`Effect`], resumed into the state machine.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub enum Resume {}
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub enum Resume {
+    /// An effect that does not require resuming.
+    #[default]
+    Noop,
+    /// Resume by forwarding a resolved action.
+    Action(Box<Action>),
+}
 
 /// Performs the validator's [`Effect`]s, resuming with a [`Resume`].
-pub struct Handler;
+pub struct Handler {
+    /// The account of the running validator.
+    pub account: Address,
+    /// The secret store containing randomly generated secrets.
+    pub secrets: SecretStore,
+}
+
+impl Handler {
+    async fn try_perform_effect(&mut self, effect: Effect) -> Result<Resume, InternalError> {
+        match effect {
+            Effect::BuildKeyGenCommitment {
+                id,
+                participants,
+                count,
+                threshold,
+                context,
+                poap,
+                expires_at,
+            } => {
+                let mut rng = rand::thread_rng();
+                let setup = frost::keygen::setup(&mut rng, self.account, count, threshold)?;
+                let stored = self
+                    .secrets
+                    .store_keygen_secrets(id, self.account, &setup.secrets)
+                    .await?;
+                if !stored {
+                    tracing::info!(group_id = %id, "not resubmitting already created keygen commitments");
+                    return Ok(Resume::Noop);
+                }
+
+                Ok(Resume::Action(Box::new(Action::KeyGenAndCommit {
+                    participants,
+                    count,
+                    threshold,
+                    context,
+                    poap,
+                    commitment: setup.commitment,
+                    expires_at,
+                })))
+            }
+        }
+    }
+}
 
 impl EffectHandler<Effect, Resume> for Handler {
     async fn perform_effect(&mut self, effect: Effect) -> Resume {
-        match effect {}
+        match self.try_perform_effect(effect.clone()).await {
+            Ok(resume) => resume,
+            Err(err) => {
+                tracing::warn!(?effect, %err, "failed to perform effect");
+                Resume::Noop
+            }
+        }
+    }
+}
+
+/// An internal error used for logging failed effects.
+#[derive(Debug)]
+struct InternalError(String);
+
+impl Display for InternalError {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
+impl<E> From<E> for InternalError
+where
+    E: Error,
+{
+    fn from(value: E) -> Self {
+        Self(value.to_string())
     }
 }

--- a/crates/validator/src/service/mod.rs
+++ b/crates/validator/src/service/mod.rs
@@ -9,13 +9,56 @@ pub use self::{
 };
 use crate::{
     bindings::{Consensus, Coordinator, Oracle},
+    config::ValidatorConfig,
+    consensus::group::{self, Epoch, ParticipantSet},
+    secrets::{self, SecretStore},
     state::{self, State},
 };
+use alloy::primitives::Address;
 use safenet_core::{driver::Service, watcher_events};
+use sqlx::SqlitePool;
 
 /// The validator service bundle: the state transition, effect handler and
 /// action encoder that the driver runs.
-pub struct ValidatorService;
+pub struct ValidatorService {
+    /// The account of the running validator.
+    account: Address,
+    /// The secret store containing keygen coeffecients and signing nonces.
+    secrets: SecretStore,
+    /// The genesis participant set.
+    genesis: ParticipantSet,
+    /// The FROST coordinator contract to submit protocol actions to.
+    coordinator: Address,
+    /// The validator configuration.
+    config: ValidatorConfig,
+}
+
+impl ValidatorService {
+    /// Creates the validator service from its machine configuration.
+    pub async fn new(
+        account: Address,
+        pool: SqlitePool,
+        coordinator: Address,
+        config: ValidatorConfig,
+    ) -> Result<Self, Error> {
+        let secrets = SecretStore::new(pool).await?;
+        let genesis = group::participants_set(
+            &config.participants,
+            Epoch::Genesis {
+                salt: config.genesis_salt,
+            },
+        )
+        .ok_or(Error::InvalidValidators)?;
+
+        Ok(Self {
+            account,
+            secrets,
+            genesis,
+            coordinator,
+            config,
+        })
+    }
+}
 
 watcher_events! {
     /// The full event set the validator watches and dispatches on: the
@@ -37,6 +80,29 @@ impl Service for ValidatorService {
     type Actions = action::Encoder;
 
     fn components(self) -> (Self::Transition, Self::Effects, Self::Actions) {
-        (state::Transition, effect::Handler, action::Encoder)
+        let ValidatorService {
+            account,
+            genesis,
+            secrets,
+            coordinator,
+            config: ValidatorConfig { .. },
+        } = self;
+        (
+            state::Transition { account, genesis },
+            effect::Handler { account, secrets },
+            action::Encoder { coordinator },
+        )
     }
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+    /// Storage error initializing the secret store.
+    #[error(transparent)]
+    Secrets(#[from] secrets::Error),
+    /// Invalid validator set.
+    ///
+    /// The configured validator set does not constitute a valid genesis group.
+    #[error("invalid validator set: unable to form a genesis group")]
+    InvalidValidators,
 }

--- a/crates/validator/src/state/keygen.rs
+++ b/crates/validator/src/state/keygen.rs
@@ -1,0 +1,50 @@
+use super::{RolloverState, State, Transition};
+use crate::{bindings::Coordinator, consensus::epoch::EpochId, service::Effect};
+use safenet_core::state::{Command, Commands};
+
+impl Transition {
+    /// Joins the genesis key generation once its group is created onchain.
+    ///
+    /// The genesis group is bootstrapped by an external `keyGen` call; each
+    /// validator reacts to the resulting `KeyGen` event by entering commitment
+    /// collection for the group it derives from its own configuration.
+    ///
+    /// Other `KeyGen` events are ignored by the validators, as regular epoch
+    /// rotation is triggered on new blocks.
+    pub(super) fn handle_genesis_key_gen(
+        &self,
+        mut state: State,
+        event: &Coordinator::KeyGen,
+    ) -> (State, Commands<State, Self>) {
+        let genesis = self.genesis.group();
+        if state.rollover != RolloverState::WaitingForGenesis || event.gid != genesis.id() {
+            return (state, Vec::new());
+        }
+
+        // The genesis group generation is not subject to a rollover deadline.
+        state.rollover = RolloverState::CollectingCommitments {
+            group_id: genesis.id(),
+            next_epoch: EpochId::Genesis,
+            deadline: None,
+        };
+
+        // Only participate in the group generation if you are part of the
+        // genesis group.
+        let commands = (self.genesis.participate_as(self.account))
+            .map(|(group, poap)| {
+                let (participants, count, threshold, context) = group.parameters();
+                vec![Command::Effect(Effect::BuildKeyGenCommitment {
+                    id: group.id(),
+                    participants,
+                    count,
+                    threshold,
+                    context,
+                    poap,
+                    expires_at: None,
+                })]
+            })
+            .unwrap_or_default();
+
+        (state, commands)
+    }
+}

--- a/crates/validator/src/state/mod.rs
+++ b/crates/validator/src/state/mod.rs
@@ -1,7 +1,14 @@
 //! The snapshotted validator state.
 
-use crate::service::{Action, Effect, Event, Resume};
-use safenet_core::state::{Commands, Message, StateTransition};
+mod keygen;
+
+use crate::{
+    bindings::Coordinator,
+    consensus::{epoch::EpochId, group::ParticipantSet},
+    service::{Action, Effect, Event, Resume},
+};
+use alloy::primitives::{Address, B256};
+use safenet_core::state::{Command, Commands, Message, StateTransition};
 use serde::{Deserialize, Serialize};
 
 /// The complete snapshotted validator state.
@@ -11,16 +18,43 @@ pub struct State {
     pub rollover: RolloverState,
 }
 
-/// The epoch-rollover / DKG state machine.
+/// The epoch-rollover / DKG state machine. Each active variant carries the
+/// group it is generating.
 #[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
 pub enum RolloverState {
     /// Idle before the genesis group's DKG has been triggered.
     #[default]
     WaitingForGenesis,
+    /// The key generation for `next_epoch` was skipped because too few
+    /// participants took part for the group to be safe.
+    EpochSkipped {
+        /// The epoch whose key generation was skipped.
+        next_epoch: EpochId,
+    },
+    /// A key generation is underway and the group's commitments are being
+    /// collected onchain.
+    CollectingCommitments {
+        /// The group being generated.
+        group_id: B256,
+        /// The epoch this group will serve.
+        next_epoch: EpochId,
+        /// The block by which the commitment round must complete. `None` to
+        /// indicate that there is no deadline.
+        deadline: Option<u64>,
+    },
 }
 
 /// The pure validator state transition.
-pub struct Transition;
+///
+/// Holds the machine configuration the transition is parameterized over; the
+/// group parameters it derives (identities, roots, thresholds) are all pure
+/// functions of this configuration rather than snapshot state.
+pub struct Transition {
+    /// The account of the running validator.
+    pub account: Address,
+    /// The genesis participant set.
+    pub genesis: ParticipantSet,
+}
 
 impl StateTransition<State> for Transition {
     type Event = Event;
@@ -34,10 +68,19 @@ impl StateTransition<State> for Transition {
         message: Message<Self::Event, Self::Resume>,
     ) -> (State, Commands<State, Self>) {
         match message {
-            // The skeleton observes the chain but drives no transitions; Phase D
-            // replaces these arms with the real handlers.
-            Message::NewBlock(_) | Message::Event(_) => (state, Vec::new()),
-            Message::Resume(result) => match result {},
+            Message::Event(log) => match log.data {
+                Event::Coordinator(Coordinator::CoordinatorEvents::KeyGen(event)) => {
+                    self.handle_genesis_key_gen(state, &event)
+                }
+                // The remaining events are wired in as their handlers land.
+                _ => (state, Vec::new()),
+            },
+            // No block-driven or effectful transitions are wired in yet.
+            Message::NewBlock(_) => (state, Vec::new()),
+            Message::Resume(result) => match result {
+                Resume::Noop => (state, Vec::new()),
+                Resume::Action(action) => (state, vec![Command::Action(*action)]),
+            },
         }
     }
 }


### PR DESCRIPTION
### Context and Motivation

This PR adds handling for the genesis `KeyGen` event that is manually emitted and used to signal "go" to the validators.

### Decisions and Tradeoffs

We use the effect system to build the commitments to ensure that the DKG secrets are stable across reorgs. Note that we chose to _not_ resubmit commitments in case secrets have already been generated, which assumes that the actions will always end up on chain.

Additionally, instead of making the group triggering fallible (as it is in the TS version), we prepare the genesis participant set upfront at startup (erroring out in case of an invalid configuration) and make the transition be infallible (the genesis group/participant set is guaranteed to be valid).

### Testing

For now, we do not include state transition tests. As discussed we want to check state transitions at a higher level (using mocked chain to test how the system as a whole behaves) instead of adding equality assertions on the state values themselves (which will change _dramatically_ over the next few PRs).

### Port

This is port of:

https://github.com/safe-research/safenet/blob/8ab73cfbf36ad2f6d7132ef9da6dff07b7c1055d/validator/src/machine/keygen/genesis.ts#L18-L49

https://github.com/safe-research/safenet/blob/8ab73cfbf36ad2f6d7132ef9da6dff07b7c1055d/validator/src/machine/keygen/trigger.ts#L17-L60

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://docs.safefoundation.org/cla).
