### PR TITLE
[C1]: Adjust integration test

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -62,6 +62,6 @@ jobs:
           name: sentinel-integration-logs
           path: |
             anvil_sentinel_logs.txt
-            ts_sentinel_logs.txt
-            rust_sentinel_logs.txt
+            sentinel_a_logs.txt
+            sentinel_b_logs.txt
           if-no-files-found: ignore

--- a/.gitignore
+++ b/.gitignore
@@ -11,7 +11,7 @@ foundry.lock
 integration_logs.txt
 lcov.info
 node_modules/
-rust_sentinel_logs.txt
+sentinel_a_logs.txt
+sentinel_b_logs.txt
 target/
-ts_sentinel_logs.txt
 validator*.toml

--- a/contracts/package.json
+++ b/contracts/package.json
@@ -10,7 +10,7 @@
 		"cmd:propose": "forge script ProposeScript",
 		"cmd:deploy:testing-erc20": "forge script DeployERC20Script",
 		"cmd:deploy:cosigner": "forge script DeployCosignerScript",
-		"cmd:deploy:sentinel-oracle": "forge script DeploySentinelOracleScript",
+		"cmd:deploy:sentinel-oracle": "forge script DeploySentinelOracleV2Script",
 		"cmd:deploy:test-consensus": "forge script DeployTestConsensusScript",
 		"cmd:propose:oracle": "forge script ProposeOracleTransactionScript",
 		"cmd:deploy:staking": "forge script DeployStakingScript",

--- a/crates/core/src/tx/signer.rs
+++ b/crates/core/src/tx/signer.rs
@@ -19,6 +19,7 @@ pub struct SigningError;
 
 /// A local account that signs and submits transactions onchain on behalf of a
 /// service.
+#[derive(Clone)]
 pub struct Signer(PrivateKeySigner);
 
 /// A raw signed transaction.

--- a/crates/sentinel/src/action.rs
+++ b/crates/sentinel/src/action.rs
@@ -1,6 +1,11 @@
 use alloy::primitives::{B256, U256};
 
 /// An action emitted by the sentinel during a state transition.
+///
+/// TODO(sentinel commit-reveal, phase C2): dead outside `service.rs`'s own
+/// tests now that `main.rs` drives `servicev2::SentinelService` instead;
+/// deleted alongside `service.rs`.
+#[cfg_attr(not(test), allow(dead_code))]
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum SentinelActionKind {
     /// Approve the fee token to be spent by the oracle (bond pre-authorisation).
@@ -21,6 +26,7 @@ pub enum SentinelActionKind {
 /// The deadline is forwarded to the `TransactionQueue` as the per-tx expiry
 /// so the queue can drop it if it goes unsubmitted past that block. `None`
 /// means the action must never expire.
+#[cfg_attr(not(test), allow(dead_code))]
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SentinelAction {
     pub kind: SentinelActionKind,

--- a/crates/sentinel/src/main.rs
+++ b/crates/sentinel/src/main.rs
@@ -7,7 +7,7 @@ mod service;
 mod servicev2;
 mod state;
 
-use self::{config::Config, detector::Detector, service::SentinelService};
+use self::{config::Config, detector::Detector, servicev2::SentinelService};
 use alloy::{
     primitives::U256,
     providers::{Provider, ProviderBuilder},
@@ -43,14 +43,13 @@ async fn main() -> Result<(), Box<dyn Error>> {
 
     let provider = ProviderBuilder::new().connect(config.rpc.as_str()).await?;
     let pool = SqlitePool::connect_with(config.database).await?;
-    let account = config.signer.address();
     let chain_id = U256::from(provider.get_chain_id().await?);
 
     let service = SentinelService::new(
         config.oracle,
         config.sentinel.fee_token,
         config.consensus,
-        account,
+        config.signer.clone(),
         chain_id,
         config.sentinel.voting_window,
         Detector::new(config.sentinel.blocklist),

--- a/crates/sentinel/src/service.rs
+++ b/crates/sentinel/src/service.rs
@@ -24,6 +24,11 @@ use safenet_core::{
 /// The sentinel service: drives the request FSM (`preparing -> pending ->
 /// committed -> finalized`) from `SentinelOracle`/`Consensus` events and maps
 /// its actions to encoded transactions.
+///
+/// TODO(sentinel commit-reveal, phase C2): dead outside this module's own
+/// tests now that `main.rs` drives `servicev2::SentinelService` instead;
+/// deleted alongside the rest of this file.
+#[cfg_attr(not(test), allow(dead_code))]
 pub struct SentinelService {
     oracle: Address,
     fee_token: Address,
@@ -36,6 +41,7 @@ pub struct SentinelService {
 
 /// Advances the request FSM (`preparing -> pending -> committed -> finalized`)
 /// in response to `SentinelOracle`/`Consensus` events.
+#[cfg_attr(not(test), allow(dead_code))]
 pub struct SentinelTransition {
     oracle: Address,
     /// The `Consensus` contract whose `OracleTransactionProposed` events are
@@ -53,6 +59,7 @@ pub struct SentinelTransition {
 
 /// Encodes [`SentinelAction`]s into the transactions that vote on, finalize and
 /// claim oracle requests.
+#[cfg_attr(not(test), allow(dead_code))]
 pub struct SentinelEncoder {
     /// The `SentinelOracle` contract that votes, finalizations and claims are
     /// submitted to, and the spender approved to pull the bond.
@@ -61,6 +68,7 @@ pub struct SentinelEncoder {
     fee_token: Address,
 }
 
+#[cfg_attr(not(test), allow(dead_code))]
 impl SentinelService {
     pub fn new(
         oracle: Address,
@@ -83,6 +91,7 @@ impl SentinelService {
     }
 }
 
+#[cfg_attr(not(test), allow(dead_code))]
 impl SentinelTransition {
     /// Starts tracking a newly proposed oracle transaction, deciding whether
     /// we vote to approve or deny it.
@@ -254,6 +263,7 @@ impl SentinelTransition {
     }
 }
 
+#[cfg_attr(not(test), allow(dead_code))]
 impl SentinelEncoder {
     fn encode_action_kind(&self, kind: SentinelActionKind) -> Transaction {
         match kind {

--- a/crates/sentinel/src/servicev2.rs
+++ b/crates/sentinel/src/servicev2.rs
@@ -63,7 +63,6 @@ pub struct SentinelEncoder {
     fee_token: Address,
 }
 
-#[cfg_attr(not(test), expect(dead_code))]
 impl SentinelService {
     pub fn new(
         oracle: Address,

--- a/crates/sentinel/src/state.rs
+++ b/crates/sentinel/src/state.rs
@@ -3,6 +3,11 @@ use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
 /// The four stages a request moves through in the sentinel FSM.
+///
+/// TODO(sentinel commit-reveal, phase C2): dead outside `service.rs`'s own
+/// tests now that `main.rs` drives `servicev2::SentinelService` instead;
+/// deleted alongside `service.rs`.
+#[cfg_attr(not(test), allow(dead_code))]
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub enum RequestStatus {
     Preparing,
@@ -12,6 +17,7 @@ pub enum RequestStatus {
 }
 
 /// Per-request state tracked by the sentinel FSM.
+#[cfg_attr(not(test), allow(dead_code))]
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct SentinelRequestState {
     /// Block at which the voting window expires.
@@ -25,6 +31,7 @@ pub struct SentinelRequestState {
 ///
 /// Serialized per block by the `StateMachine`; `B256` keys round-trip through
 /// serde_json as their hex representation.
+#[cfg_attr(not(test), allow(dead_code))]
 #[derive(Debug, Default, Clone, Serialize, Deserialize)]
 pub struct State(pub HashMap<B256, SentinelRequestState>);
 

--- a/scripts/run_integration_test.sh
+++ b/scripts/run_integration_test.sh
@@ -14,18 +14,27 @@ PARTICIPANTS=(
 # Anvil account 0 — used as deployer for all contracts
 DEPLOYER=0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266
 
-# --- 1. Start Anvil in the background ---
+# --- 1. Build the Rust sentinel ---
+# Built up front, before Anvil or anything else starts, so a compile error
+# fails fast. The TS sentinel can no longer complete a commit-reveal vote
+# against SentinelOracleV2, so the "keygen and oracle signing flow" test
+# drives this binary directly instead (see SENTINEL_BINARY_PATH below).
+echo "Building the Rust sentinel..."
+cargo build --package sentinel
+export SENTINEL_BINARY_PATH="$ROOT/target/debug/sentinel"
+
+# --- 2. Start Anvil in the background ---
 echo "Starting Anvil..."
 # Mute anvil logs
 anvil > ./anvil_logs.txt &
 ANVIL_PID=$!
 echo "Anvil started with PID $ANVIL_PID"
 
-# --- 2. Setup Cleanup ---
+# --- 3. Setup Cleanup ---
 trap 'echo "Stopping Anvil (PID $ANVIL_PID)..." && kill $ANVIL_PID' EXIT
 sleep 2
 
-# --- 3. Deploy Contracts ---
+# --- 4. Deploy Contracts ---
 echo "Deploying contracts..."
 env \
     PARTICIPANTS=$(IFS=, ; echo "${PARTICIPANTS[*]}") \
@@ -39,7 +48,7 @@ CONSENSUS=$(jq -r '.returns.consensus.value' \
     "$ROOT/contracts/build/broadcast/Deploy.s.sol/31337/run-latest.json")
 echo "Consensus deployed at $CONSENSUS"
 
-# --- 4. Deploy Fee Token ---
+# --- 5. Deploy Fee Token ---
 echo "Deploying fee token..."
 env FACTORY=2 \
 npm run -w contracts cmd:deploy:testing-erc20 -- \
@@ -52,7 +61,7 @@ FEE_TOKEN=$(jq -r '.returns.erc20.value' \
     "$ROOT/contracts/build/broadcast/DeployERC20.s.sol/31337/run-latest.json")
 echo "Fee token deployed at $FEE_TOKEN"
 
-# --- 5. Deploy Sentinel Oracle ---
+# --- 6. Deploy Sentinel Oracle ---
 echo "Deploying Sentinel Oracle..."
 env \
     FACTORY=2 \
@@ -60,7 +69,8 @@ env \
     SENTINEL_CONSENSUS=$CONSENSUS \
     SENTINEL_FEE_TOKEN=$FEE_TOKEN \
     SENTINEL_REQUEST_FEE=1000 \
-    SENTINEL_VOTING_WINDOW=10 \
+    SENTINEL_COMMIT_WINDOW=10 \
+    SENTINEL_REVEAL_WINDOW=10 \
     SENTINEL_GOVERNANCE_DELAY=0 \
     SENTINEL_BOND_MULTIPLIER=2 \
 npm run -w contracts cmd:deploy:sentinel-oracle -- \
@@ -69,7 +79,7 @@ npm run -w contracts cmd:deploy:sentinel-oracle -- \
     --sender $DEPLOYER \
     --broadcast
 
-# --- 6. Run Client Integration Tests ---
+# --- 7. Run Client Integration Tests ---
 echo "Running integration tests..."
 npm test -w validator -- integration
 

--- a/scripts/run_sentinel_integration_test.sh
+++ b/scripts/run_sentinel_integration_test.sh
@@ -1,18 +1,18 @@
 #!/bin/bash
-# Interop/integration test for the sentinels (epic Phase F1): runs the TS and
-# Rust sentinel implementations side by side against the same dispute on
-# Anvil, and asserts they agree (no arbitration) and settle fees/bonds
-# correctly. Unlike scripts/run_integration_test.sh, this does not require a
-# full validator/FROST genesis: a `TestConsensus` contract stands in for
-# `Consensus`, only emitting the `OracleTransactionProposed` event the
-# sentinels need.
+# Interop/integration test for the Rust sentinel (epic Phase F1, adapted for
+# commit-reveal): runs two independent Rust sentinel instances side by side
+# against the same dispute on Anvil, and asserts they agree (no arbitration)
+# and settle fees/bonds correctly. Unlike scripts/run_integration_test.sh, this does
+# not require a full validator/FROST genesis: a `TestConsensus` contract
+# stands in for `Consensus`, only emitting the `OracleTransactionProposed`
+# event the sentinels need.
 set -eo pipefail
 # Job control, so each `&`-backgrounded command below gets its own process
 # group (its PID doubling as its PGID) instead of sharing this script's.
 # Cleanup then kills each job's *group* (`kill -- -$pid`), reaping the
-# node/tsx or compiled-binary grandchildren `npm run`/`cargo run` spawn,
-# without touching whatever else happens to share this script's own process
-# group (e.g. a CI runner's step wrapper) the way `kill 0` would.
+# compiled-binary grandchildren `cargo run` spawns, without touching whatever
+# else happens to share this script's own process group (e.g. a CI runner's
+# step wrapper) the way `kill 0` would.
 set -m
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
@@ -23,7 +23,8 @@ CHAIN_ID=31337
 BLOCK_TIME_SECONDS=1
 REQUEST_FEE=1000
 BOND_MULTIPLIER=2
-VOTING_WINDOW=5
+COMMIT_WINDOW=5
+REVEAL_WINDOW=5
 GOVERNANCE_DELAY=0
 FUNDING_ETH=1ether
 FUNDING_TOKEN=1000000
@@ -47,11 +48,11 @@ cleanup() {
 	echo "Stopping background processes (${PIDS[*]})..."
 	for pid in "${PIDS[@]}"; do
 		# Negative PID targets the whole process group `set -m` gave this job,
-		# so `npm run`/`cargo run`'s node/tsx or compiled-binary children are
-		# reaped too rather than left orphaned holding a port.
+		# so `cargo run`'s compiled-binary children are reaped too rather than
+		# left orphaned holding a port.
 		kill -- "-$pid" >/dev/null 2>&1 || true
 	done
-	rm -f "$RUST_SENTINEL_CONFIG"
+	rm -f "$SENTINEL_A_CONFIG" "$SENTINEL_B_CONFIG"
 }
 trap cleanup EXIT
 sleep 2
@@ -75,36 +76,37 @@ env \
 	SENTINEL_CONSENSUS="$CONSENSUS" \
 	SENTINEL_FEE_TOKEN="$FEE_TOKEN" \
 	SENTINEL_REQUEST_FEE="$REQUEST_FEE" \
-	SENTINEL_VOTING_WINDOW="$VOTING_WINDOW" \
+	SENTINEL_COMMIT_WINDOW="$COMMIT_WINDOW" \
+	SENTINEL_REVEAL_WINDOW="$REVEAL_WINDOW" \
 	SENTINEL_GOVERNANCE_DELAY="$GOVERNANCE_DELAY" \
 	SENTINEL_BOND_MULTIPLIER="$BOND_MULTIPLIER" \
 	npm run -w contracts cmd:deploy:sentinel-oracle -- --rpc-url "$RPC_URL" --private-key "$DEPLOYER_PK" --broadcast
-ORACLE=$(jq -r '.returns.sentinelOracle.value' "$ROOT/contracts/build/broadcast/DeploySentinelOracle.s.sol/$CHAIN_ID/run-latest.json")
+ORACLE=$(jq -r '.returns.sentinelOracle.value' "$ROOT/contracts/build/broadcast/DeploySentinelOracleV2.s.sol/$CHAIN_ID/run-latest.json")
 echo "Sentinel oracle deployed at $ORACLE"
 
 # --- 4. Fund the required accounts ---
 echo "Generating sentinel and proposer accounts..."
 WALLETS=$(cast wallet new --json --number 3)
-TS_SENTINEL_ADDR=$(echo "$WALLETS" | jq -r '.[0].address')
-TS_SENTINEL_PK=$(echo "$WALLETS" | jq -r '.[0].private_key')
-RUST_SENTINEL_ADDR=$(echo "$WALLETS" | jq -r '.[1].address')
-RUST_SENTINEL_PK=$(echo "$WALLETS" | jq -r '.[1].private_key')
+SENTINEL_A_ADDR=$(echo "$WALLETS" | jq -r '.[0].address')
+SENTINEL_A_PK=$(echo "$WALLETS" | jq -r '.[0].private_key')
+SENTINEL_B_ADDR=$(echo "$WALLETS" | jq -r '.[1].address')
+SENTINEL_B_PK=$(echo "$WALLETS" | jq -r '.[1].private_key')
 PROPOSER_ADDR=$(echo "$WALLETS" | jq -r '.[2].address')
 PROPOSER_PK=$(echo "$WALLETS" | jq -r '.[2].private_key')
-echo "TS sentinel:   $TS_SENTINEL_ADDR"
-echo "Rust sentinel: $RUST_SENTINEL_ADDR"
-echo "Proposer:      $PROPOSER_ADDR"
+echo "Sentinel A: $SENTINEL_A_ADDR"
+echo "Sentinel B: $SENTINEL_B_ADDR"
+echo "Proposer:   $PROPOSER_ADDR"
 
 echo "Funding accounts with ETH and the fee token..."
-for addr in "$TS_SENTINEL_ADDR" "$RUST_SENTINEL_ADDR" "$PROPOSER_ADDR"; do
+for addr in "$SENTINEL_A_ADDR" "$SENTINEL_B_ADDR" "$PROPOSER_ADDR"; do
 	cast send --rpc-url "$RPC_URL" --private-key "$DEPLOYER_PK" --value "$FUNDING_ETH" "$addr" >/dev/null
 	cast send --rpc-url "$RPC_URL" --private-key "$DEPLOYER_PK" \
 		"$FEE_TOKEN" "transfer(address,uint256)" "$addr" "$FUNDING_TOKEN" >/dev/null
 done
 
 echo "Registering both sentinels..."
-cast send --rpc-url "$RPC_URL" --private-key "$DEPLOYER_PK" "$ORACLE" "addSentinel(address)" "$TS_SENTINEL_ADDR" >/dev/null
-cast send --rpc-url "$RPC_URL" --private-key "$DEPLOYER_PK" "$ORACLE" "addSentinel(address)" "$RUST_SENTINEL_ADDR" >/dev/null
+cast send --rpc-url "$RPC_URL" --private-key "$DEPLOYER_PK" "$ORACLE" "addSentinel(address)" "$SENTINEL_A_ADDR" >/dev/null
+cast send --rpc-url "$RPC_URL" --private-key "$DEPLOYER_PK" "$ORACLE" "addSentinel(address)" "$SENTINEL_B_ADDR" >/dev/null
 
 echo "Approving the oracle to pull the request fee from the proposer..."
 cast send --rpc-url "$RPC_URL" --private-key "$PROPOSER_PK" \
@@ -117,55 +119,50 @@ cast send --rpc-url "$RPC_URL" --private-key "$PROPOSER_PK" \
 balance_of() {
 	cast call --rpc-url "$RPC_URL" --json "$FEE_TOKEN" "balanceOf(address)(uint256)" "$1" | jq -r '.[0]'
 }
-TS_BALANCE_BEFORE=$(balance_of "$TS_SENTINEL_ADDR")
-RUST_BALANCE_BEFORE=$(balance_of "$RUST_SENTINEL_ADDR")
+SENTINEL_A_BALANCE_BEFORE=$(balance_of "$SENTINEL_A_ADDR")
+SENTINEL_B_BALANCE_BEFORE=$(balance_of "$SENTINEL_B_ADDR")
 
-# --- 5. Spin up the TS sentinel ---
-echo "Starting the TS sentinel..."
-env \
-	RPC_URL="$RPC_URL" \
-	CHAIN_ID="$CHAIN_ID" \
-	PRIVATE_KEY="$TS_SENTINEL_PK" \
-	SENTINEL_ORACLE_ADDRESS="$ORACLE" \
-	SENTINEL_ORACLE_FEE_TOKEN="$FEE_TOKEN" \
-	CONSENSUS_ADDRESS="$CONSENSUS" \
-	SENTINEL_VOTING_WINDOW="$VOTING_WINDOW" \
-	BLOCK_TIME_OVERRIDE=$((BLOCK_TIME_SECONDS * 1000)) \
-	METRICS_PORT=0 \
-	LOG_LEVEL=notice \
-	npm run -w validator dev:sentinel >"$ROOT/ts_sentinel_logs.txt" 2>&1 &
-PIDS+=("$!")
-
-# --- 6. Spin up the Rust sentinel ---
-# Already built in step 1, so this just runs it.
-RUST_SENTINEL_CONFIG=$(mktemp)
-cat >"$RUST_SENTINEL_CONFIG" <<EOF
+# --- 5. Spin up both Rust sentinels ---
+# Already built in step 1, so this just runs it — twice, once per account,
+# each with its own config file and in-memory database.
+sentinel_config() {
+	local signer=$1
+	cat <<EOF
 rpc = "$RPC_URL"
-signer = "$RUST_SENTINEL_PK"
+signer = "$signer"
 database = "sqlite::memory:"
 oracle = "$ORACLE"
 consensus = "$CONSENSUS"
 
 [sentinel]
 fee_token = "$FEE_TOKEN"
-voting_window = $VOTING_WINDOW
+voting_window = $((COMMIT_WINDOW + REVEAL_WINDOW))
 blocklist = []
 
 [index]
 block_time = $((BLOCK_TIME_SECONDS * 1000))
 EOF
+}
 
-echo "Starting the Rust sentinel..."
-cargo run --package sentinel -- --config-file "$RUST_SENTINEL_CONFIG" >"$ROOT/rust_sentinel_logs.txt" 2>&1 &
+SENTINEL_A_CONFIG=$(mktemp)
+sentinel_config "$SENTINEL_A_PK" >"$SENTINEL_A_CONFIG"
+SENTINEL_B_CONFIG=$(mktemp)
+sentinel_config "$SENTINEL_B_PK" >"$SENTINEL_B_CONFIG"
+
+echo "Starting sentinel A..."
+cargo run --package sentinel -- --config-file "$SENTINEL_A_CONFIG" >"$ROOT/sentinel_a_logs.txt" 2>&1 &
+PIDS+=("$!")
+
+echo "Starting sentinel B..."
+cargo run --package sentinel -- --config-file "$SENTINEL_B_CONFIG" >"$ROOT/sentinel_b_logs.txt" 2>&1 &
 PIDS+=("$!")
 
 # Give both sentinels time to connect and start watching before the dispute
 # exists. Neither watcher replays history, so proposing too early makes a
-# sentinel miss the block entirely; the TS sentinel's Node/tsx cold start is
-# the slower of the two.
-sleep 8
+# sentinel miss the block entirely.
+sleep 3
 
-# --- 7. Propose a transaction ---
+# --- 6. Propose a transaction ---
 echo "Proposing an oracle-checked transaction..."
 env \
 	CONSENSUS_ADDRESS="$CONSENSUS" \
@@ -177,10 +174,10 @@ env \
 	npm run -w contracts cmd:propose:oracle -- --rpc-url "$RPC_URL" --private-key "$PROPOSER_PK" --broadcast
 
 REQUEST_ID=$(cast logs --rpc-url "$RPC_URL" --json --from-block 0 --address "$ORACLE" \
-	'NewRequest(bytes32,address,uint256,uint256,uint256)' | jq -r '.[0].topics[1]')
+	'NewRequest(bytes32,address,uint256,uint256,uint256,uint256)' | jq -r '.[0].topics[1]')
 echo "Request id: $REQUEST_ID"
 
-# --- 8. Wait for 10 blocks ---
+# --- 7. Wait for 10 blocks ---
 START_BLOCK=$(cast block-number --rpc-url "$RPC_URL")
 TARGET_BLOCK=$((START_BLOCK + 10))
 echo "Waiting for block $TARGET_BLOCK (currently $START_BLOCK)..."
@@ -195,7 +192,7 @@ while [ "$(cast block-number --rpc-url "$RPC_URL")" -lt "$TARGET_BLOCK" ]; do
 	ELAPSED_SECONDS=$((ELAPSED_SECONDS + BLOCK_TIME_SECONDS))
 done
 
-# --- 9. Check the final vote ---
+# --- 8. Check the final vote ---
 # A short grace period on top of the 10-block wait for the last finalize/claim
 # transactions to land, in case they landed late in the window above. `|| true`
 # on each `cast` failure keeps the loop retrying instead of `set -e` aborting
@@ -203,9 +200,9 @@ done
 REQUEST=""
 for _ in $(seq 1 10); do
 	REQUEST=$(cast call --rpc-url "$RPC_URL" --json "$ORACLE" \
-		"getRequest(bytes32)((address,uint256,uint256,uint256,uint8,uint256,uint256,uint256,uint256,uint256,uint256))" \
+		"getRequest(bytes32)((address,uint256,uint256,uint256,uint256,uint8,uint256,uint256,uint256,uint256))" \
 		"$REQUEST_ID" 2>/dev/null) || true
-	STATE=$(echo "$REQUEST" | jq -r '.[0][4]' 2>/dev/null) || true
+	STATE=$(echo "$REQUEST" | jq -r '.[0][5]' 2>/dev/null) || true
 	[ "$STATE" = "2" ] && break
 	sleep "$BLOCK_TIME_SECONDS"
 done
@@ -215,9 +212,9 @@ if [ "$STATE" != "2" ]; then
 	echo "FAILED: expected state RESOLVED_APPROVED (2), got $STATE"
 	exit 1
 fi
-TOTAL_DENY_BOND=$(echo "$REQUEST" | jq -r '.[0][6]')
-if [ "$TOTAL_DENY_BOND" != "0" ]; then
-	echo "FAILED: expected a unanimous approve vote, but totalDenyBond is $TOTAL_DENY_BOND"
+DENY_SENTINEL_COUNT=$(echo "$REQUEST" | jq -r '.[0][9]')
+if [ "$DENY_SENTINEL_COUNT" != "0" ]; then
+	echo "FAILED: expected a unanimous approve vote, but denySentinelCount is $DENY_SENTINEL_COUNT"
 	exit 1
 fi
 DISPUTES=$(cast logs --rpc-url "$RPC_URL" --json --from-block 0 --address "$ORACLE" \
@@ -228,33 +225,33 @@ if [ "$DISPUTES" != "0" ]; then
 fi
 echo "OK: both sentinels agreed (approved) and no arbitration was triggered."
 
-# --- 10. Check the fee and bond flow ---
-TS_COMMITMENT=$(cast call --rpc-url "$RPC_URL" --json "$ORACLE" \
-	"getCommitment(bytes32,address)((bool,uint256,uint256,bool))" "$REQUEST_ID" "$TS_SENTINEL_ADDR")
-RUST_COMMITMENT=$(cast call --rpc-url "$RPC_URL" --json "$ORACLE" \
-	"getCommitment(bytes32,address)((bool,uint256,uint256,bool))" "$REQUEST_ID" "$RUST_SENTINEL_ADDR")
-if [ "$(echo "$TS_COMMITMENT" | jq -r '.[0][3]')" != "true" ] || [ "$(echo "$RUST_COMMITMENT" | jq -r '.[0][3]')" != "true" ]; then
+# --- 9. Check the fee and bond flow ---
+SENTINEL_A_COMMITMENT=$(cast call --rpc-url "$RPC_URL" --json "$ORACLE" \
+	"getCommitment(bytes32,address)((bytes32,uint256,uint8,bool))" "$REQUEST_ID" "$SENTINEL_A_ADDR")
+SENTINEL_B_COMMITMENT=$(cast call --rpc-url "$RPC_URL" --json "$ORACLE" \
+	"getCommitment(bytes32,address)((bytes32,uint256,uint8,bool))" "$REQUEST_ID" "$SENTINEL_B_ADDR")
+if [ "$(echo "$SENTINEL_A_COMMITMENT" | jq -r '.[0][3]')" != "true" ] || [ "$(echo "$SENTINEL_B_COMMITMENT" | jq -r '.[0][3]')" != "true" ]; then
 	echo "FAILED: expected both sentinels to have claimed their bond and reward"
-	echo "TS commitment: $TS_COMMITMENT"
-	echo "Rust commitment: $RUST_COMMITMENT"
+	echo "Sentinel A commitment: $SENTINEL_A_COMMITMENT"
+	echo "Sentinel B commitment: $SENTINEL_B_COMMITMENT"
 	exit 1
 fi
 
-TS_BALANCE_AFTER=$(balance_of "$TS_SENTINEL_ADDR")
-RUST_BALANCE_AFTER=$(balance_of "$RUST_SENTINEL_ADDR")
+SENTINEL_A_BALANCE_AFTER=$(balance_of "$SENTINEL_A_ADDR")
+SENTINEL_B_BALANCE_AFTER=$(balance_of "$SENTINEL_B_ADDR")
 ORACLE_BALANCE_AFTER=$(balance_of "$ORACLE")
 # Both bonds are returned in full (no slashing on a unanimous vote), so any
 # balance gained beyond the bond amount is the sentinel's share of the request
 # fee. The two shares should add up to (approximately) the whole fee: the
-# score-weighted split (favouring whoever committed first) can leave a wei or
-# two of rounding dust behind in the oracle.
-TS_REWARD=$((TS_BALANCE_AFTER - TS_BALANCE_BEFORE))
-RUST_REWARD=$((RUST_BALANCE_AFTER - RUST_BALANCE_BEFORE))
-TOTAL_REWARD=$((TS_REWARD + RUST_REWARD))
-echo "TS sentinel fee share:   $TS_REWARD"
-echo "Rust sentinel fee share: $RUST_REWARD"
+# equal-split reward can leave a wei or two of rounding dust behind in the
+# oracle.
+SENTINEL_A_REWARD=$((SENTINEL_A_BALANCE_AFTER - SENTINEL_A_BALANCE_BEFORE))
+SENTINEL_B_REWARD=$((SENTINEL_B_BALANCE_AFTER - SENTINEL_B_BALANCE_BEFORE))
+TOTAL_REWARD=$((SENTINEL_A_REWARD + SENTINEL_B_REWARD))
+echo "Sentinel A fee share: $SENTINEL_A_REWARD"
+echo "Sentinel B fee share: $SENTINEL_B_REWARD"
 echo "Oracle balance after claims (dust only): $ORACLE_BALANCE_AFTER"
-if [ "$TS_REWARD" -le 0 ] || [ "$RUST_REWARD" -le 0 ]; then
+if [ "$SENTINEL_A_REWARD" -le 0 ] || [ "$SENTINEL_B_REWARD" -le 0 ]; then
 	echo "FAILED: expected both sentinels to receive a nonzero share of the request fee"
 	exit 1
 fi

--- a/validator/src/consensus/integration.test.ts
+++ b/validator/src/consensus/integration.test.ts
@@ -1,9 +1,10 @@
+import { type ChildProcess, spawn } from "node:child_process";
+import { randomUUID } from "node:crypto";
 import fs from "node:fs";
+import os from "node:os";
 import path from "node:path";
-import Sqlite3 from "better-sqlite3";
 import {
 	type Address,
-	createPublicClient,
 	createTestClient,
 	type Hex,
 	hashTypedData,
@@ -22,8 +23,6 @@ import { waitForBlock, waitForBlocks } from "../__tests__/utils.js";
 import { hashNonceCommitments, type NonceTree } from "../consensus/signing/nonces.js";
 import { toPoint } from "../frost/math.js";
 import { calcGenesisGroup, calcGroupContext, calcThreshold } from "../machine/keygen/group.js";
-import { createDetector } from "../sentinel/detector.js";
-import { SentinelService } from "../sentinel/service.js";
 import { createValidatorService, type ValidatorService } from "../service/service.js";
 import type { WatcherConfig } from "../shared/watcher.js";
 import {
@@ -49,6 +48,11 @@ const TEST_RUNTIME_IN_SECONDS = 60;
 const SENTINEL_PK: Hex = "0x92db14e403b83dfe3df233f83dfa3a0d7096f21ca9b0d6d6b8d88b2b4ec1564e";
 // Anvil account 0 — deployer, MyToken owner, and SentinelOracle arbitrator
 const DEPLOYER: Address = "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266";
+// Built by scripts/run_integration_test.sh before Anvil even starts; the TS
+// sentinel can no longer complete a commit-reveal vote against
+// SentinelOracleV2 (see epics/2026_07_02_sentinel_commit_reveal_voting.md),
+// so the oracle signing flow test below drives this binary directly instead.
+const SENTINEL_BINARY_PATH = process.env.SENTINEL_BINARY_PATH;
 
 const ERC20_ABI = parseAbi([
 	"function mint(address to, uint256 amount) external",
@@ -60,7 +64,8 @@ const SENTINEL_ORACLE_ABI = parseAbi([
 	"function addSentinel(address sentinel) external",
 	"function FEE_TOKEN() external view returns (address)",
 	"function REQUEST_FEE() external view returns (uint256)",
-	"function VOTING_WINDOW() external view returns (uint256)",
+	"function COMMIT_WINDOW() external view returns (uint256)",
+	"function REVEAL_WINDOW() external view returns (uint256)",
 	"function bondMultiplier() external view returns (uint256)",
 ]);
 
@@ -112,7 +117,8 @@ describe("integration", () => {
 	let snapshotId: Hex | undefined;
 	let miner: NodeJS.Timeout | undefined;
 	let currentClients: { account: Account; service: ValidatorService }[] | undefined;
-	let sentinelService: SentinelService | undefined;
+	let sentinelProcess: ChildProcess | undefined;
+	let sentinelConfigFile: string | undefined;
 
 	beforeAll(async () => {
 		try {
@@ -145,7 +151,7 @@ describe("integration", () => {
 		if (!erc20Returns) {
 			return undefined;
 		}
-		const sentinelOracleReturns = loadScriptResults("DeploySentinelOracle.s.sol");
+		const sentinelOracleReturns = loadScriptResults("DeploySentinelOracleV2.s.sol");
 		if (!sentinelOracleReturns) {
 			return undefined;
 		}
@@ -295,12 +301,16 @@ describe("integration", () => {
 	};
 
 	afterEach(async () => {
-		// Cleanup sentinel service before validators to avoid log noise from pending actions
-		if (sentinelService !== undefined) {
+		// Cleanup the Rust sentinel process before validators to avoid log noise from pending actions
+		if (sentinelProcess !== undefined) {
+			sentinelProcess.kill();
+			sentinelProcess = undefined;
+		}
+		if (sentinelConfigFile !== undefined) {
 			try {
-				await sentinelService.stop();
+				fs.rmSync(sentinelConfigFile);
 			} catch (_e) {}
-			sentinelService = undefined;
+			sentinelConfigFile = undefined;
 		}
 		// Cleanup services
 		for (const { service } of currentClients ?? []) {
@@ -609,6 +619,13 @@ describe("integration", () => {
 			skip();
 			return;
 		}
+		// The TS sentinel can no longer complete a commit-reveal vote against
+		// SentinelOracleV2; this test drives the Rust sentinel binary
+		// (built by scripts/run_integration_test.sh) as a subprocess instead.
+		if (SENTINEL_BINARY_PATH === undefined) {
+			skip();
+			return;
+		}
 		const { coordinator, consensus, erc20, sentinelOracle, triggerKeyGen } = setupInfo;
 		testLogger.notice("Test configuration", {
 			erc20: erc20.address,
@@ -617,7 +634,7 @@ describe("integration", () => {
 		});
 
 		// Read oracle parameters from deployed contract
-		const [feeToken, requestFee, votingWindow, bondMultiplier] = await Promise.all([
+		const [feeToken, requestFee, commitWindow, revealWindow, bondMultiplier] = await Promise.all([
 			testClient.readContract({
 				...sentinelOracle,
 				functionName: "FEE_TOKEN",
@@ -628,7 +645,11 @@ describe("integration", () => {
 			}),
 			testClient.readContract({
 				...sentinelOracle,
-				functionName: "VOTING_WINDOW",
+				functionName: "COMMIT_WINDOW",
+			}),
+			testClient.readContract({
+				...sentinelOracle,
+				functionName: "REVEAL_WINDOW",
 			}),
 			testClient.readContract({
 				...sentinelOracle,
@@ -639,7 +660,8 @@ describe("integration", () => {
 		testLogger.notice("Oracle configuration", {
 			feeToken,
 			requestFee,
-			votingWindow,
+			commitWindow,
+			revealWindow,
 			bondMultiplier,
 		});
 		const sentinelAccount = privateKeyToAccount(SENTINEL_PK);
@@ -676,27 +698,33 @@ describe("integration", () => {
 			args: [sentinelOracle.address, requestFee],
 		});
 
-		// Start the sentinel service — watches Consensus for OracleTransactionProposed
-		// and SentinelOracle for NewRequest to commit bonds, finalize, and claim
-		const publicClient = createPublicClient({ chain: anvil, transport: http() });
-		sentinelService = new SentinelService({
-			account: sentinelAccount,
-			publicClient,
-			config: {
-				account: sentinelAccount.address,
-				oracle: sentinelOracle.address,
-				feeToken: erc20.address,
-				consensus: consensus.address,
-				chainId: BigInt(anvil.id),
-				votingWindow,
-			},
-			detector: createDetector(),
-			logger: testLogger,
-			watcherConfig: { maxReorgDepth: 1, blockTimeOverride: BLOCK_TIME_MS },
-			database: new Sqlite3(":memory:"),
-			metrics: testMetrics,
+		// Start the Rust sentinel — watches Consensus for OracleTransactionProposed
+		// and SentinelOracle for NewRequest to commit bonds, reveal, finalize, and claim
+		sentinelConfigFile = path.join(os.tmpdir(), `sentinel-${randomUUID()}.toml`);
+		fs.writeFileSync(
+			sentinelConfigFile,
+			[
+				'rpc = "http://127.0.0.1:8545"',
+				`signer = "${SENTINEL_PK}"`,
+				'database = "sqlite::memory:"',
+				`oracle = "${sentinelOracle.address}"`,
+				`consensus = "${consensus.address}"`,
+				"",
+				"[sentinel]",
+				`fee_token = "${erc20.address}"`,
+				// How long the client keeps a `WaitingForRequest` guess alive before
+				// giving up, not the oracle's own commit/reveal windows — generous
+				// since the request resolves well within this test's runtime.
+				"voting_window = 1000",
+				"blocklist = []",
+				"",
+				"[index]",
+				`block_time = ${BLOCK_TIME_MS}`,
+			].join("\n"),
+		);
+		sentinelProcess = spawn(SENTINEL_BINARY_PATH, ["--config-file", sentinelConfigFile], {
+			stdio: "ignore",
 		});
-		await sentinelService.start();
 
 		await triggerKeyGen();
 		await waitForBlocks(testClient, BLOCKS_PER_EPOCH / 2n);


### PR DESCRIPTION
With the new commit reveal implementation the TypeScript and Rust versions is no longer compatible. Therefore all tests will be run against the Rust version.

For now this will also mean that the validator integration tests are using the Sentinel Rust binary. This should be refactored as soon as the validator oxidation is completed.

The sentinel integration tests now run against multiple instances of the same Sentinel binary and configuration. This is acceptable for now and should be revisited (latest together with the validator oxidation completion)

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://docs.safefoundation.org/cla).
