### PR TITLE
[D 1ii/Refactor] Refactor Secrets Sampling

### DIFF
--- a/crates/validator/src/consensus/group.rs
+++ b/crates/validator/src/consensus/group.rs
@@ -44,9 +44,11 @@ use crate::{
     merkle::{MerkleRoot, MerkleTree},
 };
 use alloy::primitives::{Address, B256, keccak256};
+use serde::{Deserialize, Serialize};
 use std::{collections::BTreeSet, num::NonZeroU64};
 
 /// A key generation group.
+#[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Group {
     id: B256,
     participants: MerkleRoot,
@@ -67,6 +69,11 @@ impl Group {
     /// process onchain.
     pub fn parameters(&self) -> (MerkleRoot, u16, u16, B256) {
         (self.participants, self.count, self.threshold, self.context)
+    }
+
+    /// Return the group size: the count and threshold.
+    pub fn size(&self) -> (u16, u16) {
+        (self.count, self.threshold)
     }
 }
 

--- a/crates/validator/src/frost/ecdh.rs
+++ b/crates/validator/src/frost/ecdh.rs
@@ -14,6 +14,7 @@ use k256::{
 };
 use rand::{CryptoRng, RngCore};
 use serde::{Deserialize, Deserializer, Serialize, Serializer, de};
+use std::fmt::{self, Debug, Formatter};
 
 /// A locally-generated ECDH encryption key. The secret scalar is sampled by the
 /// effect handler and never leaves the secret store; only [`public_key`] is
@@ -43,6 +44,12 @@ impl EncryptionKey {
     /// encryption public key. See [`ecdh`].
     pub(super) fn ecdh(&self, public_key: &EncryptionPublicKey, msg: [u8; 32]) -> [u8; 32] {
         ecdh(&self.0, public_key, msg)
+    }
+}
+
+impl Debug for EncryptionKey {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+        f.debug_tuple("EncryptionKey").field(&"redacted").finish()
     }
 }
 

--- a/crates/validator/src/frost/keygen.rs
+++ b/crates/validator/src/frost/keygen.rs
@@ -9,7 +9,7 @@ use super::{
 use crate::{bindings, frost::ecdh::EncryptionPublicKey};
 use alloy::primitives::{Address, U256};
 use frost_secp256k1::{
-    Identifier,
+    Identifier, Signature,
     keys::{
         self,
         dkg::{self, round1, round2},
@@ -21,27 +21,32 @@ use std::collections::BTreeMap;
 /// A participant's generated secrets created at [`setup`] and required by
 /// [`verify_commitment`] and [`generate_secret_shares`]. Persisted to the
 /// secret store between rounds.
-#[derive(Clone, Deserialize, Serialize)]
-pub struct Secrets {
-    encryption_key: EncryptionKey,
-    secret_package: round1::SecretPackage,
-}
-
-/// The result of [`setup`]: the secrets to persist across rounds and the
-/// onchain commitment to publish.
 ///
 /// Note that the secrets are generated with randomness, meaning that they must
 /// be persisted in a reorg-resistant way.
-pub struct Setup {
-    pub secrets: Secrets,
-    pub commitment: bindings::KeyGenCommitment,
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct Secrets {
+    encryption_key: EncryptionKey,
+    secret_package: round1::SecretPackage,
+    proof_of_knowledge: Signature,
+}
+
+impl Secrets {
+    /// Builds the onchain [`KeyGenCommitment`](bindings::KeyGenCommitment) to
+    /// publish for these secrets.
+    pub fn commitment(&self) -> bindings::KeyGenCommitment {
+        let round1_package = round1::Package::new(
+            self.secret_package.commitment().clone(),
+            self.proof_of_knowledge,
+        );
+        marshal::solidity_commitment(&self.encryption_key.public_key(), &round1_package)
+    }
 }
 
 /// Sets up key generation for `me`: samples the ECDH encryption key and the
-/// secret polynomial (to persist to the secret store) alongside the onchain
-/// [`KeyGenCommitment`](bindings::KeyGenCommitment) to publish. The `rng` is
-/// supplied by the caller.
-pub fn setup<R>(rng: &mut R, me: Address, count: u16, threshold: u16) -> Result<Setup, Error>
+/// secret polynomial to persist to the secret store. The `rng` is supplied by
+/// the caller.
+pub fn setup<R>(rng: &mut R, me: Address, count: u16, threshold: u16) -> Result<Secrets, Error>
 where
     R: rand::RngCore + rand::CryptoRng,
 {
@@ -49,14 +54,12 @@ where
     let encryption_key = EncryptionKey::generate(&mut *rng);
     let (secret_package, package) =
         dkg::part1(identifier, count, threshold, &mut *rng).err_unexpected()?;
-    let commitment = marshal::solidity_commitment(&encryption_key.public_key(), &package);
+    let proof_of_knowledge = *package.proof_of_knowledge();
 
-    Ok(Setup {
-        secrets: Secrets {
-            encryption_key,
-            secret_package,
-        },
-        commitment,
+    Ok(Secrets {
+        encryption_key,
+        secret_package,
+        proof_of_knowledge,
     })
 }
 

--- a/crates/validator/src/frost/mod.rs
+++ b/crates/validator/src/frost/mod.rs
@@ -42,9 +42,10 @@ mod tests {
         let mut secrets = BTreeMap::new();
         let mut commitments = BTreeMap::new();
         for participant in participants {
-            let setup = keygen::setup(&mut rng, participant, count, threshold).unwrap();
-            secrets.insert(participant, setup.secrets);
-            commitments.insert(participant, setup.commitment);
+            let participant_secrets =
+                keygen::setup(&mut rng, participant, count, threshold).unwrap();
+            commitments.insert(participant, participant_secrets.commitment());
+            secrets.insert(participant, participant_secrets);
         }
 
         // Each participant uses their random secrets to proceed to the next

--- a/crates/validator/src/secrets.rs
+++ b/crates/validator/src/secrets.rs
@@ -115,9 +115,8 @@ impl SecretStore {
         .map_err(Error::from)
     }
 
-    /// Persists the DKG `secrets` `me` generated for `group`, returning whether
-    /// they were stored (`true`) or dropped because secrets already exist for
-    /// the key (`false`).
+    /// Persists the DKG `secrets` `me` generated for `group` and returns the
+    /// secrets stored for that key.
     ///
     /// Existing secrets are **never overwritten**: a keygen commit effect
     /// reuses the retained secrets rather than resampling them, so a
@@ -127,18 +126,21 @@ impl SecretStore {
         &self,
         group: B256,
         me: Address,
-        secrets: &Secrets,
-    ) -> Result<bool, Error> {
-        let inserted = sqlx::query(
+        secrets: Secrets,
+    ) -> Result<Secrets, Error> {
+        let stored = sqlx::query_scalar::<_, String>(
             "INSERT INTO keygen_secrets (group_id, address, secrets) VALUES (?, ?, ?)
-             ON CONFLICT (group_id, address) DO NOTHING",
+             ON CONFLICT (group_id, address) DO UPDATE
+                 SET secrets = keygen_secrets.secrets
+             RETURNING secrets",
         )
         .bind(key(group))
         .bind(key(me))
-        .bind(serde_json::to_string(secrets)?)
-        .execute(&self.pool)
+        .bind(serde_json::to_string(&secrets)?)
+        .fetch_one(&self.pool)
         .await?;
-        Ok(inserted.rows_affected() == 1)
+        let stored = serde_json::from_str(&stored)?;
+        Ok(stored)
     }
 
     /// Deletes `group`'s DKG secrets once its keygen resolves (successfully or
@@ -339,9 +341,7 @@ mod tests {
     }
 
     fn keygen_secrets() -> keygen::Secrets {
-        keygen::setup(&mut rand::thread_rng(), ME, 3, 2)
-            .unwrap()
-            .secrets
+        keygen::setup(&mut rand::thread_rng(), ME, 3, 2).unwrap()
     }
 
     fn nonce_chunk(size: u64) -> NonceChunk {
@@ -355,10 +355,15 @@ mod tests {
 
         let secrets = keygen_secrets();
         store
-            .store_keygen_secrets(GROUP, ME, &secrets)
+            .store_keygen_secrets(GROUP, ME, secrets.clone())
             .await
             .unwrap();
-        assert!(store.keygen_secrets(GROUP, ME).await.unwrap().is_some());
+
+        let read = store.keygen_secrets(GROUP, ME).await.unwrap().unwrap();
+        assert_eq!(
+            serde_json::to_string(&read).unwrap(),
+            serde_json::to_string(&secrets).unwrap(),
+        )
     }
 
     #[tokio::test]
@@ -366,26 +371,33 @@ mod tests {
         // A re-run of the commit effect (for example after a reorg re-includes
         // the commitment) must reuse the retained secrets, not resample them.
         let store = store().await;
+
         let first = keygen_secrets();
-        // The first store persists the secrets; the second is dropped.
-        assert!(store.store_keygen_secrets(GROUP, ME, &first).await.unwrap());
-
-        let second = keygen_secrets();
-        assert!(
-            !store
-                .store_keygen_secrets(GROUP, ME, &second)
-                .await
-                .unwrap()
-        );
-
-        let stored = store.keygen_secrets(GROUP, ME).await.unwrap().unwrap();
+        let stored = store
+            .store_keygen_secrets(GROUP, ME, first.clone())
+            .await
+            .unwrap();
         assert_eq!(
             serde_json::to_string(&stored).unwrap(),
             serde_json::to_string(&first).unwrap(),
         );
+
+        let second = keygen_secrets();
         assert_ne!(
             serde_json::to_string(&first).unwrap(),
             serde_json::to_string(&second).unwrap(),
+        );
+
+        let stored = store.store_keygen_secrets(GROUP, ME, second).await.unwrap();
+        assert_eq!(
+            serde_json::to_string(&stored).unwrap(),
+            serde_json::to_string(&first).unwrap(),
+        );
+
+        let read = store.keygen_secrets(GROUP, ME).await.unwrap().unwrap();
+        assert_eq!(
+            serde_json::to_string(&read).unwrap(),
+            serde_json::to_string(&first).unwrap(),
         );
     }
 
@@ -393,7 +405,7 @@ mod tests {
     async fn prune_removes_resolved_group_secrets() {
         let store = store().await;
         store
-            .store_keygen_secrets(GROUP, ME, &keygen_secrets())
+            .store_keygen_secrets(GROUP, ME, keygen_secrets())
             .await
             .unwrap();
 

--- a/crates/validator/src/service/effect.rs
+++ b/crates/validator/src/service/effect.rs
@@ -1,6 +1,9 @@
 //! The validator effect system and its handler.
 
-use crate::{frost, merkle::MerkleRoot, secrets::SecretStore, service::Action};
+use crate::{
+    frost::{self, keygen::Secrets},
+    secrets::SecretStore,
+};
 use alloy::primitives::{Address, B256};
 use safenet_core::state::EffectHandler;
 use std::{
@@ -9,28 +12,29 @@ use std::{
 };
 
 /// An impure operation the state transition asks the handler to perform.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone)]
 pub enum Effect {
-    /// Build a key gen commitment action.
-    BuildKeyGenCommitment {
-        id: B256,
-        participants: MerkleRoot,
+    /// Set up key generation: sample the participant's secrets, persist them
+    /// to the secret store.
+    KeyGenSetup {
+        group_id: B256,
         count: u16,
         threshold: u16,
-        context: B256,
-        poap: Vec<B256>,
-        expires_at: Option<u64>,
     },
 }
 
 /// The result of performing an [`Effect`], resumed into the state machine.
-#[derive(Debug, Clone, Default, PartialEq, Eq)]
+#[allow(clippy::large_enum_variant)]
+#[derive(Debug, Clone, Default)]
 pub enum Resume {
     /// An effect that does not require resuming.
     #[default]
     Noop,
-    /// Resume by forwarding a resolved action.
-    Action(Box<Action>),
+    /// Resume with the key gen commitment produced by a [`Effect::KeyGenSetup`].
+    Setup {
+        group_id: B256,
+        secrets: Box<Secrets>,
+    },
 }
 
 /// Performs the validator's [`Effect`]s, resuming with a [`Resume`].
@@ -44,35 +48,21 @@ pub struct Handler {
 impl Handler {
     async fn try_perform_effect(&mut self, effect: Effect) -> Result<Resume, InternalError> {
         match effect {
-            Effect::BuildKeyGenCommitment {
-                id,
-                participants,
+            Effect::KeyGenSetup {
+                group_id,
                 count,
                 threshold,
-                context,
-                poap,
-                expires_at,
             } => {
                 let mut rng = rand::thread_rng();
-                let setup = frost::keygen::setup(&mut rng, self.account, count, threshold)?;
+                let secrets = frost::keygen::setup(&mut rng, self.account, count, threshold)?;
                 let stored = self
                     .secrets
-                    .store_keygen_secrets(id, self.account, &setup.secrets)
+                    .store_keygen_secrets(group_id, self.account, secrets)
                     .await?;
-                if !stored {
-                    tracing::info!(group_id = %id, "not resubmitting already created keygen commitments");
-                    return Ok(Resume::Noop);
-                }
-
-                Ok(Resume::Action(Box::new(Action::KeyGenAndCommit {
-                    participants,
-                    count,
-                    threshold,
-                    context,
-                    poap,
-                    commitment: setup.commitment,
-                    expires_at,
-                })))
+                Ok(Resume::Setup {
+                    group_id,
+                    secrets: Box::new(stored),
+                })
             }
         }
     }

--- a/crates/validator/src/state/keygen.rs
+++ b/crates/validator/src/state/keygen.rs
@@ -1,5 +1,11 @@
 use super::{RolloverState, State, Transition};
-use crate::{bindings::Coordinator, consensus::epoch::EpochId, service::Effect};
+use crate::{
+    bindings::Coordinator,
+    consensus::epoch::EpochId,
+    frost::keygen::Secrets,
+    service::{Action, Effect},
+};
+use alloy::primitives::B256;
 use safenet_core::state::{Command, Commands};
 
 impl Transition {
@@ -13,38 +19,93 @@ impl Transition {
     /// rotation is triggered on new blocks.
     pub(super) fn handle_genesis_key_gen(
         &self,
-        mut state: State,
+        state: State,
         event: &Coordinator::KeyGen,
     ) -> (State, Commands<State, Self>) {
         let genesis = self.genesis.group();
-        if state.rollover != RolloverState::WaitingForGenesis || event.gid != genesis.id() {
+        if !matches!(state.rollover, RolloverState::WaitingForGenesis) || event.gid != genesis.id()
+        {
             return (state, Vec::new());
         }
 
-        // The genesis group generation is not subject to a rollover deadline.
-        state.rollover = RolloverState::CollectingCommitments {
-            group_id: genesis.id(),
-            next_epoch: EpochId::Genesis,
-            deadline: None,
-        };
-
         // Only participate in the group generation if you are part of the
-        // genesis group.
-        let commands = (self.genesis.participate_as(self.account))
-            .map(|(group, poap)| {
-                let (participants, count, threshold, context) = group.parameters();
-                vec![Command::Effect(Effect::BuildKeyGenCommitment {
-                    id: group.id(),
-                    participants,
+        // genesis group; otherwise go straight to collecting the other
+        // participants' commitments. The genesis group generation is not
+        // subject to a rollover deadline.
+        if let Some((group, poap)) = self.genesis.participate_as(self.account) {
+            let group_id = group.id();
+            let (count, threshold) = group.size();
+            (
+                State {
+                    rollover: RolloverState::WaitingForSetup {
+                        next_epoch: EpochId::Genesis,
+                        group,
+                        poap,
+                        deadline: None,
+                    },
+                    ..state
+                },
+                vec![Command::Effect(Effect::KeyGenSetup {
+                    group_id,
                     count,
                     threshold,
-                    context,
-                    poap,
-                    expires_at: None,
-                })]
-            })
-            .unwrap_or_default();
+                })],
+            )
+        } else {
+            (
+                State {
+                    rollover: RolloverState::CollectingCommitments {
+                        next_epoch: EpochId::Genesis,
+                        group: self.genesis.group(),
+                        secrets: None,
+                        deadline: None,
+                    },
+                    ..state
+                },
+                Vec::new(),
+            )
+        }
+    }
 
-        (state, commands)
+    /// Publishes the key gen commitment once the [`Effect::KeyGenSetup`]
+    /// effect has produced it, moving the group into commitment collection.
+    pub fn handle_key_gen_setup(
+        &self,
+        state: State,
+        group_id: B256,
+        secrets: Box<Secrets>,
+    ) -> (State, Commands<State, Self>) {
+        match state.rollover {
+            RolloverState::WaitingForSetup {
+                next_epoch,
+                group,
+                poap,
+                deadline,
+            } if group_id == group.id() => {
+                let (participants, count, threshold, context) = group.parameters();
+                let commitment = secrets.commitment();
+                (
+                    State {
+                        rollover: RolloverState::CollectingCommitments {
+                            next_epoch,
+                            group,
+                            secrets: Some(secrets),
+                            deadline,
+                        },
+                        ..state
+                    },
+                    vec![Command::Action(Action::KeyGenAndCommit {
+                        participants,
+                        count,
+                        threshold,
+                        context,
+                        poap,
+                        commitment,
+                        expires_at: deadline,
+                    })],
+                )
+            }
+            _ => (state, Vec::new()),
+        }
     }
 }

--- a/crates/validator/src/state/mod.rs
+++ b/crates/validator/src/state/mod.rs
@@ -1,18 +1,28 @@
 //! The snapshotted validator state.
 
+// Right now, we only have a single field in our state but this is expected to
+// change. To avoid a large swath of changes when that happens, use `..state`
+// splat everywhere and silence the clippy lint. This will be removed once the
+// validator state gets new fields.
+#![expect(clippy::needless_update)]
+
 mod keygen;
 
 use crate::{
     bindings::Coordinator,
-    consensus::{epoch::EpochId, group::ParticipantSet},
+    consensus::{
+        epoch::EpochId,
+        group::{Group, ParticipantSet},
+    },
+    frost::keygen::Secrets,
     service::{Action, Effect, Event, Resume},
 };
 use alloy::primitives::{Address, B256};
-use safenet_core::state::{Command, Commands, Message, StateTransition};
+use safenet_core::state::{Commands, Message, StateTransition};
 use serde::{Deserialize, Serialize};
 
 /// The complete snapshotted validator state.
-#[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct State {
     /// The epoch-rollover / DKG state machine.
     pub rollover: RolloverState,
@@ -20,7 +30,7 @@ pub struct State {
 
 /// The epoch-rollover / DKG state machine. Each active variant carries the
 /// group it is generating.
-#[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub enum RolloverState {
     /// Idle before the genesis group's DKG has been triggered.
     #[default]
@@ -31,13 +41,29 @@ pub enum RolloverState {
         /// The epoch whose key generation was skipped.
         next_epoch: EpochId,
     },
+    /// This validator is participating in the group's key generation and is
+    /// waiting for the [`Effect::KeyGenSetup`] effect to complete before the
+    /// commitment can be published onchain.
+    WaitingForSetup {
+        /// The epoch this group will serve.
+        next_epoch: EpochId,
+        /// The group being generated.
+        group: Group,
+        /// This validator's PoAP Merkle proof.
+        poap: Vec<B256>,
+        /// The block by which the commitment round must complete. `None` to
+        /// indicate that there is no deadline.
+        deadline: Option<u64>,
+    },
     /// A key generation is underway and the group's commitments are being
     /// collected onchain.
     CollectingCommitments {
-        /// The group being generated.
-        group_id: B256,
         /// The epoch this group will serve.
         next_epoch: EpochId,
+        /// The group being generated.
+        group: Group,
+        /// Key generation secrets, or `None` if not participating.
+        secrets: Option<Box<Secrets>>,
         /// The block by which the commitment round must complete. `None` to
         /// indicate that there is no deadline.
         deadline: Option<u64>,
@@ -79,7 +105,9 @@ impl StateTransition<State> for Transition {
             Message::NewBlock(_) => (state, Vec::new()),
             Message::Resume(result) => match result {
                 Resume::Noop => (state, Vec::new()),
-                Resume::Action(action) => (state, vec![Command::Action(*action)]),
+                Resume::Setup { group_id, secrets } => {
+                    self.handle_key_gen_setup(state, group_id, secrets)
+                }
             },
         }
     }

--- a/epics/2026_07_01_rust_validator_port.md
+++ b/epics/2026_07_01_rust_validator_port.md
@@ -75,11 +75,11 @@ A faithful port needs the whole data flow, so it is catalogued here. References 
 | `service/service.ts`                                                     | `ValidatorService`: wires storage + protocol + state machine + watcher; **`start()` reconciles the staker address**, then starts the watcher. | the loop is `safenet-core::driver::Driver`; the validator supplies the `Service` components; staker reconciliation becomes a `GetValidatorStaker` effect + `ValidatorStakerSet` handling (Phase D5) |
 | `service/machine.ts`                                                     | `SafenetStateMachine`: transition **queue**, block/event dispatch, applies `StateDiff`s, yields `ProtocolAction`s.                            | subsumed by `safenet-core::state::StateMachine`; the validator implements the pure `StateTransition` + an `EffectHandler`                          |
 | `machine/types.ts`, `machine/transitions/types.ts`                       | `RolloverState` / `SigningState` FSMs, `ConsensusState`, `StateDiff`, and the full typed event set.                                           | `state/` (the snapshot `State` + `Transition`) + the `sol!` event set in `service/mod.rs`                                                          |
-| `consensus/rollover.ts`, `keygen/*`                                      | Epoch rollover, DKG rounds (genesis, commitments, shares, confirmations, complaints), timeouts.                                               | transition handlers (Phase D1/D2)                                                                                                                  |
+| `consensus/rollover.ts`, `keygen/*`                                      | Epoch rollover, DKG rounds (genesis, commitments, shares, confirmations, complaints), timeouts.                                               | transition handlers (genesis DKG Phase D1; rollover + timeouts Phase D4)                                                                            |
 | `consensus/signing/*`                                                    | Nonce-tree preprocessing, nonce-commitment reveal, signature-share creation (+ **nonce burn**), completion.                                   | transition handlers + nonce effects (Phase D3) + the secret store (Phase C1)                                                                       |
 | `consensus/keyGen/client.ts`, `signing/client.ts`                        | Thin wrappers over `SqliteClientStorage` holding **all** crypto state.                                                                        | **removed**: deterministic crypto state moves into the snapshot `State`; random secrets move into the secret store behind the `EffectHandler` (see Architecture Decision) |
 | `consensus/storage/sqlite.ts`                                            | 7-table SQLite store: groups, participants, secret shares, nonce links, nonces, signatures, commitments.                                      | **split**: non-secret crypto state → snapshot `State`; local random secrets → `secrets.rs` store (Phase C)                                         |
-| `consensus/verify/engine.ts`, `service/checks.ts`, `verify/*/hashing.ts` | Packet verification, Safe-transaction policy checks, EIP-712 message hashing.                                                                 | `checks.rs` + transition handlers (Phase D4); hashing via `alloy` `SolStruct::eip712_signing_hash`                                                 |
+| `consensus/verify/engine.ts`, `service/checks.ts`, `verify/*/hashing.ts` | Packet verification, Safe-transaction policy checks, EIP-712 message hashing.                                                                 | `checks.rs` + transition handlers (Phase D2); hashing via `alloy` `SolStruct::eip712_signing_hash`                                                 |
 | `consensus/protocol/{base,onchain,transaction}.ts`                       | Action queue + action→calldata encoding + tx submission/nonce/fee management.                                                                 | `ActionEncoder::encode_action` (Phase E1); the queue/fees/resubmit are `safenet-core::tx::TransactionQueue`                                        |
 | `consensus/protocol/sqlite.ts`                                           | Persistent action queue + tx nonce/fee store.                                                                                                 | subsumed by the `Driver` + `TransactionQueue` (no separate action queue)                                                                           |
 | `frost/*`, `consensus/merkle.ts`, `utils/participants.ts`                | FROST math, hashing, VSS, ECDH, nonces, signing, merkle trees.                                                                                | `frost/*` + `merkle.rs` (Phase B)                                                                                                                  |
@@ -303,12 +303,12 @@ crates/validator/
     state/                   # Phase C2: the snapshot State and its pure Transition, grown through Phase D
       mod.rs                 #   State (starts as just RolloverState::WaitingForGenesis) + the pure
                              #   Transition (no-op skeleton in C2; rollover/signing/consensus/DKG in D)
-    checks.rs                # Phase D4a: Safe-transaction policy checks (delegatecall/multisend/config)
+    checks.rs                # Phase D2i: Safe-transaction policy checks (delegatecall/multisend/config)
     service/                 # Phase C2: the ValidatorService bundle + the watched event set
       mod.rs                 #   ValidatorService + the watcher_events! Event set (Consensus/Coordinator/Oracle)
       action.rs              #   the (empty in C2) Action enum + its Encoder, one arm per Phase D action
       effect.rs              #   Effect + Resume enums and their Handler (empty in C2; grows the
-                             #   secret store + provider + RNG through D2/D3/D5)
+                             #   secret store + provider + RNG through D1/D3/D5)
     hashing.rs               # EIP-712 message hashing (SafeTx / rollover / oracle proposal); reuse sentinel's where possible
 ```
 
@@ -468,8 +468,8 @@ identical state. Handlers never fail — errors are data in `Resume`. The catalo
 | `UseNonce { group_id, signature_id, sequence }` | atomic fetch-and-burn via `use_nonce`                                                | the `SigningNonces`, or `AlreadyBurned`               |
 | `PruneGroupNonces { group_id }`                 | delete the retired group's nonce trees                                               | acknowledgment (no commands)                          |
 
-The exact effect granularity (one per DKG round, as listed) is confirmed during Phase D2 — see Open
-Questions.
+The exact effect granularity (one per DKG round, as listed) is confirmed as the D1 DKG slices land
+(D1iii–D1v) — see Open Questions.
 
 ### State transitions (`state/` + submodules)
 
@@ -601,34 +601,115 @@ B1/B2 are the foundation; the rest fan out. All wrappers are pure — RNG is pas
 
 ### Phase D — State transitions & effects (depends on A1, B, C)
 
-Each D PR **grows the snapshot `State` and the `Action` / `Effect` sets** with exactly the fields
-and variants its transitions need — the skeleton from C2 is fleshed out incrementally, so the FSM
-structure is chosen against real transition logic. The shapes catalogued in the "State & secret
-store", "Effects" and "Action encoding" specs are the target these converge on.
+Each D PR **grows the snapshot `State` and the `Action` / `Effect` sets** with exactly the fields and
+variants **one event (or one `NewBlock` check) needs** — the skeleton from C2 is fleshed out one
+handler at a time, so the FSM structure is chosen against real transition logic and every PR is an
+independently reviewable chunk. The shapes catalogued in the "State & secret store", "Effects" and
+"Action encoding" specs are the target these converge on. Roman-numeral slices land in order within a
+sub-phase; "Depends on" gives cross-slice ordering. `EpochProposed` is a deliberate no-op (its
+rollover message was already verified when `KeyGenConfirmed` was handled) and needs no slice.
 
-- **D1 — Rollover, epoch & genesis + timeouts.** `Message::NewBlock` epoch-rollover / keygen-trigger /
-  timeout checks; genesis + epoch-staged handlers. Timeouts that retire a keygen emit
-  `PruneDkgSecrets`. Ports `consensus/rollover.ts`, `keygen/genesis.ts`. Depends on A1, B3, C2.
-- **D2 — KeyGen handlers & DKG effects.** Grows `service/effect.rs` (the `Effect`/`Resume` enums +
-  the `Handler` over the secret store): `KeyGen`/`KeyGenCommitted`/`KeyGenSecretShared`/
-  `KeyGenConfirmed` + complaint submitted/responded, with the `DkgCommit`/`DkgShares`/`DkgFinalize`
-  effects and their resume handlers. The commit effect **reuses any existing stored secrets** (the
-  reorg-safety fix); confirmation/abort emits `PruneDkgSecrets`. Ports `keygen/*`. Depends on B3, C1,
-  C2.
-- **D3 — Signing handlers & nonce effects.** `Preprocess`/`Sign`/`SignRevealedNonces`/`SignShared`/
-  `SignCompleted`/decline; the `NonceTree` and `UseNonce` effects and their resumes — nonce-tree
-  generation, commitment reveal, signature-share creation **+ nonce burn**, incl. the **graceful no-op
-  on `AlreadyBurned`**. Ports `signing/*`. Depends on B4/B5, C1, C2. _The effectful heart of the
-  machine._
-- **D4a — Safe-transaction checks.** `checks.rs`: delegatecall/self/selector/multisend/config-call
-  policy checks. Ports `service/checks.ts`. Depends on A1.
-- **D4b — Transaction & oracle handlers.** `TransactionProposed`/`Attested`,
-  `OracleTransactionProposed`/`Attested`, `OracleResult`; EIP-712 message hashing (`hashing.rs`, reuse
-  sentinel structs where possible), verify→attest-or-decline→`sign_request`. Depends on D4a, B, C2.
-- **D5 — Staker reconciliation.** The `GetValidatorStaker` effect (handler holds the provider), the
-  `ValidatorStakerSet` event handler, the staker fields on `State`, and the `SetValidatorStaker`
-  action emission — a faithful, effect-based port of `service.ts`'s `#setStakerAddress` (replaces the
-  original plan's core `Service::initialize` hook). Depends on A1, C2.
+The sub-phases are ordered by dependency rather than by contract: the genesis group must go live
+before any signing can run, and signing must exist before a non-genesis epoch rollover — whose packet
+is itself signed — can complete. That cycle is broken by **splitting `KeyGenConfirmed`**: its
+self-contained genesis branch lands in D1, and its rollover-packet branch lands in D4 once signing
+exists. All `NewBlock`-driven checks (epoch rollover, keygen timeouts, signing timeouts) likewise
+depend on the full event-driven machine and so are grouped into D4.
+
+**D1 — Genesis DKG lifecycle.** Drive the genesis group through the rollover FSM
+(`CollectingCommitments → CollectingShares → CollectingConfirmations → EpochStaged`), growing
+`RolloverState` and the DKG effects/actions one `KeyGen*` event at a time. Ports `keygen/*`.
+
+- **D1i — Group & participant-set derivation.** ✅ Landed (#551). `consensus/{group,epoch}.rs`: the
+  pure group/threshold/context/root derivation the handlers build on.
+- **D1ii — Genesis `KeyGen`.** ✅ Landed (#553). `WaitingForGenesis → CollectingCommitments` + the
+  `BuildKeyGenCommitment` (`DkgCommit`) effect and `KeyGenAndCommit` action.
+- **D1iii — `KeyGenCommitted`.** Register peers' commitments in `State`; when all have committed,
+  `→ CollectingShares` and emit `DkgShares` → the `KeyGenSecretShare` action (ECDH-encrypted shares).
+  Ports `keygen/committed.ts`. Depends on B3, D1ii.
+- **D1iv — `KeyGenSecretShared`.** Collect/verify shares (invalid share → `KeyGenComplain` action);
+  when all shared, `→ CollectingConfirmations` and — if my share set completed — emit `DkgFinalize`
+  → the `KeyGenConfirm` action. Ports `keygen/secretShares.ts`. Depends on B3, D1iii.
+- **D1v — `KeyGenConfirmed` (genesis branch).** Collect confirmations; when the genesis group is fully
+  confirmed, `→ EpochStaged{epoch 0}`, record `epoch_groups[0]`, emit `NonceTree` →
+  `RegisterNonceCommitments`, and `PruneDkgSecrets`. _(The non-genesis rollover-packet branch lands in
+  D4iii, once signing exists.)_ Ports the genesis path of `keygen/confirmed.ts`. Depends on B3/B4, C1,
+  D1iv.
+- **D1vi — `KeyGenComplained`.** Complaint accounting; at threshold, restart the keygen via the shared
+  `trigger_keygen` helper (adjusted participants) + `PruneDkgSecrets`; if accused, emit the
+  `KeyGenComplaintResponse` action. Ports `keygen/complaintSubmitted.ts`. Depends on D1iv.
+- **D1vii — `KeyGenComplaintResponded`.** Register/verify the revealed share; invalid → restart;
+  share set completed → `KeyGenConfirm`. Ports `keygen/complaintResponse.ts`. Depends on D1vi.
+
+**D2 — Transaction & oracle intake.** Verify proposed transactions and open the signing sessions
+(the `WaitingForRequest` / `WaitingToDecline` / `WaitingForOracle` FSM entries). Pure verification and
+hashing — no secrets. Ports `service/checks.ts`, `verify/*` and the consensus proposed/attested
+handlers. Exercised end to end against a D1-established group, but each handler unit-tests against a
+hand-crafted `State`.
+
+- **D2i — Safe-transaction checks.** `checks.rs`: delegatecall / self / selector / multisend /
+  config-call policy. No event; pure helper. Ports `service/checks.ts`. Depends on A1.
+- **D2ii — EIP-712 hashing & packet verification.** `hashing.rs` + the packet→message-hash helper
+  (reuse the sentinel `SolStruct` structs where possible) the transaction/oracle/rollover handlers
+  share. No event; helper. Depends on A1, D2i.
+- **D2iii — `TransactionProposed`.** Verify → `WaitingForRequest` (valid) or `WaitingToDecline`
+  (invalid). Ports `consensus/transactionProposed.ts`. Depends on D2ii.
+- **D2iv — `TransactionAttested`.** Clear the `WaitingForAttestation` entry once the attestation
+  lands. Ports `consensus/transactionAttested.ts`. Depends on D2ii.
+- **D2v — `OracleTransactionProposed`.** Verify → `WaitingForRequest` (oracle packet). Ports
+  `consensus/oracleTransactionProposed.ts`. Depends on D2ii.
+- **D2vi — `OracleTransactionAttested`.** Clear the entry. Ports
+  `consensus/oracleTransactionAttested.ts`. Depends on D2ii.
+
+**D3 — Signing lifecycle.** The nonce effects and the signing FSM that consumes the sessions D2 opens
+— the effectful heart of the machine. The last signer's `SignShare` action carries the attestation
+`callbackContext` that submits the result on the happy path (Open Question #5); the standalone
+attest/stage actions are the timeout fallbacks in D4. Ports `signing/*` + `consensus/oracleResult.ts`.
+
+- **D3i — `Preprocess`.** Link committed nonces to their chunk (the nonce-store `link` effect) and
+  clear the group's pending-nonces marker. Ports `signing/preprocess.ts`. Depends on B4, C1.
+- **D3ii — `Sign`.** For a live request: top up nonces when low (`NonceTree`), then reveal
+  commitments (`RevealNonceCommitments` action, `→ CollectNonceCommitments`); oracle packet →
+  `WaitingForOracle`; declined packet → `SignDecline`. Ports `signing/sign.ts` + `commitments.ts`.
+  Depends on B4/B5, C1, D2iii/D2v.
+- **D3iii — `OracleResult`.** On approval, reveal nonce commitments (as D3ii); on rejection, drop the
+  session. Ports `consensus/oracleResult.ts`. Depends on D3ii, D2v.
+- **D3iv — `SignRevealedNonces`.** Create the signature share, **burning the nonce** via the atomic
+  `UseNonce` effect, with the **graceful no-op on `AlreadyBurned`**; `→ CollectSigningShares` + the
+  `SignShare` action (carrying the transaction/oracle attestation callback; the rollover `stageEpoch`
+  callback branch lands with D4iii). Ports `signing/nonces.ts` (`handleRevealedNonces`). Depends on
+  B5, C1, D3ii.
+- **D3v — `SignShared`.** Track collected signature shares. Ports `signing/shares.ts`. Depends on
+  D3iv.
+- **D3vi — `SignCompleted`.** `→ WaitingForAttestation`. Ports `signing/completed.ts`. Depends on
+  D3v. _(Completes the minimal genesis DKG + one-signing-round flow the F1 interop test drives.)_
+
+**D4 — Epoch rollover & timeouts.** The block-driven epoch machine, the non-genesis DKG trigger, and
+all `NewBlock` timeout checks — reusing the D3 signing FSM for the rollover packet. Ports
+`consensus/rollover.ts`, `keygen/trigger.ts`, `keygen/timeouts.ts`, `signing/timeouts.ts`, the
+rollover branch of `keygen/confirmed.ts`, and `consensus/epochStaged.ts`.
+
+- **D4i — `trigger_keygen` helper + `NewBlock` epoch rollover.** Extract the shared `trigger_keygen`
+  (participants/threshold/context → `CollectingCommitments` + `DkgCommit`, or `EpochSkipped`) that
+  D1vi/D1vii already call, then port `checkEpochRollover`: roll `active_epoch`, trigger the next
+  epoch's keygen, and clean up retired epoch groups (`PruneGroupNonces`). Ports `consensus/rollover.ts`
+  + `keygen/trigger.ts`. Depends on D1, C1.
+- **D4ii — Keygen timeouts (`NewBlock`).** Retire timed-out participants and restart via
+  `trigger_keygen`; retiring a keygen emits `PruneDkgSecrets`. Ports `keygen/timeouts.ts`. Depends on
+  D4i.
+- **D4iii — `KeyGenConfirmed` (rollover branch) + `EpochStaged`.** Non-genesis confirmation computes
+  the epoch-rollover packet, `→ SignRollover`, and opens its signing session; `EpochStaged` moves
+  `SignRollover → EpochStaged`, records `epoch_groups`, and preprocesses the new group (`NonceTree` →
+  `RegisterNonceCommitments`). Completes `keygen/confirmed.ts`; ports `consensus/epochStaged.ts`.
+  Depends on D1v, D2ii, D3.
+- **D4iv — Signing timeouts (`NewBlock`).** Per-session retry / decline / drop across the signing FSM,
+  emitting `SignRequest` on retry and the standalone `AttestTransaction` / `StageEpoch` fallback
+  actions. Ports `signing/timeouts.ts`. Depends on D3vi, D4iii.
+
+**D5 — Staker reconciliation.** The `GetValidatorStaker` effect (handler holds the provider), the
+`ValidatorStakerSet` event handler, the staker fields on `State`, the `NewBlock` staker check, and the
+`SetValidatorStaker` action emission — a faithful, effect-based port of `service.ts`'s
+`#setStakerAddress` (replaces the original plan's core `Service::initialize` hook). Depends on A1, C2.
 
 ### Phase E — Service assembly (depends on D)
 
@@ -652,11 +733,13 @@ store", "Effects" and "Action encoding" specs are the target these converge on.
 
 ### Critical path
 
-`A1 → B1 → B4 → B5 → D3 → E1 → E2 → F1`. Phase B fans out from B1 (B2 also needs A1; B3 needs B1+B2;
-B4 needs B1; B5 needs B1+B2+B4). C1 (secret store) follows B; C2 (the service skeleton) needs only
-A1 and can land early; D follows A/B/C and grows the state machine C2 stood up; D4a needs only A1,
-and D5 only A1+C2, so both sit off the critical path. FROST (B) is a thin wrapper now, so the state
-machine (D) shares the critical path with it.
+`A1 → B1 → B4 → B5 → D3 → D4iii → E1 → E2 → F1`. Phase B fans out from B1 (B2 also needs A1; B3 needs
+B1+B2; B4 needs B1; B5 needs B1+B2+B4). C1 (secret store) follows B; C2 (the service skeleton) needs
+only A1 and can land early. Phase D grows the state machine C2 stood up, one event per slice, in
+dependency order: D1 (genesis DKG) → D2 (intake) → D3 (signing) unblocks the F1 interop test's
+"genesis DKG + one signing round"; D4 (rollover + timeouts) then reuses D3's signing FSM. D2i
+(`checks.rs`) needs only A1, and D5 (staker) only A1+C2, so both sit off the critical path. FROST (B)
+is a thin wrapper now, so the state machine (D) shares the critical path with it.
 
 ---
 
@@ -680,14 +763,14 @@ machine (D) shares the critical path with it.
    `provider.estimate_gas` if they prove brittle.
 4. **Shared EIP-712 hashing with the sentinel.** The `SafeTx` / proposal `sol!` structs and hashing
    overlap the sentinel crate. **Recommended:** factor the shared structs into a small shared module
-   (in `safenet-core` or a shared crate) rather than duplicating; decide when D4b lands.
+   (in `safenet-core` or a shared crate) rather than duplicating; decide when D2ii lands.
 5. **`callback` variants (`keyGenConfirmWithCallback` / `signShareWithCallback`).** The TS actions carry
    an optional callback context. Confirm whether the Rust port must support callbacks in the initial
    port or can defer them.
 6. **DKG effect granularity.** The plan models one effect per DKG round (`DkgCommit` / `DkgShares` /
    `DkgFinalize`), keeping round outputs in the snapshot `State` and only the secrets in the store.
    **Recommended:** keep per-round effects (smallest impure surface); confirm against the actual
-   `frost` API shapes when D2 lands.
+   `frost` API shapes as the D1 DKG slices (D1iii–D1v) land.
 
 **Assumptions**
 


### PR DESCRIPTION
### Context and Motivation

I noticed in further changes to the state machine that we _need_ the secrets value right away for verifying commitments. This change modifies the effect to just sample the random secrets, store them, and then resume the state machine with them; the state machine is responsible to push the commit action once it sees the result of the effect.

This allows the state machine to hold a copy of the `Secrets` value so that it can use in its state transitions.

As before, secrets are just sampled once and reused per group ID.

### Decisions and Tradeoffs

A new `WiatingForSetup` state was introduced. This gives us a nice bonus as failure to write to the storage or generate the secrets gives us a chance to resample. This makes the state machine more resilient (resampling will be added once we start handling block updates - if we see a new block update and are still in the `WaitingForSetup` phase, then we know that we should try sampling again).

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://docs.safefoundation.org/cla).
