### PR TITLE
[D 1iii]: Handle KeyGen Commitments

### DIFF
--- a/crates/validator/src/frost/ecdh.rs
+++ b/crates/validator/src/frost/ecdh.rs
@@ -62,7 +62,7 @@ impl Drop for EncryptionKey {
 impl ZeroizeOnDrop for EncryptionKey {}
 
 /// An encryption public key that can be serialized.
-#[derive(Clone, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct EncryptionPublicKey(ProjectivePoint);
 
 impl EncryptionPublicKey {

--- a/crates/validator/src/frost/keygen.rs
+++ b/crates/validator/src/frost/keygen.rs
@@ -9,7 +9,7 @@ use super::{
 use crate::{bindings, frost::ecdh::EncryptionPublicKey};
 use alloy::primitives::{Address, U256};
 use frost_secp256k1::{
-    Identifier, Signature,
+    Identifier, Signature, VerifyingKey,
     keys::{
         self,
         dkg::{self, round1, round2},
@@ -64,27 +64,26 @@ where
 }
 
 /// A validated public commitment from a participant.
-#[derive(Clone, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct VerifiedCommitment {
     encryption_public_key: EncryptionPublicKey,
     package: round1::Package,
 }
 
-/// Verifies a participant's public commitment.
+/// Verifies a participant's public commitment against the group's `threshold`.
 ///
 /// These are applied to _both_ `me`, the validator itself, and all peers that
-/// publish key generation commitments onchain.
+/// publish key generation commitments onchain; unlike [`generate_secret_shares`]
+/// this does not require `me` to be a participant in the key generation.
 pub fn verify_commitment(
-    secrets: &Secrets,
+    threshold: u16,
     participant: Address,
     commitment: &bindings::KeyGenCommitment,
 ) -> Result<VerifiedCommitment, Error> {
     let identifier = participants::identifier(participant);
     marshal::frost_commitment(commitment)
         .and_then(|(encryption_public_key, package)| {
-            if package.commitment().coefficients().len() as u16
-                != *secrets.secret_package.min_signers()
-            {
+            if package.commitment().coefficients().len() as u16 != threshold {
                 return Err(frost_secp256k1::Error::IncorrectNumberOfCommitments);
             }
             frost_core::keys::dkg::verify_proof_of_knowledge(
@@ -100,13 +99,33 @@ pub fn verify_commitment(
         .err_with_culprit(participant)
 }
 
+/// The public key for a generated FROST group.
+#[derive(Copy, Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(transparent)]
+pub struct GroupKey(VerifyingKey);
+
+impl GroupKey {
+    /// Returns the underlying FROST verifying key.
+    pub(super) fn as_verifying_key(&self) -> &VerifyingKey {
+        &self.0
+    }
+}
+
+/// Derives the group's public key from every participant's verified
+/// commitment.
+pub fn group_key(commitments: &BTreeMap<Address, VerifiedCommitment>) -> Result<GroupKey, Error> {
+    let commitment = group_commitment(commitments).err_unexpected()?;
+    let key = VerifyingKey::from_commitment(&commitment).err_unexpected()?;
+    Ok(GroupKey(key))
+}
+
 /// A participant's own secret key-generation state after sharing. Persisted to
 /// the secret store and consumed by [`finalize`].
 ///
 /// Unlike [`Secrets`], this can be reconstructed using the generated secrets
 /// from [`setup`] and onchain state, and therefore can be stored in the state
 /// machine (and does not require a reorg-resistant storage).
-#[derive(Clone, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct SharingState {
     encryption_key: EncryptionKey,
     secret_package: round2::SecretPackage,
@@ -149,12 +168,7 @@ pub fn generate_secret_shares(
 
             // Build the verifying share (i.e. the participant's "public key")
             // from the commitments.
-            let group_commitment = frost_core::keys::sum_commitments(
-                &commitments
-                    .values()
-                    .map(|verified| verified.package.commitment())
-                    .collect::<Vec<_>>(),
-            )?;
+            let group_commitment = group_commitment(&commitments)?;
             let verifying_share = keys::VerifyingShare::from_commitment(
                 *secrets.secret_package.identifier(),
                 &group_commitment,
@@ -196,8 +210,19 @@ pub fn generate_secret_shares(
         .err_unexpected()
 }
 
+fn group_commitment(
+    commitments: &BTreeMap<Address, VerifiedCommitment>,
+) -> Result<keys::VerifiableSecretSharingCommitment, frost_secp256k1::Error> {
+    frost_core::keys::sum_commitments(
+        &commitments
+            .values()
+            .map(|verified| verified.package.commitment())
+            .collect::<Vec<_>>(),
+    )
+}
+
 /// A validated signing share from a peer.
-#[derive(Clone, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct VerifiedShare {
     package: round2::Package,
 }

--- a/crates/validator/src/frost/mod.rs
+++ b/crates/validator/src/frost/mod.rs
@@ -48,24 +48,24 @@ mod tests {
             secrets.insert(participant, participant_secrets);
         }
 
+        // Each participant verifies the commitments they observe onchain.
+        let verified_commitments = participants
+            .into_iter()
+            .map(|participant| {
+                let commitment =
+                    keygen::verify_commitment(threshold, participant, &commitments[&participant])
+                        .unwrap();
+                (participant, commitment)
+            })
+            .collect::<BTreeMap<_, _>>();
+
         // Each participant uses their random secrets to proceed to the next
         // stage and generate encrypted secret shares that published onchain.
         let mut sharing_states = BTreeMap::new();
         let mut shares = BTreeMap::new();
         for (participant, secrets) in secrets {
-            let verified_commitments = participants
-                .into_iter()
-                .map(|participant| {
-                    let commitment = keygen::verify_commitment(
-                        &secrets,
-                        participant,
-                        &commitments[&participant],
-                    )
-                    .unwrap();
-                    (participant, commitment)
-                })
-                .collect();
-            let share = keygen::generate_secret_shares(secrets, verified_commitments).unwrap();
+            let share =
+                keygen::generate_secret_shares(secrets, verified_commitments.clone()).unwrap();
             sharing_states.insert(participant, share.sharing_state);
             shares.insert(participant, share.share);
         }
@@ -89,17 +89,15 @@ mod tests {
         // Here, all participants should share the same group verifying key.
         // Additionally, the group key should equal to the sum of all the
         // publicly posted commitments C_0.
-        let group_key = key_shares
-            .values()
-            .next()
-            .unwrap()
-            .as_key_package()
-            .verifying_key();
+        let group_key = keygen::group_key(&verified_commitments).unwrap();
         for key_share in key_shares.values() {
-            assert_eq!(group_key, key_share.as_key_package().verifying_key());
+            assert_eq!(
+                group_key.as_verifying_key(),
+                key_share.as_key_package().verifying_key()
+            );
         }
         assert_eq!(
-            group_key.to_element(),
+            group_key.as_verifying_key().to_element(),
             commitments
                 .values()
                 .map(|commitments| marshal::frost_point(&commitments.c[0]).unwrap())
@@ -215,7 +213,7 @@ mod tests {
                 .collect();
             let public_key_package = frost_secp256k1::keys::PublicKeyPackage::new(
                 verifying_shares,
-                *group_key,
+                *group_key.as_verifying_key(),
                 Some(threshold),
             );
 

--- a/crates/validator/src/service/action.rs
+++ b/crates/validator/src/service/action.rs
@@ -23,6 +23,12 @@ pub enum Action {
         commitment: bindings::KeyGenCommitment,
         expires_at: Option<u64>,
     },
+    /// An action to publish a key generation secret share onchain.
+    KeyGenSecretShare {
+        group_id: B256,
+        share: bindings::KeyGenSecretShare,
+        expires_at: Option<u64>,
+    },
 }
 
 /// Encodes [`Action`]s into the transactions the queue submits.
@@ -59,6 +65,27 @@ impl ActionEncoder<Action> for Encoder {
                 },
                 expires_at,
             ),
+            Action::KeyGenSecretShare {
+                group_id,
+                share,
+                expires_at,
+            } => {
+                let gas = 250_000 + 25_000 * share.f.len() as u64;
+                (
+                    Transaction {
+                        to: self.coordinator,
+                        value: U256::ZERO,
+                        data: Coordinator::keyGenSecretShareCall {
+                            gid: group_id,
+                            share,
+                        }
+                        .abi_encode()
+                        .into(),
+                        gas,
+                    },
+                    expires_at,
+                )
+            }
         }
     }
 }

--- a/crates/validator/src/service/mod.rs
+++ b/crates/validator/src/service/mod.rs
@@ -85,10 +85,16 @@ impl Service for ValidatorService {
             genesis,
             secrets,
             coordinator,
-            config: ValidatorConfig { .. },
+            config: ValidatorConfig {
+                key_gen_timeout, ..
+            },
         } = self;
         (
-            state::Transition { account, genesis },
+            state::Transition {
+                account,
+                genesis,
+                key_gen_timeout,
+            },
             effect::Handler { account, secrets },
             action::Encoder { coordinator },
         )

--- a/crates/validator/src/state/keygen.rs
+++ b/crates/validator/src/state/keygen.rs
@@ -2,11 +2,15 @@ use super::{RolloverState, State, Transition};
 use crate::{
     bindings::Coordinator,
     consensus::epoch::EpochId,
-    frost::keygen::Secrets,
+    frost::{
+        self,
+        keygen::{SecretShares, Secrets},
+    },
     service::{Action, Effect},
 };
 use alloy::primitives::B256;
 use safenet_core::state::{Command, Commands};
+use std::collections::BTreeMap;
 
 impl Transition {
     /// Joins the genesis key generation once its group is created onchain.
@@ -58,6 +62,7 @@ impl Transition {
                         next_epoch: EpochId::Genesis,
                         group: self.genesis.group(),
                         secrets: None,
+                        commitments: BTreeMap::new(),
                         deadline: None,
                     },
                     ..state
@@ -90,6 +95,7 @@ impl Transition {
                             next_epoch,
                             group,
                             secrets: Some(secrets),
+                            commitments: BTreeMap::new(),
                             deadline,
                         },
                         ..state
@@ -104,6 +110,128 @@ impl Transition {
                         expires_at: deadline,
                     })],
                 )
+            }
+            _ => (state, Vec::new()),
+        }
+    }
+
+    /// Registers a peer's key generation commitment. Once every participant
+    /// has committed, moves the group into secret-share collection: kicking
+    /// off the [`Effect::DkgShares`] effect if this validator is participating,
+    /// or straight into [`RolloverState::CollectingShares`] otherwise.
+    pub(super) fn handle_key_gen_committed(
+        &self,
+        state: State,
+        block: u64,
+        event: &Coordinator::KeyGenCommitted,
+    ) -> (State, Commands<State, Self>) {
+        match state.rollover {
+            RolloverState::CollectingCommitments {
+                next_epoch,
+                group,
+                secrets,
+                mut commitments,
+                deadline,
+            } if group.id() == event.gid => {
+                let (count, threshold) = group.size();
+
+                // Only consider valid commitments; invalid ones are ignored,
+                // the participant will be removed from the group on timeout.
+                if let Ok(commitment) = frost::keygen::verify_commitment(
+                    threshold,
+                    event.participant,
+                    &event.commitment,
+                ) {
+                    commitments.insert(event.participant, commitment);
+                };
+
+                if commitments.len() as u16 != count {
+                    // We are still missing commitments, so stay in the same
+                    // collecting state with the (possibly) updated commitments
+                    // map.
+                    return (
+                        State {
+                            rollover: RolloverState::CollectingCommitments {
+                                next_epoch,
+                                group,
+                                secrets,
+                                commitments,
+                                deadline,
+                            },
+                            ..state
+                        },
+                        Vec::new(),
+                    );
+                }
+
+                // Every participant has committed, so a fresh round starts:
+                // push the deadline forward from the current block. Genesis
+                // is not subject to a rollover deadline, so `None` stays
+                // `None`.
+                let deadline = deadline.map(|_| block.saturating_add(self.key_gen_timeout.get()));
+
+                // Compute the group key from the commitments, and if part of
+                // the group, the secret shares to publish onchain.
+                match frost::keygen::group_key(&commitments).and_then(|group_key| {
+                    let secret_shares = secrets
+                        .map(|secrets| frost::keygen::generate_secret_shares(*secrets, commitments))
+                        .transpose()?;
+                    Ok((group_key, secret_shares))
+                }) {
+                    Ok((group_key, secret_shares)) => {
+                        let group_id = group.id();
+                        let (sharing_state, commands) = if let Some(SecretShares {
+                            sharing_state,
+                            share,
+                        }) = secret_shares
+                        {
+                            (
+                                Some(Box::new(sharing_state)),
+                                vec![Command::Action(Action::KeyGenSecretShare {
+                                    group_id,
+                                    share,
+                                    expires_at: deadline,
+                                })],
+                            )
+                        } else {
+                            // If we are just observing, the continue without
+                            // a secret sharing state or emitting any actions.
+                            (None, Vec::new())
+                        };
+
+                        (
+                            State {
+                                rollover: RolloverState::CollectingShares {
+                                    next_epoch,
+                                    group,
+                                    group_key,
+                                    sharing_state,
+                                    shares: BTreeMap::new(),
+                                    deadline,
+                                },
+                                ..state
+                            },
+                            commands,
+                        )
+                    }
+                    Err(err) => {
+                        let rollover = if let EpochId::Number { number: next_epoch } = next_epoch {
+                            tracing::warn!(
+                                %err,
+                                ?next_epoch,
+                                "failed to advance key generation, skipping to next epoch"
+                            );
+                            RolloverState::EpochSkipped { next_epoch }
+                        } else {
+                            tracing::error!(
+                                %err,
+                                "failed to advance genesis key generation, permanently halted"
+                            );
+                            RolloverState::Halted
+                        };
+                        (State { rollover, ..state }, Vec::new())
+                    }
+                }
             }
             _ => (state, Vec::new()),
         }

--- a/crates/validator/src/state/mod.rs
+++ b/crates/validator/src/state/mod.rs
@@ -14,12 +14,13 @@ use crate::{
         epoch::EpochId,
         group::{Group, ParticipantSet},
     },
-    frost::keygen::Secrets,
+    frost::keygen::{GroupKey, Secrets, SharingState, VerifiedCommitment, VerifiedShare},
     service::{Action, Effect, Event, Resume},
 };
 use alloy::primitives::{Address, B256};
 use safenet_core::state::{Commands, Message, StateTransition};
 use serde::{Deserialize, Serialize};
+use std::{collections::BTreeMap, num::NonZeroU64};
 
 /// The complete snapshotted validator state.
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]
@@ -35,11 +36,16 @@ pub enum RolloverState {
     /// Idle before the genesis group's DKG has been triggered.
     #[default]
     WaitingForGenesis,
+    /// The rollover has halted in an unrecoverable way.
+    ///
+    /// This can either be an unrecoverable error during DKG or we have reached
+    /// the heat death of the universe and there are no more epochs.
+    Halted,
     /// The key generation for `next_epoch` was skipped because too few
     /// participants took part for the group to be safe.
     EpochSkipped {
         /// The epoch whose key generation was skipped.
-        next_epoch: EpochId,
+        next_epoch: NonZeroU64,
     },
     /// This validator is participating in the group's key generation and is
     /// waiting for the [`Effect::KeyGenSetup`] effect to complete before the
@@ -64,7 +70,28 @@ pub enum RolloverState {
         group: Group,
         /// Key generation secrets, or `None` if not participating.
         secrets: Option<Box<Secrets>>,
+        /// Verified commitments received from peers so far, keyed by
+        /// participant.
+        commitments: BTreeMap<Address, VerifiedCommitment>,
         /// The block by which the commitment round must complete. `None` to
+        /// indicate that there is no deadline.
+        deadline: Option<u64>,
+    },
+    /// Every participant has committed and the group's secret shares are
+    /// being collected onchain.
+    CollectingShares {
+        /// The epoch this group will serve.
+        next_epoch: EpochId,
+        /// The group being generated.
+        group: Group,
+        /// The public key derived from the participants' commitments.
+        group_key: GroupKey,
+        /// This validator's sharing state, or `None` if not participating.
+        sharing_state: Option<Box<SharingState>>,
+        /// Verified secret shares received from peers so far, keyed by
+        /// participant.
+        shares: BTreeMap<Address, VerifiedShare>,
+        /// The block by which the secret-share round must complete. `None` to
         /// indicate that there is no deadline.
         deadline: Option<u64>,
     },
@@ -80,6 +107,9 @@ pub struct Transition {
     pub account: Address,
     /// The genesis participant set.
     pub genesis: ParticipantSet,
+    /// The number of blocks a distributed key generation ceremony may run
+    /// before timing out.
+    pub key_gen_timeout: NonZeroU64,
 }
 
 impl StateTransition<State> for Transition {
@@ -97,6 +127,9 @@ impl StateTransition<State> for Transition {
             Message::Event(log) => match log.data {
                 Event::Coordinator(Coordinator::CoordinatorEvents::KeyGen(event)) => {
                     self.handle_genesis_key_gen(state, &event)
+                }
+                Event::Coordinator(Coordinator::CoordinatorEvents::KeyGenCommitted(event)) => {
+                    self.handle_key_gen_committed(state, log.block, &event)
                 }
                 // The remaining events are wired in as their handlers land.
                 _ => (state, Vec::new()),


### PR DESCRIPTION
### Context and Motivation

The next major step in key generation is to handle commitments. This PR adds a new handler for `KeyGenCommitted` events that verifies the commitment (the proof size and the proof of knowledge) as and collects them into a map. Once all the commitments have been collected, secret shares are generated and posted onchain.

### Decisions and Tradeoffs

We added an additional `Halted` rollover state: if for whatever reason the genesis key generation process fails at the point of secret share generation, it is in an irrecoverable state and log an error.

### Port

This ports:

https://github.com/safe-research/safenet/blob/bc95de24b6307222ef2d37c32b259b6ba7c23954/validator/src/machine/keygen/committed.ts#L14-L63

https://github.com/safe-research/safenet/blob/bc95de24b6307222ef2d37c32b259b6ba7c23954/validator/src/consensus/protocol/onchain.ts#L122-L130

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://docs.safefoundation.org/cla).
