### PR TITLE
[D 1iv 1/2]: Split Secret Share Verification

### DIFF
--- a/crates/validator/src/frost/keygen.rs
+++ b/crates/validator/src/frost/keygen.rs
@@ -63,29 +63,29 @@ where
     })
 }
 
-/// A validated public commitment from a participant.
+/// A verified public commitment from a participant.
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct VerifiedCommitment {
     encryption_public_key: EncryptionPublicKey,
     package: round1::Package,
 }
 
-/// Verifies a participant's public commitment against the group's `threshold`.
+/// Verifies a participant's public commitment by decoding its values and
+/// checking its proof of knowledge.
 ///
 /// These are applied to _both_ `me`, the validator itself, and all peers that
 /// publish key generation commitments onchain; unlike [`generate_secret_shares`]
 /// this does not require `me` to be a participant in the key generation.
 pub fn verify_commitment(
-    threshold: u16,
     participant: Address,
     commitment: &bindings::KeyGenCommitment,
 ) -> Result<VerifiedCommitment, Error> {
+    // Note that we do not check the length of the commitments, this is enforced
+    // by the smart contract and any issues will be caught later and produce an
+    // unexpected FROST error.
     let identifier = participants::identifier(participant);
     marshal::frost_commitment(commitment)
         .and_then(|(encryption_public_key, package)| {
-            if package.commitment().coefficients().len() as u16 != threshold {
-                return Err(frost_secp256k1::Error::IncorrectNumberOfCommitments);
-            }
             frost_core::keys::dkg::verify_proof_of_knowledge(
                 identifier,
                 package.commitment(),
@@ -99,24 +99,34 @@ pub fn verify_commitment(
         .err_with_culprit(participant)
 }
 
-/// The public key for a generated FROST group.
-#[derive(Copy, Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
-#[serde(transparent)]
-pub struct GroupKey(VerifyingKey);
+/// FROST group commitments.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct GroupCommitments {
+    commitments: BTreeMap<Address, VerifiedCommitment>,
+    group_commitment: keys::VerifiableSecretSharingCommitment,
+    verifying_key: VerifyingKey,
+}
 
-impl GroupKey {
-    /// Returns the underlying FROST verifying key.
-    pub(super) fn as_verifying_key(&self) -> &VerifyingKey {
-        &self.0
+impl GroupCommitments {
+    /// Returns the underlying FROST group verifying key.
+    pub(super) fn verifying_key(&self) -> &VerifyingKey {
+        &self.verifying_key
     }
 }
 
 /// Derives the group's public key from every participant's verified
 /// commitment.
-pub fn group_key(commitments: &BTreeMap<Address, VerifiedCommitment>) -> Result<GroupKey, Error> {
-    let commitment = group_commitment(commitments).err_unexpected()?;
-    let key = VerifyingKey::from_commitment(&commitment).err_unexpected()?;
-    Ok(GroupKey(key))
+pub fn group_commitments(
+    commitments: BTreeMap<Address, VerifiedCommitment>,
+) -> Result<GroupCommitments, Error> {
+    let group_commitment = group_commitment(&commitments).err_unexpected()?;
+    let verifying_key = VerifyingKey::from_commitment(&group_commitment).err_unexpected()?;
+
+    Ok(GroupCommitments {
+        commitments,
+        group_commitment,
+        verifying_key,
+    })
 }
 
 /// A participant's own secret key-generation state after sharing. Persisted to
@@ -129,15 +139,14 @@ pub fn group_key(commitments: &BTreeMap<Address, VerifiedCommitment>) -> Result<
 pub struct SharingState {
     encryption_key: EncryptionKey,
     secret_package: round2::SecretPackage,
-    group_commitment: keys::VerifiableSecretSharingCommitment,
-    commitments: BTreeMap<Address, VerifiedCommitment>,
+    group_commitments: GroupCommitments,
 }
 
-/// The result of [`generate_secret_shares`]: the sharing state and the onchain
-/// secret share to publish.
-pub struct SecretShares {
-    pub sharing_state: SharingState,
-    pub share: bindings::KeyGenSecretShare,
+impl SharingState {
+    /// Returns the group key for the sharing state.
+    pub fn group_commitments(&self) -> &GroupCommitments {
+        &self.group_commitments
+    }
 }
 
 /// Given every participant's verified commitment, produces the sharing state
@@ -146,7 +155,7 @@ pub struct SecretShares {
 pub fn generate_secret_shares(
     secrets: Secrets,
     commitments: BTreeMap<Address, VerifiedCommitment>,
-) -> Result<SecretShares, Error> {
+) -> Result<(SharingState, bindings::KeyGenSecretShare), Error> {
     let (round1_peer_packages, round1_me_package) = peer_packages(
         secrets.secret_package.identifier(),
         &commitments,
@@ -154,10 +163,10 @@ pub fn generate_secret_shares(
     )?;
 
     // By construction, the second round of DKG should have no participant
-    // culprits (as the `commitments` have already verified the length of the
-    // commitments and the proof of knowledge). The only way we encounter an
-    // error here is if the caller were to mix secrets and commitments from
-    // different DKG ceremonies.
+    // culprits (the contract has checked coefficient lengths, and the
+    // commitments' proofs of knowledge have been verified). The only way we
+    // encounter an error here is if the caller were to mix secrets and
+    // commitments from different DKG ceremonies.
     dkg::part2(secrets.secret_package.clone(), &round1_peer_packages)
         .and_then(|(secret_package, round2_packages)| {
             // Ensure that the `me` commitment is also valid, the FROST library
@@ -173,6 +182,7 @@ pub fn generate_secret_shares(
                 *secrets.secret_package.identifier(),
                 &group_commitment,
             );
+            let verifying_key = VerifyingKey::from_commitment(&group_commitment)?;
 
             // Encrypt each of the other shares for the other participants,
             // using their publicly broadcasted public encryption keys.
@@ -197,15 +207,19 @@ pub fn generate_secret_shares(
                 .collect::<Result<Vec<_>, frost_secp256k1::Error>>()?;
             let share = marshal::solidity_secret_share(&verifying_share, &encrypted_shares);
 
-            Ok(SecretShares {
-                sharing_state: SharingState {
-                    encryption_key: secrets.encryption_key,
-                    secret_package,
-                    group_commitment,
+            // Build the sharing state that we will need to verify secret shares
+            // and finalize our key share.
+            let sharing_state = SharingState {
+                encryption_key: secrets.encryption_key,
+                secret_package,
+                group_commitments: GroupCommitments {
                     commitments,
+                    group_commitment,
+                    verifying_key,
                 },
-                share,
-            })
+            };
+
+            Ok((sharing_state, share))
         })
         .err_unexpected()
 }
@@ -221,25 +235,77 @@ fn group_commitment(
     )
 }
 
-/// A validated signing share from a peer.
+/// A verified public key share.
+///
+/// Public key shares are verified against the commitments made by the
+/// participant at the start of the keygen ceremony.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct PublicKeyShare {
+    verifying_share: keys::VerifyingShare,
+}
+
+/// A participant's encrypted key shares, in canonical publishing order.
+pub struct EncryptedSecretShares {
+    shares: Vec<[u8; 32]>,
+}
+
+/// Verifies the public portion of a participant's secret-share broadcast by
+/// checking that its advertised public key share matches the group
+/// commitments, and decodes its encrypted shares for participant-specific
+/// verification.
+///
+/// These are applied to _both_ `me`, the validator itself, and all peers that
+/// publish key generation secret shares onchain.
+pub fn verify_secret_share(
+    group_commitments: &GroupCommitments,
+    participant: Address,
+    share: &bindings::KeyGenSecretShare,
+) -> Result<(PublicKeyShare, EncryptedSecretShares), Error> {
+    if !group_commitments.commitments.contains_key(&participant) {
+        return Err(frost_secp256k1::Error::UnknownIdentifier).err_unexpected();
+    }
+
+    let identifier = participants::identifier(participant);
+    let public_key = marshal::frost_point(&share.y)
+        .and_then(|y| {
+            let verifying_share = keys::VerifyingShare::from_commitment(
+                identifier,
+                &group_commitments.group_commitment,
+            );
+            if y != verifying_share.to_element() {
+                return Err(frost_secp256k1::Error::MalformedVerifyingKey);
+            }
+
+            Ok(PublicKeyShare { verifying_share })
+        })
+        .err_with_culprit(participant)?;
+
+    // Note that we explicitly do not check the length of the encrypted shares,
+    // as this is done by the contract. Any error in the length will trigger an
+    // unexpected FROST error at finalization.
+    let encrypted_shares = EncryptedSecretShares {
+        shares: share.f.iter().map(U256::to_be_bytes).collect(),
+    };
+
+    Ok((public_key, encrypted_shares))
+}
+
+/// A validated signing share from a participant.
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct VerifiedShare {
     package: round2::Package,
 }
 
-/// Verifies a participant's secret signing share.
+/// Decrypts this validator's encrypted share from a participant and verifies
+/// that it matches that participant's commitment.
 ///
 /// These are applied to _both_ `me`, the validator itself, and all peers that
 /// publish key generation secret shares onchain.
-pub fn verify_secret_share(
+pub fn verify_encrypted_secret_share(
     sharing_state: &SharingState,
     participant: Address,
-    share: &bindings::KeyGenSecretShare,
+    encrypted_shares: EncryptedSecretShares,
 ) -> Result<VerifiedShare, Error> {
-    if share.f.len() as u16 != sharing_state.secret_package.max_signers() - 1 {
-        return Err(frost_secp256k1::Error::IncorrectNumberOfShares).err_with_culprit(participant);
-    }
-
     let identifier = participants::identifier(participant);
     let (commitment, secret_share) = if identifier == *sharing_state.secret_package.identifier() {
         (
@@ -252,6 +318,7 @@ pub fn verify_secret_share(
         )
     } else {
         sharing_state
+            .group_commitments
             .commitments
             .get(&participant)
             .ok_or(frost_secp256k1::Error::UnknownIdentifier)
@@ -263,6 +330,7 @@ pub fn verify_secret_share(
                 // decrypt it so that we can verify it against the peer's
                 // commitments.
                 let index = sharing_state
+                    .group_commitments
                     .commitments
                     .keys()
                     .filter(|address| **address != participant)
@@ -271,32 +339,25 @@ pub fn verify_secret_share(
                             == *sharing_state.secret_package.identifier()
                     })
                     .ok_or(frost_secp256k1::Error::UnknownIdentifier)?;
-                let encrypted_share = share
-                    .f
+                let encrypted_share = encrypted_shares
+                    .shares
                     .get(index)
                     .ok_or(frost_core::Error::IncorrectNumberOfShares)?;
                 let secret_share = sharing_state
                     .encryption_key
-                    .ecdh(encryption_public_key, encrypted_share.to_be_bytes());
+                    .ecdh(encryption_public_key, *encrypted_share);
 
                 Ok((commitment, secret_share))
             })
             .err_unexpected()?
     };
 
-    let package = marshal::frost_point(&share.y)
-        .and_then(|y| {
-            let verifying_share =
-                keys::VerifyingShare::from_commitment(identifier, &sharing_state.group_commitment);
-            if y != verifying_share.to_element() {
-                return Err(frost_secp256k1::Error::MalformedVerifyingKey);
-            }
-
+    let package = marshal::frost_scalar(&U256::from_be_bytes(secret_share))
+        .and_then(|secret_share| {
             // Pre-verify the share to make sure it matches the commitment from
             // the peer; this allows us to complain right away in case an
             // invalid share was provided.
-            let signing_share =
-                keys::SigningShare::new(marshal::frost_scalar(&U256::from_be_bytes(secret_share))?);
+            let signing_share = keys::SigningShare::new(secret_share);
             let _ = keys::SecretShare::new(
                 *sharing_state.secret_package.identifier(),
                 signing_share,
@@ -314,7 +375,7 @@ pub fn verify_secret_share(
 /// A participant's share of the group signing key: its secret signing share,
 /// verifying share, and the group verifying key. The final result of DKG,
 /// persisted to the secret store and used to sign.
-#[derive(Clone, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(transparent)]
 pub struct KeyShare(keys::KeyPackage);
 
@@ -345,7 +406,7 @@ pub fn finalize(
 ) -> Result<KeyShare, Error> {
     let (round1_peer_packages, _) = peer_packages(
         sharing_state.secret_package.identifier(),
-        &sharing_state.commitments,
+        &sharing_state.group_commitments.commitments,
         |commitment| commitment.package.clone(),
     )?;
     let (round2_peer_packages, round2_me_package) = peer_packages(

--- a/crates/validator/src/frost/mod.rs
+++ b/crates/validator/src/frost/mod.rs
@@ -53,8 +53,7 @@ mod tests {
             .into_iter()
             .map(|participant| {
                 let commitment =
-                    keygen::verify_commitment(threshold, participant, &commitments[&participant])
-                        .unwrap();
+                    keygen::verify_commitment(participant, &commitments[&participant]).unwrap();
                 (participant, commitment)
             })
             .collect::<BTreeMap<_, _>>();
@@ -64,10 +63,10 @@ mod tests {
         let mut sharing_states = BTreeMap::new();
         let mut shares = BTreeMap::new();
         for (participant, secrets) in secrets {
-            let share =
+            let (sharing_state, share) =
                 keygen::generate_secret_shares(secrets, verified_commitments.clone()).unwrap();
-            sharing_states.insert(participant, share.sharing_state);
-            shares.insert(participant, share.share);
+            sharing_states.insert(participant, sharing_state);
+            shares.insert(participant, share);
         }
 
         // Once the secret sharing is complete, the key generation process can
@@ -77,8 +76,19 @@ mod tests {
             let verified_shares = shares
                 .iter()
                 .map(|(peer, share)| {
-                    let verified_share =
-                        keygen::verify_secret_share(&sharing_state, *peer, share).unwrap();
+                    let (_, encrypted_shares) = keygen::verify_secret_share(
+                        sharing_state.group_commitments(),
+                        *peer,
+                        share,
+                    )
+                    .unwrap();
+                    let verified_share = keygen::verify_encrypted_secret_share(
+                        &sharing_state,
+                        *peer,
+                        encrypted_shares,
+                    )
+                    .unwrap();
+
                     (*peer, verified_share)
                 })
                 .collect();
@@ -89,15 +99,15 @@ mod tests {
         // Here, all participants should share the same group verifying key.
         // Additionally, the group key should equal to the sum of all the
         // publicly posted commitments C_0.
-        let group_key = keygen::group_key(&verified_commitments).unwrap();
+        let group_commitments = keygen::group_commitments(verified_commitments).unwrap();
         for key_share in key_shares.values() {
             assert_eq!(
-                group_key.as_verifying_key(),
+                group_commitments.verifying_key(),
                 key_share.as_key_package().verifying_key()
             );
         }
         assert_eq!(
-            group_key.as_verifying_key().to_element(),
+            group_commitments.verifying_key().to_element(),
             commitments
                 .values()
                 .map(|commitments| marshal::frost_point(&commitments.c[0]).unwrap())
@@ -213,7 +223,7 @@ mod tests {
                 .collect();
             let public_key_package = frost_secp256k1::keys::PublicKeyPackage::new(
                 verifying_shares,
-                *group_key.as_verifying_key(),
+                *group_commitments.verifying_key(),
                 Some(threshold),
             );
 

--- a/crates/validator/src/state/keygen.rs
+++ b/crates/validator/src/state/keygen.rs
@@ -2,15 +2,13 @@ use super::{RolloverState, State, Transition};
 use crate::{
     bindings::Coordinator,
     consensus::epoch::EpochId,
-    frost::{
-        self,
-        keygen::{SecretShares, Secrets},
-    },
+    frost::{self, keygen::Secrets},
     service::{Action, Effect},
+    state::KeyGenParticipation,
 };
 use alloy::primitives::B256;
 use safenet_core::state::{Command, Commands};
-use std::collections::BTreeMap;
+use std::{collections::BTreeMap, fmt::Display};
 
 impl Transition {
     /// Joins the genesis key generation once its group is created onchain.
@@ -74,7 +72,7 @@ impl Transition {
 
     /// Publishes the key gen commitment once the [`Effect::KeyGenSetup`]
     /// effect has produced it, moving the group into commitment collection.
-    pub fn handle_key_gen_setup(
+    pub(super) fn handle_key_gen_setup(
         &self,
         state: State,
         group_id: B256,
@@ -133,16 +131,21 @@ impl Transition {
                 mut commitments,
                 deadline,
             } if group.id() == event.gid => {
-                let (count, threshold) = group.size();
+                let (count, _) = group.size();
 
                 // Only consider valid commitments; invalid ones are ignored,
                 // the participant will be removed from the group on timeout.
-                if let Ok(commitment) = frost::keygen::verify_commitment(
-                    threshold,
-                    event.participant,
-                    &event.commitment,
-                ) {
-                    commitments.insert(event.participant, commitment);
+                match frost::keygen::verify_commitment(event.participant, &event.commitment) {
+                    Ok(commitment) => {
+                        commitments.insert(event.participant, commitment);
+                    }
+                    Err(err) => {
+                        tracing::warn!(
+                            %err,
+                            participant = %event.participant,
+                            "invalid key gen commitment"
+                        );
+                    }
                 };
 
                 if commitments.len() as u16 != count {
@@ -170,70 +173,79 @@ impl Transition {
                 // `None`.
                 let deadline = deadline.map(|_| block.saturating_add(self.key_gen_timeout.get()));
 
-                // Compute the group key from the commitments, and if part of
-                // the group, the secret shares to publish onchain.
-                match frost::keygen::group_key(&commitments).and_then(|group_key| {
-                    let secret_shares = secrets
-                        .map(|secrets| frost::keygen::generate_secret_shares(*secrets, commitments))
-                        .transpose()?;
-                    Ok((group_key, secret_shares))
-                }) {
-                    Ok((group_key, secret_shares)) => {
-                        let group_id = group.id();
-                        let (sharing_state, commands) = if let Some(SecretShares {
-                            sharing_state,
-                            share,
-                        }) = secret_shares
-                        {
-                            (
-                                Some(Box::new(sharing_state)),
-                                vec![Command::Action(Action::KeyGenSecretShare {
-                                    group_id,
-                                    share,
-                                    expires_at: deadline,
-                                })],
-                            )
-                        } else {
-                            // If we are just observing, the continue without
-                            // a secret sharing state or emitting any actions.
-                            (None, Vec::new())
-                        };
-
-                        (
+                // Compute the group participation state for the validator,
+                // depending on whether or not it is observing.
+                let (participation, commands) = match if let Some(secrets) = secrets {
+                    // We are participating, so compute the secret shares to
+                    // publish onchain and the sharing state.
+                    frost::keygen::generate_secret_shares(*secrets, commitments).map(
+                        |(sharing_state, share)| {
+                            let participation = KeyGenParticipation::Participating(sharing_state);
+                            let commands = vec![Command::Action(Action::KeyGenSecretShare {
+                                group_id: group.id(),
+                                share,
+                                expires_at: deadline,
+                            })];
+                            (participation, commands)
+                        },
+                    )
+                } else {
+                    // We are observing, just compute the group commitments that
+                    // are required to verify secret share public key shares and
+                    // complain responses.
+                    frost::keygen::group_commitments(commitments).map(|group_commitments| {
+                        let participation = KeyGenParticipation::Observing(group_commitments);
+                        (participation, Vec::new())
+                    })
+                } {
+                    Ok(result) => result,
+                    Err(err) => {
+                        // There was an issue with the verified commitments,
+                        // which is an unexpected an unrecoverable error.
+                        return (
                             State {
-                                rollover: RolloverState::CollectingShares {
-                                    next_epoch,
-                                    group,
-                                    group_key,
-                                    sharing_state,
-                                    shares: BTreeMap::new(),
-                                    deadline,
-                                },
+                                rollover: rollover_failure(next_epoch, err),
                                 ..state
                             },
-                            commands,
-                        )
+                            Vec::new(),
+                        );
                     }
-                    Err(err) => {
-                        let rollover = if let EpochId::Number { number: next_epoch } = next_epoch {
-                            tracing::warn!(
-                                %err,
-                                ?next_epoch,
-                                "failed to advance key generation, skipping to next epoch"
-                            );
-                            RolloverState::EpochSkipped { next_epoch }
-                        } else {
-                            tracing::error!(
-                                %err,
-                                "failed to advance genesis key generation, permanently halted"
-                            );
-                            RolloverState::Halted
-                        };
-                        (State { rollover, ..state }, Vec::new())
-                    }
-                }
+                };
+
+                (
+                    State {
+                        rollover: RolloverState::CollectingShares {
+                            next_epoch,
+                            group,
+                            participation: Box::new(participation),
+                            public_keys: BTreeMap::new(),
+                            shares: BTreeMap::new(),
+                            deadline,
+                        },
+                        ..state
+                    },
+                    commands,
+                )
             }
             _ => (state, Vec::new()),
         }
+    }
+}
+
+/// Handle a FROST error and return the next rollover state.
+fn rollover_failure(next_epoch: EpochId, err: impl Display) -> RolloverState {
+    if let EpochId::Number { number: next_epoch } = next_epoch {
+        tracing::warn!(
+            %err,
+            ?next_epoch,
+            "failed to advance key generation, skipping to next epoch"
+        );
+        RolloverState::EpochSkipped { next_epoch }
+    } else {
+        tracing::error!(
+            %err,
+            "failed to advance genesis key generation, permanently halted"
+        );
+        RolloverState::Halted
     }
 }

--- a/crates/validator/src/state/mod.rs
+++ b/crates/validator/src/state/mod.rs
@@ -14,7 +14,9 @@ use crate::{
         epoch::EpochId,
         group::{Group, ParticipantSet},
     },
-    frost::keygen::{GroupKey, Secrets, SharingState, VerifiedCommitment, VerifiedShare},
+    frost::keygen::{
+        GroupCommitments, PublicKeyShare, Secrets, SharingState, VerifiedCommitment, VerifiedShare,
+    },
     service::{Action, Effect, Event, Resume},
 };
 use alloy::primitives::{Address, B256};
@@ -26,13 +28,13 @@ use std::{collections::BTreeMap, num::NonZeroU64};
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct State {
     /// The epoch-rollover / DKG state machine.
-    pub rollover: RolloverState,
+    rollover: RolloverState,
 }
 
 /// The epoch-rollover / DKG state machine. Each active variant carries the
 /// group it is generating.
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]
-pub enum RolloverState {
+enum RolloverState {
     /// Idle before the genesis group's DKG has been triggered.
     #[default]
     WaitingForGenesis,
@@ -84,10 +86,10 @@ pub enum RolloverState {
         next_epoch: EpochId,
         /// The group being generated.
         group: Group,
-        /// The public key derived from the participants' commitments.
-        group_key: GroupKey,
-        /// This validator's sharing state, or `None` if not participating.
-        sharing_state: Option<Box<SharingState>>,
+        /// This validator's participation.
+        participation: Box<KeyGenParticipation>,
+        /// Verified participant public key shares.
+        public_keys: BTreeMap<Address, PublicKeyShare>,
         /// Verified secret shares received from peers so far, keyed by
         /// participant.
         shares: BTreeMap<Address, VerifiedShare>,
@@ -95,6 +97,18 @@ pub enum RolloverState {
         /// indicate that there is no deadline.
         deadline: Option<u64>,
     },
+}
+
+/// The keygen participation status for the validator.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+enum KeyGenParticipation {
+    /// The validator is an active participant that is part of the keygen
+    /// ceremony and holds its keygen sharing state.
+    Participating(SharingState),
+    /// The validator is an observer to the ceremony, and keeps track of the
+    /// public commitments needed to verify publicly revealed shares in case of
+    /// complaints as well as public participant public key shares.
+    Observing(GroupCommitments),
 }
 
 /// The pure validator state transition.


### PR DESCRIPTION
### Context and Motivation

Right now, `verify_secret_share` does a lot:

- It checks the size of the shares array is as expected (_public, uneeded_)
- It checks that the submitted public key share matches the group commitments (_public_)
- It checks that the encrypted share matches the participant's commitments (_secret_)

Because observers also need to know if a participant is misbehaving, the FROST API for verifying secret shares was split into two pieces: one for the public parts, and one for the secret part. This will allow for more fine-grained misbehaviour detection in the following PR.

### Decisions and Tradeoffs

Now that we've split `bindings::KeyGenSecretShare` verification into both public and secret parts, we also modify the state transition to more closely model whether or not we are just observing (and should only verify the public parts), or we are participating (and also need to verify the secret parts). We introduced a new enum to model this.

Additionally, length checks have been changed to be unexpected errors, since the smart contract already checks the length (so any length mismatches are the fault of the caller for mixing and matching state from separate keygen ceremonies).

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://docs.safefoundation.org/cla).
