### PR TITLE
[D 1iv 2/2]: Collect Secret Shares

### DIFF
--- a/crates/validator/src/service/action.rs
+++ b/crates/validator/src/service/action.rs
@@ -11,6 +11,9 @@ use alloy::{
 use safenet_core::{driver::ActionEncoder, tx::Transaction};
 
 /// An onchain action the validator emits during a state transition.
+// The `KeyGen*` prefix mirrors the onchain function names; more variants
+// with other prefixes (`Sign*`, `Consensus*`, ...) land as their handlers do.
+#[expect(clippy::enum_variant_names)]
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Action {
     /// An action to publish key generation commitments onchain.
@@ -27,6 +30,17 @@ pub enum Action {
     KeyGenSecretShare {
         group_id: B256,
         share: bindings::KeyGenSecretShare,
+        expires_at: Option<u64>,
+    },
+    /// An action to complain about an invalid key generation secret share.
+    KeyGenComplain {
+        group_id: B256,
+        accused: Address,
+        expires_at: Option<u64>,
+    },
+    /// An action to confirm participation in a completed key generation.
+    KeyGenConfirm {
+        group_id: B256,
         expires_at: Option<u64>,
     },
 }
@@ -86,6 +100,38 @@ impl ActionEncoder<Action> for Encoder {
                     expires_at,
                 )
             }
+            Action::KeyGenComplain {
+                group_id,
+                accused,
+                expires_at,
+            } => (
+                Transaction {
+                    to: self.coordinator,
+                    value: U256::ZERO,
+                    data: Coordinator::keyGenComplainCall {
+                        gid: group_id,
+                        accused,
+                    }
+                    .abi_encode()
+                    .into(),
+                    gas: 300_000,
+                },
+                expires_at,
+            ),
+            Action::KeyGenConfirm {
+                group_id,
+                expires_at,
+            } => (
+                Transaction {
+                    to: self.coordinator,
+                    value: U256::ZERO,
+                    data: Coordinator::keyGenConfirmCall { gid: group_id }
+                        .abi_encode()
+                        .into(),
+                    gas: 200_000,
+                },
+                expires_at,
+            ),
         }
     }
 }

--- a/crates/validator/src/state/keygen.rs
+++ b/crates/validator/src/state/keygen.rs
@@ -2,13 +2,19 @@ use super::{RolloverState, State, Transition};
 use crate::{
     bindings::Coordinator,
     consensus::epoch::EpochId,
-    frost::{self, keygen::Secrets},
+    frost::{
+        self,
+        keygen::{GroupCommitments, Secrets},
+    },
     service::{Action, Effect},
-    state::KeyGenParticipation,
+    state::{ConfirmationDeadlines, KeyGenConfirmation, KeyGenParticipation},
 };
 use alloy::primitives::B256;
 use safenet_core::state::{Command, Commands};
-use std::{collections::BTreeMap, fmt::Display};
+use std::{
+    collections::{BTreeMap, BTreeSet},
+    fmt::Display,
+};
 
 impl Transition {
     /// Joins the genesis key generation once its group is created onchain.
@@ -228,6 +234,178 @@ impl Transition {
                 )
             }
             _ => (state, Vec::new()),
+        }
+    }
+
+    /// Registers a peer's key generation secret share, verified against its
+    /// earlier commitment. An invalid share raises a [`Action::KeyGenComplain`]
+    /// against its sender; share collection still completes once every
+    /// participant has submitted one (valid or not), no different from a valid
+    /// share, as invalid shares are resolved through the complaint flow. Once
+    /// every share has been submitted, moves the group into confirmation
+    /// collection, finalizing this validator's key share and emitting
+    /// [`Action::KeyGenConfirm`] if every share it received was valid.
+    pub(super) fn handle_key_gen_secret_shared(
+        &self,
+        state: State,
+        block: u64,
+        event: &Coordinator::KeyGenSecretShared,
+    ) -> (State, Commands<State, Self>) {
+        match state.rollover {
+            RolloverState::CollectingShares {
+                next_epoch,
+                group,
+                participation,
+                mut public_keys,
+                mut shares,
+                deadline,
+            } if group.id() == event.gid => {
+                let (count, _) = group.size();
+                let mut commands = Vec::new();
+
+                // Only consider valid shared secrets (public key share that
+                // matches their commitments and correct number of secret
+                // shares); invalid ones are ignored, the participant will be
+                // removed from the group on timeout.
+                let encrypted_shares = match frost::keygen::verify_secret_share(
+                    participation.group_commitments(),
+                    event.participant,
+                    &event.share,
+                ) {
+                    Ok((public_key, encrypted_shares)) => {
+                        public_keys.insert(event.participant, public_key);
+                        Some(encrypted_shares)
+                    }
+                    Err(err) => {
+                        tracing::warn!(
+                            %err,
+                            participant = %event.participant,
+                            "invalid key gen secret share"
+                        );
+                        None
+                    }
+                };
+
+                // If we are participating, also verify the encrypted key shares
+                // against our sharing state, and emit a complaint if required.
+                if let (KeyGenParticipation::Participating(sharing_state), Some(encrypted_shares)) =
+                    (&*participation, encrypted_shares)
+                {
+                    match frost::keygen::verify_encrypted_secret_share(
+                        sharing_state,
+                        event.participant,
+                        encrypted_shares,
+                    ) {
+                        Ok(share) => {
+                            shares.insert(event.participant, share);
+                        }
+                        Err(err) => {
+                            tracing::warn!(
+                                %err,
+                                participant = %event.participant,
+                                "invalid key gen encrypted secret share"
+                            );
+
+                            // The complaint actions have a whole other key gen
+                            // timeout to arrive onchain.
+                            let expires_at =
+                                deadline.map(|_| block.saturating_add(self.key_gen_timeout.get()));
+
+                            commands.push(Command::Action(Action::KeyGenComplain {
+                                group_id: group.id(),
+                                accused: event.participant,
+                                expires_at,
+                            }));
+                        }
+                    }
+                }
+
+                if public_keys.len() as u16 != count {
+                    // We are still missing shares from some participants, so
+                    // stay in the same collecting state.
+                    return (
+                        State {
+                            rollover: RolloverState::CollectingShares {
+                                next_epoch,
+                                group,
+                                participation,
+                                public_keys,
+                                shares,
+                                deadline,
+                            },
+                            ..state
+                        },
+                        commands,
+                    );
+                }
+
+                // Every participant has submitted a share, so a fresh round
+                // starts: push the deadlines forward from the current block.
+                let deadlines = deadline.map(|_| ConfirmationDeadlines {
+                    complain: block.saturating_add(self.key_gen_timeout.get()),
+                    response: block.saturating_add(self.key_gen_timeout.get().saturating_mul(2)),
+                    confirm: block.saturating_add(self.key_gen_timeout.get().saturating_mul(3)),
+                });
+
+                // Finalize our key share only if every share we received was
+                // valid; otherwise wait for the complaint flow to resolve.
+                let status = match &*participation {
+                    KeyGenParticipation::Participating(sharing_state)
+                        if shares.len() as u16 == count =>
+                    {
+                        match frost::keygen::finalize(sharing_state.clone(), shares) {
+                            Ok(key_share) => {
+                                commands.push(Command::Action(Action::KeyGenConfirm {
+                                    group_id: group.id(),
+                                    expires_at: deadlines
+                                        .as_ref()
+                                        .map(|deadlines| deadlines.confirm),
+                                }));
+                                KeyGenConfirmation::Confirmed(Box::new(key_share))
+                            }
+                            Err(err) => {
+                                // Finalization failures are unexpected, since
+                                // all secret shares were already verified.
+                                return (
+                                    State {
+                                        rollover: rollover_failure(next_epoch, err),
+                                        ..state
+                                    },
+                                    commands,
+                                );
+                            }
+                        }
+                    }
+                    KeyGenParticipation::Participating(_) => KeyGenConfirmation::Collecting(shares),
+                    KeyGenParticipation::Observing(_) => KeyGenConfirmation::Observing,
+                };
+
+                (
+                    State {
+                        rollover: RolloverState::CollectingConfirmations {
+                            next_epoch,
+                            group,
+                            participation,
+                            status,
+                            confirmations: BTreeSet::new(),
+                            deadlines,
+                        },
+                        ..state
+                    },
+                    commands,
+                )
+            }
+            _ => (state, Vec::new()),
+        }
+    }
+}
+
+impl KeyGenParticipation {
+    /// Gets the group commitments for regardless of participation.
+    fn group_commitments(&self) -> &GroupCommitments {
+        match self {
+            KeyGenParticipation::Participating(sharing_state) => sharing_state.group_commitments(),
+            KeyGenParticipation::Observing(group_commitments) => group_commitments,
         }
     }
 }

--- a/crates/validator/src/state/mod.rs
+++ b/crates/validator/src/state/mod.rs
@@ -15,14 +15,18 @@ use crate::{
         group::{Group, ParticipantSet},
     },
     frost::keygen::{
-        GroupCommitments, PublicKeyShare, Secrets, SharingState, VerifiedCommitment, VerifiedShare,
+        GroupCommitments, KeyShare, PublicKeyShare, Secrets, SharingState, VerifiedCommitment,
+        VerifiedShare,
     },
     service::{Action, Effect, Event, Resume},
 };
 use alloy::primitives::{Address, B256};
 use safenet_core::state::{Commands, Message, StateTransition};
 use serde::{Deserialize, Serialize};
-use std::{collections::BTreeMap, num::NonZeroU64};
+use std::{
+    collections::{BTreeMap, BTreeSet},
+    num::NonZeroU64,
+};
 
 /// The complete snapshotted validator state.
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]
@@ -97,6 +101,23 @@ enum RolloverState {
         /// indicate that there is no deadline.
         deadline: Option<u64>,
     },
+    /// Every participant has submitted a secret share (valid or not) and the
+    /// group's confirmations are being collected onchain.
+    CollectingConfirmations {
+        /// The epoch this group will serve.
+        next_epoch: EpochId,
+        /// The group being generated.
+        group: Group,
+        /// This validator's participation.
+        participation: Box<KeyGenParticipation>,
+        /// The status of the confirmation for the current validator.
+        status: KeyGenConfirmation,
+        /// Participants that have confirmed so far.
+        confirmations: BTreeSet<Address>,
+        /// The confirmation deadlines for the confirmation collection phase.
+        /// `None` to indicate that there is no deadline.
+        deadlines: Option<ConfirmationDeadlines>,
+    },
 }
 
 /// The keygen participation status for the validator.
@@ -109,6 +130,30 @@ enum KeyGenParticipation {
     /// public commitments needed to verify publicly revealed shares in case of
     /// complaints as well as public participant public key shares.
     Observing(GroupCommitments),
+}
+
+/// The keygen secret share confirmation status.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+enum KeyGenConfirmation {
+    /// Keygen confirmation is being observed.
+    Observing,
+    /// Secret shares are still being collected, as there were some shares that
+    /// could not be verified.
+    Collecting(BTreeMap<Address, VerifiedShare>),
+    /// All secret shares have been collected and a secret key share has been
+    /// constructed.
+    Confirmed(Box<KeyShare>),
+}
+
+/// The deadlines for collecting confirmations.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+struct ConfirmationDeadlines {
+    /// The deadline to receive the last complaint.
+    complain: u64,
+    /// The deadline to receive the last complaint response.
+    response: u64,
+    /// The deadline to receive the last confirmation.
+    confirm: u64,
 }
 
 /// The pure validator state transition.
@@ -144,6 +189,9 @@ impl StateTransition<State> for Transition {
                 }
                 Event::Coordinator(Coordinator::CoordinatorEvents::KeyGenCommitted(event)) => {
                     self.handle_key_gen_committed(state, log.block, &event)
+                }
+                Event::Coordinator(Coordinator::CoordinatorEvents::KeyGenSecretShared(event)) => {
+                    self.handle_key_gen_secret_shared(state, log.block, &event)
                 }
                 // The remaining events are wired in as their handlers land.
                 _ => (state, Vec::new()),


### PR DESCRIPTION
### Context and Motivation

Handle `KeyGenSecretShare` events, to continue with the keygen process.

### Decisions and Tradeoffs

Since we now keep more precise tracking of our role in the key generation: either observing or participating. This dictates the extent to which we can verify the data from the `KeyGenSecretShare` event.

We use the split verification from #559 to differentiate between "the participant posted clearly incorrect data", and "the encrypted data they posted is incorrect, we need to post a complaint".

### Port

This is a port of:

https://github.com/safe-research/safenet/blob/4c3188fd65d977c17c5e26c4785ec7eb8193f2a5/validator/src/machine/keygen/secretShares.ts#L15-L84

> [!IMPORTANT]
> There is a notable change compared to the TypeScript implementation. In particular:
>
> * We validate the publicly posted public key share against the group commitments. This is important, otherwise we may sign over groups that have invalid participant public key shares onchain. AFAICT, the TypeScript implementation does not do this.
> * We do not proceed with the keygen process in case of publicly verifiable invalid information (invalid public key share, or incorrect number of encrypted secret shares).
>
> This ensures observers do not sign a rotation into a bad group in case some of these publicly verifiable facts are not met. In particular, the TypeScript validator allows performing an epoch rotation into a group with an invalid participant public key share.

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://docs.safefoundation.org/cla).
