### PR TITLE
[D 1v]: Genesis Group Confirmation

### DIFF
--- a/crates/validator/src/service/action.rs
+++ b/crates/validator/src/service/action.rs
@@ -11,9 +11,6 @@ use alloy::{
 use safenet_core::{driver::ActionEncoder, tx::Transaction};
 
 /// An onchain action the validator emits during a state transition.
-// The `KeyGen*` prefix mirrors the onchain function names; more variants
-// with other prefixes (`Sign*`, `Consensus*`, ...) land as their handlers do.
-#[expect(clippy::enum_variant_names)]
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Action {
     /// An action to publish key generation commitments onchain.
@@ -42,6 +39,12 @@ pub enum Action {
     KeyGenConfirm {
         group_id: B256,
         expires_at: Option<u64>,
+    },
+    /// An action to perform the preprocessing step and register a freshly
+    /// sampled nonce tree's commitments.
+    Preprocess {
+        group_id: B256,
+        nonces_commitment: B256,
     },
 }
 
@@ -131,6 +134,25 @@ impl ActionEncoder<Action> for Encoder {
                     gas: 200_000,
                 },
                 expires_at,
+            ),
+            Action::Preprocess {
+                group_id,
+                nonces_commitment,
+            } => (
+                Transaction {
+                    to: self.coordinator,
+                    value: U256::ZERO,
+                    data: Coordinator::preprocessCall {
+                        gid: group_id,
+                        commitment: nonces_commitment,
+                    }
+                    .abi_encode()
+                    .into(),
+                    gas: 250_000,
+                },
+                // Nonce registration doesn't carry an expiry - we cannot
+                // reliably know for how long it is valuable.
+                None,
             ),
         }
     }

--- a/crates/validator/src/service/effect.rs
+++ b/crates/validator/src/service/effect.rs
@@ -1,7 +1,10 @@
 //! The validator effect system and its handler.
 
 use crate::{
-    frost::{self, keygen::Secrets},
+    frost::{
+        self,
+        keygen::{KeyShare, Secrets},
+    },
     secrets::SecretStore,
 };
 use alloy::primitives::{Address, B256};
@@ -21,6 +24,11 @@ pub enum Effect {
         count: u16,
         threshold: u16,
     },
+    /// Sample a fresh nonce tree for `key_share` and persist it.
+    NonceTree {
+        group_id: B256,
+        key_share: Box<KeyShare>,
+    },
 }
 
 /// The result of performing an [`Effect`], resumed into the state machine.
@@ -35,6 +43,9 @@ pub enum Resume {
         group_id: B256,
         secrets: Box<Secrets>,
     },
+    /// Resume with the nonce tree commitment produced by a
+    /// [`Effect::NonceTree`].
+    NonceTree { group_id: B256, commitment: B256 },
 }
 
 /// Performs the validator's [`Effect`]s, resuming with a [`Resume`].
@@ -62,6 +73,21 @@ impl Handler {
                 Ok(Resume::Setup {
                     group_id,
                     secrets: Box::new(stored),
+                })
+            }
+            Effect::NonceTree {
+                group_id,
+                key_share,
+            } => {
+                let mut rng = rand::thread_rng();
+                let chunk = frost::preprocess::NonceChunk::generate(&key_share, &mut rng)?;
+                let commitment = self
+                    .secrets
+                    .register_nonces_chunk(group_id, self.account, chunk)
+                    .await?;
+                Ok(Resume::NonceTree {
+                    group_id,
+                    commitment,
                 })
             }
         }

--- a/crates/validator/src/state/keygen.rs
+++ b/crates/validator/src/state/keygen.rs
@@ -398,6 +398,71 @@ impl Transition {
             _ => (state, Vec::new()),
         }
     }
+
+    /// Registers a peer's confirmation of a completed key generation.
+    pub(super) fn handle_key_gen_confirmed(
+        &self,
+        state: State,
+        event: &Coordinator::KeyGenConfirmed,
+    ) -> (State, Commands<State, Self>) {
+        match state.rollover {
+            RolloverState::CollectingConfirmations {
+                next_epoch,
+                group,
+                participation,
+                status,
+                mut confirmations,
+                deadlines,
+            } if group.id() == event.gid => {
+                let (count, _) = group.size();
+
+                confirmations.insert(event.participant);
+                if confirmations.len() as u16 != count {
+                    // We are still missing confirmations from some
+                    // participants, or this is a non-genesis confirmation
+                    // whose rollover-packet branch isn't wired in yet.
+                    return (
+                        State {
+                            rollover: RolloverState::CollectingConfirmations {
+                                next_epoch,
+                                group,
+                                participation,
+                                status,
+                                confirmations,
+                                deadlines,
+                            },
+                            ..state
+                        },
+                        Vec::new(),
+                    );
+                }
+
+                match next_epoch {
+                    // On genesis: the group is confirmed it is ready to go.
+                    EpochId::Genesis => {
+                        let commands = if let KeyGenConfirmation::Confirmed(key_share) = status {
+                            vec![Command::Effect(Effect::NonceTree {
+                                group_id: group.id(),
+                                key_share,
+                            })]
+                        } else {
+                            Vec::new()
+                        };
+
+                        (
+                            State {
+                                rollover: RolloverState::EpochStaged { next_epoch },
+                                ..state
+                            },
+                            commands,
+                        )
+                    }
+                    _ => todo!("only genesis is supported!"),
+                }
+            }
+            _ => (state, Vec::new()),
+        }
+    }
 }
 
 impl KeyGenParticipation {

--- a/crates/validator/src/state/mod.rs
+++ b/crates/validator/src/state/mod.rs
@@ -7,6 +7,7 @@
 #![expect(clippy::needless_update)]
 
 mod keygen;
+mod preprocess;
 
 use crate::{
     bindings::Coordinator,
@@ -118,6 +119,11 @@ enum RolloverState {
         /// `None` to indicate that there is no deadline.
         deadlines: Option<ConfirmationDeadlines>,
     },
+    /// This group's key generation completed and the group is staged.
+    EpochStaged {
+        /// The epoch that was just staged.
+        next_epoch: EpochId,
+    },
 }
 
 /// The keygen participation status for the validator.
@@ -193,6 +199,9 @@ impl StateTransition<State> for Transition {
                 Event::Coordinator(Coordinator::CoordinatorEvents::KeyGenSecretShared(event)) => {
                     self.handle_key_gen_secret_shared(state, log.block, &event)
                 }
+                Event::Coordinator(Coordinator::CoordinatorEvents::KeyGenConfirmed(event)) => {
+                    self.handle_key_gen_confirmed(state, &event)
+                }
                 // The remaining events are wired in as their handlers land.
                 _ => (state, Vec::new()),
             },
@@ -203,6 +212,10 @@ impl StateTransition<State> for Transition {
                 Resume::Setup { group_id, secrets } => {
                     self.handle_key_gen_setup(state, group_id, secrets)
                 }
+                Resume::NonceTree {
+                    group_id,
+                    commitment,
+                } => self.handle_nonce_tree(state, group_id, commitment),
             },
         }
     }

--- a/crates/validator/src/state/preprocess.rs
+++ b/crates/validator/src/state/preprocess.rs
@@ -1,0 +1,23 @@
+use super::{State, Transition};
+use crate::service::Action;
+use alloy::primitives::B256;
+use safenet_core::state::{Command, Commands};
+
+impl Transition {
+    /// Publishes this validator's freshly sampled nonce tree commitment once
+    /// the [`Effect::NonceTree`] effect has produced it.
+    pub(super) fn handle_nonce_tree(
+        &self,
+        state: State,
+        group_id: B256,
+        nonces_commitment: B256,
+    ) -> (State, Commands<State, Self>) {
+        (
+            state,
+            vec![Command::Action(Action::Preprocess {
+                group_id,
+                nonces_commitment,
+            })],
+        )
+    }
+}


### PR DESCRIPTION
### Context and Motivation

Handle key generation confirmations to finish the key generation ceremony. We additionally do nonce pre-processing to already build and submit our nonces chunk onchain.

### Decisions and Tradeoffs

For now, we only support genesis keygen ceremonies, and left a `todo!()` to be filled in later.

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://docs.safefoundation.org/cla).
