### PR TITLE
[D 1vi]: Handle Complaints

### DIFF
--- a/crates/validator/src/consensus/group.rs
+++ b/crates/validator/src/consensus/group.rs
@@ -52,6 +52,7 @@ use std::{collections::BTreeSet, num::NonZeroU64};
 pub struct Group {
     id: B256,
     participants: MerkleRoot,
+    excluded: BTreeSet<Address>,
     count: u16,
     threshold: u16,
     context: B256,
@@ -75,11 +76,17 @@ impl Group {
     pub fn size(&self) -> (u16, u16) {
         (self.count, self.threshold)
     }
+
+    /// Returns the set of excluded participants from the group.
+    pub fn excluded(&self) -> impl Iterator<Item = Address> + '_ {
+        self.excluded.iter().copied()
+    }
 }
 
 /// A participant set.
 pub struct ParticipantSet {
     addresses: BTreeSet<Address>,
+    excluded: BTreeSet<Address>,
     context: B256,
 }
 
@@ -123,6 +130,7 @@ impl ParticipantSet {
         let group = Group {
             id: group_id(participants.root(), count, threshold, context),
             participants: participants.root(),
+            excluded: self.excluded.clone(),
             count,
             threshold,
             context,
@@ -132,37 +140,36 @@ impl ParticipantSet {
 }
 
 /// The epoch details for computing a participant set.
-pub enum Epoch<'a> {
+pub enum Epoch {
     Genesis {
         salt: B256,
     },
     Number {
         consensus: Address,
         number: NonZeroU64,
-        exclude: &'a BTreeSet<Address>,
+        excluded: BTreeSet<Address>,
     },
 }
 
 /// The participant set active for `epoch`, returns `None` if the participant
 /// set is not valid (for example, if there are not enough participants).
 pub fn participants_set(participants: &[Participant], epoch: Epoch) -> Option<ParticipantSet> {
-    let (addresses, total, context) = match epoch {
+    let (mut addresses, excluded, context) = match epoch {
         Epoch::Genesis { salt } => {
             let addresses = participants
                 .iter()
                 .filter(|p| p.active_from == 0)
                 .map(|p| p.address)
                 .collect::<BTreeSet<_>>();
-            let total = addresses.len();
             let context = genesis_context(salt);
-            (addresses, total, context)
+            (addresses, BTreeSet::new(), context)
         }
         Epoch::Number {
             consensus,
             number,
-            exclude,
+            excluded,
         } => {
-            let mut addresses = participants
+            let addresses = participants
                 .iter()
                 .filter(|p| {
                     p.active_from <= number.get()
@@ -170,18 +177,22 @@ pub fn participants_set(participants: &[Participant], epoch: Epoch) -> Option<Pa
                 })
                 .map(|p| p.address)
                 .collect::<BTreeSet<_>>();
-            let total = addresses.len();
-            for address in exclude {
-                addresses.remove(address);
-            }
             let context = group_context(consensus, number.get());
-            (addresses, total, context)
+            (addresses, excluded, context)
         }
     };
 
-    let total = u16::try_from(total).ok()?;
+    let total = u16::try_from(addresses.len()).ok()?;
+    for address in &excluded {
+        addresses.remove(address);
+    }
+
     let count = u16::try_from(addresses.len()).ok()?;
-    (count >= min_participants(total)).then_some(ParticipantSet { addresses, context })
+    (count >= min_participants(total)).then_some(ParticipantSet {
+        addresses,
+        excluded,
+        context,
+    })
 }
 
 /// The FROST signing threshold for a group of `count` participants.
@@ -364,7 +375,7 @@ mod tests {
             Epoch::Number {
                 consensus: CONSENSUS,
                 number: NonZeroU64::new(32729).unwrap(),
-                exclude: &BTreeSet::new(),
+                excluded: BTreeSet::new(),
             },
         )
         .unwrap();

--- a/crates/validator/src/frost/keygen.rs
+++ b/crates/validator/src/frost/keygen.rs
@@ -139,6 +139,7 @@ pub fn group_commitments(
 pub struct SharingState {
     encryption_key: EncryptionKey,
     secret_package: round2::SecretPackage,
+    peer_packages: BTreeMap<Identifier, round2::Package>,
     group_commitments: GroupCommitments,
 }
 
@@ -212,6 +213,7 @@ pub fn generate_secret_shares(
             let sharing_state = SharingState {
                 encryption_key: secrets.encryption_key,
                 secret_package,
+                peer_packages: round2_packages,
                 group_commitments: GroupCommitments {
                     commitments,
                     group_commitment,
@@ -370,6 +372,19 @@ pub fn verify_encrypted_secret_share(
         .err_with_culprit(participant)?;
 
     Ok(VerifiedShare { package })
+}
+
+/// Reveals this validator's own plaintext secret share computed for `peer`,
+/// published onchain in response to a complaint so that anyone can verify it
+/// against this validator's committed polynomial.
+pub fn reveal_secret_share(sharing_state: &SharingState, peer: Address) -> Result<U256, Error> {
+    let identifier = participants::identifier(peer);
+    sharing_state
+        .peer_packages
+        .get(&identifier)
+        .map(|package| marshal::solidity_scalar(&package.signing_share().to_scalar()))
+        .ok_or(frost_secp256k1::Error::UnknownIdentifier)
+        .err_unexpected()
 }
 
 /// A participant's share of the group signing key: its secret signing share,

--- a/crates/validator/src/service/action.rs
+++ b/crates/validator/src/service/action.rs
@@ -40,6 +40,14 @@ pub enum Action {
         group_id: B256,
         expires_at: Option<u64>,
     },
+    /// An action to reveal a unencrypted secret share, in response to a
+    /// complaint raised against the validator.
+    KeyGenComplaintResponse {
+        group_id: B256,
+        plaintiff: Address,
+        secret_share: U256,
+        expires_at: Option<u64>,
+    },
     /// An action to perform the preprocessing step and register a freshly
     /// sampled nonce tree's commitments.
     Preprocess {
@@ -132,6 +140,26 @@ impl ActionEncoder<Action> for Encoder {
                         .abi_encode()
                         .into(),
                     gas: 200_000,
+                },
+                expires_at,
+            ),
+            Action::KeyGenComplaintResponse {
+                group_id,
+                plaintiff,
+                secret_share,
+                expires_at,
+            } => (
+                Transaction {
+                    to: self.coordinator,
+                    value: U256::ZERO,
+                    data: Coordinator::keyGenComplaintResponseCall {
+                        gid: group_id,
+                        plaintiff,
+                        secretShare: secret_share,
+                    }
+                    .abi_encode()
+                    .into(),
+                    gas: 250_000,
                 },
                 expires_at,
             ),

--- a/crates/validator/src/service/mod.rs
+++ b/crates/validator/src/service/mod.rs
@@ -85,15 +85,13 @@ impl Service for ValidatorService {
             genesis,
             secrets,
             coordinator,
-            config: ValidatorConfig {
-                key_gen_timeout, ..
-            },
+            config,
         } = self;
         (
             state::Transition {
                 account,
                 genesis,
-                key_gen_timeout,
+                config,
             },
             effect::Handler { account, secrets },
             action::Encoder { coordinator },

--- a/crates/validator/src/state/keygen.rs
+++ b/crates/validator/src/state/keygen.rs
@@ -1,7 +1,10 @@
 use super::{RolloverState, State, Transition};
 use crate::{
     bindings::Coordinator,
-    consensus::epoch::EpochId,
+    consensus::{
+        epoch::EpochId,
+        group::{self, ParticipantSet},
+    },
     frost::{
         self,
         keygen::{GroupCommitments, Secrets},
@@ -14,6 +17,7 @@ use safenet_core::state::{Command, Commands};
 use std::{
     collections::{BTreeMap, BTreeSet},
     fmt::Display,
+    iter,
 };
 
 impl Transition {
@@ -36,44 +40,8 @@ impl Transition {
             return (state, Vec::new());
         }
 
-        // Only participate in the group generation if you are part of the
-        // genesis group; otherwise go straight to collecting the other
-        // participants' commitments. The genesis group generation is not
-        // subject to a rollover deadline.
-        if let Some((group, poap)) = self.genesis.participate_as(self.account) {
-            let group_id = group.id();
-            let (count, threshold) = group.size();
-            (
-                State {
-                    rollover: RolloverState::WaitingForSetup {
-                        next_epoch: EpochId::Genesis,
-                        group,
-                        poap,
-                        deadline: None,
-                    },
-                    ..state
-                },
-                vec![Command::Effect(Effect::KeyGenSetup {
-                    group_id,
-                    count,
-                    threshold,
-                })],
-            )
-        } else {
-            (
-                State {
-                    rollover: RolloverState::CollectingCommitments {
-                        next_epoch: EpochId::Genesis,
-                        group: self.genesis.group(),
-                        secrets: None,
-                        commitments: BTreeMap::new(),
-                        deadline: None,
-                    },
-                    ..state
-                },
-                Vec::new(),
-            )
-        }
+        // The genesis group generation is not subject to a rollover deadline.
+        self.start_key_gen(state, EpochId::Genesis, &self.genesis, None)
     }
 
     /// Publishes the key gen commitment once the [`Effect::KeyGenSetup`]
@@ -177,7 +145,8 @@ impl Transition {
                 // push the deadline forward from the current block. Genesis
                 // is not subject to a rollover deadline, so `None` stays
                 // `None`.
-                let deadline = deadline.map(|_| block.saturating_add(self.key_gen_timeout.get()));
+                let deadline =
+                    deadline.map(|_| block.saturating_add(self.config.key_gen_timeout.get()));
 
                 // Compute the group participation state for the validator,
                 // depending on whether or not it is observing.
@@ -226,6 +195,7 @@ impl Transition {
                             participation: Box::new(participation),
                             public_keys: BTreeMap::new(),
                             shares: BTreeMap::new(),
+                            complaints: BTreeMap::new(),
                             deadline,
                         },
                         ..state
@@ -258,6 +228,7 @@ impl Transition {
                 participation,
                 mut public_keys,
                 mut shares,
+                complaints,
                 deadline,
             } if group.id() == event.gid => {
                 let (count, _) = group.size();
@@ -308,8 +279,8 @@ impl Transition {
 
                             // The complaint actions have a whole other key gen
                             // timeout to arrive onchain.
-                            let expires_at =
-                                deadline.map(|_| block.saturating_add(self.key_gen_timeout.get()));
+                            let expires_at = deadline
+                                .map(|_| block.saturating_add(self.config.key_gen_timeout.get()));
 
                             commands.push(Command::Action(Action::KeyGenComplain {
                                 group_id: group.id(),
@@ -331,6 +302,7 @@ impl Transition {
                                 participation,
                                 public_keys,
                                 shares,
+                                complaints,
                                 deadline,
                             },
                             ..state
@@ -342,9 +314,11 @@ impl Transition {
                 // Every participant has submitted a share, so a fresh round
                 // starts: push the deadlines forward from the current block.
                 let deadlines = deadline.map(|_| ConfirmationDeadlines {
-                    complain: block.saturating_add(self.key_gen_timeout.get()),
-                    response: block.saturating_add(self.key_gen_timeout.get().saturating_mul(2)),
-                    confirm: block.saturating_add(self.key_gen_timeout.get().saturating_mul(3)),
+                    complain: block.saturating_add(self.config.key_gen_timeout.get()),
+                    response: block
+                        .saturating_add(self.config.key_gen_timeout.get().saturating_mul(2)),
+                    confirm: block
+                        .saturating_add(self.config.key_gen_timeout.get().saturating_mul(3)),
                 });
 
                 // Finalize our key share only if every share we received was
@@ -388,6 +362,7 @@ impl Transition {
                             participation,
                             status,
                             confirmations: BTreeSet::new(),
+                            complaints,
                             deadlines,
                         },
                         ..state
@@ -412,6 +387,7 @@ impl Transition {
                 participation,
                 status,
                 mut confirmations,
+                complaints,
                 deadlines,
             } if group.id() == event.gid => {
                 let (count, _) = group.size();
@@ -429,6 +405,7 @@ impl Transition {
                                 participation,
                                 status,
                                 confirmations,
+                                complaints,
                                 deadlines,
                             },
                             ..state
@@ -461,6 +438,204 @@ impl Transition {
                 }
             }
             _ => (state, Vec::new()),
+        }
+    }
+
+    /// Registers a complaint raised against a participant. Once enough
+    /// complaints have accrued against a single participant to reach the
+    /// group's signing threshold, key generation restarts excluding them;
+    /// otherwise, if this validator is the one accused, it reveals its own
+    /// secret share for the plaintiff via [`Action::KeyGenComplaintResponse`].
+    pub(super) fn handle_key_gen_complained(
+        &self,
+        mut state: State,
+        block: u64,
+        event: &Coordinator::KeyGenComplained,
+    ) -> (State, Commands<State, Self>) {
+        let (next_epoch, group, participation, complaints, restart_deadline, response_expires_at) =
+            match &mut state.rollover {
+                RolloverState::CollectingShares {
+                    next_epoch,
+                    group,
+                    participation,
+                    complaints,
+                    deadline,
+                    ..
+                } if group.id() == event.gid => {
+                    let restart_deadline =
+                        deadline.map(|_| block.saturating_add(self.config.key_gen_timeout.get()));
+                    // We get at least another `key_gen_timeout` to get the
+                    // complaint response onchain, which ends up being the same
+                    // value as the restart deadline (by coincidence).
+                    let response_expires_at = restart_deadline;
+                    (
+                        *next_epoch,
+                        &*group,
+                        &*participation,
+                        complaints,
+                        restart_deadline,
+                        response_expires_at,
+                    )
+                }
+                RolloverState::CollectingConfirmations {
+                    next_epoch,
+                    group,
+                    participation,
+                    complaints,
+                    deadlines,
+                    ..
+                } if group.id() == event.gid
+                    && deadlines
+                        .as_ref()
+                        .is_none_or(|deadlines| block <= deadlines.complain) =>
+                {
+                    let restart_deadline = deadlines
+                        .as_ref()
+                        .map(|_| block.saturating_add(self.config.key_gen_timeout.get()));
+                    let response_expires_at =
+                        deadlines.as_ref().map(|deadlines| deadlines.response);
+                    (
+                        *next_epoch,
+                        &*group,
+                        &*participation,
+                        complaints,
+                        restart_deadline,
+                        response_expires_at,
+                    )
+                }
+                _ => return (state, Vec::new()),
+            };
+
+        let complaint = complaints.entry(event.accused).or_default();
+        complaint.total += 1;
+        complaint.unresponded += 1;
+
+        // If we ever get threshold complaints, the keygen is done. This is
+        // because it would reveal sufficient public information to compute
+        // secret key shares from one or more participants.
+        let (_, threshold) = group.size();
+        if complaint.total >= threshold {
+            tracing::warn!(
+                accused = %event.accused,
+                "restarting key generation after too many complaints"
+            );
+
+            let participants = match if let EpochId::Number { number } = next_epoch {
+                let excluded = group.excluded().chain(iter::once(event.accused)).collect();
+                group::participants_set(
+                    &self.config.participants,
+                    group::Epoch::Number {
+                        consensus: self.config.consensus,
+                        number,
+                        excluded,
+                    },
+                )
+            } else {
+                // In case we need to restart keygen during genesis - halt! The
+                // The genesis keygen is special in that it cannot be restart
+                // since the group ID has special authorization, and any restart
+                // would issue a new and different group ID.
+                None
+            } {
+                Some(participants) => participants,
+                None => {
+                    // We were not able to build a new participant set (either
+                    // we are in genesis, where restarts aren't allowed or there
+                    // are too few remaining participants). Error out.
+                    return (
+                        State {
+                            rollover: rollover_failure(
+                                next_epoch,
+                                "could not form new participant set following too many complaints",
+                            ),
+                            ..state
+                        },
+                        Vec::new(),
+                    );
+                }
+            };
+
+            // Restart the key generation with the new participant set.
+            return self.start_key_gen(state, next_epoch, &participants, restart_deadline);
+        }
+
+        let mut commands = Vec::new();
+        if let KeyGenParticipation::Participating(sharing_state) = &**participation
+            && event.accused == self.account
+        {
+            match frost::keygen::reveal_secret_share(sharing_state, event.plaintiff) {
+                Ok(secret_share) => {
+                    commands.push(Command::Action(Action::KeyGenComplaintResponse {
+                        group_id: group.id(),
+                        plaintiff: event.plaintiff,
+                        secret_share,
+                        expires_at: response_expires_at,
+                    }));
+                }
+                Err(err) => {
+                    tracing::warn!(
+                        %err,
+                        plaintiff = %event.plaintiff,
+                        "failed to reveal secret share for complaint response"
+                    );
+                }
+            }
+        }
+
+        (state, commands)
+    }
+
+    /// Starts a key generation ceremony for `next_epoch` with `participants`,
+    /// entering [`RolloverState::WaitingForSetup`] if this validator is part of
+    /// the group, or heading straight to
+    /// [`RolloverState::CollectingCommitments`] as an observer otherwise.
+    // Right now, since state has only a single field, this triggers a "unused
+    // variable" warning (since the `..state` splat is a no-op). Once `state`
+    // gets more fields, this will go away.
+    #[expect(unused_variables)]
+    fn start_key_gen(
+        &self,
+        state: State,
+        next_epoch: EpochId,
+        participants: &ParticipantSet,
+        deadline: Option<u64>,
+    ) -> (State, Commands<State, Self>) {
+        // Only participate in the group generation if you are part of the
+        // participant set; otherwise go straight to collecting the other
+        // participants' commitments.
+        if let Some((group, poap)) = participants.participate_as(self.account) {
+            let group_id = group.id();
+            let (count, threshold) = group.size();
+            (
+                State {
+                    rollover: RolloverState::WaitingForSetup {
+                        next_epoch,
+                        group,
+                        poap,
+                        deadline,
+                    },
+                    ..state
+                },
+                vec![Command::Effect(Effect::KeyGenSetup {
+                    group_id,
+                    count,
+                    threshold,
+                })],
+            )
+        } else {
+            (
+                State {
+                    rollover: RolloverState::CollectingCommitments {
+                        next_epoch,
+                        group: participants.group(),
+                        secrets: None,
+                        commitments: BTreeMap::new(),
+                        deadline,
+                    },
+                    ..state
+                },
+                Vec::new(),
+            )
         }
     }
 }

--- a/crates/validator/src/state/mod.rs
+++ b/crates/validator/src/state/mod.rs
@@ -11,6 +11,7 @@ mod preprocess;
 
 use crate::{
     bindings::Coordinator,
+    config::ValidatorConfig,
     consensus::{
         epoch::EpochId,
         group::{Group, ParticipantSet},
@@ -98,6 +99,8 @@ enum RolloverState {
         /// Verified secret shares received from peers so far, keyed by
         /// participant.
         shares: BTreeMap<Address, VerifiedShare>,
+        /// Complaints raised so far, keyed by accused participant.
+        complaints: BTreeMap<Address, Complaint>,
         /// The block by which the secret-share round must complete. `None` to
         /// indicate that there is no deadline.
         deadline: Option<u64>,
@@ -115,6 +118,8 @@ enum RolloverState {
         status: KeyGenConfirmation,
         /// Participants that have confirmed so far.
         confirmations: BTreeSet<Address>,
+        /// Complaints raised so far, keyed by accused participant.
+        complaints: BTreeMap<Address, Complaint>,
         /// The confirmation deadlines for the confirmation collection phase.
         /// `None` to indicate that there is no deadline.
         deadlines: Option<ConfirmationDeadlines>,
@@ -151,6 +156,15 @@ enum KeyGenConfirmation {
     Confirmed(Box<KeyShare>),
 }
 
+/// The complaints raised against a single accused participant.
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
+struct Complaint {
+    /// The total number of complaints raised against the participant.
+    total: u16,
+    /// The number of complaints not yet responded to.
+    unresponded: u16,
+}
+
 /// The deadlines for collecting confirmations.
 #[derive(Clone, Debug, Deserialize, Serialize)]
 struct ConfirmationDeadlines {
@@ -172,9 +186,8 @@ pub struct Transition {
     pub account: Address,
     /// The genesis participant set.
     pub genesis: ParticipantSet,
-    /// The number of blocks a distributed key generation ceremony may run
-    /// before timing out.
-    pub key_gen_timeout: NonZeroU64,
+    /// The validator configuration.
+    pub config: ValidatorConfig,
 }
 
 impl StateTransition<State> for Transition {
@@ -201,6 +214,9 @@ impl StateTransition<State> for Transition {
                 }
                 Event::Coordinator(Coordinator::CoordinatorEvents::KeyGenConfirmed(event)) => {
                     self.handle_key_gen_confirmed(state, &event)
+                }
+                Event::Coordinator(Coordinator::CoordinatorEvents::KeyGenComplained(event)) => {
+                    self.handle_key_gen_complained(state, log.block, &event)
                 }
                 // The remaining events are wired in as their handlers land.
                 _ => (state, Vec::new()),

--- a/epics/2026_07_01_rust_validator_port.md
+++ b/epics/2026_07_01_rust_validator_port.md
@@ -625,21 +625,21 @@ depend on the full event-driven machine and so are grouped into D4.
 - **D1ii — Genesis `KeyGen`.** ✅ Landed (#553). `WaitingForGenesis → CollectingCommitments` + the
   `BuildKeyGenCommitment` (`DkgCommit`) effect and `KeyGenAndCommit` action.
 - **D1iii — `KeyGenCommitted`.** Register peers' commitments in `State`; when all have committed,
-  `→ CollectingShares` and emit `DkgShares` → the `KeyGenSecretShare` action (ECDH-encrypted shares).
+  `→ CollectingShares` and emit `KeyGenSecretShare` action (ECDH-encrypted shares).
   Ports `keygen/committed.ts`. Depends on B3, D1ii.
 - **D1iv — `KeyGenSecretShared`.** Collect/verify shares (invalid share → `KeyGenComplain` action);
-  when all shared, `→ CollectingConfirmations` and — if my share set completed — emit `DkgFinalize`
-  → the `KeyGenConfirm` action. Ports `keygen/secretShares.ts`. Depends on B3, D1iii.
+  when all shared, `→ CollectingConfirmations` and — if my share set completed — emit the `KeyGenConfirm` action. Ports `keygen/secretShares.ts`. Depends on B3, D1iii.
 - **D1v — `KeyGenConfirmed` (genesis branch).** Collect confirmations; when the genesis group is fully
   confirmed, `→ EpochStaged{epoch 0}`, record `epoch_groups[0]`, emit `NonceTree` →
-  `RegisterNonceCommitments`, and `PruneDkgSecrets`. _(The non-genesis rollover-packet branch lands in
+  `RegisterNonceCommitments`. _(The non-genesis rollover-packet branch lands in
   D4iii, once signing exists.)_ Ports the genesis path of `keygen/confirmed.ts`. Depends on B3/B4, C1,
   D1iv.
-- **D1vi — `KeyGenComplained`.** Complaint accounting; at threshold, restart the keygen via the shared
-  `trigger_keygen` helper (adjusted participants) + `PruneDkgSecrets`; if accused, emit the
+- **D1vi — `KeyGenComplained`.** Complaint accounting; at threshold, restart the keygen; if accused, emit the
   `KeyGenComplaintResponse` action. Ports `keygen/complaintSubmitted.ts`. Depends on D1iv.
 - **D1vii — `KeyGenComplaintResponded`.** Register/verify the revealed share; invalid → restart;
   share set completed → `KeyGenConfirm`. Ports `keygen/complaintResponse.ts`. Depends on D1vi.
+- **D1viii** Secrets pruning, keep a `Vec` of `(u64 /* block */, Prune)` of things to prune. Later, in
+  
 
 **D2 — Transaction & oracle intake.** Verify proposed transactions and open the signing sessions
 (the `WaitingForRequest` / `WaitingToDecline` / `WaitingForOracle` FSM entries). Pure verification and
@@ -705,6 +705,8 @@ rollover branch of `keygen/confirmed.ts`, and `consensus/epochStaged.ts`.
 - **D4iv — Signing timeouts (`NewBlock`).** Per-session retry / decline / drop across the signing FSM,
   emitting `SignRequest` on retry and the standalone `AttestTransaction` / `StageEpoch` fallback
   actions. Ports `signing/timeouts.ts`. Depends on D3vi, D4iii.
+- **D4v — Pruning maturity** When a safe block is reached, trigger pruning effects for the things that
+  need to be pruned.
 
 **D5 — Staker reconciliation.** The `GetValidatorStaker` effect (handler holds the provider), the
 `ValidatorStakerSet` event handler, the staker fields on `State`, the `NewBlock` staker check, and the


### PR DESCRIPTION
### Context and Motivation

This PR adds complaint handling to the validator. Upon receiving a `KeyGenComplained` event, it will accumulate the complaint and respond if necessary. In case there are too many complaints against a single participant, the key generation ceremony is aborted and restarted.

### Decisions and Tradeoffs

> [!IMPORTANT]
> Unlike with the TypeScript implementation, we error out in case we try to restart keygen while doing genesis. This is required since genesis cannot be restarted (the group ID is special for genesis, restarting would yield a different group ID and not be successful).

### Port

This is port of:

https://github.com/safe-research/safenet/blob/b71cee770018ddefdae3bc7c7313862d2283ceaa/validator/src/machine/keygen/complaintSubmitted.ts#L17-L79

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://docs.safefoundation.org/cla).
