### PR TITLE
[D 1vii]: Complaint Response Flow

### DIFF
--- a/crates/validator/src/consensus/group.rs
+++ b/crates/validator/src/consensus/group.rs
@@ -77,9 +77,10 @@ impl Group {
         (self.count, self.threshold)
     }
 
-    /// Returns the set of excluded participants from the group.
-    pub fn excluded(&self) -> impl Iterator<Item = Address> + '_ {
-        self.excluded.iter().copied()
+    /// Returns a new set of excluded participants including the ones that were
+    /// already excluded in this group along with `also_excluded`.
+    pub fn also_exclude(&self, also_excluded: impl Iterator<Item = Address>) -> BTreeSet<Address> {
+        self.excluded.iter().copied().chain(also_excluded).collect()
     }
 }
 

--- a/crates/validator/src/frost/keygen.rs
+++ b/crates/validator/src/frost/keygen.rs
@@ -298,6 +298,31 @@ pub struct VerifiedShare {
     package: round2::Package,
 }
 
+impl VerifiedShare {
+    /// Creates a new verified share from a plaintext secret share `secret_share`
+    /// from `peer` against `commitment`, registered to `me`.
+    fn new(
+        me: Identifier,
+        peer: Address,
+        commitment: keys::VerifiableSecretSharingCommitment,
+        secret_share: [u8; 32],
+    ) -> Result<VerifiedShare, Error> {
+        let package = marshal::frost_scalar(&U256::from_be_bytes(secret_share))
+            .and_then(|secret_share| {
+                // Pre-verify the share to make sure it matches the commitment from
+                // the peer; this allows us to complain right away in case an
+                // invalid share was provided.
+                let signing_share = keys::SigningShare::new(secret_share);
+                let _ = keys::SecretShare::new(me, signing_share, commitment).verify()?;
+
+                Ok(round2::Package::new(signing_share))
+            })
+            .err_with_culprit(peer)?;
+
+        Ok(VerifiedShare { package })
+    }
+}
+
 /// Decrypts this validator's encrypted share from a participant and verifies
 /// that it matches that participant's commitment.
 ///
@@ -354,24 +379,33 @@ pub fn verify_encrypted_secret_share(
             .err_unexpected()?
     };
 
-    let package = marshal::frost_scalar(&U256::from_be_bytes(secret_share))
-        .and_then(|secret_share| {
-            // Pre-verify the share to make sure it matches the commitment from
-            // the peer; this allows us to complain right away in case an
-            // invalid share was provided.
-            let signing_share = keys::SigningShare::new(secret_share);
-            let _ = keys::SecretShare::new(
-                *sharing_state.secret_package.identifier(),
-                signing_share,
-                commitment,
-            )
-            .verify()?;
+    let me = *sharing_state.secret_package.identifier();
+    VerifiedShare::new(me, participant, commitment, secret_share)
+}
 
-            Ok(round2::Package::new(signing_share))
-        })
-        .err_with_culprit(participant)?;
+/// Verifies a secret share publicly revealed by `accused`, in response to a
+/// complaint raised by `plaintiff`, against `accused`'s commitment.
+///
+/// Unlike [`verify_encrypted_secret_share`], this takes the plaintext scalar
+/// directly (as published onchain in response to a complaint) rather than
+/// this validator's own ECDH-encrypted broadcast.
+pub fn verify_revealed_secret_share(
+    group_commitments: &GroupCommitments,
+    plaintiff: Address,
+    accused: Address,
+    secret_share: U256,
+) -> Result<VerifiedShare, Error> {
+    let plaintiff = participants::identifier(plaintiff);
+    let commitment = group_commitments
+        .commitments
+        .get(&accused)
+        .ok_or(frost_secp256k1::Error::UnknownIdentifier)
+        .err_unexpected()?
+        .package
+        .commitment()
+        .clone();
 
-    Ok(VerifiedShare { package })
+    VerifiedShare::new(plaintiff, accused, commitment, secret_share.to_be_bytes())
 }
 
 /// Reveals this validator's own plaintext secret share computed for `peer`,

--- a/crates/validator/src/state/keygen.rs
+++ b/crates/validator/src/state/keygen.rs
@@ -12,12 +12,12 @@ use crate::{
     service::{Action, Effect},
     state::{ConfirmationDeadlines, KeyGenConfirmation, KeyGenParticipation},
 };
-use alloy::primitives::B256;
+use alloy::primitives::{Address, B256};
 use safenet_core::state::{Command, Commands};
 use std::{
     collections::{BTreeMap, BTreeSet},
     fmt::Display,
-    iter,
+    iter, mem,
 };
 
 impl Transition {
@@ -520,43 +520,8 @@ impl Transition {
                 "restarting key generation after too many complaints"
             );
 
-            let participants = match if let EpochId::Number { number } = next_epoch {
-                let excluded = group.excluded().chain(iter::once(event.accused)).collect();
-                group::participants_set(
-                    &self.config.participants,
-                    group::Epoch::Number {
-                        consensus: self.config.consensus,
-                        number,
-                        excluded,
-                    },
-                )
-            } else {
-                // In case we need to restart keygen during genesis - halt! The
-                // The genesis keygen is special in that it cannot be restart
-                // since the group ID has special authorization, and any restart
-                // would issue a new and different group ID.
-                None
-            } {
-                Some(participants) => participants,
-                None => {
-                    // We were not able to build a new participant set (either
-                    // we are in genesis, where restarts aren't allowed or there
-                    // are too few remaining participants). Error out.
-                    return (
-                        State {
-                            rollover: rollover_failure(
-                                next_epoch,
-                                "could not form new participant set following too many complaints",
-                            ),
-                            ..state
-                        },
-                        Vec::new(),
-                    );
-                }
-            };
-
-            // Restart the key generation with the new participant set.
-            return self.start_key_gen(state, next_epoch, &participants, restart_deadline);
+            let excluded = group.also_exclude(iter::once(event.accused));
+            return self.restart_key_gen_excluding(state, next_epoch, excluded, restart_deadline);
         }
 
         let mut commands = Vec::new();
@@ -578,6 +543,155 @@ impl Transition {
                         plaintiff = %event.plaintiff,
                         "failed to reveal secret share for complaint response"
                     );
+                }
+            }
+        }
+
+        (state, commands)
+    }
+
+    /// Registers a revealed secret share published in response to a complaint.
+    /// If this validator is the complaint's plaintiff, the revealed share is
+    /// registered as its own - finalizing and confirming the key share if that
+    /// was the last one missing; otherwise, the revealed share is simply
+    /// verified against the accused's public commitment. An invalid revealed
+    /// share restarts key generation excluding the accused.
+    pub(super) fn handle_key_gen_complaint_responded(
+        &self,
+        mut state: State,
+        block: u64,
+        event: &Coordinator::KeyGenComplaintResponded,
+    ) -> (State, Commands<State, Self>) {
+        let (next_epoch, group, participation, shares, complaints, deadline) =
+            match &mut state.rollover {
+                RolloverState::CollectingShares {
+                    next_epoch,
+                    group,
+                    participation,
+                    shares,
+                    complaints,
+                    deadline,
+                    ..
+                } if group.id() == event.gid => (
+                    *next_epoch,
+                    &*group,
+                    &*participation,
+                    Some(shares),
+                    complaints,
+                    *deadline,
+                ),
+                RolloverState::CollectingConfirmations {
+                    next_epoch,
+                    group,
+                    participation,
+                    status,
+                    complaints,
+                    deadlines,
+                    ..
+                } if group.id() == event.gid
+                    && deadlines
+                        .as_ref()
+                        .is_none_or(|deadlines| block <= deadlines.response) =>
+                {
+                    let shares = if let KeyGenConfirmation::Collecting(shares) = status {
+                        Some(shares)
+                    } else {
+                        None
+                    };
+                    let deadline = deadlines.as_ref().map(|deadlines| deadlines.response);
+
+                    (
+                        *next_epoch,
+                        &*group,
+                        &*participation,
+                        shares,
+                        complaints,
+                        deadline,
+                    )
+                }
+                _ => return (state, Vec::new()),
+            };
+
+        let Some(complaint) = complaints
+            .get_mut(&event.accused)
+            .filter(|complaint| complaint.unresponded > 0)
+        else {
+            return (state, Vec::new());
+        };
+
+        match frost::keygen::verify_revealed_secret_share(
+            participation.group_commitments(),
+            event.plaintiff,
+            event.accused,
+            event.secretShare,
+        ) {
+            Ok(share) => {
+                if let Some(shares) = shares
+                    && event.plaintiff == self.account
+                {
+                    shares.insert(event.accused, share);
+                }
+                complaint.unresponded -= 1;
+            }
+            Err(err) => {
+                tracing::warn!(
+                    %err,
+                    accused = %event.accused,
+                    "invalid secret share revealed in response to a complaint"
+                );
+
+                let excluded = group.also_exclude(iter::once(event.accused));
+                let restart_deadline =
+                    deadline.map(|_| block.saturating_add(self.config.key_gen_timeout.get()));
+
+                return self.restart_key_gen_excluding(
+                    state,
+                    next_epoch,
+                    excluded,
+                    restart_deadline,
+                );
+            }
+        }
+
+        // In case we are in the confirmation phase, collecting shares, and
+        // got the final share, we have to finalize the keygen process and emit
+        // a keygen confirmation action.
+        let mut commands = Vec::new();
+        if let RolloverState::CollectingConfirmations {
+            group,
+            participation,
+            status,
+            deadlines,
+            ..
+        } = &mut state.rollover
+        {
+            let (count, _) = group.size();
+            if let (
+                KeyGenParticipation::Participating(sharing_state),
+                KeyGenConfirmation::Collecting(shares),
+            ) = (&**participation, &mut *status)
+                && shares.len() as u16 == count
+            {
+                let sharing_state = sharing_state.clone();
+                match frost::keygen::finalize(sharing_state, mem::take(shares)) {
+                    Ok(key_share) => {
+                        commands.push(Command::Action(Action::KeyGenConfirm {
+                            group_id: group.id(),
+                            expires_at: deadlines.as_ref().map(|deadlines| deadlines.confirm),
+                        }));
+                        *status = KeyGenConfirmation::Confirmed(Box::new(key_share));
+                    }
+                    Err(err) => {
+                        // Finalization failures are unexpected, as all secret
+                        // shares were already verified.
+                        return (
+                            State {
+                                rollover: rollover_failure(next_epoch, err),
+                                ..state
+                            },
+                            commands,
+                        );
+                    }
                 }
             }
         }
@@ -636,6 +750,51 @@ impl Transition {
                 },
                 Vec::new(),
             )
+        }
+    }
+
+    /// Restarts key generation for `next_epoch` excluding `excluded`, or
+    /// halts/skips the epoch (via [`rollover_failure`], logging `reason`) if
+    /// too few participants would remain -- or if `next_epoch` is the genesis
+    /// epoch, which cannot be restarted since its group ID is externally
+    /// authorized onchain and any restart would produce a different,
+    /// unauthorized one.
+    fn restart_key_gen_excluding(
+        &self,
+        state: State,
+        next_epoch: EpochId,
+        excluded: BTreeSet<Address>,
+        deadline: Option<u64>,
+    ) -> (State, Commands<State, Self>) {
+        let participants = if let EpochId::Number { number } = next_epoch {
+            group::participants_set(
+                &self.config.participants,
+                group::Epoch::Number {
+                    consensus: self.config.consensus,
+                    number,
+                    excluded,
+                },
+            )
+        } else {
+            // In case we need to restart keygen during genesis - halt! The
+            // The genesis keygen is special in that it cannot be restart
+            // since the group ID has special authorization, and any restart
+            // would issue a new and different group ID
+            None
+        };
+
+        match participants {
+            Some(participants) => self.start_key_gen(state, next_epoch, &participants, deadline),
+            None => (
+                State {
+                    rollover: rollover_failure(
+                        next_epoch,
+                        "could not form new participant set to restart keygen",
+                    ),
+                    ..state
+                },
+                Vec::new(),
+            ),
         }
     }
 }

--- a/crates/validator/src/state/mod.rs
+++ b/crates/validator/src/state/mod.rs
@@ -218,6 +218,9 @@ impl StateTransition<State> for Transition {
                 Event::Coordinator(Coordinator::CoordinatorEvents::KeyGenComplained(event)) => {
                     self.handle_key_gen_complained(state, log.block, &event)
                 }
+                Event::Coordinator(Coordinator::CoordinatorEvents::KeyGenComplaintResponded(
+                    event,
+                )) => self.handle_key_gen_complaint_responded(state, log.block, &event),
                 // The remaining events are wired in as their handlers land.
                 _ => (state, Vec::new()),
             },


### PR DESCRIPTION
### Context and Motivation

Implement the complaint response flow. Like for the complaint flow, it does not restart keygen in genesis.]]

### Port

This is a port of:

https://github.com/safe-research/safenet/blob/4c3188fd65d977c17c5e26c4785ec7eb8193f2a5/validator/src/machine/keygen/complaintResponse.ts#L18-L89

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://docs.safefoundation.org/cla).
