### PR TITLE
[D 1viii]: Schedule KeyGen Secrets Pruning

### DIFF
--- a/crates/validator/src/state/keygen.rs
+++ b/crates/validator/src/state/keygen.rs
@@ -1,4 +1,4 @@
-use super::{RolloverState, State, Transition};
+use super::{Prune, RolloverState, State, Transition};
 use crate::{
     bindings::Coordinator,
     consensus::{
@@ -177,13 +177,7 @@ impl Transition {
                     Err(err) => {
                         // There was an issue with the verified commitments,
                         // which is an unexpected an unrecoverable error.
-                        return (
-                            State {
-                                rollover: rollover_failure(next_epoch, err),
-                                ..state
-                            },
-                            Vec::new(),
-                        );
+                        return fail_rollover!(state, block, next_epoch, group.id(), err);
                     }
                 };
 
@@ -340,13 +334,7 @@ impl Transition {
                             Err(err) => {
                                 // Finalization failures are unexpected, since
                                 // all secret shares were already verified.
-                                return (
-                                    State {
-                                        rollover: rollover_failure(next_epoch, err),
-                                        ..state
-                                    },
-                                    commands,
-                                );
+                                return fail_rollover!(state, block, next_epoch, group.id(), err);
                             }
                         }
                     }
@@ -378,6 +366,7 @@ impl Transition {
     pub(super) fn handle_key_gen_confirmed(
         &self,
         state: State,
+        block: u64,
         event: &Coordinator::KeyGenConfirmed,
     ) -> (State, Commands<State, Self>) {
         match state.rollover {
@@ -417,9 +406,10 @@ impl Transition {
                 match next_epoch {
                     // On genesis: the group is confirmed it is ready to go.
                     EpochId::Genesis => {
+                        let group_id = group.id();
                         let commands = if let KeyGenConfirmation::Confirmed(key_share) = status {
                             vec![Command::Effect(Effect::NonceTree {
-                                group_id: group.id(),
+                                group_id,
                                 key_share,
                             })]
                         } else {
@@ -430,7 +420,8 @@ impl Transition {
                             State {
                                 rollover: RolloverState::EpochStaged { next_epoch },
                                 ..state
-                            },
+                            }
+                            .and_prune(block, Prune::KeyGenSecrets { group_id }),
                             commands,
                         )
                     }
@@ -520,8 +511,15 @@ impl Transition {
                 "restarting key generation after too many complaints"
             );
 
+            let group_id = group.id();
             let excluded = group.also_exclude(iter::once(event.accused));
-            return self.restart_key_gen_excluding(state, next_epoch, excluded, restart_deadline);
+
+            return self.restart_key_gen_excluding(
+                state.and_prune(block, Prune::KeyGenSecrets { group_id }),
+                next_epoch,
+                excluded,
+                restart_deadline,
+            );
         }
 
         let mut commands = Vec::new();
@@ -640,12 +638,13 @@ impl Transition {
                     "invalid secret share revealed in response to a complaint"
                 );
 
+                let group_id = group.id();
                 let excluded = group.also_exclude(iter::once(event.accused));
                 let restart_deadline =
                     deadline.map(|_| block.saturating_add(self.config.key_gen_timeout.get()));
 
                 return self.restart_key_gen_excluding(
-                    state,
+                    state.and_prune(block, Prune::KeyGenSecrets { group_id }),
                     next_epoch,
                     excluded,
                     restart_deadline,
@@ -684,13 +683,7 @@ impl Transition {
                     Err(err) => {
                         // Finalization failures are unexpected, as all secret
                         // shares were already verified.
-                        return (
-                            State {
-                                rollover: rollover_failure(next_epoch, err),
-                                ..state
-                            },
-                            commands,
-                        );
+                        return fail_rollover!(state, block, next_epoch, group.id(), err);
                     }
                 }
             }
@@ -703,10 +696,6 @@ impl Transition {
     /// entering [`RolloverState::WaitingForSetup`] if this validator is part of
     /// the group, or heading straight to
     /// [`RolloverState::CollectingCommitments`] as an observer otherwise.
-    // Right now, since state has only a single field, this triggers a "unused
-    // variable" warning (since the `..state` splat is a no-op). Once `state`
-    // gets more fields, this will go away.
-    #[expect(unused_variables)]
     fn start_key_gen(
         &self,
         state: State,
@@ -826,3 +815,22 @@ fn rollover_failure(next_epoch: EpochId, err: impl Display) -> RolloverState {
         RolloverState::Halted
     }
 }
+
+// This is a macro instead of a function because keygen handlers partially move
+// `state.rollover` while matching its fields. The remaining `state` therefore
+// cannot be passed whole to a function, but a macro can reconstruct it at the
+// call site before scheduling the resolved group's secrets for pruning.
+macro_rules! fail_rollover {
+    ($state:ident, $block:expr, $next_epoch:expr, $group_id:expr, $err:expr) => {{
+        let (block, next_epoch, group_id, err) = ($block, $next_epoch, $group_id, $err);
+        (
+            State {
+                rollover: rollover_failure(next_epoch, err),
+                ..($state)
+            }
+            .and_prune(block, Prune::KeyGenSecrets { group_id }),
+            Vec::new(),
+        )
+    }};
+}
+use fail_rollover;

--- a/crates/validator/src/state/mod.rs
+++ b/crates/validator/src/state/mod.rs
@@ -1,11 +1,5 @@
 //! The snapshotted validator state.
 
-// Right now, we only have a single field in our state but this is expected to
-// change. To avoid a large swath of changes when that happens, use `..state`
-// splat everywhere and silence the clippy lint. This will be removed once the
-// validator state gets new fields.
-#![expect(clippy::needless_update)]
-
 mod keygen;
 mod preprocess;
 
@@ -35,6 +29,29 @@ use std::{
 pub struct State {
     /// The epoch-rollover / DKG state machine.
     rollover: RolloverState,
+    /// Things queued up to be pruned, along with the block at which they were
+    /// queued. Pruning itself only happens once the entry is mature enough to
+    /// be reorg-safe.
+    to_prune: Vec<(u64, Prune)>,
+}
+
+impl State {
+    /// Queues `prune` to be pruned, recording the current `block` so its
+    /// maturity can later be determined.
+    fn and_prune(mut self, block: u64, prune: Prune) -> Self {
+        self.to_prune.push((block, prune));
+        self
+    }
+}
+
+/// Something queued up to be pruned once mature.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+enum Prune {
+    /// A resolved group's keygen secrets.
+    KeyGenSecrets {
+        /// The resolved group.
+        group_id: B256,
+    },
 }
 
 /// The epoch-rollover / DKG state machine. Each active variant carries the
@@ -213,7 +230,7 @@ impl StateTransition<State> for Transition {
                     self.handle_key_gen_secret_shared(state, log.block, &event)
                 }
                 Event::Coordinator(Coordinator::CoordinatorEvents::KeyGenConfirmed(event)) => {
-                    self.handle_key_gen_confirmed(state, &event)
+                    self.handle_key_gen_confirmed(state, log.block, &event)
                 }
                 Event::Coordinator(Coordinator::CoordinatorEvents::KeyGenComplained(event)) => {
                     self.handle_key_gen_complained(state, log.block, &event)

--- a/epics/2026_07_01_rust_validator_port.md
+++ b/epics/2026_07_01_rust_validator_port.md
@@ -638,7 +638,7 @@ depend on the full event-driven machine and so are grouped into D4.
   `KeyGenComplaintResponse` action. Ports `keygen/complaintSubmitted.ts`. Depends on D1iv.
 - **D1vii — `KeyGenComplaintResponded`.** Register/verify the revealed share; invalid → restart;
   share set completed → `KeyGenConfirm`. Ports `keygen/complaintResponse.ts`. Depends on D1vi.
-- **D1viii** Secrets pruning, keep a `Vec` of `(u64 /* block */, Prune)` of things to prune. Later, in
+- **D1viii** Secrets pruning, keep a `Vec` of `(u64 /* block */, Prune)` of things to prune. Later, in D4v the actual pruning will happen.
   
 
 **D2 — Transaction & oracle intake.** Verify proposed transactions and open the signing sessions


### PR DESCRIPTION
### Context and Motivation

KeyGen DKG secrets need to be pruned from the secret store. This PR does the first step in that direction by registering group IDs for DKG secret pruning.

### Decisions and Tradeoffs

KeyGen secrets need to be pruned, but in a reorg-aware way. The simplest solution to this is to queue up things to prune with the block on which they should be pruned, and the emit the correct effects when we observe `safe` blocks past the pruning point. The actual pruning will happen when we introduce block handling in D4.

I also simplified some of the failure paths with a macro (the reason for using a macro is explained in its doc comment). The `use ${MACRO_NAME}` pattern just allows the macro to appear anywhere in the file (instead of before first use, macros have a different and weird scoping rules).

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://docs.safefoundation.org/cla).
