### PR TITLE
[D 2iii]: Handle Transaction Proposals

### DIFF
--- a/crates/validator/src/consensus/checks/mod.rs
+++ b/crates/validator/src/consensus/checks/mod.rs
@@ -1,5 +1,3 @@
-#![cfg_attr(not(test), expect(dead_code))]
-
 mod multi_send;
 
 use self::multi_send::{MultiSendVersion, decode_multi_send};

--- a/crates/validator/src/consensus/epoch.rs
+++ b/crates/validator/src/consensus/epoch.rs
@@ -12,9 +12,17 @@ pub enum EpochId {
 }
 
 impl EpochId {
+    /// Returns the epoch ID for a raw value.
+    pub const fn from_raw(value: u64) -> Self {
+        match NonZeroU64::new(value) {
+            Some(number) => Self::Number { number },
+            None => Self::Genesis,
+        }
+    }
+
     /// Returns the epoch ID as a raw numerical value. Genesis is represented
     /// by the value 0.
-    pub fn raw_value(self) -> u64 {
+    pub const fn raw_value(self) -> u64 {
         match self {
             EpochId::Genesis => 0,
             EpochId::Number { number } => number.get(),

--- a/crates/validator/src/consensus/group.rs
+++ b/crates/validator/src/consensus/group.rs
@@ -51,7 +51,8 @@ use std::{collections::BTreeSet, num::NonZeroU64};
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Group {
     id: B256,
-    participants: MerkleRoot,
+    root: MerkleRoot,
+    participants: BTreeSet<Address>,
     excluded: BTreeSet<Address>,
     count: u16,
     threshold: u16,
@@ -69,12 +70,17 @@ impl Group {
     /// These are all the required parameters for starting a key generation
     /// process onchain.
     pub fn parameters(&self) -> (MerkleRoot, u16, u16, B256) {
-        (self.participants, self.count, self.threshold, self.context)
+        (self.root, self.count, self.threshold, self.context)
     }
 
     /// Return the group size: the count and threshold.
     pub fn size(&self) -> (u16, u16) {
         (self.count, self.threshold)
+    }
+
+    /// Return the group's participant addresses.
+    pub fn participants(&self) -> &BTreeSet<Address> {
+        &self.participants
     }
 
     /// Returns a new set of excluded participants including the ones that were
@@ -119,7 +125,7 @@ impl ParticipantSet {
     }
 
     fn group_and_participants_tree(&self) -> (Group, MerkleTree) {
-        let participants = participants_tree(&self.addresses);
+        let tree = participants_tree(&self.addresses);
         let count = self
             .addresses
             .len()
@@ -129,14 +135,15 @@ impl ParticipantSet {
         let context = self.context;
 
         let group = Group {
-            id: group_id(participants.root(), count, threshold, context),
-            participants: participants.root(),
+            id: group_id(tree.root(), count, threshold, context),
+            root: tree.root(),
+            participants: self.addresses.clone(),
             excluded: self.excluded.clone(),
             count,
             threshold,
             context,
         };
-        (group, participants)
+        (group, tree)
     }
 }
 

--- a/crates/validator/src/consensus/hashing.rs
+++ b/crates/validator/src/consensus/hashing.rs
@@ -9,12 +9,16 @@
 
 #![cfg_attr(not(test), expect(dead_code))]
 
-use crate::bindings::{Point, SafeTransaction};
+use crate::{
+    bindings::{Point, SafeTransaction},
+    consensus::epoch::EpochId,
+};
 use alloy::{
     primitives::{Address, B256, U256},
     sol,
     sol_types::{Eip712Domain, SolStruct},
 };
+use std::num::NonZeroU64;
 
 sol! {
     /// The classic Safe `SafeTx` EIP-712 struct.
@@ -87,11 +91,11 @@ pub struct ConsensusDomain(Eip712Domain);
 impl ConsensusDomain {
     /// Builds the domain a validator network's own consensus group attests
     /// over: the chain the `Consensus` contract lives on and its address.
-    pub const fn new(chain: U256, consensus: Address) -> Self {
+    pub const fn new(chain: u64, consensus: Address) -> Self {
         Self(Eip712Domain::new(
             None,
             None,
-            Some(chain),
+            Some(U256::from_limbs([chain, 0, 0, 0])),
             Some(consensus),
             None,
         ))
@@ -99,9 +103,9 @@ impl ConsensusDomain {
 
     /// The consensus-domain hash of a Safe transaction proposal, embedding the
     /// already-computed [`safe_tx_hash`] as its `safeTxHash` field.
-    pub fn transaction_proposal_hash(&self, epoch: u64, safe_tx_hash: B256) -> B256 {
+    pub fn transaction_proposal_hash(&self, epoch: EpochId, safe_tx_hash: B256) -> B256 {
         TransactionProposal {
-            epoch,
+            epoch: epoch.raw_value(),
             safeTxHash: safe_tx_hash,
         }
         .eip712_signing_hash(&self.0)
@@ -109,7 +113,7 @@ impl ConsensusDomain {
 
     /// The consensus-domain hash of a Safe transaction packet: shorthand for
     /// [`transaction_proposal_hash`] with [`safe_tx_hash`] computed from `tx`.
-    pub fn transaction_packet_hash(&self, epoch: u64, tx: &SafeTransaction) -> B256 {
+    pub fn transaction_packet_hash(&self, epoch: EpochId, tx: &SafeTransaction) -> B256 {
         self.transaction_proposal_hash(epoch, safe_tx_hash(tx))
     }
 
@@ -117,12 +121,12 @@ impl ConsensusDomain {
     /// embedding the already-computed [`safe_tx_hash`] as its `safeTxHash` field.
     pub fn oracle_transaction_proposal_hash(
         &self,
-        epoch: u64,
+        epoch: EpochId,
         oracle: Address,
         safe_tx_hash: B256,
     ) -> B256 {
         OracleTransactionProposal {
-            epoch,
+            epoch: epoch.raw_value(),
             oracle,
             safeTxHash: safe_tx_hash,
         }
@@ -134,7 +138,7 @@ impl ConsensusDomain {
     /// computed from `tx`.
     pub fn oracle_transaction_packet_hash(
         &self,
-        epoch: u64,
+        epoch: EpochId,
         oracle: Address,
         tx: &SafeTransaction,
     ) -> B256 {
@@ -144,14 +148,14 @@ impl ConsensusDomain {
     /// The consensus-domain hash of an epoch rollover proposal.
     pub fn epoch_rollover_hash(
         &self,
-        active_epoch: u64,
-        proposed_epoch: u64,
+        active_epoch: EpochId,
+        proposed_epoch: NonZeroU64,
         rollover_block: u64,
         group_key: &Point,
     ) -> B256 {
         EpochRollover {
-            activeEpoch: active_epoch,
-            proposedEpoch: proposed_epoch,
+            activeEpoch: active_epoch.raw_value(),
+            proposedEpoch: proposed_epoch.get(),
             rolloverBlock: rollover_block,
             groupKeyX: group_key.x,
             groupKeyY: group_key.y,
@@ -164,13 +168,11 @@ impl ConsensusDomain {
 mod tests {
     use super::*;
     use crate::bindings::Operation;
-    use alloy::{
-        primitives::{Bytes, address, b256},
-        uint,
-    };
+    use alloy::primitives::{Bytes, address, b256};
 
     const TEST_ADDRESS: Address = address!("d8dA6BF26964aF9D7eEd9e03E53415D37aA96045");
-    const TEST_DOMAIN: ConsensusDomain = ConsensusDomain::new(uint!(1_U256), TEST_ADDRESS);
+    const TEST_DOMAIN: ConsensusDomain = ConsensusDomain::new(1, TEST_ADDRESS);
+    const EPOCH_ONE: EpochId = EpochId::from_raw(1);
 
     fn safe_tx() -> SafeTransaction {
         SafeTransaction {
@@ -200,7 +202,7 @@ mod tests {
     #[test]
     fn reference_transaction_packet_hash() {
         assert_eq!(
-            TEST_DOMAIN.transaction_packet_hash(1, &safe_tx()),
+            TEST_DOMAIN.transaction_packet_hash(EPOCH_ONE, &safe_tx()),
             b256!("3ff98ecae85843603560e9509346df2f35c0ad1dd1ceda5dcbb145745dfc4e00")
         );
     }
@@ -208,7 +210,7 @@ mod tests {
     #[test]
     fn sample_oracle_transaction_packet_hash() {
         assert_eq!(
-            TEST_DOMAIN.oracle_transaction_packet_hash(1, TEST_ADDRESS, &safe_tx()),
+            TEST_DOMAIN.oracle_transaction_packet_hash(EPOCH_ONE, TEST_ADDRESS, &safe_tx()),
             b256!("b89cd5ddc8b9a71c6469b79711f8ce0000edd6fc3f47ad057a772302fcfa82af")
         );
     }
@@ -220,7 +222,7 @@ mod tests {
             y: U256::from(2u64),
         };
         assert_eq!(
-            TEST_DOMAIN.epoch_rollover_hash(0, 1, 1000, &group_key),
+            TEST_DOMAIN.epoch_rollover_hash(EpochId::Genesis, NonZeroU64::MIN, 1000, &group_key),
             b256!("75b33b36b42d249c4cccf1c86bce59897c0ebbaa829ab5d8926e1bff1cee4355")
         );
     }

--- a/crates/validator/src/main.rs
+++ b/crates/validator/src/main.rs
@@ -8,7 +8,7 @@ mod service;
 mod state;
 
 use self::{bindings::Consensus, config::Config, service::ValidatorService};
-use alloy::providers::ProviderBuilder;
+use alloy::providers::{Provider, ProviderBuilder};
 use argh::FromArgs;
 use safenet_core::{Driver, observability};
 use sqlx::sqlite::SqlitePool;
@@ -46,12 +46,14 @@ async fn main() -> Result<(), Box<dyn Error>> {
         .getCoordinator()
         .call()
         .await?;
-    tracing::debug!(%consensus, %coordinator, "resolved onchain contracts");
+    let chain_id = provider.get_chain_id().await?;
+    tracing::debug!(chain_id, %consensus, %coordinator, "resolved onchain contracts");
 
     let mut watched = vec![consensus, coordinator];
     watched.extend(config.validator.oracles.iter().copied());
 
     let service = ValidatorService::new(
+        chain_id,
         config.signer.address(),
         pool.clone(),
         coordinator,

--- a/crates/validator/src/service/mod.rs
+++ b/crates/validator/src/service/mod.rs
@@ -10,7 +10,10 @@ pub use self::{
 use crate::{
     bindings::{Consensus, Coordinator, Oracle},
     config::ValidatorConfig,
-    consensus::group::{self, Epoch, ParticipantSet},
+    consensus::{
+        group::{self, Epoch, ParticipantSet},
+        hashing::ConsensusDomain,
+    },
     secrets::{self, SecretStore},
     state::{self, State},
 };
@@ -27,6 +30,8 @@ pub struct ValidatorService {
     secrets: SecretStore,
     /// The genesis participant set.
     genesis: ParticipantSet,
+    /// The consensus signing domain.
+    consensus: ConsensusDomain,
     /// The FROST coordinator contract to submit protocol actions to.
     coordinator: Address,
     /// The validator configuration.
@@ -36,6 +41,7 @@ pub struct ValidatorService {
 impl ValidatorService {
     /// Creates the validator service from its machine configuration.
     pub async fn new(
+        chain_id: u64,
         account: Address,
         pool: SqlitePool,
         coordinator: Address,
@@ -49,11 +55,13 @@ impl ValidatorService {
             },
         )
         .ok_or(Error::InvalidValidators)?;
+        let consensus = ConsensusDomain::new(chain_id, config.consensus);
 
         Ok(Self {
             account,
             secrets,
             genesis,
+            consensus,
             coordinator,
             config,
         })
@@ -84,6 +92,7 @@ impl Service for ValidatorService {
             account,
             genesis,
             secrets,
+            consensus,
             coordinator,
             config,
         } = self;
@@ -91,6 +100,7 @@ impl Service for ValidatorService {
             state::Transition {
                 account,
                 genesis,
+                consensus,
                 config,
             },
             effect::Handler { account, secrets },

--- a/crates/validator/src/state/keygen.rs
+++ b/crates/validator/src/state/keygen.rs
@@ -365,7 +365,7 @@ impl Transition {
     /// Registers a peer's confirmation of a completed key generation.
     pub(super) fn handle_key_gen_confirmed(
         &self,
-        state: State,
+        mut state: State,
         block: u64,
         event: &Coordinator::KeyGenConfirmed,
     ) -> (State, Commands<State, Self>) {
@@ -415,6 +415,8 @@ impl Transition {
                         } else {
                             Vec::new()
                         };
+
+                        state.epoch_groups.insert(next_epoch.raw_value(), group);
 
                         (
                             State {

--- a/crates/validator/src/state/mod.rs
+++ b/crates/validator/src/state/mod.rs
@@ -2,13 +2,15 @@
 
 mod keygen;
 mod preprocess;
+mod transactions;
 
 use crate::{
-    bindings::Coordinator,
+    bindings::{Consensus, Coordinator, SafeTransaction},
     config::ValidatorConfig,
     consensus::{
         epoch::EpochId,
         group::{Group, ParticipantSet},
+        hashing::ConsensusDomain,
     },
     frost::keygen::{
         GroupCommitments, KeyShare, PublicKeyShare, Secrets, SharingState, VerifiedCommitment,
@@ -29,6 +31,12 @@ use std::{
 pub struct State {
     /// The epoch-rollover / DKG state machine.
     rollover: RolloverState,
+    /// The resolved group for each epoch that has completed its key
+    /// generation.
+    epoch_groups: BTreeMap<u64, Group>,
+    /// The signing sessions tracked so far, keyed by the message hash the
+    /// group signature attests to.
+    signing: BTreeMap<B256, SigningState>,
     /// Things queued up to be pruned, along with the block at which they were
     /// queued. Pruning itself only happens once the entry is mature enough to
     /// be reorg-safe.
@@ -193,6 +201,43 @@ struct ConfirmationDeadlines {
     confirm: u64,
 }
 
+/// A packet a validator group signs an attestation over.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+enum Packet {
+    /// A proposed Safe transaction.
+    Transaction {
+        /// The epoch whose group signs the attestation.
+        epoch: EpochId,
+        /// The proposed transaction.
+        transaction: SafeTransaction,
+    },
+}
+
+/// A signing session, keyed by the message hash the group signature attests
+/// to.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+enum SigningState {
+    /// The packet was verified; waiting for this validator's own `Sign`
+    /// action to open the nonce-commitment round.
+    WaitingForRequest {
+        /// The packet being signed.
+        packet: Packet,
+        /// The group members expected to take part in signing.
+        signers: BTreeSet<Address>,
+        /// The block by which the signing round must complete. `None` to
+        /// indicate that there is no deadline.
+        deadline: Option<u64>,
+    },
+    /// The packet failed verification; waiting to submit a decline.
+    WaitingToDecline {
+        /// The packet that failed verification.
+        packet: Packet,
+        /// The block by which the decline must be submitted. `None` to
+        /// indicate that there is no deadline.
+        deadline: Option<u64>,
+    },
+}
+
 /// The pure validator state transition.
 ///
 /// Holds the machine configuration the transition is parameterized over; the
@@ -203,6 +248,8 @@ pub struct Transition {
     pub account: Address,
     /// The genesis participant set.
     pub genesis: ParticipantSet,
+    /// The consensus signing domain.
+    pub consensus: ConsensusDomain,
     /// The validator configuration.
     pub config: ValidatorConfig,
 }
@@ -238,6 +285,9 @@ impl StateTransition<State> for Transition {
                 Event::Coordinator(Coordinator::CoordinatorEvents::KeyGenComplaintResponded(
                     event,
                 )) => self.handle_key_gen_complaint_responded(state, log.block, &event),
+                Event::Consensus(Consensus::ConsensusEvents::TransactionProposed(event)) => {
+                    self.handle_transaction_proposed(state, log.block, &event)
+                }
                 // The remaining events are wired in as their handlers land.
                 _ => (state, Vec::new()),
             },

--- a/crates/validator/src/state/transactions.rs
+++ b/crates/validator/src/state/transactions.rs
@@ -1,0 +1,67 @@
+use std::collections::btree_map;
+
+use super::{Packet, SigningState, State, Transition};
+use crate::{
+    bindings::Consensus,
+    consensus::{checks, epoch::EpochId},
+};
+use safenet_core::state::Commands;
+
+impl Transition {
+    /// Verifies a proposed Safe transaction against the epoch's resolved
+    /// group, opening a signing session for it: [`SigningState::WaitingForRequest`]
+    /// if it passes Safenet policy, [`SigningState::WaitingToDecline`]
+    /// otherwise. A transaction proposed for an unknown or unresolved epoch,
+    /// or one whose group this validator is not part of, is ignored.
+    pub(super) fn handle_transaction_proposed(
+        &self,
+        mut state: State,
+        block: u64,
+        event: &Consensus::TransactionProposed,
+    ) -> (State, Commands<State, Self>) {
+        let Some(group) = state
+            .epoch_groups
+            .get(&event.epoch)
+            .filter(|group| group.participants().contains(&self.account))
+        else {
+            return (state, Vec::new());
+        };
+
+        let epoch = EpochId::from_raw(event.epoch);
+        let message = self
+            .consensus
+            .transaction_packet_hash(epoch, &event.transaction);
+
+        // Prevent duplicate ongoing transaction proposals. This is to prevent
+        // malicious parties from blocking transaction attestations from ever
+        // being produced by resetting the signing state of honest validators.
+        if let btree_map::Entry::Vacant(signing) = state.signing.entry(message) {
+            let packet = Packet::Transaction {
+                epoch,
+                transaction: event.transaction.clone(),
+            };
+
+            let signers = group.participants().clone();
+            let deadline = Some(block.saturating_add(self.config.signing_timeout.get()));
+
+            let signing_state = if checks::check_transaction(&event.transaction) {
+                SigningState::WaitingForRequest {
+                    packet,
+                    signers,
+                    deadline,
+                }
+            } else {
+                SigningState::WaitingToDecline { packet, deadline }
+            };
+
+            signing.insert(signing_state);
+        } else {
+            tracing::warn!(
+                %message,
+                "ignoring duplicate transaction proposal"
+            )
+        }
+
+        (state, Vec::new())
+    }
+}


### PR DESCRIPTION
### Context and Motivation

Handle transaction proposal events and verify them, progressing the signing state.

### Decisions and Tradeoffs

I decided to make the `epoch` types stricter on hashing as well. This allows us to clearly differentiate between "genesis" and other epochs (since the value 0 onchain carries special meaning).

> [!IMPORTANT]
> Unlike the TypeScript implementation, we _do not_ restart any ongoing signing ceremonies for new proposals.
>
> This is because the current TypeScript behaviour causes a consensus soundness bug: a malicious validator can re-propose transactions mid-signing ceremony in order to prevent them from ever getting attested, as the honest validators will happily restart the signing ceremony with the full set every time it sees a transaction proposal. The cost of this attack is less than the cost of partial signing ceremonies paid by the honest validators. The attack is more expensive with oracle transactions, but still an issue (fee per total timeout period, which is quite a low sustained cost).

### Port

https://github.com/safe-research/safenet/blob/4c3188fd65d977c17c5e26c4785ec7eb8193f2a5/validator/src/machine/consensus/transactionProposed.ts#L18-L69

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://docs.safefoundation.org/cla).
