### PR TITLE
[D 2iv]: Handle Transaction Attestations

### DIFF
--- a/crates/validator/src/state/mod.rs
+++ b/crates/validator/src/state/mod.rs
@@ -37,6 +37,9 @@ pub struct State {
     /// The signing sessions tracked so far, keyed by the message hash the
     /// group signature attests to.
     signing: BTreeMap<B256, SigningState>,
+    /// The message hash each pending signature id was requested over, so its
+    /// signing session can be found once the signature is submitted onchain.
+    signature_id_to_message: BTreeMap<B256, B256>,
     /// Things queued up to be pruned, along with the block at which they were
     /// queued. Pruning itself only happens once the entry is mature enough to
     /// be reorg-safe.
@@ -215,7 +218,10 @@ enum Packet {
 
 /// A signing session, keyed by the message hash the group signature attests
 /// to.
+// Every variant is a distinct wait state (for a request, an attestation, or
+// to decline); the shared prefix reflects that, not redundant naming.
 #[derive(Clone, Debug, Deserialize, Serialize)]
+#[allow(clippy::enum_variant_names)]
 enum SigningState {
     /// The packet was verified; waiting for this validator's own `Sign`
     /// action to open the nonce-commitment round.
@@ -227,6 +233,12 @@ enum SigningState {
         /// The block by which the signing round must complete. `None` to
         /// indicate that there is no deadline.
         deadline: Option<u64>,
+    },
+    /// A complete group signature was produced; waiting for the attestation
+    /// to be submitted onchain.
+    WaitingForAttestation {
+        /// The signature id the completed signing round produced.
+        signature_id: B256,
     },
     /// The packet failed verification; waiting to submit a decline.
     WaitingToDecline {
@@ -287,6 +299,9 @@ impl StateTransition<State> for Transition {
                 )) => self.handle_key_gen_complaint_responded(state, log.block, &event),
                 Event::Consensus(Consensus::ConsensusEvents::TransactionProposed(event)) => {
                     self.handle_transaction_proposed(state, log.block, &event)
+                }
+                Event::Consensus(Consensus::ConsensusEvents::TransactionAttested(event)) => {
+                    self.handle_transaction_attested(state, &event)
                 }
                 // The remaining events are wired in as their handlers land.
                 _ => (state, Vec::new()),

--- a/crates/validator/src/state/transactions.rs
+++ b/crates/validator/src/state/transactions.rs
@@ -5,6 +5,7 @@ use crate::{
     bindings::Consensus,
     consensus::{checks, epoch::EpochId},
 };
+use alloy::primitives::B256;
 use safenet_core::state::Commands;
 
 impl Transition {
@@ -63,5 +64,56 @@ impl Transition {
         }
 
         (state, Vec::new())
+    }
+
+    /// Clears a completed signing session once its attestation lands
+    /// onchain, keyed by the same proposal hash used to open it:
+    /// [`SigningState::WaitingForRequest`] verifies the full transaction,
+    /// while the attestation only carries its
+    /// [`safe_tx_hash`](crate::consensus::hashing::safe_tx_hash), so the
+    /// proposal is re-hashed directly from the event rather than the packet.
+    pub(super) fn handle_transaction_attested(
+        &self,
+        mut state: State,
+        event: &Consensus::TransactionAttested,
+    ) -> (State, Commands<State, Self>) {
+        let epoch = EpochId::from_raw(event.epoch);
+        let message = self
+            .consensus
+            .transaction_proposal_hash(epoch, event.safeTxHash);
+
+        // Always clean up signing states when we observe attestations onchain
+        // to prevent dangling signing references. This _should_ only happen in
+        // case other validators diverge and produce an attestation under a
+        // different signature ID, so this is purely defensive.
+        let signing = state.signing.remove(&message);
+        if let Some(signature_id) = signing.as_ref().and_then(|signing| signing.signature_id()) {
+            state.signature_id_to_message.remove(&signature_id);
+        }
+
+        // In case we weren't in an expected state (either waiting for an
+        // attestation or just observing but not participating in the signing
+        // ceremony), log a warning, since this should never happen.
+        match &signing {
+            Some(SigningState::WaitingForAttestation { .. }) | None => {}
+            Some(_) => tracing::warn!(
+                %message,
+                signature_id = %event.signatureId,
+                "received attestation on unexpected signing state"
+            ),
+        }
+
+        (state, Vec::new())
+    }
+}
+
+impl SigningState {
+    /// Returns the known signature ID for a signing state, or `None` if none
+    /// have been assigned yet.
+    fn signature_id(&self) -> Option<B256> {
+        match self {
+            SigningState::WaitingForAttestation { signature_id } => Some(*signature_id),
+            SigningState::WaitingForRequest { .. } | SigningState::WaitingToDecline { .. } => None,
+        }
     }
 }


### PR DESCRIPTION
### Context and Motivation

When a transaction attestation is observed, clean up the left over signing state.

### Decisions and Tradeoffs

We already introduce the reverse `SignatureID -> Message` mapping in the state (even if we do not populate it yet). It will get populated once we start handling `Sign` events.

> [!IMPORTANT]
> Unlike in the TypeScript implementation, we are more defensive with cleaning up message signing state. This is to ensure that we don't leave dangling `message` and `signatureIdToMessage` references.
>
> With the current approach, we would drop the second signing ceremony started for the same transaction, and will soft-fork with the TS implementation (AFAICT, in a non-critical way, as the attestation will end up onchain with our participation).
>
> This is in addition to the other consensus change regarding duplicate transaction proposals, see #568 

### Port

https://github.com/safe-research/safenet/blob/4c3188fd65d977c17c5e26c4785ec7eb8193f2a5/validator/src/machine/consensus/transactionAttested.ts#L7-L34

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://docs.safefoundation.org/cla).
