### PR TITLE
[D 2v]: Handle Oracle Transaction Proposals

### DIFF
--- a/crates/validator/src/config.rs
+++ b/crates/validator/src/config.rs
@@ -4,7 +4,7 @@ use alloy::primitives::{Address, B256};
 use safenet_core::{driver, observability, tx::Signer};
 use serde::Deserialize;
 use sqlx::sqlite::SqliteConnectOptions;
-use std::{num::NonZeroU64, path::Path};
+use std::{collections::BTreeSet, num::NonZeroU64, path::Path};
 use tokio::{fs, io};
 use url::Url;
 
@@ -68,7 +68,7 @@ pub struct ValidatorConfig {
     /// The oracle contracts whose results the validator honors when signing
     /// oracle transactions.
     #[serde(default)]
-    pub oracles: Vec<Address>,
+    pub oracles: BTreeSet<Address>,
     /// The salt mixed into the genesis group's key generation context.
     #[serde(default)]
     pub genesis_salt: B256,
@@ -209,10 +209,10 @@ mod tests {
         assert_eq!(validator.oracle_timeout.get(), 40);
         assert_eq!(
             validator.oracles,
-            [
+            BTreeSet::from([
                 address!("0x4444444444444444444444444444444444444444"),
                 address!("0x5555555555555555555555555555555555555555"),
-            ]
+            ])
         );
 
         // The first participant omits its epoch window, defaulting to active

--- a/crates/validator/src/state/mod.rs
+++ b/crates/validator/src/state/mod.rs
@@ -214,6 +214,15 @@ enum Packet {
         /// The proposed transaction.
         transaction: SafeTransaction,
     },
+    /// A proposed oracle-backed Safe transaction.
+    OracleTransaction {
+        /// The epoch whose group signs the attestation.
+        epoch: EpochId,
+        /// The oracle vouching for the transaction.
+        oracle: Address,
+        /// The proposed transaction.
+        transaction: SafeTransaction,
+    },
 }
 
 /// A signing session, keyed by the message hash the group signature attests
@@ -302,6 +311,9 @@ impl StateTransition<State> for Transition {
                 }
                 Event::Consensus(Consensus::ConsensusEvents::TransactionAttested(event)) => {
                     self.handle_transaction_attested(state, &event)
+                }
+                Event::Consensus(Consensus::ConsensusEvents::OracleTransactionProposed(event)) => {
+                    self.handle_oracle_transaction_proposed(state, log.block, &event)
                 }
                 // The remaining events are wired in as their handlers land.
                 _ => (state, Vec::new()),

--- a/crates/validator/src/state/transactions.rs
+++ b/crates/validator/src/state/transactions.rs
@@ -105,6 +105,57 @@ impl Transition {
 
         (state, Vec::new())
     }
+
+    /// Verifies a proposed oracle-backed Safe transaction against the
+    /// epoch's resolved group, opening a [`SigningState::WaitingForRequest`]
+    /// signing session for it. Unlike a plain [`Consensus::TransactionProposed`],
+    /// the transaction itself is not checked against Safenet policy here -
+    /// the oracle vouches for it, and its result is checked once attested -
+    /// only the oracle's own identity is verified against the configured
+    /// allow-list. A transaction proposed for an unknown or unresolved epoch,
+    /// one whose group this validator is not part of, or from a disallowed
+    /// oracle, is ignored.
+    pub(super) fn handle_oracle_transaction_proposed(
+        &self,
+        mut state: State,
+        block: u64,
+        event: &Consensus::OracleTransactionProposed,
+    ) -> (State, Commands<State, Self>) {
+        let Some(group) = state.epoch_groups.get(&event.epoch).filter(|group| {
+            group.participants().contains(&self.account)
+                && self.config.oracles.contains(&event.oracle)
+        }) else {
+            return (state, Vec::new());
+        };
+
+        let epoch = EpochId::from_raw(event.epoch);
+        let message =
+            self.consensus
+                .oracle_transaction_packet_hash(epoch, event.oracle, &event.transaction);
+
+        // Prevent duplicate ongoing transaction proposals. This is to prevent
+        // malicious parties from blocking transaction attestations from ever
+        // being produced by resetting the signing state of honest validators.
+        if let btree_map::Entry::Vacant(signing) = state.signing.entry(message) {
+            let packet = Packet::OracleTransaction {
+                epoch,
+                oracle: event.oracle,
+                transaction: event.transaction.clone(),
+            };
+            let signers = group.participants().clone();
+            let deadline = Some(block.saturating_add(self.config.signing_timeout.get()));
+
+            signing.insert(SigningState::WaitingForRequest {
+                packet,
+                signers,
+                deadline,
+            });
+        } else {
+            tracing::warn!(%message, "ignoring duplicate oracle transaction proposal");
+        }
+
+        (state, Vec::new())
+    }
 }
 
 impl SigningState {


### PR DESCRIPTION
### Context and Motivation

Handle oracle transaction proposals by adding the appropriate entry to the signing map.

### Decisions and Tradeoffs

> [!IMPORTANT]
> Like with transaction proposals, we prevent resetting the signing state on duplicate proposals. See #568 for rationale.

### Port

https://github.com/safe-research/safenet/blob/4c3188fd65d977c17c5e26c4785ec7eb8193f2a5/validator/src/machine/consensus/oracleTransactionProposed.ts#L18-L58

https://github.com/safe-research/safenet/blob/4c3188fd65d977c17c5e26c4785ec7eb8193f2a5/validator/src/consensus/verify/oracleTx/handler.ts#L19-L24

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://docs.safefoundation.org/cla).
