### PR TITLE
[D 2vi]: Handle Oracle Transaction Attestations

### DIFF
--- a/crates/validator/src/state/mod.rs
+++ b/crates/validator/src/state/mod.rs
@@ -315,6 +315,9 @@ impl StateTransition<State> for Transition {
                 Event::Consensus(Consensus::ConsensusEvents::OracleTransactionProposed(event)) => {
                     self.handle_oracle_transaction_proposed(state, log.block, &event)
                 }
+                Event::Consensus(Consensus::ConsensusEvents::OracleTransactionAttested(event)) => {
+                    self.handle_oracle_transaction_attested(state, &event)
+                }
                 // The remaining events are wired in as their handlers land.
                 _ => (state, Vec::new()),
             },

--- a/crates/validator/src/state/transactions.rs
+++ b/crates/validator/src/state/transactions.rs
@@ -156,6 +156,42 @@ impl Transition {
 
         (state, Vec::new())
     }
+
+    /// Clears a completed oracle-backed signing session once its attestation
+    /// lands onchain.
+    pub(super) fn handle_oracle_transaction_attested(
+        &self,
+        mut state: State,
+        event: &Consensus::OracleTransactionAttested,
+    ) -> (State, Commands<State, Self>) {
+        let epoch = EpochId::from_raw(event.epoch);
+        let message =
+            self.consensus
+                .oracle_transaction_proposal_hash(epoch, event.oracle, event.safeTxHash);
+
+        // Always clean up signing states when we observe attestations onchain
+        // to prevent dangling signing references. This _should_ only happen in
+        // case other validators diverge and produce an attestation under a
+        // different signature ID, so this is purely defensive.
+        let signing = state.signing.remove(&message);
+        if let Some(signature_id) = signing.as_ref().and_then(|signing| signing.signature_id()) {
+            state.signature_id_to_message.remove(&signature_id);
+        }
+
+        // In case we weren't in an expected state (either waiting for an
+        // attestation or just observing but not participating in the signing
+        // ceremony), log a warning, since this should never happen.
+        match &signing {
+            Some(SigningState::WaitingForAttestation { .. }) | None => {}
+            Some(_) => tracing::warn!(
+                %message,
+                signature_id = %event.signatureId,
+                "received attestation on unexpected signing state"
+            ),
+        }
+
+        (state, Vec::new())
+    }
 }
 
 impl SigningState {


### PR DESCRIPTION
### Context and Motivation

Handle oracle transaction attestations in a similar way to beta transaction attestations.

### Decisions and Tradeoffs

I intentionally did not factor out the common code between beta transaction attestations and oracle attestations, since we plan on removing the former.

> [!IMPORTANT]
> Like for transaction attestations, we are more defensive with cleaning up dangling message and signature mapping references. See #569 for rationale.

### Port

https://github.com/safe-research/safenet/blob/4c3188fd65d977c17c5e26c4785ec7eb8193f2a5/validator/src/machine/consensus/transactionAttested.ts#L14-L34

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://docs.safefoundation.org/cla).
