### PR TITLE
[D 3i]: Nonces Chunk Linking

### DIFF
--- a/crates/validator/src/secrets.rs
+++ b/crates/validator/src/secrets.rs
@@ -91,7 +91,11 @@ impl SecretStore {
              );
 
              CREATE UNIQUE INDEX IF NOT EXISTS idx_nonces_chunks_lookup
-                 ON nonces_chunks (group_id, address, chunk);",
+                 ON nonces_chunks (group_id, address, chunk);
+
+             CREATE UNIQUE INDEX IF NOT EXISTS idx_nonces_chunks_unlinked
+                 ON nonces_chunks (group_id, address)
+                 WHERE chunk IS NULL;",
         )
         .execute(&pool)
         .await?;
@@ -153,19 +157,36 @@ impl SecretStore {
         Ok(())
     }
 
-    /// Persists a freshly generated preprocessing `chunk` for `me` in `group`,
-    /// returning its merkle root (the onchain `preprocess` commitment). The
-    /// chunk is stored unlinked; [`link_nonces_chunk`](Self::link_nonces_chunk)
-    /// associates it with a sequence chunk once assigned onchain.
+    /// Persists the freshly generated preprocessing `chunk` for `me` in
+    /// `group` and returns its merkle root, or returns `None` when another
+    /// unlinked chunk is already pending. At most one unlinked chunk is
+    /// retained per participant and group; the existing root is deliberately
+    /// not returned so callers cannot submit it under a second onchain chunk.
+    /// [`link_nonces_chunk`](Self::link_nonces_chunk) associates the new root
+    /// with a sequence chunk once assigned onchain.
     pub async fn register_nonces_chunk(
         &self,
         group: B256,
         me: Address,
         chunk: NonceChunk,
-    ) -> Result<B256, Error> {
+    ) -> Result<Option<B256>, Error> {
         let root = chunk.commitment.0;
 
         let mut tx = self.pool.begin().await?;
+        let existing = sqlx::query_scalar::<_, i64>(
+            "SELECT 1 FROM nonces_chunks
+             WHERE group_id = ? AND address = ? AND chunk IS NULL",
+        )
+        .bind(key(group))
+        .bind(key(me))
+        .fetch_optional(&mut *tx)
+        .await?;
+
+        // We only allow a single pending
+        if existing.is_some() {
+            return Ok(None);
+        };
+
         sqlx::query("INSERT INTO nonces_chunks (root, group_id, address) VALUES (?, ?, ?)")
             .bind(key(root))
             .bind(key(group))
@@ -182,12 +203,13 @@ impl SecretStore {
         }
         tx.commit().await?;
 
-        Ok(root)
+        Ok(Some(root))
     }
 
     /// Links a registered nonce tree (by `root`) to the onchain sequence
-    /// `chunk` for `me` in `group`. Errors if the root is unknown or already
-    /// linked.
+    /// `chunk` for `me` in `group`. Replaces a previous chunk assignment, as
+    /// canonical replay after a reorg may assign the commitment a different
+    /// index. Errors if the root is unknown.
     pub async fn link_nonces_chunk(
         &self,
         group: B256,
@@ -195,20 +217,43 @@ impl SecretStore {
         chunk: u64,
         root: B256,
     ) -> Result<(), Error> {
-        let updated = sqlx::query(
-            "UPDATE nonces_chunks SET chunk = ?
-             WHERE root = ? AND group_id = ? AND address = ? AND chunk IS NULL",
+        let chunk = i64::try_from(chunk)?;
+
+        // A canonical replay can assign this root an index that is still
+        // occupied locally by a root linked on an orphaned chain. Because we
+        // may be moving a root linked to one chunk to another, we cannot simply
+        // mark the old root as pending either. To work around this, we give the
+        // root a negative unreachable chunk, until that one gets linked.
+        let mut tx = self.pool.begin().await?;
+
+        // First, make the old root inaccessible by giving it a negative chunk.
+        sqlx::query(
+            "UPDATE nonces_chunks SET chunk = -rowid
+             WHERE root != ? AND group_id = ? AND address = ? AND chunk = ?",
         )
-        .bind(i64::try_from(chunk)?)
         .bind(key(root))
         .bind(key(group))
         .bind(key(me))
-        .execute(&self.pool)
+        .bind(chunk)
+        .execute(&mut *tx)
         .await?;
 
-        if updated.rows_affected() == 0 {
+        // Update the linked nonce.
+        let update = sqlx::query(
+            "UPDATE nonces_chunks SET chunk = ?
+             WHERE root = ? AND group_id = ? AND address = ?",
+        )
+        .bind(chunk)
+        .bind(key(root))
+        .bind(key(group))
+        .bind(key(me))
+        .execute(&mut *tx)
+        .await?;
+        if update.rows_affected() == 0 {
             return Err(Error::Database(sqlx::Error::RowNotFound));
         }
+
+        tx.commit().await?;
         Ok(())
     }
 
@@ -419,24 +464,58 @@ mod tests {
     async fn nonces_chunk_link_and_count() {
         let store = store().await;
         let root = store
-            .register_nonces_chunk(GROUP, ME, nonce_chunk(4))
+            .register_nonces_chunk(GROUP, ME, nonce_chunk(11))
+            .await
+            .unwrap()
+            .unwrap();
+        let reused = store
+            .register_nonces_chunk(GROUP, ME, nonce_chunk(12))
             .await
             .unwrap();
-        let other = store
-            .register_nonces_chunk(GROUP, ME, nonce_chunk(4))
-            .await
-            .unwrap();
+        assert_eq!(reused, None);
 
         // Until linked to a sequence chunk, it is not addressable by chunk.
         assert_eq!(store.available_nonce_count(GROUP, ME, 0).await.unwrap(), 0);
         store.link_nonces_chunk(GROUP, ME, 0, root).await.unwrap();
-        assert_eq!(store.available_nonce_count(GROUP, ME, 0).await.unwrap(), 4);
+        assert_eq!(store.available_nonce_count(GROUP, ME, 0).await.unwrap(), 11);
 
-        // Re-linking the same root is rejected.
-        assert!(store.link_nonces_chunk(GROUP, ME, 0, root).await.is_err());
+        // Once linked, a fresh chunk can be registered.
+        let other = store
+            .register_nonces_chunk(GROUP, ME, nonce_chunk(13))
+            .await
+            .unwrap()
+            .unwrap();
+        assert_ne!(other, root);
 
-        // Linking a different root to the same chunk is also rejected.
-        assert!(store.link_nonces_chunk(GROUP, ME, 0, other).await.is_err());
+        // The newly registered chunk starts unlinked.
+        assert_eq!(store.available_nonce_count(GROUP, ME, 0).await.unwrap(), 11);
+        assert_eq!(store.available_nonce_count(GROUP, ME, 1).await.unwrap(), 0);
+
+        // It can be linked to a chunk.
+        store.link_nonces_chunk(GROUP, ME, 1, other).await.unwrap();
+        assert_eq!(store.available_nonce_count(GROUP, ME, 0).await.unwrap(), 11);
+        assert_eq!(store.available_nonce_count(GROUP, ME, 1).await.unwrap(), 13);
+        assert_eq!(store.available_nonce_count(GROUP, ME, 2).await.unwrap(), 0);
+
+        // Nonce assignment is idempotent.
+        store.link_nonces_chunk(GROUP, ME, 0, root).await.unwrap();
+        assert_eq!(store.available_nonce_count(GROUP, ME, 0).await.unwrap(), 11);
+        assert_eq!(store.available_nonce_count(GROUP, ME, 1).await.unwrap(), 13);
+        assert_eq!(store.available_nonce_count(GROUP, ME, 2).await.unwrap(), 0);
+
+        // Canonical replay can reassign a root after a reorg, displacing a
+        // stale assignment left by the orphaned chain.
+        store.link_nonces_chunk(GROUP, ME, 1, root).await.unwrap();
+        assert_eq!(store.available_nonce_count(GROUP, ME, 0).await.unwrap(), 0);
+        assert_eq!(store.available_nonce_count(GROUP, ME, 1).await.unwrap(), 11);
+        assert_eq!(store.available_nonce_count(GROUP, ME, 2).await.unwrap(), 0);
+
+        // The displaced root can itself be assigned by a later canonical
+        // event.
+        store.link_nonces_chunk(GROUP, ME, 2, other).await.unwrap();
+        assert_eq!(store.available_nonce_count(GROUP, ME, 0).await.unwrap(), 0);
+        assert_eq!(store.available_nonce_count(GROUP, ME, 1).await.unwrap(), 11);
+        assert_eq!(store.available_nonce_count(GROUP, ME, 2).await.unwrap(), 13);
     }
 
     #[tokio::test]
@@ -445,6 +524,7 @@ mod tests {
         let root = store
             .register_nonces_chunk(GROUP, ME, nonce_chunk(4))
             .await
+            .unwrap()
             .unwrap();
         store.link_nonces_chunk(GROUP, ME, 0, root).await.unwrap();
 
@@ -464,6 +544,7 @@ mod tests {
         let root = store
             .register_nonces_chunk(GROUP, ME, nonce_chunk(4))
             .await
+            .unwrap()
             .unwrap();
         store.link_nonces_chunk(GROUP, ME, 0, root).await.unwrap();
 
@@ -516,6 +597,7 @@ mod tests {
         let root = store
             .register_nonces_chunk(GROUP, ME, nonce_chunk(2))
             .await
+            .unwrap()
             .unwrap();
         store.link_nonces_chunk(GROUP, ME, 0, root).await.unwrap();
 

--- a/crates/validator/src/service/effect.rs
+++ b/crates/validator/src/service/effect.rs
@@ -29,6 +29,13 @@ pub enum Effect {
         group_id: B256,
         key_share: Box<KeyShare>,
     },
+    /// Link a registered nonce tree (identified by its `root` commitment) to
+    /// the onchain sequence `chunk` it was assigned.
+    LinkNonceTree {
+        group_id: B256,
+        chunk: u64,
+        root: B256,
+    },
 }
 
 /// The result of performing an [`Effect`], resumed into the state machine.
@@ -81,14 +88,30 @@ impl Handler {
             } => {
                 let mut rng = rand::thread_rng();
                 let chunk = frost::preprocess::NonceChunk::generate(&key_share, &mut rng)?;
-                let commitment = self
+                let result = self
                     .secrets
                     .register_nonces_chunk(group_id, self.account, chunk)
+                    .await?
+                    // In case registration worked, then resume with the nonce
+                    // chunk commitment hash so it may be recorded onchain.
+                    .map(|commitment| Resume::NonceTree {
+                        group_id,
+                        commitment,
+                    })
+                    // There is already a pending nonce chunk, and therefore we
+                    // do not want to register a new one.
+                    .unwrap_or(Resume::Noop);
+                Ok(result)
+            }
+            Effect::LinkNonceTree {
+                group_id,
+                chunk,
+                root,
+            } => {
+                self.secrets
+                    .link_nonces_chunk(group_id, self.account, chunk, root)
                     .await?;
-                Ok(Resume::NonceTree {
-                    group_id,
-                    commitment,
-                })
+                Ok(Resume::Noop)
             }
         }
     }

--- a/crates/validator/src/state/mod.rs
+++ b/crates/validator/src/state/mod.rs
@@ -306,6 +306,9 @@ impl StateTransition<State> for Transition {
                 Event::Coordinator(Coordinator::CoordinatorEvents::KeyGenComplaintResponded(
                     event,
                 )) => self.handle_key_gen_complaint_responded(state, log.block, &event),
+                Event::Coordinator(Coordinator::CoordinatorEvents::Preprocess(event)) => {
+                    self.handle_preprocess(state, &event)
+                }
                 Event::Consensus(Consensus::ConsensusEvents::TransactionProposed(event)) => {
                     self.handle_transaction_proposed(state, log.block, &event)
                 }

--- a/crates/validator/src/state/preprocess.rs
+++ b/crates/validator/src/state/preprocess.rs
@@ -1,5 +1,8 @@
 use super::{State, Transition};
-use crate::service::Action;
+use crate::{
+    bindings::Coordinator,
+    service::{Action, Effect},
+};
 use alloy::primitives::B256;
 use safenet_core::state::{Command, Commands};
 
@@ -17,6 +20,29 @@ impl Transition {
             vec![Command::Action(Action::Preprocess {
                 group_id,
                 nonces_commitment,
+            })],
+        )
+    }
+
+    /// Links a committed nonce tree to its assigned onchain chunk. This can
+    /// happen regardless of the current rollover/signing state. Only this
+    /// validator's own commitment is linked; other participants' commitments
+    /// are for their own local secret stores.
+    pub(super) fn handle_preprocess(
+        &self,
+        state: State,
+        event: &Coordinator::Preprocess,
+    ) -> (State, Commands<State, Self>) {
+        if event.participant != self.account {
+            return (state, Vec::new());
+        }
+
+        (
+            state,
+            vec![Command::Effect(Effect::LinkNonceTree {
+                group_id: event.gid,
+                chunk: event.chunk,
+                root: event.commitment,
             })],
         )
     }


### PR DESCRIPTION
This PR links locally stored nonce chunks to their onchain indices while preventing duplicate submissions and nonce reuse.

### Context and Motivation

Nonces must survive reorgs and remain associated with the canonical `Preprocess` event without relying on reorg-aware state.

### Decisions and Tradeoffs

The secret store permits one unlinked chunk per group and participant; transaction resubmission handles reorgs without submitting the same root twice.

Reorg-displaced roots are parked at unique negative indices until canonically relinked. This is needed as a reorg will temporarily make chunks potentially go out of order and may collide with another existing pending chunk (which would violate DB uniqueness constraints). The action submission logic will guarantee that, under reorg, our `Preprocess` transactions will get back onchain and settle any negative indices.

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://docs.safefoundation.org/cla).
