### PR TITLE
[D3ii]:  Nonce Reveal

### DIFF
--- a/crates/validator/src/frost/preprocess.rs
+++ b/crates/validator/src/frost/preprocess.rs
@@ -21,6 +21,15 @@ use serde::{Deserialize, Serialize};
 /// `FROSTNonceCommitmentSet` sequence chunk size.
 pub const SEQUENCE_CHUNK_SIZE: u64 = 1024;
 
+/// Decodes a global nonce `sequence` number into its `(chunk, offset)`
+/// coordinates within that chunk.
+pub fn decode_sequence(sequence: u64) -> (u64, u64) {
+    (
+        sequence / SEQUENCE_CHUNK_SIZE,
+        sequence % SEQUENCE_CHUNK_SIZE,
+    )
+}
+
 /// A single preprocessing nonce pair and its precomputed inclusion proof in the
 /// chunk's merkle tree. Because the proof is stored with the nonce, a nonce can
 /// be revealed in isolation without the rest of the chunk.

--- a/crates/validator/src/frost/sign.rs
+++ b/crates/validator/src/frost/sign.rs
@@ -22,7 +22,7 @@ use std::collections::BTreeMap;
 /// have already been merkle-checked against their preprocessing commitment;
 /// this additionally attributes malformed or identity point to a misbehaving
 /// participant.
-#[derive(Clone, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct RevealedNonces {
     commitments: round1::SigningCommitments,
 }

--- a/crates/validator/src/service/action.rs
+++ b/crates/validator/src/service/action.rs
@@ -54,6 +54,20 @@ pub enum Action {
         group_id: B256,
         nonces_commitment: B256,
     },
+    /// An action to reveal this validator's nonce commitment for a signing
+    /// round.
+    RevealNonceCommitments {
+        signature_id: B256,
+        nonces: bindings::SignNonces,
+        proof: Vec<B256>,
+        expires_at: Option<u64>,
+    },
+    /// An action to decline participation in a signing round for a packet
+    /// that failed verification.
+    SignDecline {
+        signature_id: B256,
+        expires_at: Option<u64>,
+    },
 }
 
 /// Encodes [`Action`]s into the transactions the queue submits.
@@ -181,6 +195,40 @@ impl ActionEncoder<Action> for Encoder {
                 // Nonce registration doesn't carry an expiry - we cannot
                 // reliably know for how long it is valuable.
                 None,
+            ),
+            Action::RevealNonceCommitments {
+                signature_id,
+                nonces,
+                proof,
+                expires_at,
+            } => (
+                Transaction {
+                    to: self.coordinator,
+                    value: U256::ZERO,
+                    data: Coordinator::signRevealNoncesCall {
+                        sid: signature_id,
+                        nonces,
+                        proof,
+                    }
+                    .abi_encode()
+                    .into(),
+                    gas: 250_000,
+                },
+                expires_at,
+            ),
+            Action::SignDecline {
+                signature_id,
+                expires_at,
+            } => (
+                Transaction {
+                    to: self.coordinator,
+                    value: U256::ZERO,
+                    data: Coordinator::signDeclineCall { sid: signature_id }
+                        .abi_encode()
+                        .into(),
+                    gas: 150_000,
+                },
+                expires_at,
             ),
         }
     }

--- a/crates/validator/src/service/effect.rs
+++ b/crates/validator/src/service/effect.rs
@@ -1,6 +1,7 @@
 //! The validator effect system and its handler.
 
 use crate::{
+    bindings,
     frost::{
         self,
         keygen::{KeyShare, Secrets},
@@ -12,6 +13,7 @@ use safenet_core::state::EffectHandler;
 use std::{
     error::Error,
     fmt::{self, Display, Formatter},
+    sync::Arc,
 };
 
 /// An impure operation the state transition asks the handler to perform.
@@ -27,7 +29,7 @@ pub enum Effect {
     /// Sample a fresh nonce tree for `key_share` and persist it.
     NonceTree {
         group_id: B256,
-        key_share: Box<KeyShare>,
+        key_share: Arc<KeyShare>,
     },
     /// Link a registered nonce tree (identified by its `root` commitment) to
     /// the onchain sequence `chunk` it was assigned.
@@ -35,6 +37,14 @@ pub enum Effect {
         group_id: B256,
         chunk: u64,
         root: B256,
+    },
+    /// Reveal this validator's nonce commitment for the signing round at
+    /// `sequence`.
+    RevealNonceCommitments {
+        group_id: B256,
+        signature_id: B256,
+        message: B256,
+        sequence: u64,
     },
 }
 
@@ -53,6 +63,14 @@ pub enum Resume {
     /// Resume with the nonce tree commitment produced by a
     /// [`Effect::NonceTree`].
     NonceTree { group_id: B256, commitment: B256 },
+    /// Resume with the nonce commitment revealed by a
+    /// [`Effect::RevealNonceCommitments`].
+    NonceCommitments {
+        signature_id: B256,
+        message: B256,
+        nonces: bindings::SignNonces,
+        proof: Vec<B256>,
+    },
 }
 
 /// Performs the validator's [`Effect`]s, resuming with a [`Resume`].
@@ -112,6 +130,28 @@ impl Handler {
                     .link_nonces_chunk(group_id, self.account, chunk, root)
                     .await?;
                 Ok(Resume::Noop)
+            }
+            Effect::RevealNonceCommitments {
+                group_id,
+                signature_id,
+                message,
+                sequence,
+            } => {
+                let (chunk, offset) = frost::preprocess::decode_sequence(sequence);
+                let result = self
+                    .secrets
+                    .nonces_reveal(group_id, self.account, chunk, offset)
+                    .await?
+                    .map(|(nonces, proof)| Resume::NonceCommitments {
+                        signature_id,
+                        message,
+                        nonces,
+                        proof,
+                    })
+                    // The nonce was not generated, used up, or the tree isn't
+                    // linked yet; nothing to reveal.
+                    .unwrap_or(Resume::Noop);
+                Ok(result)
             }
         }
     }

--- a/crates/validator/src/state/keygen.rs
+++ b/crates/validator/src/state/keygen.rs
@@ -1,4 +1,4 @@
-use super::{Prune, RolloverState, State, Transition};
+use super::{Epoch, Prune, RolloverState, State, Transition};
 use crate::{
     bindings::Coordinator,
     consensus::{
@@ -18,6 +18,7 @@ use std::{
     collections::{BTreeMap, BTreeSet},
     fmt::Display,
     iter, mem,
+    sync::Arc,
 };
 
 impl Transition {
@@ -329,7 +330,7 @@ impl Transition {
                                         .as_ref()
                                         .map(|deadlines| deadlines.confirm),
                                 }));
-                                KeyGenConfirmation::Confirmed(Box::new(key_share))
+                                KeyGenConfirmation::Confirmed(Arc::new(key_share))
                             }
                             Err(err) => {
                                 // Finalization failures are unexpected, since
@@ -408,6 +409,13 @@ impl Transition {
                     EpochId::Genesis => {
                         let group_id = group.id();
                         let commands = if let KeyGenConfirmation::Confirmed(key_share) = status {
+                            state.epochs.insert(
+                                next_epoch.raw_value(),
+                                Epoch {
+                                    group,
+                                    key_share: key_share.clone(),
+                                },
+                            );
                             vec![Command::Effect(Effect::NonceTree {
                                 group_id,
                                 key_share,
@@ -415,8 +423,6 @@ impl Transition {
                         } else {
                             Vec::new()
                         };
-
-                        state.epoch_groups.insert(next_epoch.raw_value(), group);
 
                         (
                             State {
@@ -680,7 +686,7 @@ impl Transition {
                             group_id: group.id(),
                             expires_at: deadlines.as_ref().map(|deadlines| deadlines.confirm),
                         }));
-                        *status = KeyGenConfirmation::Confirmed(Box::new(key_share));
+                        *status = KeyGenConfirmation::Confirmed(Arc::new(key_share));
                     }
                     Err(err) => {
                         // Finalization failures are unexpected, as all secret

--- a/crates/validator/src/state/mod.rs
+++ b/crates/validator/src/state/mod.rs
@@ -2,6 +2,7 @@
 
 mod keygen;
 mod preprocess;
+mod sign;
 mod transactions;
 
 use crate::{
@@ -12,9 +13,12 @@ use crate::{
         group::{Group, ParticipantSet},
         hashing::ConsensusDomain,
     },
-    frost::keygen::{
-        GroupCommitments, KeyShare, PublicKeyShare, Secrets, SharingState, VerifiedCommitment,
-        VerifiedShare,
+    frost::{
+        keygen::{
+            GroupCommitments, KeyShare, PublicKeyShare, Secrets, SharingState, VerifiedCommitment,
+            VerifiedShare,
+        },
+        sign::RevealedNonces,
     },
     service::{Action, Effect, Event, Resume},
 };
@@ -24,6 +28,7 @@ use serde::{Deserialize, Serialize};
 use std::{
     collections::{BTreeMap, BTreeSet},
     num::NonZeroU64,
+    sync::Arc,
 };
 
 /// The complete snapshotted validator state.
@@ -31,9 +36,11 @@ use std::{
 pub struct State {
     /// The epoch-rollover / DKG state machine.
     rollover: RolloverState,
-    /// The resolved group for each epoch that has completed its key
-    /// generation.
-    epoch_groups: BTreeMap<u64, Group>,
+    /// The epochs that the validator is participating in and have completed
+    /// their key generation, keyed by epoch number and retained past
+    /// `EpochStaged` so later handlers can look up a resolved group and the
+    /// generated key share.
+    epochs: BTreeMap<u64, Epoch>,
     /// The signing sessions tracked so far, keyed by the message hash the
     /// group signature attests to.
     signing: BTreeMap<B256, SigningState>,
@@ -53,6 +60,16 @@ impl State {
         self.to_prune.push((block, prune));
         self
     }
+}
+
+/// A resolved epoch that the validator is participating in, retained past
+/// `EpochStaged` to access resolved group and epoch key material.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+struct Epoch {
+    /// The resolved group.
+    group: Group,
+    /// This validator's key share.
+    key_share: Arc<KeyShare>,
 }
 
 /// Something queued up to be pruned once mature.
@@ -181,7 +198,7 @@ enum KeyGenConfirmation {
     Collecting(BTreeMap<Address, VerifiedShare>),
     /// All secret shares have been collected and a secret key share has been
     /// constructed.
-    Confirmed(Box<KeyShare>),
+    Confirmed(Arc<KeyShare>),
 }
 
 /// The complaints raised against a single accused participant.
@@ -235,6 +252,8 @@ enum SigningState {
     /// The packet was verified; waiting for this validator's own `Sign`
     /// action to open the nonce-commitment round.
     WaitingForRequest {
+        /// The key share for participating in the signing ceremony.
+        key_share: Arc<KeyShare>,
         /// The packet being signed.
         packet: Packet,
         /// The group members expected to take part in signing.
@@ -243,11 +262,51 @@ enum SigningState {
         /// indicate that there is no deadline.
         deadline: Option<u64>,
     },
+    /// An oracle-backed packet's signing round is on hold until the oracle's
+    /// result is attested.
+    WaitingForOracle {
+        /// The key share for participating in the signing ceremony.
+        key_share: Arc<KeyShare>,
+        /// The oracle whose result is awaited.
+        oracle: Address,
+        /// The group generating the signature.
+        group_id: B256,
+        /// The signature id assigned to this signing round.
+        signature_id: B256,
+        /// The nonce sequence number assigned to this signing round.
+        sequence: u64,
+        /// The packet being signed.
+        packet: Packet,
+        /// The group members expected to take part in signing.
+        signers: BTreeSet<Address>,
+        /// The block by which the oracle result must land. `None` to
+        /// indicate that there is no deadline.
+        deadline: Option<u64>,
+    },
+    /// This validator has revealed its nonce commitment and is waiting for
+    /// its peers to reveal theirs.
+    CollectNonceCommitments {
+        /// The key share for participating in the signing ceremony.
+        key_share: Arc<KeyShare>,
+        /// The signature id assigned to this signing round.
+        signature_id: B256,
+        /// Verified revealed nonce commitments received from peers so far.
+        revealed: BTreeMap<Address, RevealedNonces>,
+        /// The packet being signed.
+        packet: Packet,
+        /// The group members expected to take part in signing.
+        signers: BTreeSet<Address>,
+        /// The block by which the commitment round must complete. `None` to
+        /// indicate that there is no deadline.
+        deadline: Option<u64>,
+    },
     /// A complete group signature was produced; waiting for the attestation
     /// to be submitted onchain.
     WaitingForAttestation {
         /// The signature id the completed signing round produced.
         signature_id: B256,
+        /// The block by which the signing attestation must arrive.
+        deadline: Option<u64>,
     },
     /// The packet failed verification; waiting to submit a decline.
     WaitingToDecline {
@@ -309,6 +368,9 @@ impl StateTransition<State> for Transition {
                 Event::Coordinator(Coordinator::CoordinatorEvents::Preprocess(event)) => {
                     self.handle_preprocess(state, &event)
                 }
+                Event::Coordinator(Coordinator::CoordinatorEvents::Sign(event)) => {
+                    self.handle_sign(state, log.block, &event)
+                }
                 Event::Consensus(Consensus::ConsensusEvents::TransactionProposed(event)) => {
                     self.handle_transaction_proposed(state, log.block, &event)
                 }
@@ -335,6 +397,12 @@ impl StateTransition<State> for Transition {
                     group_id,
                     commitment,
                 } => self.handle_nonce_tree(state, group_id, commitment),
+                Resume::NonceCommitments {
+                    signature_id,
+                    message,
+                    nonces,
+                    proof,
+                } => self.handle_nonce_commitments(state, signature_id, message, nonces, proof),
             },
         }
     }

--- a/crates/validator/src/state/sign.rs
+++ b/crates/validator/src/state/sign.rs
@@ -1,0 +1,125 @@
+use super::{Packet, SigningState, State, Transition};
+use crate::{
+    bindings::{Coordinator, SignNonces},
+    service::{Action, Effect},
+};
+use alloy::primitives::B256;
+use safenet_core::state::{Command, Commands};
+use std::collections::BTreeMap;
+
+impl Transition {
+    /// Handles a validator's own request to sign a packet.
+    pub(super) fn handle_sign(
+        &self,
+        mut state: State,
+        block: u64,
+        event: &Coordinator::Sign,
+    ) -> (State, Commands<State, Self>) {
+        let mut commands = Vec::new();
+        match state.signing.remove(&event.message) {
+            Some(SigningState::WaitingToDecline { deadline, .. }) => {
+                commands.push(Command::Action(Action::SignDecline {
+                    signature_id: event.sid,
+                    expires_at: deadline,
+                }));
+            }
+            Some(SigningState::WaitingForRequest {
+                key_share,
+                packet,
+                signers,
+                ..
+            }) => match packet {
+                Packet::OracleTransaction { oracle, .. } => {
+                    let deadline = Some(block.saturating_add(self.config.oracle_timeout.get()));
+                    state.signing.insert(
+                        event.message,
+                        SigningState::WaitingForOracle {
+                            key_share,
+                            oracle,
+                            group_id: event.gid,
+                            signature_id: event.sid,
+                            sequence: event.sequence,
+                            packet,
+                            signers,
+                            deadline,
+                        },
+                    );
+                    state
+                        .signature_id_to_message
+                        .insert(event.sid, event.message);
+                }
+                Packet::Transaction { .. } => {
+                    let deadline = Some(block.saturating_add(self.config.signing_timeout.get()));
+                    state.signing.insert(
+                        event.message,
+                        SigningState::CollectNonceCommitments {
+                            key_share,
+                            signature_id: event.sid,
+                            revealed: BTreeMap::new(),
+                            packet,
+                            signers,
+                            deadline,
+                        },
+                    );
+                    state
+                        .signature_id_to_message
+                        .insert(event.sid, event.message);
+                    commands.push(Command::Effect(Effect::RevealNonceCommitments {
+                        group_id: event.gid,
+                        signature_id: event.sid,
+                        message: event.message,
+                        sequence: event.sequence,
+                    }));
+                }
+            },
+            Some(other) => {
+                tracing::warn!(
+                    message = %event.message,
+                    signature_id = %event.sid,
+                    "unexpected sign event for message",
+                );
+                state.signing.insert(event.message, other);
+            }
+            None => {
+                tracing::debug!(
+                    message = %event.message,
+                    signature_id = %event.sid,
+                    "not participating in message signing ceremony",
+                );
+            }
+        }
+
+        (state, commands)
+    }
+
+    /// Publishes this validator's revealed nonce commitment once the
+    /// [`Effect::RevealNonceCommitments`] effect has produced it, entering
+    /// [`SigningState::CollectNonceCommitments`]'s collection round.
+    pub(super) fn handle_nonce_commitments(
+        &self,
+        state: State,
+        signature_id: B256,
+        message: B256,
+        nonces: SignNonces,
+        proof: Vec<B256>,
+    ) -> (State, Commands<State, Self>) {
+        let deadline = match state.signing.get(&message) {
+            Some(SigningState::CollectNonceCommitments {
+                signature_id: sid,
+                deadline,
+                ..
+            }) if *sid == signature_id => *deadline,
+            _ => return (state, Vec::new()),
+        };
+
+        (
+            state,
+            vec![Command::Action(Action::RevealNonceCommitments {
+                signature_id,
+                nonces,
+                proof,
+                expires_at: deadline,
+            })],
+        )
+    }
+}

--- a/crates/validator/src/state/transactions.rs
+++ b/crates/validator/src/state/transactions.rs
@@ -20,11 +20,7 @@ impl Transition {
         block: u64,
         event: &Consensus::TransactionProposed,
     ) -> (State, Commands<State, Self>) {
-        let Some(group) = state
-            .epoch_groups
-            .get(&event.epoch)
-            .filter(|group| group.participants().contains(&self.account))
-        else {
+        let Some(participating_epoch) = state.epochs.get(&event.epoch) else {
             return (state, Vec::new());
         };
 
@@ -42,11 +38,12 @@ impl Transition {
                 transaction: event.transaction.clone(),
             };
 
-            let signers = group.participants().clone();
+            let signers = participating_epoch.group.participants().clone();
             let deadline = Some(block.saturating_add(self.config.signing_timeout.get()));
 
             let signing_state = if checks::check_transaction(&event.transaction) {
                 SigningState::WaitingForRequest {
+                    key_share: participating_epoch.key_share.clone(),
                     packet,
                     signers,
                     deadline,
@@ -121,10 +118,11 @@ impl Transition {
         block: u64,
         event: &Consensus::OracleTransactionProposed,
     ) -> (State, Commands<State, Self>) {
-        let Some(group) = state.epoch_groups.get(&event.epoch).filter(|group| {
-            group.participants().contains(&self.account)
-                && self.config.oracles.contains(&event.oracle)
-        }) else {
+        let Some(participating_epoch) = state
+            .epochs
+            .get(&event.epoch)
+            .filter(|_| self.config.oracles.contains(&event.oracle))
+        else {
             return (state, Vec::new());
         };
 
@@ -142,10 +140,11 @@ impl Transition {
                 oracle: event.oracle,
                 transaction: event.transaction.clone(),
             };
-            let signers = group.participants().clone();
+            let signers = participating_epoch.group.participants().clone();
             let deadline = Some(block.saturating_add(self.config.signing_timeout.get()));
 
             signing.insert(SigningState::WaitingForRequest {
+                key_share: participating_epoch.key_share.clone(),
                 packet,
                 signers,
                 deadline,
@@ -199,7 +198,9 @@ impl SigningState {
     /// have been assigned yet.
     fn signature_id(&self) -> Option<B256> {
         match self {
-            SigningState::WaitingForAttestation { signature_id } => Some(*signature_id),
+            SigningState::WaitingForAttestation { signature_id, .. }
+            | SigningState::WaitingForOracle { signature_id, .. }
+            | SigningState::CollectNonceCommitments { signature_id, .. } => Some(*signature_id),
             SigningState::WaitingForRequest { .. } | SigningState::WaitingToDecline { .. } => None,
         }
     }


### PR DESCRIPTION
### Context and Motivation

Adds the initial signing flow: handling signing requests, declining invalid transactions, revealing nonce commitments.

### Decisions and Tradeoffs

- Key shares use `Arc<KeyShare>` so active ceremonies retain handles after their epoch rotates out and is removed (this simplifies epoch pruning logic later on).
- Only participating epochs are retained because non-participating epochs have no key share or signing work for this validator.

### Port

Partial port of:

https://github.com/safe-research/safenet/blob/4c3188fd65d977c17c5e26c4785ec7eb8193f2a5/validator/src/machine/signing/sign.ts#L20-L84

> [!TIP]
> We currently do not deal with nonce topup like in the TS handler linked above. Additionally, we have implicit participation checks by being in the `WaitingForRequest` state.

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://docs.safefoundation.org/cla).
