### PR TITLE
[D 3iv]: Handle Revealed Nonces

### DIFF
--- a/crates/validator/src/bindings.rs
+++ b/crates/validator/src/bindings.rs
@@ -97,7 +97,7 @@ sol! {
     }
 
     /// Callback target and context for the `*WithCallback` coordinator calls.
-    #[derive(Debug, Default)]
+    #[derive(Debug, Default, PartialEq, Eq)]
     struct Callback {
         address target;
         bytes context;

--- a/crates/validator/src/frost/preprocess.rs
+++ b/crates/validator/src/frost/preprocess.rs
@@ -5,6 +5,8 @@
 //! revealing a single nonce needs only that one entry rather than the whole
 //! chunk resident in memory.
 
+use std::fmt::Debug;
+
 use super::{keygen::KeyShare, marshal};
 use crate::{
     bindings,
@@ -56,6 +58,15 @@ impl Nonces {
     /// share.
     pub(super) fn signing_nonces(&self) -> &round1::SigningNonces {
         &self.signing_nonces
+    }
+}
+
+impl Debug for Nonces {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Nonces")
+            .field("signing_nonces", &"<redacted>")
+            .field("proof", &self.proof)
+            .finish()
     }
 }
 

--- a/crates/validator/src/service/action.rs
+++ b/crates/validator/src/service/action.rs
@@ -68,6 +68,16 @@ pub enum Action {
         signature_id: B256,
         expires_at: Option<u64>,
     },
+    /// An action to publish this validator's signature share, along with the
+    /// callback invoked once the group's signature completes.
+    SignShare {
+        signature_id: B256,
+        selection: bindings::SignSelection,
+        share: bindings::SignatureShare,
+        proof: Vec<B256>,
+        callback: bindings::Callback,
+        expires_at: Option<u64>,
+    },
 }
 
 /// Encodes [`Action`]s into the transactions the queue submits.
@@ -227,6 +237,30 @@ impl ActionEncoder<Action> for Encoder {
                         .abi_encode()
                         .into(),
                     gas: 150_000,
+                },
+                expires_at,
+            ),
+            Action::SignShare {
+                signature_id,
+                selection,
+                share,
+                proof,
+                callback,
+                expires_at,
+            } => (
+                Transaction {
+                    to: self.coordinator,
+                    value: U256::ZERO,
+                    data: Coordinator::signShareWithCallbackCall {
+                        sid: signature_id,
+                        selection,
+                        share,
+                        proof,
+                        callback,
+                    }
+                    .abi_encode()
+                    .into(),
+                    gas: 350_000,
                 },
                 expires_at,
             ),

--- a/crates/validator/src/service/effect.rs
+++ b/crates/validator/src/service/effect.rs
@@ -5,6 +5,7 @@ use crate::{
     frost::{
         self,
         keygen::{KeyShare, Secrets},
+        preprocess::Nonces,
     },
     secrets::SecretStore,
 };
@@ -46,6 +47,13 @@ pub enum Effect {
         message: B256,
         sequence: u64,
     },
+    /// Use this validator's own nonce for the signing round at `sequence`.
+    /// Once the nonce is taken, it is burned and can no longer be used.
+    UseNonce {
+        group_id: B256,
+        message: B256,
+        sequence: u64,
+    },
 }
 
 /// The result of performing an [`Effect`], resumed into the state machine.
@@ -71,6 +79,8 @@ pub enum Resume {
         nonces: bindings::SignNonces,
         proof: Vec<B256>,
     },
+    /// Resume with the nonce burned by [`Effect::UseNonce`].
+    Nonce { message: B256, nonces: Nonces },
 }
 
 /// Performs the validator's [`Effect`]s, resuming with a [`Resume`].
@@ -150,6 +160,23 @@ impl Handler {
                     })
                     // The nonce was not generated, used up, or the tree isn't
                     // linked yet; nothing to reveal.
+                    .unwrap_or(Resume::Noop);
+                Ok(result)
+            }
+            Effect::UseNonce {
+                group_id,
+                message,
+                sequence,
+            } => {
+                let (chunk, offset) = frost::preprocess::decode_sequence(sequence);
+                let result = self
+                    .secrets
+                    .take_nonce(group_id, self.account, chunk, offset)
+                    .await?
+                    .map(|nonces| Resume::Nonce { message, nonces })
+                    // The nonce was already burned, for example by a reorg
+                    // replaying this effect; gracefully no-op instead of
+                    // producing a duplicate signature share.
                     .unwrap_or(Resume::Noop);
                 Ok(result)
             }

--- a/crates/validator/src/state/mod.rs
+++ b/crates/validator/src/state/mod.rs
@@ -288,8 +288,12 @@ enum SigningState {
     CollectNonceCommitments {
         /// The key share for participating in the signing ceremony.
         key_share: Arc<KeyShare>,
+        /// The group generating the signature.
+        group_id: B256,
         /// The signature id assigned to this signing round.
         signature_id: B256,
+        /// The nonce sequence number assigned to this signing round.
+        sequence: u64,
         /// Verified revealed nonce commitments received from peers so far.
         revealed: BTreeMap<Address, RevealedNonces>,
         /// The packet being signed.
@@ -298,6 +302,26 @@ enum SigningState {
         signers: BTreeSet<Address>,
         /// The block by which the commitment round must complete. `None` to
         /// indicate that there is no deadline.
+        deadline: Option<u64>,
+    },
+    /// Every signer's nonce commitment has been revealed and this
+    /// validator's own signature share is being produced; waiting for the
+    /// [`Effect::UseNonce`] effect to complete before it can be published.
+    CollectSigningShares {
+        /// The key share for participating in the signing ceremony.
+        key_share: Arc<KeyShare>,
+        /// The group generating the signature.
+        group_id: B256,
+        /// The signature id assigned to this signing round.
+        signature_id: B256,
+        /// Verified revealed nonce commitments received from peers so far.
+        revealed: BTreeMap<Address, RevealedNonces>,
+        /// The packet being signed.
+        packet: Packet,
+        /// The group members expected to take part in signing.
+        signers: BTreeSet<Address>,
+        /// The block by which the signature share round must complete.
+        /// `None` to indicate that there is no deadline.
         deadline: Option<u64>,
     },
     /// A complete group signature was produced; waiting for the attestation
@@ -371,6 +395,9 @@ impl StateTransition<State> for Transition {
                 Event::Coordinator(Coordinator::CoordinatorEvents::Sign(event)) => {
                     self.handle_sign(state, log.block, &event)
                 }
+                Event::Coordinator(Coordinator::CoordinatorEvents::SignRevealedNonces(event)) => {
+                    self.handle_sign_revealed_nonces(state, log.block, &event)
+                }
                 Event::Consensus(Consensus::ConsensusEvents::TransactionProposed(event)) => {
                     self.handle_transaction_proposed(state, log.block, &event)
                 }
@@ -406,6 +433,7 @@ impl StateTransition<State> for Transition {
                     nonces,
                     proof,
                 } => self.handle_nonce_commitments(state, signature_id, message, nonces, proof),
+                Resume::Nonce { message, nonces } => self.handle_nonces(state, message, nonces),
             },
         }
     }

--- a/crates/validator/src/state/sign.rs
+++ b/crates/validator/src/state/sign.rs
@@ -1,9 +1,14 @@
 use super::{Packet, SigningState, State, Transition};
 use crate::{
-    bindings::{Coordinator, Oracle, SignNonces},
+    bindings::{self, Consensus, Coordinator, Oracle, SignNonces},
+    consensus::hashing,
+    frost::{self, preprocess::Nonces},
     service::{Action, Effect},
 };
-use alloy::primitives::{Address, B256};
+use alloy::{
+    primitives::{Address, B256},
+    sol_types::SolCall as _,
+};
 use safenet_core::state::{Command, Commands};
 use std::collections::BTreeMap;
 
@@ -54,7 +59,9 @@ impl Transition {
                         event.message,
                         SigningState::CollectNonceCommitments {
                             key_share,
+                            group_id: event.gid,
                             signature_id: event.sid,
+                            sequence: event.sequence,
                             revealed: BTreeMap::new(),
                             packet,
                             signers,
@@ -152,7 +159,9 @@ impl Transition {
                     event.requestId,
                     SigningState::CollectNonceCommitments {
                         key_share,
+                        group_id,
                         signature_id,
+                        sequence,
                         revealed: BTreeMap::new(),
                         packet,
                         signers,
@@ -189,6 +198,200 @@ impl Transition {
                 (state, Vec::new())
             }
             None => (state, Vec::new()),
+        }
+    }
+
+    /// Tracks a peer's revealed nonce commitment. Once every expected signer
+    /// has revealed, enters [`SigningState::CollectSigningShares`] and
+    /// dispatches the [`Effect::UseNonce`] effect to burn this validator's own
+    /// nonce and produce a signature share from the now-complete set of
+    /// revealed commitments.
+    pub(super) fn handle_sign_revealed_nonces(
+        &self,
+        mut state: State,
+        block: u64,
+        event: &Coordinator::SignRevealedNonces,
+    ) -> (State, Commands<State, Self>) {
+        let Some(&message) = state.signature_id_to_message.get(&event.sid) else {
+            return (state, Vec::new());
+        };
+
+        match state.signing.remove(&message) {
+            Some(SigningState::CollectNonceCommitments {
+                key_share,
+                group_id,
+                signature_id,
+                sequence,
+                mut revealed,
+                packet,
+                signers,
+                deadline,
+            }) => {
+                match signers
+                    .contains(&event.participant)
+                    .then(|| frost::sign::verify_revealed_nonces(event.participant, &event.nonces))
+                {
+                    Some(Ok(nonces)) => {
+                        revealed.insert(event.participant, nonces);
+                    }
+                    Some(Err(err)) => {
+                        tracing::warn!(
+                            signature_id = %signature_id,
+                            participant = %event.participant,
+                            %err,
+                            "ignoring invalid revealed nonce commitment",
+                        );
+                    }
+                    None => {
+                        tracing::warn!(
+                            signature_id = %signature_id,
+                            participant = %event.participant,
+                            signing_selection = ?signers,
+                            "ignoring nonce commitment from participant not in signing selection",
+                        );
+                    }
+                }
+
+                if revealed.len() < signers.len() {
+                    state.signing.insert(
+                        message,
+                        SigningState::CollectNonceCommitments {
+                            key_share,
+                            group_id,
+                            signature_id,
+                            sequence,
+                            revealed,
+                            packet,
+                            signers,
+                            deadline,
+                        },
+                    );
+                    return (state, Vec::new());
+                }
+
+                let deadline = Some(block.saturating_add(self.config.signing_timeout.get()));
+                state.signing.insert(
+                    message,
+                    SigningState::CollectSigningShares {
+                        key_share,
+                        group_id,
+                        signature_id,
+                        revealed,
+                        packet,
+                        signers,
+                        deadline,
+                    },
+                );
+
+                (
+                    state,
+                    vec![Command::Effect(Effect::UseNonce {
+                        group_id,
+                        message,
+                        sequence,
+                    })],
+                )
+            }
+            Some(other) => {
+                state.signing.insert(message, other);
+                (state, Vec::new())
+            }
+            None => (state, Vec::new()),
+        }
+    }
+
+    /// Publishes this validator's signature share once the
+    /// [`Effect::UseNonce`] effect has produced it, attaching the packet's
+    /// completion callback (`attestTransaction`/`attestOracleTransaction`) so
+    /// the group's completed signature carries out its onchain effect
+    /// automatically.
+    pub(super) fn handle_nonces(
+        &self,
+        state: State,
+        message: B256,
+        nonces: Nonces,
+    ) -> (State, Commands<State, Self>) {
+        let Some(SigningState::CollectSigningShares {
+            key_share,
+            signature_id,
+            revealed,
+            packet,
+            deadline,
+            ..
+        }) = state.signing.get(&message)
+        else {
+            return (state, Vec::new());
+        };
+
+        let result = match frost::sign::signature_share(key_share, nonces, revealed, &message) {
+            Ok(result) => result,
+            Err(err) => {
+                tracing::warn!(
+                    %message,
+                    %signature_id,
+                    %err,
+                    "failed to compute signature shares for signing ceremony"
+                );
+                return (state, Vec::new());
+            }
+        };
+
+        let signature_id = *signature_id;
+        let callback = packet.attestation_callback(self.config.consensus);
+        let expires_at = *deadline;
+
+        (
+            state,
+            vec![Command::Action(Action::SignShare {
+                signature_id,
+                selection: result.selection,
+                share: result.share,
+                proof: result.proof,
+                callback,
+                expires_at,
+            })],
+        )
+    }
+}
+
+impl Packet {
+    /// Builds the callback invoked once this packet's group signature
+    /// completes: `attestTransaction`/`attestOracleTransaction` calldata
+    /// targeting the `Consensus` contract. The signature id argument is left
+    /// as a zero placeholder - the `Consensus` contract fills it in itself
+    /// when it invokes the callback from a completed `signShareWithCallback`.
+    fn attestation_callback(&self, consensus: Address) -> bindings::Callback {
+        let (epoch, oracle, transaction) = match self {
+            Packet::Transaction { epoch, transaction } => (*epoch, None, transaction),
+            Packet::OracleTransaction {
+                epoch,
+                oracle,
+                transaction,
+            } => (*epoch, Some(*oracle), transaction),
+        };
+        let safe_tx_struct_hash = hashing::safe_tx_hash(transaction);
+        let context = match oracle {
+            None => Consensus::attestTransactionCall {
+                epoch: epoch.raw_value(),
+                chainId: transaction.chainId,
+                safe: transaction.safe,
+                safeTxStructHash: safe_tx_struct_hash,
+                signatureId: B256::ZERO,
+            }
+            .abi_encode(),
+            Some(oracle) => Consensus::attestOracleTransactionCall {
+                epoch: epoch.raw_value(),
+                oracle,
+                chainId: transaction.chainId,
+                safe: transaction.safe,
+                safeTxStructHash: safe_tx_struct_hash,
+                signatureId: B256::ZERO,
+            }
+            .abi_encode(),
+        };
+        bindings::Callback {
+            target: consensus,
+            context: context.into(),
         }
     }
 }

--- a/crates/validator/src/state/transactions.rs
+++ b/crates/validator/src/state/transactions.rs
@@ -200,7 +200,8 @@ impl SigningState {
         match self {
             SigningState::WaitingForAttestation { signature_id, .. }
             | SigningState::WaitingForOracle { signature_id, .. }
-            | SigningState::CollectNonceCommitments { signature_id, .. } => Some(*signature_id),
+            | SigningState::CollectNonceCommitments { signature_id, .. }
+            | SigningState::CollectSigningShares { signature_id, .. } => Some(*signature_id),
             SigningState::WaitingForRequest { .. } | SigningState::WaitingToDecline { .. } => None,
         }
     }

--- a/epics/2026_07_01_rust_validator_port.md
+++ b/epics/2026_07_01_rust_validator_port.md
@@ -683,6 +683,9 @@ attest/stage actions are the timeout fallbacks in D4. Ports `signing/*` + `conse
   D3iv.
 - **D3vi — `SignCompleted`.** `→ WaitingForAttestation`. Ports `signing/completed.ts`. Depends on
   D3v. _(Completes the minimal genesis DKG + one-signing-round flow the F1 interop test drives.)_
+- **D3vii.** Revisit nonce topup, it needs to be done in a wholistic way (we need to be able to
+  topup nonces for all participating groups, even for signing ceremonies for which we do not care
+  for; I suspect the correct way is to use the secret store).
 
 **D4 — Epoch rollover & timeouts.** The block-driven epoch machine, the non-genesis DKG trigger, and
 all `NewBlock` timeout checks — reusing the D3 signing FSM for the rollover packet. Ports


### PR DESCRIPTION
### Context and Motivation

This PR handles nonce commitment receipt events, and once sufficient nonce commitments are received, produces a signature share onchain.

### Decisions and Tradeoffs

Nonces are produced using effects. This is required since they get burned on first use, which means that repeated state transitions can fail to progress. Note that the action submission logic (which will re-submit transactions onchain post reorg) will ensure that the secret share transaction will be pushed back on chain, allowing the signing ceremony to continue in case of reorgs as long as in the new canonical chain the signing sequence did not change.

### Port

https://github.com/safe-research/safenet/blob/4c3188fd65d977c17c5e26c4785ec7eb8193f2a5/validator/src/machine/signing/nonces.ts#L10-L113

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://docs.safefoundation.org/cla).
