### PR TITLE
[D 3v]: Handle Signature Share Collection and Completion

### DIFF
--- a/crates/validator/src/merkle.rs
+++ b/crates/validator/src/merkle.rs
@@ -62,7 +62,7 @@ impl MerkleTree {
 }
 
 /// A Merkle root that can be used to verify a proof.
-#[derive(Clone, Copy, Debug, Default, Eq, PartialEq, Deserialize, Serialize)]
+#[derive(Clone, Copy, Debug, Default, Eq, Ord, PartialEq, PartialOrd, Deserialize, Serialize)]
 #[serde(transparent)]
 pub struct MerkleRoot(pub B256);
 

--- a/crates/validator/src/state/mod.rs
+++ b/crates/validator/src/state/mod.rs
@@ -20,6 +20,7 @@ use crate::{
         },
         sign::RevealedNonces,
     },
+    merkle::MerkleRoot,
     service::{Action, Effect, Event, Resume},
 };
 use alloy::primitives::{Address, B256};
@@ -316,6 +317,8 @@ enum SigningState {
         signature_id: B256,
         /// Verified revealed nonce commitments received from peers so far.
         revealed: BTreeMap<Address, RevealedNonces>,
+        /// The signing selections.
+        selections: BTreeMap<MerkleRoot, SigningSelection>,
         /// The packet being signed.
         packet: Packet,
         /// The group members expected to take part in signing.
@@ -329,6 +332,11 @@ enum SigningState {
     WaitingForAttestation {
         /// The signature id the completed signing round produced.
         signature_id: B256,
+        /// The participant responsible for submitting the attestation, or
+        /// `None` if unknown, in which case every participant is responsible.
+        responsible: Option<Address>,
+        /// The packet being signed.
+        packet: Packet,
         /// The block by which the signing attestation must arrive.
         deadline: Option<u64>,
     },
@@ -340,6 +348,16 @@ enum SigningState {
         /// indicate that there is no deadline.
         deadline: Option<u64>,
     },
+}
+
+/// A Signing selection.
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
+struct SigningSelection {
+    /// The participants that have published their signature share to this
+    /// selection root.
+    shares_from: BTreeSet<Address>,
+    /// The last participant to publish a signature share, if any.
+    last_signer: Option<Address>,
 }
 
 /// The pure validator state transition.
@@ -397,6 +415,12 @@ impl StateTransition<State> for Transition {
                 }
                 Event::Coordinator(Coordinator::CoordinatorEvents::SignRevealedNonces(event)) => {
                     self.handle_sign_revealed_nonces(state, log.block, &event)
+                }
+                Event::Coordinator(Coordinator::CoordinatorEvents::SignShared(event)) => {
+                    self.handle_sign_shared(state, &event)
+                }
+                Event::Coordinator(Coordinator::CoordinatorEvents::SignCompleted(event)) => {
+                    self.handle_sign_completed(state, log.block, &event)
                 }
                 Event::Consensus(Consensus::ConsensusEvents::TransactionProposed(event)) => {
                     self.handle_transaction_proposed(state, log.block, &event)

--- a/crates/validator/src/state/sign.rs
+++ b/crates/validator/src/state/sign.rs
@@ -3,6 +3,7 @@ use crate::{
     bindings::{self, Consensus, Coordinator, Oracle, SignNonces},
     consensus::hashing,
     frost::{self, preprocess::Nonces},
+    merkle::MerkleRoot,
     service::{Action, Effect},
 };
 use alloy::{
@@ -277,6 +278,7 @@ impl Transition {
                         group_id,
                         signature_id,
                         revealed,
+                        selections: BTreeMap::new(),
                         packet,
                         signers,
                         deadline,
@@ -351,6 +353,91 @@ impl Transition {
                 expires_at,
             })],
         )
+    }
+
+    /// Tracks a peer's published signature share against a tracked
+    /// [`SigningState::CollectSigningShares`] round. A share for anything else
+    /// (untracked, already completed, or a different round entirely) is
+    /// ignored.
+    pub(super) fn handle_sign_shared(
+        &self,
+        mut state: State,
+        event: &Coordinator::SignShared,
+    ) -> (State, Commands<State, Self>) {
+        let Some(&message) = state.signature_id_to_message.get(&event.sid) else {
+            return (state, Vec::new());
+        };
+
+        if let Some(SigningState::CollectSigningShares { selections, .. }) =
+            state.signing.get_mut(&message)
+        {
+            let selection_root = MerkleRoot(event.selectionRoot);
+            let selection = selections.entry(selection_root).or_default();
+
+            // Note that we do not verify whether or not `participant` is part
+            // of our `signers` list. The contract already verifies that they
+            // are part of the group, and it would not be possible for them to
+            // submit a share to the same selection root as we did (because of
+            // the Merkle inclusion proof that is verified onchain).
+            selection.shares_from.insert(event.participant);
+            selection.last_signer = Some(event.participant);
+        }
+
+        (state, Vec::new())
+    }
+
+    /// Completes a tracked [`SigningState::CollectSigningShares`] round,
+    /// entering [`SigningState::WaitingForAttestation`]. The participant
+    /// responsible for submitting the attestation is the last one to have
+    /// published a share against the completed selection root, or unknown
+    /// (in which case every participant is responsible) if this validator
+    /// never observed a share for that particular selection.
+    pub(super) fn handle_sign_completed(
+        &self,
+        mut state: State,
+        block: u64,
+        event: &Coordinator::SignCompleted,
+    ) -> (State, Commands<State, Self>) {
+        let Some(&message) = state.signature_id_to_message.get(&event.sid) else {
+            return (state, Vec::new());
+        };
+
+        match state.signing.remove(&message) {
+            Some(SigningState::CollectSigningShares {
+                signature_id,
+                selections,
+                packet,
+                ..
+            }) => {
+                let responsible = selections
+                    .get(&MerkleRoot(event.selectionRoot))
+                    .and_then(|selection| selection.last_signer);
+                if responsible.is_none() {
+                    tracing::warn!(
+                        %signature_id,
+                        selection_root = %event.selectionRoot,
+                        "signing ceremony completed under an unobserved selection",
+                    );
+                }
+
+                let deadline = Some(block.saturating_add(self.config.signing_timeout.get()));
+                state.signing.insert(
+                    message,
+                    SigningState::WaitingForAttestation {
+                        signature_id,
+                        responsible,
+                        packet,
+                        deadline,
+                    },
+                );
+                (state, Vec::new())
+            }
+            Some(other) => {
+                state.signing.insert(message, other);
+                (state, Vec::new())
+            }
+            None => (state, Vec::new()),
+        }
     }
 }
 


### PR DESCRIPTION
### Context and Motivation

This PR handles completing signing ceremonies by tracking the `SignShared` and `SignCompleted` events.

### Decisions and Tradeoffs

> [!IMPORTANT]
> Unlike the TypeScript version, we track share participation by selection root. This is important in order to prevent malicious signers from submitting shares to the incorrect selection root, but still being included in the restarted signing ceremony (since the TypeScript version considers anyone that submitted a share as participating and being included in the rebooted signing selection - [source](https://github.com/safe-research/safenet/blob/4c3188fd65d977c17c5e26c4785ec7eb8193f2a5/validator/src/machine/signing/timeouts.ts#L188-L191)).

### Port

https://github.com/safe-research/safenet/blob/4c3188fd65d977c17c5e26c4785ec7eb8193f2a5/validator/src/machine/signing/shares.ts#L10-L27

https://github.com/safe-research/safenet/blob/4c3188fd65d977c17c5e26c4785ec7eb8193f2a5/validator/src/machine/signing/completed.ts#L10-L31

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://docs.safefoundation.org/cla).
