### PR TITLE
[D 3vi]: Nonce Topup

### DIFF
--- a/crates/validator/src/consensus/epoch.rs
+++ b/crates/validator/src/consensus/epoch.rs
@@ -1,14 +1,32 @@
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use std::{cmp::Ordering, num::NonZeroU64};
 
 /// An epoch ID.
-#[derive(Copy, Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
+#[derive(Copy, Clone, Debug, Default, Eq, PartialEq)]
 pub enum EpochId {
     /// The genesis epoch.
     #[default]
     Genesis,
     /// A regular epoch established after genesis.
     Number { number: NonZeroU64 },
+}
+
+impl Serialize for EpochId {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_u64(self.raw_value())
+    }
+}
+
+impl<'de> Deserialize<'de> for EpochId {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        Ok(Self::from_raw(u64::deserialize(deserializer)?))
+    }
 }
 
 impl EpochId {

--- a/crates/validator/src/secrets.rs
+++ b/crates/validator/src/secrets.rs
@@ -331,24 +331,46 @@ impl SecretStore {
         .map_err(Error::from)
     }
 
-    /// Returns the number of unused nonces in the tree `me` linked to sequence
-    /// `chunk` in `group`, or `0` when no such tree is linked.
+    /// Returns the number of unused nonces in `me`'s trees for `group` from
+    /// sequence `(chunk, offset)` onward (inclusive), summed across every
+    /// linked chunk from `chunk` on, plus any not-yet-linked pending chunk.
+    ///
+    /// A single chunk's count is not enough to answer "how many usable
+    /// nonces are left": the group's sequence counter is shared by every
+    /// participant and only ever advances, so once it moves past `chunk`,
+    /// this validator must draw from later chunks regardless of whatever is
+    /// still sitting unused in earlier ones. Summing forward from the given
+    /// position is what actually reflects the remaining usable supply.
+    /// Including the pending (registered but not yet onchain-linked) chunk,
+    /// if any, avoids sampling and registering a needless extra one while a
+    /// top-up is already in flight.
     pub async fn available_nonce_count(
         &self,
         group: B256,
         me: Address,
         chunk: u64,
+        offset: u64,
     ) -> Result<u64, Error> {
+        let chunk = i64::try_from(chunk)?;
+        let offset = i64::try_from(offset)?;
+
         let count = sqlx::query_scalar::<_, i64>(
-            "SELECT COUNT(*) FROM nonces
-             WHERE root = (
-                 SELECT root FROM nonces_chunks
-                 WHERE group_id = ? AND address = ? AND chunk = ?
-             )",
+            "SELECT COUNT(*)
+             FROM nonces AS nonce
+             JOIN nonces_chunks AS chunks ON chunks.root = nonce.root
+             WHERE chunks.group_id = ?
+               AND chunks.address = ?
+               AND (
+                   chunks.chunk IS NULL
+                   OR chunks.chunk > ?
+                   OR (chunks.chunk = ? AND nonce.offs >= ?)
+               )",
         )
         .bind(key(group))
         .bind(key(me))
-        .bind(i64::try_from(chunk)?)
+        .bind(chunk)
+        .bind(chunk)
+        .bind(offset)
         .fetch_one(&self.pool)
         .await?;
         Ok(u64::try_from(count)?)
@@ -391,6 +413,23 @@ mod tests {
 
     fn nonce_chunk(size: u64) -> NonceChunk {
         NonceChunk::with_size(size, &keygen::KeyShare::dummy(), &mut rand::thread_rng()).unwrap()
+    }
+
+    async fn count_chunk_nonces(store: &SecretStore, chunk: u64) -> u64 {
+        let count = sqlx::query_scalar::<_, i64>(
+            "SELECT COUNT(*) FROM nonces
+             WHERE root = (
+                 SELECT root FROM nonces_chunks
+                 WHERE group_id = ? AND address = ? AND chunk = ?
+             )",
+        )
+        .bind(key(GROUP))
+        .bind(key(ME))
+        .bind(i64::try_from(chunk).unwrap())
+        .fetch_one(&store.pool)
+        .await
+        .unwrap();
+        u64::try_from(count).unwrap()
     }
 
     #[tokio::test]
@@ -461,7 +500,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn nonces_chunk_link_and_count() {
+    async fn nonces_chunk_linking() {
         let store = store().await;
         let root = store
             .register_nonces_chunk(GROUP, ME, nonce_chunk(11))
@@ -475,9 +514,9 @@ mod tests {
         assert_eq!(reused, None);
 
         // Until linked to a sequence chunk, it is not addressable by chunk.
-        assert_eq!(store.available_nonce_count(GROUP, ME, 0).await.unwrap(), 0);
+        assert_eq!(count_chunk_nonces(&store, 0).await, 0);
         store.link_nonces_chunk(GROUP, ME, 0, root).await.unwrap();
-        assert_eq!(store.available_nonce_count(GROUP, ME, 0).await.unwrap(), 11);
+        assert_eq!(count_chunk_nonces(&store, 0).await, 11);
 
         // Once linked, a fresh chunk can be registered.
         let other = store
@@ -488,34 +527,98 @@ mod tests {
         assert_ne!(other, root);
 
         // The newly registered chunk starts unlinked.
-        assert_eq!(store.available_nonce_count(GROUP, ME, 0).await.unwrap(), 11);
-        assert_eq!(store.available_nonce_count(GROUP, ME, 1).await.unwrap(), 0);
+        assert_eq!(count_chunk_nonces(&store, 0).await, 11);
+        assert_eq!(count_chunk_nonces(&store, 1).await, 0);
 
         // It can be linked to a chunk.
         store.link_nonces_chunk(GROUP, ME, 1, other).await.unwrap();
-        assert_eq!(store.available_nonce_count(GROUP, ME, 0).await.unwrap(), 11);
-        assert_eq!(store.available_nonce_count(GROUP, ME, 1).await.unwrap(), 13);
-        assert_eq!(store.available_nonce_count(GROUP, ME, 2).await.unwrap(), 0);
+        assert_eq!(count_chunk_nonces(&store, 0).await, 11);
+        assert_eq!(count_chunk_nonces(&store, 1).await, 13);
+        assert_eq!(count_chunk_nonces(&store, 2).await, 0);
 
         // Nonce assignment is idempotent.
         store.link_nonces_chunk(GROUP, ME, 0, root).await.unwrap();
-        assert_eq!(store.available_nonce_count(GROUP, ME, 0).await.unwrap(), 11);
-        assert_eq!(store.available_nonce_count(GROUP, ME, 1).await.unwrap(), 13);
-        assert_eq!(store.available_nonce_count(GROUP, ME, 2).await.unwrap(), 0);
+        assert_eq!(count_chunk_nonces(&store, 0).await, 11);
+        assert_eq!(count_chunk_nonces(&store, 1).await, 13);
+        assert_eq!(count_chunk_nonces(&store, 2).await, 0);
 
         // Canonical replay can reassign a root after a reorg, displacing a
         // stale assignment left by the orphaned chain.
         store.link_nonces_chunk(GROUP, ME, 1, root).await.unwrap();
-        assert_eq!(store.available_nonce_count(GROUP, ME, 0).await.unwrap(), 0);
-        assert_eq!(store.available_nonce_count(GROUP, ME, 1).await.unwrap(), 11);
-        assert_eq!(store.available_nonce_count(GROUP, ME, 2).await.unwrap(), 0);
+        assert_eq!(count_chunk_nonces(&store, 0).await, 0);
+        assert_eq!(count_chunk_nonces(&store, 1).await, 11);
+        assert_eq!(count_chunk_nonces(&store, 2).await, 0);
 
         // The displaced root can itself be assigned by a later canonical
         // event.
         store.link_nonces_chunk(GROUP, ME, 2, other).await.unwrap();
-        assert_eq!(store.available_nonce_count(GROUP, ME, 0).await.unwrap(), 0);
-        assert_eq!(store.available_nonce_count(GROUP, ME, 1).await.unwrap(), 11);
-        assert_eq!(store.available_nonce_count(GROUP, ME, 2).await.unwrap(), 13);
+        assert_eq!(count_chunk_nonces(&store, 0).await, 0);
+        assert_eq!(count_chunk_nonces(&store, 1).await, 11);
+        assert_eq!(count_chunk_nonces(&store, 2).await, 13);
+    }
+
+    #[tokio::test]
+    async fn available_nonce_count_sums_forward_and_includes_pending() {
+        let store = store().await;
+        let root0 = store
+            .register_nonces_chunk(GROUP, ME, nonce_chunk(11))
+            .await
+            .unwrap()
+            .unwrap();
+        store.link_nonces_chunk(GROUP, ME, 0, root0).await.unwrap();
+        let root1 = store
+            .register_nonces_chunk(GROUP, ME, nonce_chunk(13))
+            .await
+            .unwrap()
+            .unwrap();
+        store.link_nonces_chunk(GROUP, ME, 1, root1).await.unwrap();
+
+        // Counting from chunk 0 sums every linked chunk from there on, not
+        // just chunk 0's own count.
+        assert_eq!(
+            store.available_nonce_count(GROUP, ME, 0, 0).await.unwrap(),
+            11 + 13
+        );
+        assert_eq!(
+            store.available_nonce_count(GROUP, ME, 1, 0).await.unwrap(),
+            13
+        );
+        assert_eq!(
+            store.available_nonce_count(GROUP, ME, 2, 0).await.unwrap(),
+            0
+        );
+
+        // An offset into the starting chunk deducts the nonces already
+        // behind it.
+        assert_eq!(
+            store.available_nonce_count(GROUP, ME, 0, 5).await.unwrap(),
+            (11 - 5) + 13
+        );
+
+        // A registered-but-not-yet-linked chunk counts too, regardless of
+        // position, so a top-up in flight is not needlessly duplicated.
+        store
+            .register_nonces_chunk(GROUP, ME, nonce_chunk(7))
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(
+            store.available_nonce_count(GROUP, ME, 0, 0).await.unwrap(),
+            11 + 13 + 7
+        );
+        assert_eq!(
+            store.available_nonce_count(GROUP, ME, 2, 0).await.unwrap(),
+            7
+        );
+
+        // A displaced (orphaned) chunk from a reorg drops out of the running
+        // count entirely: a validator only ever counts forward from its
+        // current position, and the orphan no longer occupies a slot there.
+        store.link_nonces_chunk(GROUP, ME, 1, root0).await.unwrap();
+        assert_eq!(
+            store.available_nonce_count(GROUP, ME, 0, 0).await.unwrap(),
+            11 + 7
+        );
     }
 
     #[tokio::test]
@@ -534,7 +637,7 @@ mod tests {
         assert!(store.take_nonce(GROUP, ME, 0, 2).await.unwrap().is_none());
 
         // The used nonce is gone; the rest of the chunk is untouched.
-        assert_eq!(store.available_nonce_count(GROUP, ME, 0).await.unwrap(), 3);
+        assert_eq!(count_chunk_nonces(&store, 0).await, 3);
         assert!(store.take_nonce(GROUP, ME, 0, 0).await.unwrap().is_some());
     }
 
@@ -564,7 +667,7 @@ mod tests {
                 .unwrap()
                 .is_some()
         );
-        assert_eq!(store.available_nonce_count(GROUP, ME, 0).await.unwrap(), 4);
+        assert_eq!(count_chunk_nonces(&store, 0).await, 4);
         assert!(store.take_nonce(GROUP, ME, 0, 1).await.unwrap().is_some());
 
         // Once taken, there is no nonce left to reveal, nor is an out-of-range

--- a/crates/validator/src/service/effect.rs
+++ b/crates/validator/src/service/effect.rs
@@ -54,7 +54,19 @@ pub enum Effect {
         message: B256,
         sequence: u64,
     },
+    /// Check that at least [`NONCE_TOPUP_THRESHOLD`] nonces remain usable for
+    /// `key_share`'s group from `(chunk, offset)` onward, generating and
+    /// registering a fresh chunk if not.
+    TopupNonces {
+        group_id: B256,
+        key_share: Arc<KeyShare>,
+        sequence: u64,
+    },
 }
+
+/// The remaining usable nonce count, per participating group, below which a
+/// fresh nonce chunk is generated and registered.
+const NONCE_TOPUP_THRESHOLD: u64 = 100;
 
 /// The result of performing an [`Effect`], resumed into the state machine.
 #[allow(clippy::large_enum_variant)]
@@ -113,24 +125,7 @@ impl Handler {
             Effect::NonceTree {
                 group_id,
                 key_share,
-            } => {
-                let mut rng = rand::thread_rng();
-                let chunk = frost::preprocess::NonceChunk::generate(&key_share, &mut rng)?;
-                let result = self
-                    .secrets
-                    .register_nonces_chunk(group_id, self.account, chunk)
-                    .await?
-                    // In case registration worked, then resume with the nonce
-                    // chunk commitment hash so it may be recorded onchain.
-                    .map(|commitment| Resume::NonceTree {
-                        group_id,
-                        commitment,
-                    })
-                    // There is already a pending nonce chunk, and therefore we
-                    // do not want to register a new one.
-                    .unwrap_or(Resume::Noop);
-                Ok(result)
-            }
+            } => self.sample_nonces(group_id, &key_share).await,
             Effect::LinkNonceTree {
                 group_id,
                 chunk,
@@ -180,7 +175,43 @@ impl Handler {
                     .unwrap_or(Resume::Noop);
                 Ok(result)
             }
+            Effect::TopupNonces {
+                group_id,
+                key_share,
+                sequence,
+            } => {
+                let (chunk, offset) = frost::preprocess::decode_sequence(sequence);
+                let available = self
+                    .secrets
+                    .available_nonce_count(group_id, self.account, chunk, offset)
+                    .await?;
+                if available >= NONCE_TOPUP_THRESHOLD {
+                    return Ok(Resume::Noop);
+                }
+                return self.sample_nonces(group_id, &key_share).await;
+            }
         }
+    }
+
+    async fn sample_nonces(
+        &self,
+        group_id: B256,
+        key_share: &KeyShare,
+    ) -> Result<Resume, InternalError> {
+        let mut rng = rand::thread_rng();
+        let nonce_chunk = frost::preprocess::NonceChunk::generate(key_share, &mut rng)?;
+        let result = self
+            .secrets
+            .register_nonces_chunk(group_id, self.account, nonce_chunk)
+            .await?
+            .map(|commitment| Resume::NonceTree {
+                group_id,
+                commitment,
+            })
+            // There is already a pending nonce chunk from an earlier
+            // top-up; do not register a second one.
+            .unwrap_or(Resume::Noop);
+        Ok(result)
     }
 }
 

--- a/crates/validator/src/state/keygen.rs
+++ b/crates/validator/src/state/keygen.rs
@@ -410,7 +410,7 @@ impl Transition {
                         let group_id = group.id();
                         let commands = if let KeyGenConfirmation::Confirmed(key_share) = status {
                             state.epochs.insert(
-                                next_epoch.raw_value(),
+                                next_epoch,
                                 Epoch {
                                     group,
                                     key_share: key_share.clone(),

--- a/crates/validator/src/state/mod.rs
+++ b/crates/validator/src/state/mod.rs
@@ -41,7 +41,7 @@ pub struct State {
     /// their key generation, keyed by epoch number and retained past
     /// `EpochStaged` so later handlers can look up a resolved group and the
     /// generated key share.
-    epochs: BTreeMap<u64, Epoch>,
+    epochs: BTreeMap<EpochId, Epoch>,
     /// The signing sessions tracked so far, keyed by the message hash the
     /// group signature attests to.
     signing: BTreeMap<B256, SigningState>,

--- a/crates/validator/src/state/sign.rs
+++ b/crates/validator/src/state/sign.rs
@@ -22,6 +22,26 @@ impl Transition {
         event: &Coordinator::Sign,
     ) -> (State, Commands<State, Self>) {
         let mut commands = Vec::new();
+
+        // Unconditionally top up the group's nonce stock, regardless of
+        // whether this validator is one of the selected signers: the
+        // sequence is shared by every participant and only ever advances, so
+        // it can run past this validator's local nonces even for signing
+        // ceremonies it was never asked to take part in. `epochs` is small
+        // (a handful of entries at most in regular operation), so a linear
+        // scan for the matching group is fine.
+        if let Some(epoch) = state
+            .epochs
+            .values()
+            .find(|epoch| epoch.group.id() == event.gid)
+        {
+            commands.push(Command::Effect(Effect::TopupNonces {
+                group_id: event.gid,
+                key_share: epoch.key_share.clone(),
+                sequence: event.sequence,
+            }));
+        }
+
         match state.signing.remove(&event.message) {
             Some(SigningState::WaitingToDecline { deadline, .. }) => {
                 commands.push(Command::Action(Action::SignDecline {

--- a/crates/validator/src/state/transactions.rs
+++ b/crates/validator/src/state/transactions.rs
@@ -20,11 +20,11 @@ impl Transition {
         block: u64,
         event: &Consensus::TransactionProposed,
     ) -> (State, Commands<State, Self>) {
-        let Some(participating_epoch) = state.epochs.get(&event.epoch) else {
+        let epoch = EpochId::from_raw(event.epoch);
+        let Some(participating_epoch) = state.epochs.get(&epoch) else {
             return (state, Vec::new());
         };
 
-        let epoch = EpochId::from_raw(event.epoch);
         let message = self
             .consensus
             .transaction_packet_hash(epoch, &event.transaction);
@@ -118,15 +118,15 @@ impl Transition {
         block: u64,
         event: &Consensus::OracleTransactionProposed,
     ) -> (State, Commands<State, Self>) {
+        let epoch = EpochId::from_raw(event.epoch);
         let Some(participating_epoch) = state
             .epochs
-            .get(&event.epoch)
+            .get(&epoch)
             .filter(|_| self.config.oracles.contains(&event.oracle))
         else {
             return (state, Vec::new());
         };
 
-        let epoch = EpochId::from_raw(event.epoch);
         let message =
             self.consensus
                 .oracle_transaction_packet_hash(epoch, event.oracle, &event.transaction);

--- a/epics/2026_07_01_rust_validator_port.md
+++ b/epics/2026_07_01_rust_validator_port.md
@@ -679,11 +679,9 @@ attest/stage actions are the timeout fallbacks in D4. Ports `signing/*` + `conse
   `SignShare` action (carrying the transaction/oracle attestation callback; the rollover `stageEpoch`
   callback branch lands with D4iii). Ports `signing/nonces.ts` (`handleRevealedNonces`). Depends on
   B5, C1, D3ii.
-- **D3v — `SignShared`.** Track collected signature shares. Ports `signing/shares.ts`. Depends on
-  D3iv.
-- **D3vi — `SignCompleted`.** `→ WaitingForAttestation`. Ports `signing/completed.ts`. Depends on
-  D3v. _(Completes the minimal genesis DKG + one-signing-round flow the F1 interop test drives.)_
-- **D3vii.** Revisit nonce topup, it needs to be done in a wholistic way (we need to be able to
+- **D3v — `SignShared` + `SignCompleted`.** Track collected signature shares. Ports `signing/shares.ts`. Depends on
+  D3iv. Completed `→ WaitingForAttestation`. Ports `signing/completed.ts`.
+- **D3vi.** Revisit nonce topup, it needs to be done in a wholistic way (we need to be able to
   topup nonces for all participating groups, even for signing ceremonies for which we do not care
   for; I suspect the correct way is to use the secret store).
 


### PR DESCRIPTION
### Context and Motivation

The preprocessed nonces eventually run out and need to be topped up. This PR adds an effect that is called on _every_ signing ceremony to determine whether or not a nonce topup is needed.

### Decisions and Tradeoffs

We needed to check for nonce topups on every signing ceremony, since _any_ signing ceremony increments the sequence (and not just the ones we want to participate in). The counting of the nonces was implemented in SQLite directly, instead of looping and counting multiple linked chunks.

> [!IMPORTANT]
> Unlike the TypeScript implementation, we do not just top up nonces for the active group. This is needed for edge cases for signing ceremonies that started in the previous epoch but get restarted (because of a timeout for example) after the epoch rotation.

I took the opportunity to fix the typing on the `epochs` map (keyed by EpochId instead of u64).

### Port

https://github.com/safe-research/safenet/blob/4c3188fd65d977c17c5e26c4785ec7eb8193f2a5/validator/src/machine/signing/sign.ts#L100-L129

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://docs.safefoundation.org/cla).
