### PR TITLE
[D 3vii]: Hook Up Epoch Rollover Signing

### DIFF
--- a/crates/validator/src/consensus/epoch.rs
+++ b/crates/validator/src/consensus/epoch.rs
@@ -1,6 +1,13 @@
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use std::{cmp::Ordering, num::NonZeroU64};
 
+/// Returns the next epoch number for `block`, given the configured number of
+/// blocks per epoch.
+pub const fn next_number(block: u64, blocks_per_epoch: NonZeroU64) -> NonZeroU64 {
+    let number = block / blocks_per_epoch.get();
+    NonZeroU64::MIN.saturating_add(number)
+}
+
 /// An epoch ID.
 #[derive(Copy, Clone, Debug, Default, Eq, PartialEq)]
 pub enum EpochId {
@@ -57,5 +64,24 @@ impl PartialOrd for EpochId {
 impl Ord for EpochId {
     fn cmp(&self, other: &Self) -> Ordering {
         u64::cmp(&self.raw_value(), &other.raw_value())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn computes_next_epoch_number_from_block() {
+        let blocks_per_epoch = NonZeroU64::new(100).unwrap();
+
+        assert_eq!(next_number(0, blocks_per_epoch).get(), 1);
+        assert_eq!(next_number(99, blocks_per_epoch).get(), 1);
+        assert_eq!(next_number(100, blocks_per_epoch).get(), 2);
+        assert_eq!(next_number(199, blocks_per_epoch).get(), 2);
+        assert_eq!(
+            next_number(u64::MAX, blocks_per_epoch).get(),
+            u64::MAX / 100 + 1
+        );
     }
 }

--- a/crates/validator/src/consensus/hashing.rs
+++ b/crates/validator/src/consensus/hashing.rs
@@ -7,8 +7,6 @@
 //! contract lives on, and the contract's own address). The latter hash is
 //! the message a validator group's FROST signature actually attests to.
 
-#![cfg_attr(not(test), expect(dead_code))]
-
 use crate::{
     bindings::{Point, SafeTransaction},
     consensus::epoch::EpochId,

--- a/crates/validator/src/frost/keygen.rs
+++ b/crates/validator/src/frost/keygen.rs
@@ -112,6 +112,11 @@ impl GroupCommitments {
     pub(super) fn verifying_key(&self) -> &VerifyingKey {
         &self.verifying_key
     }
+
+    /// Returns the group public key in its onchain representation.
+    pub fn group_key(&self) -> bindings::Point {
+        marshal::solidity_point(&self.verifying_key.to_element())
+    }
 }
 
 /// Derives the group's public key from every participant's verified

--- a/crates/validator/src/service/action.rs
+++ b/crates/validator/src/service/action.rs
@@ -38,6 +38,7 @@ pub enum Action {
     /// An action to confirm participation in a completed key generation.
     KeyGenConfirm {
         group_id: B256,
+        callback: Option<bindings::Callback>,
         expires_at: Option<u64>,
     },
     /// An action to reveal a unencrypted secret share, in response to a
@@ -155,18 +156,33 @@ impl ActionEncoder<Action> for Encoder {
             ),
             Action::KeyGenConfirm {
                 group_id,
+                callback,
                 expires_at,
-            } => (
-                Transaction {
-                    to: self.coordinator,
-                    value: U256::ZERO,
-                    data: Coordinator::keyGenConfirmCall { gid: group_id }
-                        .abi_encode()
-                        .into(),
-                    gas: 200_000,
-                },
-                expires_at,
-            ),
+            } => {
+                let (data, gas) = match callback {
+                    Some(callback) => (
+                        Coordinator::keyGenConfirmWithCallbackCall {
+                            gid: group_id,
+                            callback,
+                        }
+                        .abi_encode(),
+                        300_000,
+                    ),
+                    None => (
+                        Coordinator::keyGenConfirmCall { gid: group_id }.abi_encode(),
+                        200_000,
+                    ),
+                };
+                (
+                    Transaction {
+                        to: self.coordinator,
+                        value: U256::ZERO,
+                        data: data.into(),
+                        gas,
+                    },
+                    expires_at,
+                )
+            }
             Action::KeyGenComplaintResponse {
                 group_id,
                 plaintiff,

--- a/crates/validator/src/state/keygen.rs
+++ b/crates/validator/src/state/keygen.rs
@@ -1,8 +1,11 @@
-use super::{Epoch, Prune, RolloverState, State, Transition};
+use super::{
+    ConfirmationDeadlines, Epoch, KeyGenConfirmation, KeyGenParticipation, Packet, Prune,
+    RolloverState, SigningState, State, Transition,
+};
 use crate::{
     bindings::Coordinator,
     consensus::{
-        epoch::EpochId,
+        epoch::{self, EpochId},
         group::{self, ParticipantSet},
     },
     frost::{
@@ -10,9 +13,11 @@ use crate::{
         keygen::{GroupCommitments, Secrets},
     },
     service::{Action, Effect},
-    state::{ConfirmationDeadlines, KeyGenConfirmation, KeyGenParticipation},
 };
-use alloy::primitives::{Address, B256};
+use alloy::{
+    primitives::{Address, B256},
+    sol_types::SolValue as _,
+};
 use safenet_core::state::{Command, Commands};
 use std::{
     collections::{BTreeMap, BTreeSet},
@@ -326,6 +331,7 @@ impl Transition {
                             Ok(key_share) => {
                                 commands.push(Command::Action(Action::KeyGenConfirm {
                                     group_id: group.id(),
+                                    callback: self.key_gen_confirmation_callback(next_epoch),
                                     expires_at: deadlines
                                         .as_ref()
                                         .map(|deadlines| deadlines.confirm),
@@ -405,10 +411,12 @@ impl Transition {
                 }
 
                 match next_epoch {
-                    // On genesis: the group is confirmed it is ready to go.
+                    // On genesis: retain the active key, start preprocessing,
+                    // and immediately begin key generation for the next epoch.
                     EpochId::Genesis => {
                         let group_id = group.id();
-                        let commands = if let KeyGenConfirmation::Confirmed(key_share) = status {
+                        let mut commands = if let KeyGenConfirmation::Confirmed(key_share) = status
+                        {
                             state.epochs.insert(
                                 next_epoch,
                                 Epoch {
@@ -424,16 +432,98 @@ impl Transition {
                             Vec::new()
                         };
 
+                        let next_epoch = epoch::next_number(block, self.config.blocks_per_epoch);
+                        let state = State {
+                            rollover: RolloverState::EpochSkipped { next_epoch },
+                            ..state
+                        }
+                        .and_prune(block, Prune::KeyGenSecrets { group_id });
+
+                        let Some(participants) = group::participants_set(
+                            &self.config.participants,
+                            group::Epoch::Number {
+                                consensus: self.config.consensus,
+                                number: next_epoch,
+                                excluded: BTreeSet::new(),
+                            },
+                        ) else {
+                            return (state, commands);
+                        };
+
+                        let deadline =
+                            Some(block.saturating_add(self.config.key_gen_timeout.get()));
+                        let (state, mut keygen_commands) = self.start_key_gen(
+                            state,
+                            EpochId::Number { number: next_epoch },
+                            &participants,
+                            deadline,
+                        );
+                        commands.append(&mut keygen_commands);
+
+                        (state, commands)
+                    }
+                    EpochId::Number {
+                        number: proposed_epoch,
+                    } => {
+                        let group_id = group.id();
+
+                        // Regardless of whether or not we are part of the
+                        // active epoch and will participate in the signing
+                        // ceremony to generate the rollover attestation,
+                        // register the newly created epoch and group.
+                        if let KeyGenConfirmation::Confirmed(key_share) = status {
+                            state.epochs.insert(next_epoch, Epoch { group, key_share });
+                        }
+
+                        // Compute the rollover package that needs to be
+                        // attested for the epoch to get staged.
+                        let active_epoch = state.active_epoch;
+                        let group_key = participation.group_commitments().group_key();
+                        let rollover_block = proposed_epoch
+                            .get()
+                            .saturating_mul(self.config.blocks_per_epoch.get());
+                        let message = self.consensus.epoch_rollover_hash(
+                            active_epoch,
+                            proposed_epoch,
+                            rollover_block,
+                            &group_key,
+                        );
+
+                        // If we are participating in the active epoch, then
+                        // also register the rollover packet for signing.
+                        if let Some(participating_epoch) = state.epochs.get(&active_epoch) {
+                            state.signing.insert(
+                                message,
+                                SigningState::WaitingForRequest {
+                                    key_share: participating_epoch.key_share.clone(),
+                                    packet: Packet::EpochRollover {
+                                        active_epoch,
+                                        proposed_epoch,
+                                        rollover_block,
+                                        group_id,
+                                        group_key,
+                                    },
+                                    signers: participating_epoch.group.participants().clone(),
+                                    deadline: Some(
+                                        block.saturating_add(self.config.signing_timeout.get()),
+                                    ),
+                                },
+                            );
+                        };
+
                         (
                             State {
-                                rollover: RolloverState::EpochStaged { next_epoch },
+                                rollover: RolloverState::SigningRollover {
+                                    next_epoch: proposed_epoch,
+                                    group_id,
+                                    message,
+                                },
                                 ..state
                             }
                             .and_prune(block, Prune::KeyGenSecrets { group_id }),
-                            commands,
+                            Vec::new(),
                         )
                     }
-                    _ => todo!("only genesis is supported!"),
                 }
             }
             _ => (state, Vec::new()),
@@ -684,6 +774,7 @@ impl Transition {
                     Ok(key_share) => {
                         commands.push(Command::Action(Action::KeyGenConfirm {
                             group_id: group.id(),
+                            callback: self.key_gen_confirmation_callback(next_epoch),
                             expires_at: deadlines.as_ref().map(|deadlines| deadlines.confirm),
                         }));
                         *status = KeyGenConfirmation::Confirmed(Arc::new(key_share));
@@ -748,6 +839,30 @@ impl Transition {
                 Vec::new(),
             )
         }
+    }
+
+    /// Builds the callback that proposes a regular epoch as soon as the final
+    /// participant confirms its generated key. Genesis is externally
+    /// bootstrapped and does not need a callback.
+    fn key_gen_confirmation_callback(
+        &self,
+        next_epoch: EpochId,
+    ) -> Option<crate::bindings::Callback> {
+        let EpochId::Number { number } = next_epoch else {
+            return None;
+        };
+
+        Some(crate::bindings::Callback {
+            target: self.config.consensus,
+            context: (
+                number.get(),
+                number
+                    .get()
+                    .saturating_mul(self.config.blocks_per_epoch.get()),
+            )
+                .abi_encode()
+                .into(),
+        })
     }
 
     /// Restarts key generation for `next_epoch` excluding `excluded`, or

--- a/crates/validator/src/state/mod.rs
+++ b/crates/validator/src/state/mod.rs
@@ -6,7 +6,7 @@ mod sign;
 mod transactions;
 
 use crate::{
-    bindings::{Consensus, Coordinator, Oracle, SafeTransaction},
+    bindings::{Consensus, Coordinator, Oracle, Point, SafeTransaction},
     config::ValidatorConfig,
     consensus::{
         epoch::EpochId,
@@ -37,6 +37,8 @@ use std::{
 pub struct State {
     /// The epoch-rollover / DKG state machine.
     rollover: RolloverState,
+    /// The epoch whose group is currently active in consensus.
+    active_epoch: EpochId,
     /// The epochs that the validator is participating in and have completed
     /// their key generation, keyed by epoch number and retained past
     /// `EpochStaged` so later handlers can look up a resolved group and the
@@ -170,6 +172,16 @@ enum RolloverState {
         /// `None` to indicate that there is no deadline.
         deadlines: Option<ConfirmationDeadlines>,
     },
+    /// The next epoch's key generation completed and its rollover proposal is
+    /// being signed by the active epoch.
+    SigningRollover {
+        /// The epoch being staged.
+        next_epoch: NonZeroU64,
+        /// The generated group's ID.
+        group_id: B256,
+        /// The rollover proposal's signing hash.
+        message: B256,
+    },
     /// This group's key generation completed and the group is staged.
     EpochStaged {
         /// The epoch that was just staged.
@@ -225,6 +237,19 @@ struct ConfirmationDeadlines {
 /// A packet a validator group signs an attestation over.
 #[derive(Clone, Debug, Deserialize, Serialize)]
 enum Packet {
+    /// A proposal to stage a newly generated epoch.
+    EpochRollover {
+        /// The epoch whose group signs the rollover.
+        active_epoch: EpochId,
+        /// The epoch being staged.
+        proposed_epoch: NonZeroU64,
+        /// The block at which the staged epoch becomes active.
+        rollover_block: u64,
+        /// The newly generated group's ID.
+        group_id: B256,
+        /// The newly generated group's public key.
+        group_key: Point,
+    },
     /// A proposed Safe transaction.
     Transaction {
         /// The epoch whose group signs the attestation.

--- a/crates/validator/src/state/sign.rs
+++ b/crates/validator/src/state/sign.rs
@@ -74,7 +74,7 @@ impl Transition {
                         .signature_id_to_message
                         .insert(event.sid, event.message);
                 }
-                Packet::Transaction { .. } => {
+                Packet::Transaction { .. } | Packet::EpochRollover { .. } => {
                     let deadline = Some(block.saturating_add(self.config.signing_timeout.get()));
                     state.signing.insert(
                         event.message,
@@ -324,9 +324,9 @@ impl Transition {
 
     /// Publishes this validator's signature share once the
     /// [`Effect::UseNonce`] effect has produced it, attaching the packet's
-    /// completion callback (`attestTransaction`/`attestOracleTransaction`) so
-    /// the group's completed signature carries out its onchain effect
-    /// automatically.
+    /// completion callback (`stageEpoch`/`attestTransaction`/
+    /// `attestOracleTransaction`) so the group's completed signature carries
+    /// out its onchain effect automatically.
     pub(super) fn handle_nonces(
         &self,
         state: State,
@@ -475,7 +475,26 @@ impl Packet {
                 oracle,
                 transaction,
             } => (*epoch, Some(*oracle), transaction),
+            Packet::EpochRollover {
+                proposed_epoch,
+                rollover_block,
+                group_id,
+                ..
+            } => {
+                return bindings::Callback {
+                    target: consensus,
+                    context: Consensus::stageEpochCall {
+                        proposedEpoch: proposed_epoch.get(),
+                        rolloverBlock: *rollover_block,
+                        groupId: *group_id,
+                        signatureId: B256::ZERO,
+                    }
+                    .abi_encode()
+                    .into(),
+                };
+            }
         };
+
         let safe_tx_struct_hash = hashing::safe_tx_hash(transaction);
         let context = match oracle {
             None => Consensus::attestTransactionCall {


### PR DESCRIPTION
### Context and Motivation

The last missing piece required for epoch staging: signing epoch rollover packets. This PR adds the missing logic for starting an epoch rollover right out of genesis and handling that rollover completion with the necessary rollover signing.

### Decisions and Tradeoffs

> [!NOTE]
> Unlike in the TypeScript version, we do not handle epoch rollovers by entering an `EpochStaged { genesis }` state (our types don't allow it), but instead kick it off right away. This does mean that we submit keygen commitments one block early compared to TypeScript, but it does not cause any divergence (since the TS validator will only see that event after it processes the new block update and enters the required rollover state themselves).

### Port

https://github.com/safe-research/safenet/blob/4c3188fd65d977c17c5e26c4785ec7eb8193f2a5/validator/src/machine/keygen/confirmed.ts#L87-L153

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://docs.safefoundation.org/cla).
