### PR TITLE
[D 4i]: Handle Epoch Rollovers

### DIFF
--- a/crates/validator/src/consensus/epoch.rs
+++ b/crates/validator/src/consensus/epoch.rs
@@ -18,24 +18,6 @@ pub enum EpochId {
     Number { number: NonZeroU64 },
 }
 
-impl Serialize for EpochId {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: Serializer,
-    {
-        serializer.serialize_u64(self.raw_value())
-    }
-}
-
-impl<'de> Deserialize<'de> for EpochId {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: Deserializer<'de>,
-    {
-        Ok(Self::from_raw(u64::deserialize(deserializer)?))
-    }
-}
-
 impl EpochId {
     /// Returns the epoch ID for a raw value.
     pub const fn from_raw(value: u64) -> Self {
@@ -53,6 +35,14 @@ impl EpochId {
             EpochId::Number { number } => number.get(),
         }
     }
+
+    /// Returns the epoch number for this ID for any non-genesis group.
+    pub const fn number(self) -> Option<NonZeroU64> {
+        match self {
+            EpochId::Genesis => None,
+            EpochId::Number { number } => Some(number),
+        }
+    }
 }
 
 impl PartialOrd for EpochId {
@@ -64,6 +54,24 @@ impl PartialOrd for EpochId {
 impl Ord for EpochId {
     fn cmp(&self, other: &Self) -> Ordering {
         u64::cmp(&self.raw_value(), &other.raw_value())
+    }
+}
+
+impl Serialize for EpochId {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_u64(self.raw_value())
+    }
+}
+
+impl<'de> Deserialize<'de> for EpochId {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        Ok(Self::from_raw(u64::deserialize(deserializer)?))
     }
 }
 

--- a/crates/validator/src/state/keygen.rs
+++ b/crates/validator/src/state/keygen.rs
@@ -791,6 +791,99 @@ impl Transition {
         (state, commands)
     }
 
+    /// Drives the epoch-rollover machine forward on the block clock: once
+    /// the block reaches the rollover state's target epoch, stages the
+    /// epoch (rolling `active_epoch` forward) if it was ready, then triggers
+    /// a fresh key generation for whichever epoch is actually due now -
+    /// abandoning (and queuing for pruning) whatever attempt was in flight for
+    /// a now-stale target.
+    ///
+    /// Genesis groups do not observe the rollover clock.
+    pub(super) fn handle_rollover_new_block(
+        &self,
+        mut state: State,
+        block: u64,
+    ) -> (State, Commands<State, Self>) {
+        let Some(target_epoch_number) =
+            state.rollover.next_epoch().and_then(|epoch| epoch.number())
+        else {
+            return (state, Vec::new());
+        };
+
+        let next_epoch_number = epoch::next_number(block, self.config.blocks_per_epoch);
+        if target_epoch_number >= next_epoch_number {
+            // Not due yet.
+            return (state, Vec::new());
+        }
+
+        // In case an epoch was staged, make it the new active epoch.
+        if let RolloverState::EpochStaged { .. } = state.rollover {
+            state.active_epoch = EpochId::Number {
+                number: target_epoch_number,
+            };
+        }
+
+        // Whatever key generation was in flight for the stale target is being
+        // abandoned in favor of the epoch actually due now. Make sure to prune
+        // the key gen secrets (in case they weren't already pruned).
+        if let Some(group_id) = state.rollover.group_id() {
+            state = state.and_prune(block, Prune::KeyGenSecrets { group_id });
+        }
+
+        // Reap any old participating epochs for which there are no more
+        // signing ceremonies. This runs linearly through the entire signing
+        // ceremonies, but since it happens only once per rollover, we are OK
+        // with the performance hit.
+        let oldest_epoch = state
+            .signing
+            .values()
+            .map(|signing| signing.packet().epoch())
+            .fold(state.active_epoch, EpochId::min);
+        let reaped_epochs = split_off_front(&mut state.epochs, &oldest_epoch);
+        let state = reaped_epochs.values().fold(state, |state, reaped| {
+            state.and_prune(
+                block,
+                Prune::GroupNonces {
+                    group_id: reaped.group.id(),
+                },
+            )
+        });
+
+        // Start a new keygen ceremony for the new next block, including
+        // everyone again.
+        let deadline = Some(block.saturating_add(self.config.key_gen_timeout.get()));
+        let next_epoch = EpochId::Number {
+            number: next_epoch_number,
+        };
+        let participants = group::participants_set(
+            &self.config.participants,
+            group::Epoch::Number {
+                consensus: self.config.consensus,
+                number: next_epoch_number,
+                excluded: BTreeSet::new(),
+            },
+        );
+
+        match participants {
+            Some(participants) => self.start_key_gen(state, next_epoch, &participants, deadline),
+            None => {
+                tracing::warn!(
+                    ?next_epoch,
+                    "could not establish a fresh participant set for a new epoch; skipping"
+                );
+                (
+                    State {
+                        rollover: RolloverState::EpochSkipped {
+                            next_epoch: next_epoch_number,
+                        },
+                        ..state
+                    },
+                    Vec::new(),
+                )
+            }
+        }
+    }
+
     /// Starts a key generation ceremony for `next_epoch` with `participants`,
     /// entering [`RolloverState::WaitingForSetup`] if this validator is part of
     /// the group, or heading straight to
@@ -841,30 +934,6 @@ impl Transition {
         }
     }
 
-    /// Builds the callback that proposes a regular epoch as soon as the final
-    /// participant confirms its generated key. Genesis is externally
-    /// bootstrapped and does not need a callback.
-    fn key_gen_confirmation_callback(
-        &self,
-        next_epoch: EpochId,
-    ) -> Option<crate::bindings::Callback> {
-        let EpochId::Number { number } = next_epoch else {
-            return None;
-        };
-
-        Some(crate::bindings::Callback {
-            target: self.config.consensus,
-            context: (
-                number.get(),
-                number
-                    .get()
-                    .saturating_mul(self.config.blocks_per_epoch.get()),
-            )
-                .abi_encode()
-                .into(),
-        })
-    }
-
     /// Restarts key generation for `next_epoch` excluding `excluded`, or
     /// halts/skips the epoch (via [`rollover_failure`], logging `reason`) if
     /// too few participants would remain -- or if `next_epoch` is the genesis
@@ -907,6 +976,66 @@ impl Transition {
                 },
                 Vec::new(),
             ),
+        }
+    }
+
+    /// Builds the callback that proposes a regular epoch as soon as the final
+    /// participant confirms its generated key. Genesis is externally
+    /// bootstrapped and does not need a callback.
+    fn key_gen_confirmation_callback(
+        &self,
+        next_epoch: EpochId,
+    ) -> Option<crate::bindings::Callback> {
+        let EpochId::Number { number } = next_epoch else {
+            return None;
+        };
+
+        Some(crate::bindings::Callback {
+            target: self.config.consensus,
+            context: (
+                number.get(),
+                number
+                    .get()
+                    .saturating_mul(self.config.blocks_per_epoch.get()),
+            )
+                .abi_encode()
+                .into(),
+        })
+    }
+}
+
+impl RolloverState {
+    /// The epoch this rollover state is working toward becoming active, or
+    /// `None` for the terminal [`Self::Halted`] state.
+    fn next_epoch(&self) -> Option<EpochId> {
+        match self {
+            RolloverState::WaitingForGenesis => Some(EpochId::Genesis),
+            RolloverState::EpochSkipped { next_epoch }
+            | RolloverState::SigningRollover { next_epoch, .. }
+            | RolloverState::EpochStaged { next_epoch, .. } => Some(EpochId::Number {
+                number: *next_epoch,
+            }),
+            RolloverState::WaitingForSetup { next_epoch, .. }
+            | RolloverState::CollectingCommitments { next_epoch, .. }
+            | RolloverState::CollectingShares { next_epoch, .. }
+            | RolloverState::CollectingConfirmations { next_epoch, .. } => Some(*next_epoch),
+            RolloverState::Halted => None,
+        }
+    }
+
+    /// The ID of the group actively being generated for [`Self::next_epoch`],
+    /// if one has been created yet.
+    fn group_id(&self) -> Option<B256> {
+        match self {
+            RolloverState::WaitingForGenesis
+            | RolloverState::Halted
+            | RolloverState::EpochStaged { .. }
+            | RolloverState::EpochSkipped { .. } => None,
+            RolloverState::WaitingForSetup { group, .. }
+            | RolloverState::CollectingCommitments { group, .. }
+            | RolloverState::CollectingShares { group, .. }
+            | RolloverState::CollectingConfirmations { group, .. } => Some(group.id()),
+            RolloverState::SigningRollover { group_id, .. } => Some(*group_id),
         }
     }
 }
@@ -957,3 +1086,31 @@ macro_rules! fail_rollover {
     }};
 }
 use fail_rollover;
+
+/// Splits off the front of a B-tree map up to (but not including) the provided
+/// key.
+fn split_off_front<K, V>(map: &mut BTreeMap<K, V>, key: &K) -> BTreeMap<K, V>
+where
+    K: Ord,
+{
+    // `BTreeMap` provides an API to split the back off of a B-tree, removing
+    // all items with key **greater than or equal to** the provided value. We
+    // can use this and just swap our mutable reference with the result.
+    let mut rest = map.split_off(key);
+    mem::swap(map, &mut rest);
+    rest
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn split_off_front_splits_strictly_below_key() {
+        let mut map = BTreeMap::from([(1, "a"), (2, "b"), (3, "c"), (4, "d"), (5, "e")]);
+        let front = split_off_front(&mut map, &3);
+
+        assert_eq!(front, BTreeMap::from([(1, "a"), (2, "b")]));
+        assert_eq!(map, BTreeMap::from([(3, "c"), (4, "d"), (5, "e")]));
+    }
+}

--- a/crates/validator/src/state/mod.rs
+++ b/crates/validator/src/state/mod.rs
@@ -83,6 +83,11 @@ enum Prune {
         /// The resolved group.
         group_id: B256,
     },
+    /// A retired epoch's registered nonce trees.
+    GroupNonces {
+        /// The retired group.
+        group_id: B256,
+    },
 }
 
 /// The epoch-rollover / DKG state machine. Each active variant carries the
@@ -97,6 +102,12 @@ enum RolloverState {
     /// This can either be an unrecoverable error during DKG or we have reached
     /// the heat death of the universe and there are no more epochs.
     Halted,
+    /// This group's key generation completed and the group is staged in the
+    /// consensus contract.
+    EpochStaged {
+        /// The epoch that was just staged.
+        next_epoch: NonZeroU64,
+    },
     /// The key generation for `next_epoch` was skipped because too few
     /// participants took part for the group to be safe.
     EpochSkipped {
@@ -181,11 +192,6 @@ enum RolloverState {
         group_id: B256,
         /// The rollover proposal's signing hash.
         message: B256,
-    },
-    /// This group's key generation completed and the group is staged.
-    EpochStaged {
-        /// The epoch that was just staged.
-        next_epoch: EpochId,
     },
 }
 
@@ -465,8 +471,7 @@ impl StateTransition<State> for Transition {
                 // The remaining events are wired in as their handlers land.
                 _ => (state, Vec::new()),
             },
-            // No block-driven or effectful transitions are wired in yet.
-            Message::NewBlock(_) => (state, Vec::new()),
+            Message::NewBlock(block) => self.handle_rollover_new_block(state, block),
             Message::Resume(result) => match result {
                 Resume::Noop => (state, Vec::new()),
                 Resume::Setup { group_id, secrets } => {

--- a/crates/validator/src/state/sign.rs
+++ b/crates/validator/src/state/sign.rs
@@ -1,7 +1,7 @@
 use super::{Packet, SigningState, State, Transition};
 use crate::{
     bindings::{self, Consensus, Coordinator, Oracle, SignNonces},
-    consensus::hashing,
+    consensus::{epoch::EpochId, hashing},
     frost::{self, preprocess::Nonces},
     merkle::MerkleRoot,
     service::{Action, Effect},
@@ -461,7 +461,29 @@ impl Transition {
     }
 }
 
+impl SigningState {
+    /// The packet to sign for a particular signing state.
+    pub(super) fn packet(&self) -> &Packet {
+        match self {
+            SigningState::WaitingForRequest { packet, .. }
+            | SigningState::WaitingForOracle { packet, .. }
+            | SigningState::CollectNonceCommitments { packet, .. }
+            | SigningState::CollectSigningShares { packet, .. }
+            | SigningState::WaitingForAttestation { packet, .. }
+            | SigningState::WaitingToDecline { packet, .. } => packet,
+        }
+    }
+}
+
 impl Packet {
+    /// The epoch whose group this packet is signed by.
+    pub(super) fn epoch(&self) -> EpochId {
+        match self {
+            Packet::EpochRollover { active_epoch, .. } => *active_epoch,
+            Packet::Transaction { epoch, .. } | Packet::OracleTransaction { epoch, .. } => *epoch,
+        }
+    }
+
     /// Builds the callback invoked once this packet's group signature
     /// completes: `attestTransaction`/`attestOracleTransaction` calldata
     /// targeting the `Consensus` contract. The signature id argument is left


### PR DESCRIPTION
### Context and Motivation

Start hooking up the the block handler in order to schedule rollovers for staged blocks.

### Decisions and Tradeoffs

> [!NOTE]
> Unlike the TypeScript version, we are more exact with the epochs that we reap and prune: we remove the previously active epoch _as long as there are no active signing ceremonies_. This allows us to be more precise with our epoch pruning compared to the TypeScript implementation. It does not cause consensus differences. TypeScript defensively keeps the previous epoch around.

This does not handle _all_ block updates for the keygen logic. In particular timeouts will be handled separately in a follow-up PR.

### Port

https://github.com/safe-research/safenet/blob/4c3188fd65d977c17c5e26c4785ec7eb8193f2a5/validator/src/machine/consensus/rollover.ts#L18-L78

https://github.com/safe-research/safenet/blob/4c3188fd65d977c17c5e26c4785ec7eb8193f2a5/validator/src/machine/consensus/rollover.ts#L101-L120

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://docs.safefoundation.org/cla).
