### PR TITLE
[D 4iii]: Handle Epoch Staged

### DIFF
--- a/crates/validator/src/state/keygen.rs
+++ b/crates/validator/src/state/keygen.rs
@@ -3,14 +3,14 @@ use super::{
     RolloverState, SigningState, State, Transition,
 };
 use crate::{
-    bindings::Coordinator,
+    bindings::{Consensus, Coordinator},
     consensus::{
         epoch::{self, EpochId},
-        group::{self, ParticipantSet},
+        group::{self, Group, ParticipantSet},
     },
     frost::{
         self,
-        keygen::{GroupCommitments, Secrets},
+        keygen::{GroupCommitments, KeyShare, Secrets},
     },
     service::{Action, Effect},
 };
@@ -23,6 +23,7 @@ use std::{
     collections::{BTreeMap, BTreeSet},
     fmt::Display,
     iter, mem,
+    num::NonZeroU64,
     sync::Arc,
 };
 
@@ -414,31 +415,19 @@ impl Transition {
                     // On genesis: retain the active key, start preprocessing,
                     // and immediately begin key generation for the next epoch.
                     EpochId::Genesis => {
-                        let group_id = group.id();
-                        let mut commands = if let KeyGenConfirmation::Confirmed(key_share) = status
-                        {
-                            state.epochs.insert(
-                                next_epoch,
-                                Epoch {
-                                    group,
-                                    key_share: key_share.clone(),
-                                },
-                            );
-                            vec![Command::Effect(Effect::NonceTree {
-                                group_id,
-                                key_share,
-                            })]
-                        } else {
-                            Vec::new()
-                        };
-
                         let next_epoch = epoch::next_number(block, self.config.blocks_per_epoch);
-                        let state = State {
-                            rollover: RolloverState::EpochSkipped { next_epoch },
-                            ..state
-                        }
-                        .and_prune(block, Prune::KeyGenSecrets { group_id });
+                        let (state, finalize_commands) = self.finalize_key_gen(
+                            State {
+                                rollover: RolloverState::EpochSkipped { next_epoch },
+                                ..state
+                            },
+                            block,
+                            EpochId::Genesis,
+                            group,
+                            status.key_share(),
+                        );
 
+                        // Kick off the next keygen ceremony right away.
                         let Some(participants) = group::participants_set(
                             &self.config.participants,
                             group::Epoch::Number {
@@ -447,33 +436,25 @@ impl Transition {
                                 excluded: BTreeSet::new(),
                             },
                         ) else {
-                            return (state, commands);
+                            return (state, finalize_commands);
                         };
 
                         let deadline =
                             Some(block.saturating_add(self.config.key_gen_timeout.get()));
-                        let (state, mut keygen_commands) = self.start_key_gen(
+                        let (state, keygen_commands) = self.start_key_gen(
                             state,
                             EpochId::Number { number: next_epoch },
                             &participants,
                             deadline,
                         );
-                        commands.append(&mut keygen_commands);
 
-                        (state, commands)
+                        (state, [finalize_commands, keygen_commands].concat())
                     }
                     EpochId::Number {
                         number: proposed_epoch,
                     } => {
                         let group_id = group.id();
-
-                        // Regardless of whether or not we are part of the
-                        // active epoch and will participate in the signing
-                        // ceremony to generate the rollover attestation,
-                        // register the newly created epoch and group.
-                        if let KeyGenConfirmation::Confirmed(key_share) = status {
-                            state.epochs.insert(next_epoch, Epoch { group, key_share });
-                        }
+                        let key_share = status.key_share();
 
                         // Compute the rollover package that needs to be
                         // attested for the epoch to get staged.
@@ -515,18 +496,89 @@ impl Transition {
                             State {
                                 rollover: RolloverState::SigningRollover {
                                     next_epoch: proposed_epoch,
-                                    group_id,
+                                    group,
+                                    key_share,
                                     message,
                                 },
                                 ..state
-                            }
-                            .and_prune(block, Prune::KeyGenSecrets { group_id }),
+                            },
                             Vec::new(),
                         )
                     }
                 }
             }
             _ => (state, Vec::new()),
+        }
+    }
+
+    /// Finalizes a staged epoch once its rollover attestation lands onchain:
+    /// clears the rollover signing session and moves
+    /// [`RolloverState::SigningRollover`] to [`RolloverState::EpochStaged`],
+    /// via [`Self::finalize_key_gen`] recording the new epoch and group in
+    /// `state.epochs` (if this validator is participating) and preprocessing
+    /// it by sampling and registering its nonce tree. Ports
+    /// `consensus/epochStaged.ts`.
+    ///
+    /// `active_epoch` itself is not rolled forward here; that only happens
+    /// later, once the block clock reaches the rollover block (see
+    /// [`Self::handle_rollover_new_block`]).
+    pub(super) fn handle_epoch_staged(
+        &self,
+        state: State,
+        block: u64,
+        event: &Consensus::EpochStaged,
+    ) -> (State, Commands<State, Self>) {
+        match state.rollover {
+            RolloverState::SigningRollover {
+                next_epoch,
+                group,
+                key_share,
+                message,
+            } if group.id() == event.groupId => {
+                let epoch = EpochId::Number { number: next_epoch };
+                let (state, keygen_commands) = self.finalize_key_gen(
+                    State {
+                        rollover: RolloverState::EpochStaged { next_epoch },
+                        ..state
+                    },
+                    block,
+                    epoch,
+                    group,
+                    key_share,
+                );
+                let (state, attested_commands) =
+                    self.handle_sign_attested(state, event.signatureId, message);
+
+                (state, [keygen_commands, attested_commands].concat())
+            }
+            RolloverState::WaitingForGenesis => {
+                // We should have been waiting for genesis to start. In this,
+                // optimistically jump to skipping to the proposed epoch. This
+                // has the added benefit that if a validator joins partway
+                // through consensus, the will eventually recover and not get
+                // stuck forever waiting for genesis.
+                (
+                    State {
+                        rollover: NonZeroU64::new(event.proposedEpoch)
+                            .map(|next_epoch| RolloverState::EpochSkipped { next_epoch })
+                            // The contract should disallow proposing genesis
+                            // epochs, something is very wrong...
+                            .unwrap_or(RolloverState::Halted),
+                        ..state
+                    },
+                    Vec::new(),
+                )
+            }
+            _ => {
+                tracing::warn!(
+                    epoch = %event.proposedEpoch,
+                    "an unexpected epoch was staged; key generation may time out"
+                );
+
+                // We saw an epoch get staged when we were not expecting one.
+                // Either way, we should recover and clean up through timeouts.
+                (state, Vec::new())
+            }
         }
     }
 
@@ -1062,6 +1114,44 @@ impl Transition {
         }
     }
 
+    /// Finalizes keygen, pruning any remaining DKG secrets, and triggering
+    /// nonces preprocessing.
+    fn finalize_key_gen(
+        &self,
+        state: State,
+        block: u64,
+        epoch: EpochId,
+        group: Group,
+        key_share: Option<Arc<KeyShare>>,
+    ) -> (State, Commands<State, Self>) {
+        let group_id = group.id();
+
+        // Schedule pruning of the DKG secrets for the finalized group - we do
+        // not need them anymore.
+        let mut state = state.and_prune(block, Prune::KeyGenSecrets { group_id });
+
+        // If we are participating in the new group (in other words, we were
+        // part of the DKG ceremony and key share), register the epoch in our
+        // participating epochs map and generate a nonces chunk.
+        let commands = if let Some(key_share) = key_share {
+            state.epochs.insert(
+                epoch,
+                Epoch {
+                    group,
+                    key_share: key_share.clone(),
+                },
+            );
+            vec![Command::Effect(Effect::NonceTree {
+                group_id,
+                key_share,
+            })]
+        } else {
+            Vec::new()
+        };
+
+        (state, commands)
+    }
+
     /// Builds the callback that proposes a regular epoch as soon as the final
     /// participant confirms its generated key. Genesis is externally
     /// bootstrapped and does not need a callback.
@@ -1117,8 +1207,8 @@ impl RolloverState {
             RolloverState::WaitingForSetup { group, .. }
             | RolloverState::CollectingCommitments { group, .. }
             | RolloverState::CollectingShares { group, .. }
-            | RolloverState::CollectingConfirmations { group, .. } => Some(group.id()),
-            RolloverState::SigningRollover { group_id, .. } => Some(*group_id),
+            | RolloverState::CollectingConfirmations { group, .. }
+            | RolloverState::SigningRollover { group, .. } => Some(group.id()),
         }
     }
 }
@@ -1129,6 +1219,17 @@ impl KeyGenParticipation {
         match self {
             KeyGenParticipation::Participating(sharing_state) => sharing_state.group_commitments(),
             KeyGenParticipation::Observing(group_commitments) => group_commitments,
+        }
+    }
+}
+
+impl KeyGenConfirmation {
+    /// Returns the finalized key share, if this validator's confirmation
+    /// completed successfully.
+    fn key_share(&self) -> Option<Arc<KeyShare>> {
+        match self {
+            KeyGenConfirmation::Confirmed(key_share) => Some(key_share.clone()),
+            _ => None,
         }
     }
 }

--- a/crates/validator/src/state/mod.rs
+++ b/crates/validator/src/state/mod.rs
@@ -188,8 +188,10 @@ enum RolloverState {
     SigningRollover {
         /// The epoch being staged.
         next_epoch: NonZeroU64,
-        /// The generated group's ID.
-        group_id: B256,
+        /// The group being generated.
+        group: Group,
+        /// This validator's key share if they were participating.
+        key_share: Option<Arc<KeyShare>>,
         /// The rollover proposal's signing hash.
         message: B256,
     },
@@ -452,6 +454,9 @@ impl StateTransition<State> for Transition {
                 }
                 Event::Coordinator(Coordinator::CoordinatorEvents::SignCompleted(event)) => {
                     self.handle_sign_completed(state, log.block, &event)
+                }
+                Event::Consensus(Consensus::ConsensusEvents::EpochStaged(event)) => {
+                    self.handle_epoch_staged(state, log.block, &event)
                 }
                 Event::Consensus(Consensus::ConsensusEvents::TransactionProposed(event)) => {
                     self.handle_transaction_proposed(state, log.block, &event)

--- a/crates/validator/src/state/sign.rs
+++ b/crates/validator/src/state/sign.rs
@@ -459,9 +459,54 @@ impl Transition {
             None => (state, Vec::new()),
         }
     }
+
+    /// Handles a signature attestation, which can mean different things for
+    /// different packets. Called by the individual attestations handlers
+    /// (`EpochStaged`, `TransactionAttested`, `OracleTransactionAttested`).
+    pub(super) fn handle_sign_attested(
+        &self,
+        mut state: State,
+        signature_id: B256,
+        message: B256,
+    ) -> (State, Commands<State, Self>) {
+        // Always clean up signing states when we observe attestations onchain
+        // to prevent dangling signing references. This _should_ only happen in
+        // case other validators diverge and produce an attestation under a
+        // different signature ID, so this is purely defensive.
+        let signing = state.signing.remove(&message);
+        if let Some(signature_id) = signing.as_ref().and_then(|signing| signing.signature_id()) {
+            state.signature_id_to_message.remove(&signature_id);
+        }
+
+        // In case we weren't in an expected state (either waiting for an
+        // attestation or just observing but not participating in the signing
+        // ceremony), log a warning, since this should never happen.
+        match &signing {
+            Some(SigningState::WaitingForAttestation { .. }) | None => {}
+            Some(_) => tracing::warn!(
+                %message,
+                %signature_id,
+                "received attestation on unexpected signing state"
+            ),
+        }
+
+        (state, Vec::new())
+    }
 }
 
 impl SigningState {
+    /// Returns the known signature ID for a signing state, or `None` if none
+    /// have been assigned yet.
+    fn signature_id(&self) -> Option<B256> {
+        match self {
+            SigningState::WaitingForAttestation { signature_id, .. }
+            | SigningState::WaitingForOracle { signature_id, .. }
+            | SigningState::CollectNonceCommitments { signature_id, .. }
+            | SigningState::CollectSigningShares { signature_id, .. } => Some(*signature_id),
+            SigningState::WaitingForRequest { .. } | SigningState::WaitingToDecline { .. } => None,
+        }
+    }
+
     /// The packet to sign for a particular signing state.
     pub(super) fn packet(&self) -> &Packet {
         match self {

--- a/crates/validator/src/state/transactions.rs
+++ b/crates/validator/src/state/transactions.rs
@@ -5,7 +5,6 @@ use crate::{
     bindings::Consensus,
     consensus::{checks, epoch::EpochId},
 };
-use alloy::primitives::B256;
 use safenet_core::state::Commands;
 
 impl Transition {
@@ -71,36 +70,14 @@ impl Transition {
     /// proposal is re-hashed directly from the event rather than the packet.
     pub(super) fn handle_transaction_attested(
         &self,
-        mut state: State,
+        state: State,
         event: &Consensus::TransactionAttested,
     ) -> (State, Commands<State, Self>) {
         let epoch = EpochId::from_raw(event.epoch);
         let message = self
             .consensus
             .transaction_proposal_hash(epoch, event.safeTxHash);
-
-        // Always clean up signing states when we observe attestations onchain
-        // to prevent dangling signing references. This _should_ only happen in
-        // case other validators diverge and produce an attestation under a
-        // different signature ID, so this is purely defensive.
-        let signing = state.signing.remove(&message);
-        if let Some(signature_id) = signing.as_ref().and_then(|signing| signing.signature_id()) {
-            state.signature_id_to_message.remove(&signature_id);
-        }
-
-        // In case we weren't in an expected state (either waiting for an
-        // attestation or just observing but not participating in the signing
-        // ceremony), log a warning, since this should never happen.
-        match &signing {
-            Some(SigningState::WaitingForAttestation { .. }) | None => {}
-            Some(_) => tracing::warn!(
-                %message,
-                signature_id = %event.signatureId,
-                "received attestation on unexpected signing state"
-            ),
-        }
-
-        (state, Vec::new())
+        self.handle_sign_attested(state, event.signatureId, message)
     }
 
     /// Verifies a proposed oracle-backed Safe transaction against the
@@ -160,49 +137,13 @@ impl Transition {
     /// lands onchain.
     pub(super) fn handle_oracle_transaction_attested(
         &self,
-        mut state: State,
+        state: State,
         event: &Consensus::OracleTransactionAttested,
     ) -> (State, Commands<State, Self>) {
         let epoch = EpochId::from_raw(event.epoch);
         let message =
             self.consensus
                 .oracle_transaction_proposal_hash(epoch, event.oracle, event.safeTxHash);
-
-        // Always clean up signing states when we observe attestations onchain
-        // to prevent dangling signing references. This _should_ only happen in
-        // case other validators diverge and produce an attestation under a
-        // different signature ID, so this is purely defensive.
-        let signing = state.signing.remove(&message);
-        if let Some(signature_id) = signing.as_ref().and_then(|signing| signing.signature_id()) {
-            state.signature_id_to_message.remove(&signature_id);
-        }
-
-        // In case we weren't in an expected state (either waiting for an
-        // attestation or just observing but not participating in the signing
-        // ceremony), log a warning, since this should never happen.
-        match &signing {
-            Some(SigningState::WaitingForAttestation { .. }) | None => {}
-            Some(_) => tracing::warn!(
-                %message,
-                signature_id = %event.signatureId,
-                "received attestation on unexpected signing state"
-            ),
-        }
-
-        (state, Vec::new())
-    }
-}
-
-impl SigningState {
-    /// Returns the known signature ID for a signing state, or `None` if none
-    /// have been assigned yet.
-    fn signature_id(&self) -> Option<B256> {
-        match self {
-            SigningState::WaitingForAttestation { signature_id, .. }
-            | SigningState::WaitingForOracle { signature_id, .. }
-            | SigningState::CollectNonceCommitments { signature_id, .. }
-            | SigningState::CollectSigningShares { signature_id, .. } => Some(*signature_id),
-            SigningState::WaitingForRequest { .. } | SigningState::WaitingToDecline { .. } => None,
-        }
+        self.handle_sign_attested(state, event.signatureId, message)
     }
 }


### PR DESCRIPTION
### Context and Motivation

Handle the epoch staged event, registering the epoch if participating (so we can use it for signing).

### Decisions and Tradeoffs

> [!NOTE]
> Unlike TS, if we see a staged epoch while we are waiting for genesis, we assume that we joined partway through consensus and skip to that epoch. This has the same effect as `skip_genesis` but in a less hacky way (does not require additional configuration, and is automatically deduced just by observing events).

Previously, in #578, we had temporarily hooked up rollover signing to be able to test the genesis rollover change in #579; this was slightly incorrect (the epoch should only get registered once there is an attestation for it - otherwise it might stay dangling since the concensus contract will never roll over to it). This is fixed in this PR.

### Port

https://github.com/safe-research/safenet/blob/4c3188fd65d977c17c5e26c4785ec7eb8193f2a5/validator/src/machine/consensus/epochStaged.ts#L14-L64

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://docs.safefoundation.org/cla).
