### PR TITLE
[D 4iv A]: Attestation Actions

### DIFF
--- a/crates/validator/src/service/action.rs
+++ b/crates/validator/src/service/action.rs
@@ -1,7 +1,8 @@
 //! Validator actions and their encoding into transactions.
 
 use crate::{
-    bindings::{self, Coordinator},
+    bindings::{self, Consensus, Coordinator},
+    consensus::epoch::EpochId,
     merkle::MerkleRoot,
 };
 use alloy::{
@@ -9,9 +10,11 @@ use alloy::{
     sol_types::SolCall,
 };
 use safenet_core::{driver::ActionEncoder, tx::Transaction};
+use std::num::NonZeroU64;
 
 /// An onchain action the validator emits during a state transition.
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[expect(dead_code)]
 pub enum Action {
     /// An action to publish key generation commitments onchain.
     KeyGenAndCommit {
@@ -61,14 +64,11 @@ pub enum Action {
         signature_id: B256,
         nonces: bindings::SignNonces,
         proof: Vec<B256>,
-        expires_at: Option<u64>,
+        expires_at: u64,
     },
     /// An action to decline participation in a signing round for a packet
     /// that failed verification.
-    SignDecline {
-        signature_id: B256,
-        expires_at: Option<u64>,
-    },
+    SignDecline { signature_id: B256, expires_at: u64 },
     /// An action to publish this validator's signature share, along with the
     /// callback invoked once the group's signature completes.
     SignShare {
@@ -77,13 +77,54 @@ pub enum Action {
         share: bindings::SignatureShare,
         proof: Vec<B256>,
         callback: bindings::Callback,
-        expires_at: Option<u64>,
+        expires_at: u64,
+    },
+    /// An action to open a signing round for a verified packet, retried by
+    /// whichever participant is responsible after a timeout.
+    Sign {
+        group_id: B256,
+        message: B256,
+        expires_at: u64,
+    },
+    /// A fallback action to submit a completed transaction attestation
+    /// directly, when the automatic `signShareWithCallback` submission did
+    /// not land in time.
+    AttestTransaction {
+        epoch: EpochId,
+        chain_id: U256,
+        safe: Address,
+        safe_tx_struct_hash: B256,
+        signature_id: B256,
+        expires_at: u64,
+    },
+    /// A fallback action to submit a completed oracle-backed transaction
+    /// attestation directly, when the automatic `signShareWithCallback`
+    /// submission did not land in time.
+    AttestOracleTransaction {
+        epoch: EpochId,
+        oracle: Address,
+        chain_id: U256,
+        safe: Address,
+        safe_tx_struct_hash: B256,
+        signature_id: B256,
+        expires_at: u64,
+    },
+    /// A fallback action to stage a completed epoch rollover directly, when
+    /// the automatic `signShareWithCallback` submission did not land in
+    /// time.
+    StageEpoch {
+        proposed_epoch: NonZeroU64,
+        rollover_block: u64,
+        group_id: B256,
+        signature_id: B256,
+        expires_at: u64,
     },
 }
 
 /// Encodes [`Action`]s into the transactions the queue submits.
 pub struct Encoder {
     pub coordinator: Address,
+    pub consensus: Address,
 }
 
 impl ActionEncoder<Action> for Encoder {
@@ -240,7 +281,7 @@ impl ActionEncoder<Action> for Encoder {
                     .into(),
                     gas: 250_000,
                 },
-                expires_at,
+                Some(expires_at),
             ),
             Action::SignDecline {
                 signature_id,
@@ -254,7 +295,7 @@ impl ActionEncoder<Action> for Encoder {
                         .into(),
                     gas: 150_000,
                 },
-                expires_at,
+                Some(expires_at),
             ),
             Action::SignShare {
                 signature_id,
@@ -278,7 +319,97 @@ impl ActionEncoder<Action> for Encoder {
                     .into(),
                     gas: 400_000,
                 },
+                Some(expires_at),
+            ),
+            Action::Sign {
+                group_id,
+                message,
                 expires_at,
+            } => (
+                Transaction {
+                    to: self.coordinator,
+                    value: U256::ZERO,
+                    data: Coordinator::signCall {
+                        gid: group_id,
+                        message,
+                    }
+                    .abi_encode()
+                    .into(),
+                    gas: 150_000,
+                },
+                Some(expires_at),
+            ),
+            Action::AttestTransaction {
+                epoch,
+                chain_id,
+                safe,
+                safe_tx_struct_hash,
+                signature_id,
+                expires_at,
+            } => (
+                Transaction {
+                    to: self.consensus,
+                    value: U256::ZERO,
+                    data: Consensus::attestTransactionCall {
+                        epoch: epoch.raw_value(),
+                        chainId: chain_id,
+                        safe,
+                        safeTxStructHash: safe_tx_struct_hash,
+                        signatureId: signature_id,
+                    }
+                    .abi_encode()
+                    .into(),
+                    gas: 250_000,
+                },
+                Some(expires_at),
+            ),
+            Action::AttestOracleTransaction {
+                epoch,
+                oracle,
+                chain_id,
+                safe,
+                safe_tx_struct_hash,
+                signature_id,
+                expires_at,
+            } => (
+                Transaction {
+                    to: self.consensus,
+                    value: U256::ZERO,
+                    data: Consensus::attestOracleTransactionCall {
+                        epoch: epoch.raw_value(),
+                        oracle,
+                        chainId: chain_id,
+                        safe,
+                        safeTxStructHash: safe_tx_struct_hash,
+                        signatureId: signature_id,
+                    }
+                    .abi_encode()
+                    .into(),
+                    gas: 250_000,
+                },
+                Some(expires_at),
+            ),
+            Action::StageEpoch {
+                proposed_epoch,
+                rollover_block,
+                group_id,
+                signature_id,
+                expires_at,
+            } => (
+                Transaction {
+                    to: self.consensus,
+                    value: U256::ZERO,
+                    data: Consensus::stageEpochCall {
+                        proposedEpoch: proposed_epoch.get(),
+                        rolloverBlock: rollover_block,
+                        groupId: group_id,
+                        signatureId: signature_id,
+                    }
+                    .abi_encode()
+                    .into(),
+                    gas: 250_000,
+                },
+                Some(expires_at),
             ),
         }
     }

--- a/crates/validator/src/service/mod.rs
+++ b/crates/validator/src/service/mod.rs
@@ -96,6 +96,7 @@ impl Service for ValidatorService {
             coordinator,
             config,
         } = self;
+        let consensus_address = config.consensus;
         (
             state::Transition {
                 account,
@@ -104,7 +105,10 @@ impl Service for ValidatorService {
                 config,
             },
             effect::Handler { account, secrets },
-            action::Encoder { coordinator },
+            action::Encoder {
+                coordinator,
+                consensus: consensus_address,
+            },
         )
     }
 }

--- a/crates/validator/src/state/keygen.rs
+++ b/crates/validator/src/state/keygen.rs
@@ -477,6 +477,8 @@ impl Transition {
                                 message,
                                 SigningState::WaitingForRequest {
                                     key_share: participating_epoch.key_share.clone(),
+                                    group_id,
+                                    responsible: None,
                                     packet: Packet::EpochRollover {
                                         active_epoch,
                                         proposed_epoch,
@@ -485,9 +487,8 @@ impl Transition {
                                         group_key,
                                     },
                                     signers: participating_epoch.group.participants().clone(),
-                                    deadline: Some(
-                                        block.saturating_add(self.config.signing_timeout.get()),
-                                    ),
+                                    deadline: block
+                                        .saturating_add(self.config.signing_timeout.get()),
                                 },
                             );
                         };

--- a/crates/validator/src/state/mod.rs
+++ b/crates/validator/src/state/mod.rs
@@ -288,13 +288,17 @@ enum SigningState {
     WaitingForRequest {
         /// The key share for participating in the signing ceremony.
         key_share: Arc<KeyShare>,
+        /// The group generating the signature.
+        group_id: B256,
+        /// The participant responsible for submitting the `Sign` request, or
+        /// `None` if unknown, in which case every participant is responsible.
+        responsible: Option<Address>,
         /// The packet being signed.
         packet: Packet,
         /// The group members expected to take part in signing.
         signers: BTreeSet<Address>,
-        /// The block by which the signing round must complete. `None` to
-        /// indicate that there is no deadline.
-        deadline: Option<u64>,
+        /// The block by which the signing round must complete.
+        deadline: u64,
     },
     /// An oracle-backed packet's signing round is on hold until the oracle's
     /// result is attested.
@@ -313,9 +317,8 @@ enum SigningState {
         packet: Packet,
         /// The group members expected to take part in signing.
         signers: BTreeSet<Address>,
-        /// The block by which the oracle result must land. `None` to
-        /// indicate that there is no deadline.
-        deadline: Option<u64>,
+        /// The block by which the oracle result must land.
+        deadline: u64,
     },
     /// This validator has revealed its nonce commitment and is waiting for
     /// its peers to reveal theirs.
@@ -330,13 +333,14 @@ enum SigningState {
         sequence: u64,
         /// Verified revealed nonce commitments received from peers so far.
         revealed: BTreeMap<Address, RevealedNonces>,
+        /// The last participant to reveal a valid nonce commitment, if any.
+        last_signer: Option<Address>,
         /// The packet being signed.
         packet: Packet,
         /// The group members expected to take part in signing.
         signers: BTreeSet<Address>,
-        /// The block by which the commitment round must complete. `None` to
-        /// indicate that there is no deadline.
-        deadline: Option<u64>,
+        /// The block by which the commitment round must complete.
+        deadline: u64,
     },
     /// Every signer's nonce commitment has been revealed and this
     /// validator's own signature share is being produced; waiting for the
@@ -357,8 +361,7 @@ enum SigningState {
         /// The group members expected to take part in signing.
         signers: BTreeSet<Address>,
         /// The block by which the signature share round must complete.
-        /// `None` to indicate that there is no deadline.
-        deadline: Option<u64>,
+        deadline: u64,
     },
     /// A complete group signature was produced; waiting for the attestation
     /// to be submitted onchain.
@@ -371,15 +374,14 @@ enum SigningState {
         /// The packet being signed.
         packet: Packet,
         /// The block by which the signing attestation must arrive.
-        deadline: Option<u64>,
+        deadline: u64,
     },
     /// The packet failed verification; waiting to submit a decline.
     WaitingToDecline {
         /// The packet that failed verification.
         packet: Packet,
-        /// The block by which the decline must be submitted. `None` to
-        /// indicate that there is no deadline.
-        deadline: Option<u64>,
+        /// The block by which the decline must be submitted.
+        deadline: u64,
     },
 }
 

--- a/crates/validator/src/state/sign.rs
+++ b/crates/validator/src/state/sign.rs
@@ -56,7 +56,7 @@ impl Transition {
                 ..
             }) => match packet {
                 Packet::OracleTransaction { oracle, .. } => {
-                    let deadline = Some(block.saturating_add(self.config.oracle_timeout.get()));
+                    let deadline = block.saturating_add(self.config.oracle_timeout.get());
                     state.signing.insert(
                         event.message,
                         SigningState::WaitingForOracle {
@@ -75,7 +75,7 @@ impl Transition {
                         .insert(event.sid, event.message);
                 }
                 Packet::Transaction { .. } | Packet::EpochRollover { .. } => {
-                    let deadline = Some(block.saturating_add(self.config.signing_timeout.get()));
+                    let deadline = block.saturating_add(self.config.signing_timeout.get());
                     state.signing.insert(
                         event.message,
                         SigningState::CollectNonceCommitments {
@@ -84,6 +84,7 @@ impl Transition {
                             signature_id: event.sid,
                             sequence: event.sequence,
                             revealed: BTreeMap::new(),
+                            last_signer: None,
                             packet,
                             signers,
                             deadline,
@@ -175,7 +176,7 @@ impl Transition {
                 sequence,
                 ..
             }) if expected == oracle && event.approved => {
-                let deadline = Some(block.saturating_add(self.config.signing_timeout.get()));
+                let deadline = block.saturating_add(self.config.signing_timeout.get());
                 state.signing.insert(
                     event.requestId,
                     SigningState::CollectNonceCommitments {
@@ -184,6 +185,7 @@ impl Transition {
                         signature_id,
                         sequence,
                         revealed: BTreeMap::new(),
+                        last_signer: None,
                         packet,
                         signers,
                         deadline,
@@ -244,6 +246,7 @@ impl Transition {
                 signature_id,
                 sequence,
                 mut revealed,
+                mut last_signer,
                 packet,
                 signers,
                 deadline,
@@ -254,6 +257,7 @@ impl Transition {
                 {
                     Some(Ok(nonces)) => {
                         revealed.insert(event.participant, nonces);
+                        last_signer = Some(event.participant);
                     }
                     Some(Err(err)) => {
                         tracing::warn!(
@@ -282,6 +286,7 @@ impl Transition {
                             signature_id,
                             sequence,
                             revealed,
+                            last_signer,
                             packet,
                             signers,
                             deadline,
@@ -290,7 +295,7 @@ impl Transition {
                     return (state, Vec::new());
                 }
 
-                let deadline = Some(block.saturating_add(self.config.signing_timeout.get()));
+                let deadline = block.saturating_add(self.config.signing_timeout.get());
                 state.signing.insert(
                     message,
                     SigningState::CollectSigningShares {
@@ -440,7 +445,7 @@ impl Transition {
                     );
                 }
 
-                let deadline = Some(block.saturating_add(self.config.signing_timeout.get()));
+                let deadline = block.saturating_add(self.config.signing_timeout.get());
                 state.signing.insert(
                     message,
                     SigningState::WaitingForAttestation {
@@ -585,6 +590,48 @@ impl Packet {
         bindings::Callback {
             target: consensus,
             context: context.into(),
+        }
+    }
+
+    /// Builds the fallback action to directly submit a completed attestation,
+    /// for when the automatic `signShareWithCallback` submission did not land
+    /// in time.
+    #[expect(dead_code)]
+    fn attestation_action(&self, signature_id: B256, expires_at: u64) -> Action {
+        match self {
+            Packet::EpochRollover {
+                proposed_epoch,
+                rollover_block,
+                group_id,
+                ..
+            } => Action::StageEpoch {
+                proposed_epoch: *proposed_epoch,
+                rollover_block: *rollover_block,
+                group_id: *group_id,
+                signature_id,
+                expires_at,
+            },
+            Packet::Transaction { epoch, transaction } => Action::AttestTransaction {
+                epoch: *epoch,
+                chain_id: transaction.chainId,
+                safe: transaction.safe,
+                safe_tx_struct_hash: hashing::safe_tx_struct_hash(transaction),
+                signature_id,
+                expires_at,
+            },
+            Packet::OracleTransaction {
+                epoch,
+                oracle,
+                transaction,
+            } => Action::AttestOracleTransaction {
+                epoch: *epoch,
+                oracle: *oracle,
+                chain_id: transaction.chainId,
+                safe: transaction.safe,
+                safe_tx_struct_hash: hashing::safe_tx_struct_hash(transaction),
+                signature_id,
+                expires_at,
+            },
         }
     }
 }

--- a/crates/validator/src/state/transactions.rs
+++ b/crates/validator/src/state/transactions.rs
@@ -38,11 +38,13 @@ impl Transition {
             };
 
             let signers = participating_epoch.group.participants().clone();
-            let deadline = Some(block.saturating_add(self.config.signing_timeout.get()));
+            let deadline = block.saturating_add(self.config.signing_timeout.get());
 
             let signing_state = if checks::check_transaction(&event.transaction) {
                 SigningState::WaitingForRequest {
                     key_share: participating_epoch.key_share.clone(),
+                    group_id: participating_epoch.group.id(),
+                    responsible: None,
                     packet,
                     signers,
                     deadline,
@@ -118,10 +120,12 @@ impl Transition {
                 transaction: event.transaction.clone(),
             };
             let signers = participating_epoch.group.participants().clone();
-            let deadline = Some(block.saturating_add(self.config.signing_timeout.get()));
+            let deadline = block.saturating_add(self.config.signing_timeout.get());
 
             signing.insert(SigningState::WaitingForRequest {
                 key_share: participating_epoch.key_share.clone(),
+                group_id: participating_epoch.group.id(),
+                responsible: None,
                 packet,
                 signers,
                 deadline,


### PR DESCRIPTION
### Context and Motivation

This PR introduces attestation actions and their encoding implementation that are needed for handling signing timeouts.

It is submitted as a separate PR in effort to facilitate review.

### Decisions and Tradeoffs

I noticed that some expiries were `Option<u64>` when they should have been `u64` (all signing states and transactions have an expiry, unlike keygen - because of genesis); so I corrected the types.

There are a couple `#[expect(dead_code)]`, as the added variants and methods here do not get used until the next PR where they are removed.

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://docs.safefoundation.org/cla).
