### PR TITLE
[D 5]: Validator Staker Reconciliation

### DIFF
--- a/crates/core/src/driver.rs
+++ b/crates/core/src/driver.rs
@@ -131,6 +131,20 @@ where
         })
     }
 
+    /// Queues `action` for submission onchain, encoding it and pushing it
+    /// straight to the transaction queue.
+    ///
+    /// This is meant for queuing up initial startup actions that live outside
+    /// the state machine's semantics.
+    pub async fn queue_action(
+        &mut self,
+        action: <S::Transition as StateTransition<S::State>>::Action,
+    ) -> Result<(), Error> {
+        let transaction = self.actions.encode_action(action);
+        self.transactions.queue([transaction]).await?;
+        Ok(())
+    }
+
     /// Runs the service, processing indexer updates until a shutdown signal
     /// (such as Ctrl-C) is received or an unrecoverable error occurs.
     ///

--- a/crates/validator/src/config.rs
+++ b/crates/validator/src/config.rs
@@ -1,5 +1,3 @@
-#![cfg_attr(not(test), expect(dead_code))]
-
 use alloy::primitives::{Address, B256};
 use safenet_core::{driver, observability, tx::Signer};
 use serde::Deserialize;

--- a/crates/validator/src/main.rs
+++ b/crates/validator/src/main.rs
@@ -7,7 +7,11 @@ mod secrets;
 mod service;
 mod state;
 
-use self::{bindings::Consensus, config::Config, service::ValidatorService};
+use self::{
+    bindings::Consensus,
+    config::Config,
+    service::{Action, ValidatorService},
+};
 use alloy::providers::{Provider, ProviderBuilder};
 use argh::FromArgs;
 use safenet_core::{Driver, observability};
@@ -52,24 +56,41 @@ async fn main() -> Result<(), Box<dyn Error>> {
     let mut watched = vec![consensus, coordinator];
     watched.extend(config.validator.oracles.iter().copied());
 
+    let account = config.signer.address();
+    let staker = config.validator.staker;
+
     let service = ValidatorService::new(
         chain_id,
-        config.signer.address(),
+        account,
         pool.clone(),
         coordinator,
         config.validator,
     )
     .await?;
 
-    let driver = Driver::new(
+    let mut driver = Driver::new(
         service,
-        provider,
+        provider.clone(),
         config.signer,
         pool,
         watched,
         config.driver,
     )
     .await?;
+
+    // Reconcile the onchain staker association before starting the driver.
+    if let Some(staker) = staker {
+        let current_staker = Consensus::new(consensus, &provider)
+            .getValidatorStaker(account)
+            .call()
+            .await?;
+        if current_staker != staker {
+            tracing::info!(%account, %staker, "reconciling validator staker onchain");
+            driver
+                .queue_action(Action::SetValidatorStaker { staker })
+                .await?;
+        }
+    }
 
     tracing::info!("starting validator service");
     driver.run().await;

--- a/crates/validator/src/service/action.rs
+++ b/crates/validator/src/service/action.rs
@@ -118,6 +118,10 @@ pub enum Action {
         signature_id: B256,
         expires_at: u64,
     },
+    /// An action to associate this validator account with a staker address
+    /// onchain, submitted on startup when it does not match the configured
+    /// staker.
+    SetValidatorStaker { staker: Address },
 }
 
 /// Encodes [`Action`]s into the transactions the queue submits.
@@ -409,6 +413,17 @@ impl ActionEncoder<Action> for Encoder {
                     gas: 250_000,
                 },
                 Some(expires_at),
+            ),
+            Action::SetValidatorStaker { staker } => (
+                Transaction {
+                    to: self.consensus,
+                    value: U256::ZERO,
+                    data: Consensus::setValidatorStakerCall { staker }
+                        .abi_encode()
+                        .into(),
+                    gas: 100_000,
+                },
+                None,
             ),
         }
     }


### PR DESCRIPTION
### Context and Motivation

This PR sets the validator staker on startup.

### Decisions and Tradeoffs

I decided to go the extra simple route instead of using the effects system. The reason is that setting the validator staker is something that is done completely outside the state machine - it happens a single time on startup. Reconciling this with the state machine added an enormous amount of complexity for such a small thing that it is not worth it (it would have required the state machine have a concept of a "startup transition" where it could trigger this effect, which added a lot of extra complexity compare to this hackier solution).

We can revisit how this is implemented in the future, but I do not think it is worth it ATM.

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://docs.safefoundation.org/cla).
