### PR TITLE
[E 4]: E2E Test With Rust Validator

### DIFF
--- a/crates/core/src/state/mod.rs
+++ b/crates/core/src/state/mod.rs
@@ -124,7 +124,7 @@ pub struct StateMachine<S, T, E> {
 enum Status {
     Initialized,
     BlockPending { pending: u64 },
-    BlockEvents { latest: u64 },
+    BlockEvents { latest: u64, safe: u64 },
     WarpEvents { range: RangeInclusive<u64> },
 }
 
@@ -184,7 +184,7 @@ where
             // block returned by `snapshots.current` without round-tripping to
             // the database. Note that the `WarpEvents` status's starting block
             // gets updated as event updates are processed.
-            Status::BlockEvents { latest } => latest.checked_sub(1),
+            Status::BlockEvents { latest, .. } => latest.checked_sub(1),
             Status::WarpEvents { range } => range.start.checked_sub(1),
         }
     }
@@ -211,7 +211,7 @@ where
             }
             Update::Block(BlockUpdate::Uncle { number })
                 if matches!(status, Status::BlockPending { pending } if number < pending)
-                    || matches!(status, Status::BlockEvents { latest } if number <= latest) =>
+                    || matches!(status, Status::BlockEvents { latest, .. } if number <= latest) =>
             {
                 let (_, state) = self.snapshots.reorg(number).await?;
                 let status = Status::BlockPending { pending: number };
@@ -226,12 +226,14 @@ where
                         .apply(Message::NewBlock(number))
                         .await
                         .finish();
-                let status = Status::BlockEvents { latest: number };
-                self.snapshots.prune(safe).await?;
+                let status = Status::BlockEvents {
+                    latest: number,
+                    safe,
+                };
                 (state, status, actions)
             }
             Update::Logs(EventUpdate { blocks, logs })
-                if matches!(status, Status::BlockEvents { latest } if is_next_in_range(latest..=latest, blocks))
+                if matches!(status, Status::BlockEvents { latest, .. } if is_next_in_range(latest..=latest, blocks))
                     || matches!(status, Status::WarpEvents { range } if is_next_in_range(range, blocks)) =>
             {
                 // We are extra defensive with the updates that we pass to the
@@ -249,9 +251,16 @@ where
                 }
                 let (state, actions) = batch.finish();
 
-                // In case we are warping, we can prune intermediate state from
-                // storage for the event pages.
-                let should_prune = matches!(status, Status::WarpEvents { .. });
+                // Prune only after committing the state for the update. In
+                // particular, a new block's safe boundary must not be applied
+                // before its logs are committed: if the service stops between
+                // those updates, restart recovery still needs the parent of
+                // the last committed block for its synthetic reorg.
+                let prune = match &status {
+                    Status::BlockEvents { safe, .. } => Some(*safe),
+                    Status::WarpEvents { .. } => Some(blocks.last),
+                    _ => None,
+                };
                 let status = match status {
                     Status::WarpEvents { range } if blocks.last < range.last => {
                         let range = block_range(next_block(blocks.last)?, range.last)?;
@@ -264,8 +273,8 @@ where
                 };
 
                 self.snapshots.commit(blocks.last, &state).await?;
-                if should_prune {
-                    self.snapshots.prune(blocks.last).await?;
+                if let Some(safe) = prune {
+                    self.snapshots.prune(safe).await?;
                 }
 
                 (state, status, actions)
@@ -440,11 +449,15 @@ mod tests {
     }
 
     fn new_block(number: u64) -> Update<u64> {
+        new_block_with_safe(number, 0)
+    }
+
+    fn new_block_with_safe(number: u64, safe: u64) -> Update<u64> {
         Update::Block(BlockUpdate::New {
             number,
             hash: Default::default(),
             logs_bloom: Default::default(),
-            safe: 0,
+            safe,
         })
     }
 
@@ -527,6 +540,48 @@ mod tests {
                     blocks: vec![1, 2],
                     events: vec![10, 20],
                 },
+            ))
+        );
+    }
+
+    #[tokio::test]
+    async fn restart_can_reorg_after_observing_an_uncommitted_block() {
+        let pool = pool().await;
+        let mut machine = new_machine(&pool).await;
+
+        // Model a one-block reorg window through block 6. Processing block 6
+        // retains block 5 as the safe rollback snapshot.
+        for block in 1..=6 {
+            machine
+                .handle_update(new_block_with_safe(block, block.saturating_sub(1)))
+                .await
+                .unwrap();
+            machine
+                .handle_update(logs(block..=block, []))
+                .await
+                .unwrap();
+        }
+
+        // Observe block 7, but stop before its logs and snapshot are committed.
+        // Its newer safe boundary must not prune the rollback state needed by
+        // the watcher when it resumes from the last committed block (6).
+        machine
+            .handle_update(new_block_with_safe(7, 6))
+            .await
+            .unwrap();
+        assert_eq!(machine.last_block().await, Some(6));
+        drop(machine);
+
+        let mut machine = new_machine(&pool).await;
+        machine.handle_update(uncle(6)).await.unwrap();
+        assert_eq!(
+            committed(&pool).await,
+            Some((
+                5,
+                TestState {
+                    blocks: (1..=5).collect(),
+                    events: vec![],
+                }
             ))
         );
     }

--- a/scripts/run_integration_test.sh
+++ b/scripts/run_integration_test.sh
@@ -23,6 +23,15 @@ echo "Building the Rust sentinel..."
 cargo build --package sentinel
 export SENTINEL_BINARY_PATH="$ROOT/target/debug/sentinel"
 
+# Set SAFENET_TEST_RUST_VALIDATOR=1 to run the validator integration suite
+# against Rust validator subprocesses instead of the in-process TypeScript
+# implementation.
+if [[ "${SAFENET_TEST_RUST_VALIDATOR:-}" == "1" || "${SAFENET_TEST_RUST_VALIDATOR:-}" == "true" ]]; then
+    echo "Building the Rust validator in release mode..."
+    cargo build --package validator --release
+    export VALIDATOR_BINARY_PATH="$ROOT/target/release/validator"
+fi
+
 # --- 2. Start Anvil in the background ---
 echo "Starting Anvil..."
 # Mute anvil logs

--- a/validator/src/__tests__/config.ts
+++ b/validator/src/__tests__/config.ts
@@ -3,9 +3,12 @@ import { createMetricsService } from "../utils/metrics.js";
 
 const { SAFENET_TEST_VERBOSE } = process.env;
 
+export const envFlag = (value: string | undefined) => value === "true" || value === "1";
+
+export const isVerbose = () => envFlag(SAFENET_TEST_VERBOSE);
 export const silentLogger = createLogger({ level: "silent" });
 export const testLogger = createLogger({
-	level: SAFENET_TEST_VERBOSE === "true" || SAFENET_TEST_VERBOSE === "1" ? "debug" : "silent",
+	level: isVerbose() ? "debug" : "silent",
 	pretty: true,
 });
 

--- a/validator/src/consensus/integration.test.ts
+++ b/validator/src/consensus/integration.test.ts
@@ -1,5 +1,6 @@
 import { type ChildProcess, spawn } from "node:child_process";
 import { randomUUID } from "node:crypto";
+import { once } from "node:events";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
@@ -18,7 +19,7 @@ import {
 import { type Account, type PrivateKeyAccount, privateKeyToAccount } from "viem/accounts";
 import { anvil } from "viem/chains";
 import { afterEach, beforeAll, describe, expect, it, vi } from "vitest";
-import { silentLogger, testLogger, testMetrics } from "../__tests__/config.js";
+import { envFlag, isVerbose, silentLogger, testLogger, testMetrics } from "../__tests__/config.js";
 import { waitForBlock, waitForBlocks } from "../__tests__/utils.js";
 import { hashNonceCommitments, type NonceTree } from "../consensus/signing/nonces.js";
 import { toPoint } from "../frost/math.js";
@@ -42,7 +43,15 @@ import { verifySignature } from "./signing/verify.js";
 
 const BLOCK_TIME_MS = 250;
 const BLOCKS_PER_EPOCH = 30n;
+const DEFAULT_TIMEOUT = 120n;
 const TEST_RUNTIME_IN_SECONDS = 60;
+
+const USE_RUST_VALIDATOR = envFlag(process.env.SAFENET_TEST_RUST_VALIDATOR);
+// The integration runner builds and exports this path when the Rust-validator
+// flag is enabled. The default also supports running the test directly after a
+// local `cargo build --package validator --release`.
+const VALIDATOR_BINARY_PATH =
+	process.env.VALIDATOR_BINARY_PATH ?? path.join(process.cwd(), "..", "target", "release", "validator");
 
 // Anvil account 6 — sentinel used in the oracle signing flow test
 const SENTINEL_PK: Hex = "0x92db14e403b83dfe3df233f83dfa3a0d7096f21ca9b0d6d6b8d88b2b4ec1564e";
@@ -70,6 +79,36 @@ const SENTINEL_ORACLE_ABI = parseAbi([
 ]);
 
 type BroadcastReturns = Record<string, { value: Address }>;
+type TestValidatorService = Pick<ValidatorService, "start" | "stop">;
+
+const createRustValidatorService = (configFile: string): TestValidatorService => {
+	let process: ChildProcess | undefined;
+
+	return {
+		async start() {
+			if (process !== undefined) return;
+
+			const child = spawn(VALIDATOR_BINARY_PATH, ["--config-file", configFile], {
+				stdio: isVerbose() ? "inherit" : "ignore",
+			});
+			process = child;
+			child.once("close", () => {
+				if (process === child) process = undefined;
+			});
+
+			await once(child, "spawn");
+		},
+
+		async stop() {
+			const child = process;
+			process = undefined;
+			if (child === undefined || child.exitCode !== null || child.signalCode !== null) return;
+
+			child.kill();
+			await once(child, "close");
+		},
+	};
+};
 
 const loadScriptResults = (script: string): BroadcastReturns | undefined => {
 	const file = path.join(process.cwd(), "..", "contracts", "build", "broadcast", script, "31337", "run-latest.json");
@@ -116,7 +155,8 @@ describe("integration", () => {
 		.extend(walletActions);
 	let snapshotId: Hex | undefined;
 	let miner: NodeJS.Timeout | undefined;
-	let currentClients: { account: Account; service: ValidatorService }[] | undefined;
+	let currentClients: { account: Account; service: TestValidatorService }[] | undefined;
+	let validatorTempDirectory: string | undefined;
 	let sentinelProcess: ChildProcess | undefined;
 	let sentinelConfigFile: string | undefined;
 
@@ -199,18 +239,35 @@ describe("integration", () => {
 		testLogger.notice(`Use sentinelOracle at ${sentinelOracle.address}`);
 
 		// Private keys from anvil testnet
-		const accounts: [PrivateKeyAccount, bigint, bigint | undefined][] = [
-			[privateKeyToAccount("0x59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d"), 0n, undefined],
-			[privateKeyToAccount("0x5de4111afa1a4b94908f83103eb1f1706367c2e68ca870fc3fb9a804cdab365a"), 0n, undefined],
-			[privateKeyToAccount("0x7c852118294e51e653712a81e05800f419141751be58f605c371e15141b007a6"), 0n, undefined],
-			[privateKeyToAccount("0x47e179ec197488593b187f80a00eb0da91f1b9d0b13f8733639f19c30a34926a"), 0n, rotateOutEpoch],
-			[privateKeyToAccount("0x8b3a350cf5c34c9194ca85829a2df0ec3153be0318b5e2d3348e872092edffba"), 2n, undefined],
+		const accountConfigs: [Hex, bigint, bigint | undefined][] = [
+			["0x59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d", 0n, undefined],
+			["0x5de4111afa1a4b94908f83103eb1f1706367c2e68ca870fc3fb9a804cdab365a", 0n, undefined],
+			["0x7c852118294e51e653712a81e05800f419141751be58f605c371e15141b007a6", 0n, undefined],
+			["0x47e179ec197488593b187f80a00eb0da91f1b9d0b13f8733639f19c30a34926a", 0n, rotateOutEpoch],
+			["0x8b3a350cf5c34c9194ca85829a2df0ec3153be0318b5e2d3348e872092edffba", 2n, undefined],
 		];
-		const participants = accounts.map(([a, activeFrom, activeBefore]) => {
+		const accounts: [PrivateKeyAccount, Hex, bigint, bigint | undefined][] = accountConfigs.map(
+			([privateKey, activeFrom, activeBefore]): [PrivateKeyAccount, Hex, bigint, bigint | undefined] => [
+				privateKeyToAccount(privateKey),
+				privateKey,
+				activeFrom,
+				activeBefore,
+			],
+		);
+		const participants = accounts.map(([a, , activeFrom, activeBefore]) => {
 			return { address: a.address, activeFrom, activeBefore };
 		});
 
-		const clients = accounts.map(([a, activeFrom], i) => {
+		if (USE_RUST_VALIDATOR) {
+			if (!fs.existsSync(VALIDATOR_BINARY_PATH)) {
+				throw new Error(
+					`Rust validator binary not found at ${VALIDATOR_BINARY_PATH}; run cargo build --package validator --release`,
+				);
+			}
+			validatorTempDirectory = fs.mkdtempSync(path.join(os.tmpdir(), "safenet-validator-integration-"));
+		}
+
+		const clients = accounts.map(([a, privateKey, activeFrom], i) => {
 			const logger = i === 0 ? testLogger : silentLogger;
 			const config: ProtocolConfig = {
 				chainId: 31_337,
@@ -240,15 +297,61 @@ describe("integration", () => {
 				blockRetryDelays: [Math.floor(blockTime / 20), Math.floor(blockTime / 10), Math.floor(blockTime / 5)],
 				...blockRetryCounts,
 			};
-			const service = createValidatorService({
-				account: a,
-				rpcUrl: "http://127.0.0.1:8545",
-				logger,
-				config,
-				watcherConfig,
-				metrics: testMetrics,
-				skipGenesis: activeFrom > 0n,
-			});
+			let service: TestValidatorService;
+			if (validatorTempDirectory !== undefined) {
+				const configFile = path.join(validatorTempDirectory, `validator-${i}.toml`);
+				const databaseFile = path.join(validatorTempDirectory, `validator-${i}.sqlite`);
+				fs.writeFileSync(
+					configFile,
+					[
+						'rpc = "http://127.0.0.1:8545"',
+						`signer = "${privateKey}"`,
+						`database = "sqlite://${databaseFile}?mode=rwc"`,
+						"",
+						"[validator]",
+						`consensus = "${consensus.address}"`,
+						`staker = "${a.address}"`,
+						`oracles = ["${sentinelOracle.address}"]`,
+						`genesis_salt = "${zeroHash}"`,
+						`blocks_per_epoch = ${blocksPerEpoch ?? BLOCKS_PER_EPOCH}`,
+						`key_gen_timeout = ${timeout ?? DEFAULT_TIMEOUT}`,
+						`signing_timeout = ${timeout ?? DEFAULT_TIMEOUT}`,
+						`oracle_timeout = ${oracleTimeout ?? DEFAULT_TIMEOUT}`,
+						...participants.flatMap(({ address, activeFrom, activeBefore }) => [
+							"",
+							"[[validator.participants]]",
+							`address = "${address}"`,
+							`active_from = ${activeFrom}`,
+							...(activeBefore === undefined ? [] : [`active_before = ${activeBefore}`]),
+						]),
+						"",
+						"[observability]",
+						`log_filter = "${isVerbose() && i === 0 ? "info,safenet_core=debug,validator=debug,validator::service::effect=trace" : "off"}"`,
+						"",
+						"[index]",
+						`block_time = ${blockTime}`,
+						`block_propagation_delay = ${Math.floor(blockTime / 5)}`,
+						`block_retry_delays = [${[
+							Math.floor(blockTime / 20),
+							Math.floor(blockTime / 10),
+							Math.floor(blockTime / 5),
+						].join(", ")}]`,
+						"max_reorg_depth = 1",
+						"start_block = 0",
+					].join("\n"),
+				);
+				service = createRustValidatorService(configFile);
+			} else {
+				service = createValidatorService({
+					account: a,
+					rpcUrl: "http://127.0.0.1:8545",
+					logger,
+					config,
+					watcherConfig,
+					metrics: testMetrics,
+					skipGenesis: activeFrom > 0n,
+				});
+			}
 			return {
 				account: a,
 				service,
@@ -317,7 +420,13 @@ describe("integration", () => {
 			try {
 				await service.stop();
 			} catch (_e) {}
-			currentClients = undefined;
+		}
+		currentClients = undefined;
+		if (validatorTempDirectory !== undefined) {
+			try {
+				fs.rmSync(validatorTempDirectory, { recursive: true });
+			} catch (_e) {}
+			validatorTempDirectory = undefined;
 		}
 		// Cleanup miner
 		if (miner !== undefined) {


### PR DESCRIPTION
### Context and Motivation

In a similar spirit to #554, this PR makes an attempt to check that the Rust validator passes the same E2E tests as the TypeScript validator... And it works :tada:.

We use the same strategy as the PR linked above and add a new "use Rust validator" flag in order to start the Rust validator as a separate binary for the E2E test (and basically just use TS for instrumenting the test).

### Decisions and Tradeoffs

- We build the Rust validator in release mode. It turns out that in debug mode, having 4 validators simultaneously computing nonce trees and merkle proofs was quite slow (it took about 1.5 seconds). However, in release mode that number drops down to below 100ms, which is quite impressive: unlike with the TypeScript validator, we don't need to make a "generate fewer nonces" hack.
- There was a bug in the snapshot store :scream:. We were pruning in between states (so we would prune right when we saw a new block, but commmit only after processing all events for the block). This would cause the restarting validator to error out (it would try to go further back in time than it had snapshots. With the fix, all pruning happens at the same spot (which indicates that there _was_ a small code smell before when we were pruning in two different places).

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://docs.safefoundation.org/cla).
