### PR TITLE
[PLAN]: Additional Rust Validator Port Follow-ups

### DIFF
--- a/epics/2026_07_14_rust_validator_port_review.md
+++ b/epics/2026_07_14_rust_validator_port_review.md
@@ -1,0 +1,925 @@
+# Rust validator port review findings
+
+Review target: `41593a6` (`[E 4]: E2E Test With Rust Validator`)
+
+Compared implementations:
+
+- Rust validator: [`crates/validator/`](../crates/validator/)
+- TypeScript validator: [`validator/`](../validator/)
+
+## Executive summary
+
+The Rust validator is not ready to be treated as a drop-in production replacement for the
+TypeScript validator. Its core protocol implementation is strong and contains several meaningful
+security and maintainability improvements, but the review found multiple high-severity reliability
+issues and several consensus behaviors that are not safe to mix with TypeScript validators without
+a coordinated compatibility decision.
+
+The most important deployment conclusions are:
+
+- A coordinated "stop TypeScript, start Rust" migration after genesis can deadlock the validator
+  set.
+- Transient database or RPC failures can permanently strand DKG, nonce preprocessing, or block
+  processing.
+- Restart and reorg recovery can duplicate non-idempotent actions or fail because required
+  snapshots, DKG secrets, or nonce trees have already been pruned.
+- Under duplicate proposals, malformed DKG input, reorgs, or timeout recovery, Rust and TypeScript
+  validators can track different groups, signature IDs, signer selections, or active signing
+  phases for the same on-chain packet.
+
+The port should not be approved for production replacement until the high-severity findings and the
+restart-recovery findings are resolved and tested. A mixed Rust and TypeScript deployment should
+also be considered unsupported until the consensus inconsistencies below are either backported to
+TypeScript, removed from Rust, or explicitly activated through a coordinated protocol version.
+
+## Rust and TypeScript consensus inconsistencies
+
+### Compatibility model
+
+For this review, a consensus inconsistency is any implementation difference that can make two
+honest validators process the same canonical chain and then disagree about one of the following:
+
+- Which DKG group or epoch is being built.
+- Which transaction or rollover packet is eligible for signing.
+- Which FROST signature ID and signer selection is current.
+- Which participant should initiate a retry or fallback.
+- Whether an on-chain proposal should be signed, declined, retried, or forgotten.
+
+Not every difference is a defect in the Rust implementation. Several are deliberate Rust fixes for
+TypeScript soundness or liveness problems. They are nevertheless mixed-deployment incompatibilities:
+if one half of a validator group applies the fix and the other half retains the old behavior, the
+group can split its signature shares across different ceremonies or make different DKG decisions.
+
+The inconsistencies fall into three classes:
+
+| Class         | Meaning                                                                                                      | Deployment implication                                                               |
+| ------------- | ------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------ |
+| State fork    | Implementations retain different logical state after the same event history.                                 | Must be aligned before mixed deployment.                                             |
+| Recovery fork | Honest-path state agrees, but timeout, restart, or reorg recovery produces different actions or signer sets. | Requires identical timeout configuration and failure tests before mixed deployment.  |
+| Policy fork   | Implementations return different approve or decline decisions for the same packet.                           | The implementation majority determines policy; this must be versioned or eliminated. |
+
+Several of the Rust-side divergences below are already accepted project decisions rather than
+open questions: the stricter DKG validation timing, the genesis halt (no genesis ceremony
+restart), the aggressive cleanup on observed attestations, and the eager
+`signature_id_to_message` bookkeeping. For those, the alignment items in this document describe
+a known fork that still needs a deployment decision (backport or coordinated cutover); they are
+not newly discovered defects in the Rust port.
+
+### Consensus inconsistency summary
+
+| Area                            | Rust behavior                                                                                        | TypeScript behavior                                                                                          | Mixed-validator risk                                                                           |
+| ------------------------------- | ---------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------ | ---------------------------------------------------------------------------------------------- |
+| Reorg processing                | Rolls snapshots back and replays canonical blocks and logs.                                          | Logs the uncle but explicitly does not roll state back.                                                      | Direct state fork after any relevant orphaned event.                                           |
+| Duplicate transaction proposals | Keeps the existing signing phase and signature ID.                                                   | Replaces the signing state and follows the newest `Sign` event.                                              | Shares split across old and new signature IDs.                                                 |
+| Duplicate oracle proposals      | Keeps the existing signing phase and signature ID.                                                   | Replaces the signing state and follows the newest request.                                                   | Same split as plain proposals, plus repeated oracle requests.                                  |
+| DKG public-share validation     | Validates public verification shares against commitments and refuses invalid public input.           | Does not validate the posted public share when observing; trusts on-chain share completion.                  | Validators can disagree whether DKG entered confirmation or must exclude a participant.        |
+| DKG completion source           | Counts locally verified commitments and public shares.                                               | Uses the contract's `committed` and `shared` booleans after partial local processing.                        | Malformed input can move TypeScript ahead while Rust remains in an earlier phase.              |
+| Malformed curve-point handling  | Rejects the individual DKG or nonce event and continues with later logs.                             | Point-schema conversion throws before transition dispatch and aborts the remainder of the watcher log batch. | Later valid events in the same block or warp page are permanently observed only by Rust.       |
+| Initial signing timeout         | Drops `WaitingForRequest` when responsibility is already “everyone.”                                 | Has every validator submit `sign` once, then drops the request.                                              | Rust cannot recover the same missing `Sign` event that TypeScript recovers.                    |
+| Responsible signing timeout     | Excludes the failed responsible signer and has every remaining Rust validator submit immediately.    | Gives the responsible validator one retry window, then makes everyone responsible.                           | Different retry timing creates multiple signature IDs and signer sets.                         |
+| Attestation fallback            | Every Rust validator submits one direct fallback at the first timeout.                               | The last signer retries first; everyone retries only at the second timeout.                                  | Extra ceremonies/gas and different cleanup timing.                                             |
+| Action expiration clock         | Expires queued protocol actions at their block deadline.                                             | Keeps every queued action live for a fixed ten minutes of wall-clock time.                                   | TypeScript can submit an obsolete `sign` or share after Rust has expired the phase.            |
+| Oracle attestation fallback     | Supports direct `attestOracleTransaction`.                                                           | Builds no direct oracle fallback in `waiting_for_attestation`.                                               | Rust can complete a callback failure that TypeScript eventually abandons.                      |
+| Signature-share timeout         | Attributes participation per selection root and chooses a threshold root.                            | Counts shares across all selection roots.                                                                    | Retry signer sets diverge under competing or malicious roots.                                  |
+| Expected signing group          | Stores the expected group and rejects a `Sign` event for a different group.                          | Checks only that the local validator belongs to the event's group and that the message was verified.         | A wrong-group `Sign` can divert TypeScript recovery state but not Rust state.                  |
+| Late old-epoch signing          | Tops up the group named by the `Sign` event, including retained old groups.                          | Tops up only the currently active epoch group.                                                               | TypeScript can run out of usable nonces during an old-epoch retry while Rust continues.        |
+| Pending nonce preprocessing     | Processes a nonce-tree link only for this validator's own event.                                     | Clears the group's local pending flag when any participant's `Preprocess` event lands.                       | A peer event can make TypeScript generate duplicate local nonce trees while Rust does not.     |
+| Attestation cleanup             | Removes the packet state when an attestation lands, even if it completed under another signature ID. | Cleans up only from `waiting_for_attestation`.                                                               | TypeScript can continue retrying a packet that another ceremony already attested.              |
+| Genesis failure                 | Halts when genesis would need a different subgroup.                                                  | Attempts to restart genesis with a new group ID.                                                             | Local state diverges, although the replacement group is not the authorized genesis group.      |
+| First post-genesis DKG          | Starts immediately in the final-confirmation block.                                                  | Starts on the following block transition.                                                                    | If confirmation is the last block of an epoch, Rust and TypeScript can target adjacent epochs. |
+| Transaction policy              | Rejects delegate-call entries inside `MultiSendCallOnly`.                                            | Applies the ordinary MultiSend delegate-call allow-list to CallOnly deployments.                             | Same Safe transaction is declined by Rust and accepted by TypeScript.                          |
+| Policy operation routing        | Approves a plain `CALL` to a MultiSend, migration, `SignMessageLib`, or `CreateCall` address.        | Routes checks by `to` address before the operation and declines the same `CALL`.                             | Same Safe transaction is approved by Rust and declined by TypeScript.                          |
+| Default consensus timing        | Defaults to 1,440 blocks/epoch, 6-block signing timeout, and 12-block oracle timeout.                | Defaults to 17,280, 120, and 120 respectively.                                                               | Immediate hard split at rollover or whenever a phase crosses the shorter Rust timeout.         |
+
+### Implementation cross-reference
+
+The principal comparison points are:
+
+| Concern                                    | Rust                                                                                                                                                                                 | TypeScript                                                                                                                                                                                                                                                                                                                                                                         |
+| ------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Proposal and attestation lifecycle         | [`state/transactions.rs`](../crates/validator/src/state/transactions.rs)                                                                                                             | [`transactionProposed.ts`](../validator/src/machine/consensus/transactionProposed.ts), [`oracleTransactionProposed.ts`](../validator/src/machine/consensus/oracleTransactionProposed.ts), [`transactionAttested.ts`](../validator/src/machine/consensus/transactionAttested.ts), [`oracleTransactionAttested.ts`](../validator/src/machine/consensus/oracleTransactionAttested.ts) |
+| DKG share validation and phase advancement | [`state/keygen.rs`](../crates/validator/src/state/keygen.rs), [`frost/keygen.rs`](../crates/validator/src/frost/keygen.rs)                                                           | [`secretShares.ts`](../validator/src/machine/keygen/secretShares.ts), [`timeouts.ts`](../validator/src/machine/keygen/timeouts.ts)                                                                                                                                                                                                                                                 |
+| Signing state and timeout recovery         | [`state/sign.rs`](../crates/validator/src/state/sign.rs)                                                                                                                             | [`sign.ts`](../validator/src/machine/signing/sign.ts), [`timeouts.ts`](../validator/src/machine/signing/timeouts.ts), [`shares.ts`](../validator/src/machine/signing/shares.ts)                                                                                                                                                                                                    |
+| Epoch rollover and genesis handoff         | [`state/keygen.rs`](../crates/validator/src/state/keygen.rs), [`state/mod.rs`](../crates/validator/src/state/mod.rs)                                                                 | [`confirmed.ts`](../validator/src/machine/keygen/confirmed.ts), [`trigger.ts`](../validator/src/machine/keygen/trigger.ts), [`epochStaged.ts`](../validator/src/machine/consensus/epochStaged.ts)                                                                                                                                                                                  |
+| Reorg processing                           | [`core/state/storage.rs`](../crates/core/src/state/storage.rs), [`core/state/mod.rs`](../crates/core/src/state/mod.rs), [`core/index/blocks.rs`](../crates/core/src/index/blocks.rs) | [`shared/watcher.ts`](../validator/src/shared/watcher.ts)                                                                                                                                                                                                                                                                                                                          |
+| Safe transaction policy                    | [`consensus/checks/mod.rs`](../crates/validator/src/consensus/checks/mod.rs)                                                                                                         | [`service/checks.ts`](../validator/src/service/checks.ts), [`checks/multisend.ts`](../validator/src/consensus/verify/safeTx/checks/multisend.ts)                                                                                                                                                                                                                                   |
+
+### 1. TypeScript does not roll consensus state back on reorg
+
+The Rust indexer and state machine treat reorgs as first-class transitions: they restore the parent
+snapshot and replay the new canonical branch. The TypeScript watcher handles
+`watcher_update_uncle_block` by incrementing a metric and logging `Reorg detected, but currently not
+supported`; it does not restore consensus or FROST state.
+
+This difference is a direct state fork, not just a recovery-quality difference. For example, if an
+orphaned block contains a `TransactionProposed`, `Sign`, `EpochStaged`, `KeyGenCommitted`, or
+`Preprocess` event:
+
+1. Rust removes the orphaned transition and processes the replacement branch.
+2. TypeScript retains the orphaned rollover/signing state and locally generated protocol actions.
+3. Replacement logs at the same block and log index are out of order from the TypeScript state
+   machine's perspective and may be rejected or ignored.
+4. The implementations can subsequently sign different packets, DKG groups, or signature IDs.
+
+The TypeScript behavior is visible in
+[`validator/src/shared/watcher.ts`](../validator/src/shared/watcher.ts); Rust rollback and replay live
+under [`crates/core/src/state/`](../crates/core/src/state/) and
+[`crates/core/src/index/`](../crates/core/src/index/).
+
+Mixed operation is therefore unsafe on a chain where reorgs are within the stated threat model. A
+mixed test that exercises only linear Anvil blocks cannot establish compatibility.
+
+Required compatibility decision:
+
+- Backport snapshot rollback and canonical replay to TypeScript before mixed deployment, or
+- Perform a coordinated cutover in which no TypeScript validator remains in a signing group that
+  includes Rust validators.
+
+### 2. Duplicate proposals split the validator set across signature IDs
+
+`Consensus.proposeTransaction` and `proposeOracleTransaction` can be called repeatedly until an
+attestation exists. Each call emits a proposal and synchronously opens a new coordinator signing
+ceremony with a fresh sequence and signature ID.
+
+Rust intentionally preserves an existing signing entry keyed by the packet message. TypeScript
+unconditionally applies a new `waiting_for_request` diff for the duplicate proposal. The resulting
+event sequence is:
+
+1. Proposal 1 opens signature ID `sid-1`; all validators begin processing it.
+2. Proposal 2 for the same packet opens `sid-2` before `sid-1` completes.
+3. Rust ignores the duplicate proposal and the unexpected `sid-2` `Sign` event, remaining on
+   `sid-1`.
+4. TypeScript replaces its state and follows `sid-2`.
+5. A mixed group publishes nonce commitments and signature shares to different ceremonies.
+
+Neither ceremony reaches threshold unless one implementation alone controls a threshold of the
+group. This is a low-cost, externally triggerable mixed-deployment liveness failure. Oracle
+proposals additionally repeat the external oracle request.
+
+Rust's behavior fixes a real TypeScript denial-of-service issue documented in commits `2eabb7f` and
+`4bc18b5`. The fix should be backported to TypeScript before operating a mixed group; reverting the
+Rust behavior would reintroduce the original attack. Commit `1c79517` separately documents the
+related cleanup fork after an attestation lands.
+
+### 3. DKG validation can produce different groups and rollover states
+
+Rust validates more public DKG information than TypeScript:
+
+- Every commitment must be locally valid before it contributes to phase completion.
+- A posted public verification share must match the participant's commitments.
+- The number and shape of encrypted shares must be valid.
+- Observers perform the public checks even when they cannot decrypt a share intended for another
+  validator.
+
+TypeScript validates commitments and decrypts/verifies its own encrypted share, but its transition
+to confirmation is driven by the contract's `shared` boolean. An observer does not validate the
+posted public verification share. `sharesFrom` also records every on-chain submitter regardless of
+whether the public portion is locally valid.
+
+A malicious participant can therefore post a contract-accepted share whose public verification
+share does not match its DKG commitment:
+
+1. Rust refuses to count that participant as having shared and remains in `CollectingShares`.
+2. TypeScript can enter `collecting_confirmations` when the contract reports `shared = true`.
+3. At timeout, Rust excludes the invalid participant and derives a new group ID.
+4. TypeScript can continue confirming or signing a rollover for the original group.
+
+If TypeScript validators stage the original group, Rust validators that rejected it do not record
+the same epoch group. Their later rollover hashes and available signing keys can remain permanently
+out of sync.
+
+Rust's stronger validation is the correct security behavior and matches the rationale documented in
+the port history. It is still a protocol behavior change and needs an adversarial mixed-validator
+test plus a coordinated activation or TypeScript backport.
+
+### 4. Malformed public points abort a TypeScript log batch but not Rust processing
+
+The coordinator checks that DKG and nonce points are nonzero, but it does not establish that every
+point is a valid, non-identity secp256k1 point before emitting it. In particular, a participant can
+commit structurally valid but off-curve DKG data, or register a nonce-tree root containing
+off-curve coordinates and later reveal that leaf.
+
+Rust decodes the coordinates as contract data and performs curve validation inside the applicable
+state transition. It rejects the individual commitment, public share, or nonce reveal and then
+continues processing later logs.
+
+TypeScript transforms every FROST point through `toPoint` in
+[`transitions/schemas.ts`](../validator/src/machine/transitions/schemas.ts). An off-curve point
+throws while `logToTransition` is being evaluated, before the watcher's per-transition error
+boundary. The exception escapes the `for (const log of update.logs)` loop, and the watcher catches
+it only at the outer handler boundary. Consequences are broader than rejecting the malicious
+event:
+
+1. Every valid log after the malformed one in that `watcher_update_new_logs` batch is skipped.
+2. The underlying event watcher has already consumed the block or warp page and does not enqueue
+   those later logs again.
+3. Rust records the later valid DKG, nonce, share, and attestation events while TypeScript does not.
+4. The implementations can exclude different participants, choose different retry signer sets, or
+   remain in different phases permanently.
+
+During historical catch-up, one update can cover a page containing logs from many blocks, so the
+loss is not necessarily limited to the remainder of one block. This gives a malicious participant
+who can publish a contract-accepted malformed point influence over unrelated later consensus
+events.
+
+Required remediation:
+
+- Parse structural event data without throwing at the batch level.
+- Validate curve points inside an event-local transition boundary.
+- Continue processing later logs after recording an invalid event, or fail the entire update
+  transactionally and replay it from the same cursor.
+- Test a malformed event at the beginning, middle, and end of both a live block batch and a
+  historical warp page.
+
+### 5. Timeout defaults and responsibility rules create different ceremonies
+
+The different defaults are consensus-affecting, not merely operational:
+
+- Rust signing timeout: 6 blocks; TypeScript: 120 blocks.
+- Rust oracle timeout: 12 blocks; TypeScript: 120 blocks.
+- Rust blocks per epoch: 1,440; TypeScript: 17,280.
+
+If a signing round lasts more than six blocks under defaults, Rust can abandon the current
+signature ID and open a retry while TypeScript remains on the original ID for another 114 blocks.
+When the retry `Sign` event lands, TypeScript is not in `waiting_for_request` and ignores it. The
+mixed group is then split across two ceremonies.
+
+An oracle result arriving after block 12 but before block 120 is similarly accepted by TypeScript
+and ignored by Rust. A blocks-per-epoch mismatch is more severe: validators derive different DKG
+targets and different `rolloverBlock` values, so they hash and sign different rollover packets.
+
+Even with identical configured timeout values, the responsibility algorithms differ:
+
+- In `WaitingForRequest` with a named responsible participant, Rust removes that participant and
+  immediately has every remaining validator submit `sign`. TypeScript gives the named participant
+  one retry window and only then lets everyone act.
+- In `WaitingForRequest` with no named responsible participant, TypeScript has everyone submit once;
+  Rust drops the request without an action.
+- In `WaitingForAttestation`, Rust has everyone submit a direct fallback at the first timeout and
+  then forgets the state. TypeScript retries through the last signer first and everyone second.
+
+The implementations also disagree on when an already-queued action becomes stale. Rust attaches
+the phase's block deadline to signing, DKG, and fallback actions, and the durable transaction queue
+will not allocate a nonce after that block. TypeScript's `BaseActionQueue` gives every action a
+fixed ten-minute wall-clock lifetime, independent of the configured block timeout. On a fast chain,
+under an RPC outage, or with a short explicit timeout, TypeScript can submit an old `sign` action
+after Rust has advanced to a retry generation. That stale call increments the coordinator sequence
+and opens another signature ID.
+
+The normal proposal path emits `Sign` synchronously, so the no-responsible recovery difference is
+primarily exposed by missing logs, reorgs, or earlier processing failures. Those are exactly the
+conditions the timeout state is intended to recover from.
+
+Required compatibility decision:
+
+- Remove consensus-affecting defaults from production configuration.
+- Fail startup unless all epoch and timeout parameters are explicit.
+- Define one responsibility state machine and implement it in both languages.
+- Use the same block-based action validity rule in both transaction queues.
+
+### 6. Oracle attestation recovery exists only in Rust
+
+When `signShareWithCallback` completes the FROST signature but its consensus callback does not land,
+Rust can build direct fallback actions for epoch rollover, plain transactions, and oracle
+transactions.
+
+TypeScript's `waiting_for_attestation` timeout builds direct actions only for epoch rollover and
+plain transaction packets. An oracle packet falls through without an
+`attestOracleTransaction` action. After its second timeout, TypeScript removes the signing state and
+signature mapping without ever submitting the completed oracle attestation.
+
+In a mixed group, Rust may successfully attest the oracle transaction while TypeScript abandons it.
+The on-chain result ultimately converges, but the implementations differ in responsibility, retry
+load, and their ability to make progress without the Rust subset.
+
+The epoch-rollover fallback is also more fragile in TypeScript than in Rust. At the
+`waiting_for_attestation` timeout, TypeScript only emits `consensus_stage_epoch` when the
+rollover machine is still in `sign_rollover` for that exact message; Rust builds the direct
+`stageEpoch` action from the packet itself. If the rollover state has moved on (for example
+after a skip or restart), TypeScript abandons a staging that Rust still submits.
+
+The Rust fallback should be backported to TypeScript, and callback-failure integration tests should
+cover all three packet types.
+
+### 7. Signature-share timeout participation is defined differently
+
+The coordinator permits shares for multiple signer-selection roots within the same signature ID.
+Only shares submitted to the same root can combine into a valid threshold signature.
+
+Rust stores `shares_from` and `last_signer` separately for each selection root. On timeout it chooses
+the unique threshold-sized root with the most shares and uses only those participants for retry.
+
+TypeScript stores a single `sharesFrom` array without the selection root. A malicious participant
+can submit a valid share under a different root, be counted as participating, and remain in the
+retry signer set even though it did not contribute to the root the honest validators were building.
+
+This was intentionally fixed in commit `ed53c8a`. In a mixed deployment, Rust and TypeScript can
+derive different retry signer sets and different responsible validators from the same
+`SignShared` event sequence. The TypeScript behavior should be backported rather than retained as a
+permanent compatibility mode.
+
+The implementations also track a timed-out ceremony differently when the local validator is not
+part of the retry signer set (or the set falls below threshold): Rust drops the signing session
+entirely, removing its signature-id mapping, while TypeScript re-enters `waiting_for_request`
+and keeps observing regardless of its own membership. Subsequent retry events for the packet are
+then processed by TypeScript and ignored by Rust.
+
+### 8. Rust binds a verified packet to its expected group; TypeScript does not
+
+Rust stores `group_id` in `WaitingForRequest` and only accepts a `Sign` event when `event.gid`
+matches that expected group. TypeScript checks that the local validator belongs to `event.gid` and
+that the message is verified, but it does not compare the event group with the packet epoch's
+group.
+
+The coordinator's `sign` function is public and can be called for any finalized group and arbitrary
+nonzero message. If an old or future finalized group has the same participant addresses, a
+wrong-group `Sign` for a valid pending packet can divert TypeScript from a recovery state into a
+ceremony whose signature the consensus contract will not accept for that epoch. Rust ignores the
+same event.
+
+The initial proposal and its legitimate `Sign` are emitted atomically, which limits this attack on
+the first attempt. It remains relevant during timeout/retry windows when the packet is again in
+`WaitingForRequest`.
+
+Rust's expected-group check should be added to TypeScript and covered by a direct coordinator-sign
+test.
+
+### 9. Old-epoch nonce availability differs during late retries
+
+Any `Sign` call increments the sequence for the group named by the event. Rust locates the retained
+epoch with that group ID and tops up its nonce stock, including a group that stopped being active
+while a signing ceremony was still in progress.
+
+TypeScript's top-up path always uses `consensusState.activeEpoch`, not `event.gid`. For a late retry
+under the previous epoch, it can generate nonces for the new active group while leaving the old
+group depleted. Rust validators continue participating; TypeScript validators eventually fail to
+reveal an old-group sequence.
+
+There is a second preprocessing bookkeeping mismatch. TypeScript's `groupPendingNonces[groupId]`
+flag represents a locally generated tree, but `handlePreprocess` clears it when _any_ participant's
+event for that group lands. If a peer's preprocessing transaction is ordered before this
+validator's transaction, the next `Sign` can make TypeScript generate and enqueue another local
+tree. Rust links a tree only when `event.participant` is its own account and otherwise leaves its
+local work unchanged. This does not by itself change packet hashes, but it makes nonce inventory,
+queued actions, and recovery behavior diverge.
+
+This difference is intentional and correct in Rust. It should be backported before mixed operation
+across epoch boundaries. TypeScript should also clear pending preprocessing only for its own
+matching root.
+
+### 10. Attestation cleanup differs after competing ceremonies
+
+Rust removes the packet's signing state whenever the corresponding on-chain attestation lands,
+even if the local state was following a different signature ID or had not yet reached
+`WaitingForAttestation`.
+
+TypeScript only cleans up if its current state is exactly `waiting_for_attestation`. If a Rust
+majority completes `sid-1` while TypeScript followed `sid-2` after a duplicate proposal, TypeScript
+ignores the attestation for cleanup and can continue retrying an already-attested packet. Its later
+callbacks revert with `AlreadyAttested`, consuming nonce stock and gas.
+
+The defensive Rust cleanup should be backported together with duplicate-proposal handling so both
+implementations converge on the first valid on-chain attestation.
+
+TypeScript has a smaller related leak when an oracle rejects a request or its response times out:
+it removes the signing entry but leaves `signatureIdToMessage[sid]`. Rust removes both. Signature
+IDs are not reused, so this alone is not a ceremony fork, but it is another case where the same
+terminal event leaves different durable consensus state and routes late signature events through
+different lookup results.
+
+### 11. Genesis recovery and first-epoch timing differ
+
+Rust treats a genesis DKG restart as unrecoverable because excluding a participant changes the
+genesis group ID and the replacement is not the group authorized by deployment. TypeScript attempts
+to trigger a replacement genesis subgroup. Rust's halt is the correct behavior, but the local state
+machines diverge after a threshold complaint or equivalent genesis failure.
+
+Fresh-node recovery also differs. If an `EpochStaged` event arrives while Rust is still
+`WaitingForGenesis`, Rust moves to `EpochSkipped` so it can join a later DKG. TypeScript in
+`waiting_for_genesis` ignores the same event; it only has equivalent catch-up behavior when the
+operator starts it in the separate `SKIP_GENESIS` mode. This makes startup flags, not canonical
+chain state, determine whether otherwise identical validators ever join the active rollover flow.
+
+There is also an edge at successful genesis completion:
+
+- Rust starts the first regular DKG immediately while handling the final `KeyGenConfirmed` event,
+  targeting `floor(block / blocks_per_epoch) + 1`.
+- TypeScript records genesis as staged and starts the first regular DKG on the next block
+  transition, targeting `floor((block + 1) / blocks_per_epoch) + 1` when the next block is processed.
+
+For most blocks both expressions yield the same epoch. If the final genesis confirmation is in the
+last block before an epoch boundary, Rust targets epoch `N + 1` while TypeScript targets epoch
+`N + 2`. Their group contexts and group IDs differ, so each implementation ignores the other's DKG
+events.
+
+Commit `837ccaa` describes the one-block difference as non-divergent, but the boundary case is not
+covered. The implementations should use the same event block to derive the first post-genesis epoch,
+and an integration test should finalize genesis immediately before a boundary.
+
+### 12. Safe transaction policy has `MultiSendCallOnly` and operation-routing forks
+
+Rust distinguishes ordinary MultiSend contracts from `MultiSendCallOnly` and rejects delegate-call
+subtransactions for CallOnly addresses. TypeScript constructs the same subtransaction checker with
+`allowedDelegateCalls` for both contract families.
+
+The same proposal is therefore placed in `WaitingToDecline` by Rust and `WaitingForRequest` by
+TypeScript. A mixed group signs or declines according to which implementation controls threshold.
+Even if the CallOnly contract would later revert the unsupported subtransaction, the validator
+network should not disagree about whether the proposal satisfies policy.
+
+There is a second, independent fork in the check structure itself. TypeScript routes checks by
+`to` address before considering the operation: a plain `CALL` (operation 0) to any configured
+MultiSend, `MultiSendCallOnly`, `SafeMigration`, `SignMessageLib`, or `CreateCall` address
+reaches a checker that requires `operation == 1` and declines the proposal (the
+`checks/config` tests assert "Expected operation 1 got 0"). Rust checks the operation first
+([`consensus/checks/mod.rs`](../crates/validator/src/consensus/checks/mod.rs)) and approves any
+`CALL` to a non-self address. The same plain call to, for example, the MultiSend 1.3.0 address
+is therefore `WaitingForRequest` in Rust and `waiting_to_decline` in TypeScript. TypeScript is
+also internally inconsistent here: it allows the equivalent `CALL` when it appears as a
+sub-transaction inside a MultiSend batch.
+
+Two further differences are currently latent and should be closed with the same corpus:
+
+- Rust zeroes `chainId` and `nonce` in decoded MultiSend sub-transactions
+  ([`checks/multi_send.rs`](../crates/validator/src/consensus/checks/multi_send.rs)); TypeScript
+  propagates both from the outer transaction. No check consumes either field today.
+- TypeScript's `buildAddressSplitCheck` supports chain-scoped `eip155:<chainId>:<address>` keys
+  with no Rust counterpart. No such key is configured today; the first one would fork policy
+  silently.
+
+Outside of these forks, the two policies were verified to agree: the six allow-lists (fallback
+handlers, guards, modules, module guards, migration contracts, sign-message and create-call
+libraries) contain identical addresses, selector matching semantics agree, and the MultiSend
+byte decoding (including `to == 0` self-call mapping for v1.5.0+ and strict length handling) is
+byte-for-byte equivalent.
+
+Required remediation:
+
+- Correct the TypeScript CallOnly checker and define one operation-routing rule for calls to
+  policy-listed addresses.
+- Build a shared policy corpus and assert identical approve/decline results in both languages,
+  including plain calls (operation 0) to every policy-listed address.
+- Treat any future policy change as a versioned consensus change, not a local implementation detail.
+
+### Consensus behaviors already shown to be compatible
+
+The comparison did not find a hashing or honest-path FROST wire-format mismatch in the following
+areas:
+
+- Genesis and regular group ID derivation for the same ordered participant set and epoch context.
+- Majority signing threshold and greater-than-two-thirds minimum DKG participation formulas within
+  the supported participant-count range.
+- Safe transaction, oracle transaction, and epoch-rollover packet hashing.
+- Participant identifiers, nonce commitment leaves, signer-selection leaves, and Solidity ABI
+  encoding.
+- Honest-path DKG commitments, encrypted shares, nonce reveals, and signature shares exercised by
+  the mixed integration flow.
+- DKG `f[]` share ordering (ascending participant address, excluding self) on both the publish
+  and receive paths, and signer-selection ordering (both sort by the hashed FROST identifier).
+- Merkle trees: sorted-pair Keccak hashing, zero-hash padding, and proof generation are
+  byte-for-byte equivalent (TypeScript throws on an empty tree where Rust returns a zero root,
+  which is unreachable with valid inputs).
+- Keygen confirmation deadline structure (complain/respond/confirm at one/two/three keygen
+  timeouts from share completion) and the complaint/response acceptance windows.
+- Epoch activation timing (both implementations activate a staged epoch on the block clock at
+  `epoch * blocks_per_epoch`, and both ignore an `EpochStaged` event for a group other than the
+  one they generated) and the signing-session-aware cleanup cutoff for retired epoch groups.
+- The Safe policy allow-list addresses and the fixed per-action gas constants (identical on both
+  sides, so fixed gas is a shared operational risk rather than a divergence).
+
+These compatibility results are important but do not cover adversarial events, timeouts, restarts,
+or reorgs where the state-machine inconsistencies occur.
+
+## High-severity findings
+
+### 1. No viable live-network bootstrap or TypeScript migration path
+
+The Rust process resolves the coordinator and optionally reconciles the staker at startup, but it
+does not read the current consensus epoch, active or staged group, or rollover state from chain. See
+[`crates/validator/src/main.rs`](../crates/validator/src/main.rs).
+
+A new Rust database begins in `WaitingForGenesis`. With the default `start_block = None`, the
+indexer only processes blocks in the recent reorg window. If neither genesis nor an `EpochStaged`
+event is present in that window, the validator remains in `WaitingForGenesis` until a future staged
+event is emitted.
+
+When a validator in `WaitingForGenesis` eventually observes an `EpochStaged` event, it enters
+`EpochSkipped` and only starts DKG for a later epoch. Depending on when the event is observed, the
+validator may wait almost two full epochs before it has a usable key share.
+
+Consequences:
+
+- If all TypeScript validators are replaced simultaneously after genesis, no Rust validator starts
+  the next rollover. The validator set can remain stuck indefinitely.
+- A rolling migration can recover only while the remaining TypeScript validators retain enough
+  quorum to stage future epochs.
+- Replaying from block zero is not a migration solution. Historical DKG randomness cannot recreate
+  an existing private key share, and old protocol actions cannot safely be reproduced.
+- The TypeScript and Rust database and key-share formats have no migration or import path.
+
+The TypeScript implementation has an explicit `SKIP_GENESIS` state that allows an instance to join
+a running deployment without pretending that genesis will be observed again.
+
+This gap is also inconsistent with commit `3784513`, which removed the Rust `skip_genesis` option
+on the stated basis that the value would be derived from on-chain consensus state. That on-chain
+bootstrap was not implemented.
+
+Required remediation:
+
+- Read the current epoch, rollover state, active group, and staged group from chain during startup.
+- Define a safe state from which a new validator can join a future DKG.
+- Provide and test private-share migration if a coordinated replacement is meant to preserve the
+  active group. Otherwise explicitly prohibit big-bang migration and document a rolling migration
+  procedure.
+- Add cold-start tests for genesis, an active epoch, a staged epoch, and a deployment with no
+  TypeScript validators remaining.
+
+### 2. Critical effects fail once and are silently converted to `Noop`
+
+Every Rust effect error is logged and converted into `Resume::Noop` in
+[`crates/validator/src/service/effect.rs`](../crates/validator/src/service/effect.rs). The failed
+effect is not retained or retried.
+
+This is unsafe for state transitions that depend on one-shot effects:
+
+- `KeyGenSetup` moves the state into `WaitingForSetup` before generating and persisting secrets.
+- Keygen timeout handling covers commitment, share, and confirmation collection, but not
+  `WaitingForSetup`.
+- Genesis setup has no deadline, so one transient storage or randomness failure can strand genesis
+  permanently.
+- During a regular epoch, a setup failure strands the validator until rollover abandons that epoch.
+- If `LinkNonceTree` fails, the associated `Preprocess` event has already been consumed. The
+  unlinked chunk is nevertheless included in `available_nonce_count`, so nonce top-up sees adequate
+  capacity and does not generate a replacement. The validator can permanently lose the ability to
+  reveal the corresponding on-chain nonce commitments.
+
+Commit `69f7ef8` introduced `WaitingForSetup` specifically to allow setup to be retried on later
+block updates. The commit message states that the retry would be added when block handling landed,
+but it was never implemented.
+
+Required remediation:
+
+- Return a typed failure resume instead of collapsing all failures to `Noop`.
+- Persist retryable setup and link work in state.
+- Retry setup and linking on subsequent blocks with bounded backoff.
+- Keep a preprocessing root pending until its database link has been confirmed.
+- Test transient failures before and after database writes so retries remain idempotent.
+
+### 3. The driver consumes failed updates instead of retrying them
+
+The watcher advances before returning an update. Queued block updates are removed with
+`pop_front`, and the event watcher is updated before the block is handed to the driver. The driver
+then processes transaction housekeeping, state transition, and action enqueueing with fallible
+operations.
+
+For errors other than state-transition errors, the run loop logs that it is "retrying after delay",
+but the next iteration asks the watcher for a new update. The failed update is not retained.
+
+Concrete failure modes include:
+
+- If transaction housekeeping encounters a transient RPC error while processing a new block, the
+  state machine never receives that block. The next watcher item is normally the block's logs,
+  which the state machine rejects as out of sequence.
+- The resulting state error is classified as unrecoverable and terminates the driver.
+- If the state snapshot is committed but transaction enqueueing fails, the action is lost while the
+  state has already advanced.
+- If enqueueing succeeded and only submission failed, the durable transaction is safe, but the
+  driver does not distinguish that case from an enqueue failure.
+
+The state machine also cannot survive its own storage failures. `StateMachine::handle_update`
+takes the in-memory state (`mem::take` in [`core/state/mod.rs`](../crates/core/src/state/mod.rs))
+and only restores it on success; an error from `snapshots.commit` or `snapshots.reorg` -
+including a transient SQLite failure - leaves the machine permanently `Poisoned`. The driver
+classifies every state error as unrecoverable, so a single failed snapshot commit terminates the
+validator (with a zero exit status) instead of being retried.
+
+The documented guarantee that an update is processed to completion is therefore not true under
+internal failures. An unrecoverable driver error also returns through `main` as success, producing a
+zero exit status.
+
+Required remediation:
+
+- Introduce an acknowledgement or durable-outbox model.
+- Persist the state transition and encoded logical actions atomically.
+- Drain the durable outbox independently from state advancement.
+- Only acknowledge watcher progress after the durable transition has committed.
+- Restore the in-memory state and retry when a snapshot commit fails transiently, instead of
+  poisoning the state machine.
+- Return a nonzero process status for unrecoverable state errors.
+- Add fault-injection tests for transaction housekeeping, state persistence, action enqueueing, and
+  transaction submission.
+
+### 4. Secret and nonce pruning is not reorg-safe
+
+DKG secrets and retired group nonce trees are deleted immediately during finalization, failure,
+restart, and rollover. Effects run before the corresponding state snapshot is committed, and the
+secret store is not rolled back with state snapshots.
+
+The clearest failure is an epoch-boundary reorg:
+
+1. The validator rolls over and immediately deletes the old group nonce trees.
+2. A valid reorg restores a snapshot in which the old epoch is active.
+3. The restored state still contains the old key share, but its preprocessing trees are gone.
+4. The validator cannot reveal nonce commitments already registered on chain for that group.
+
+If the full validator set behaves this way, quorum can become unavailable after the reorg.
+
+There is a related DKG risk if finalization and pruning happen within the reorg window. A rollback
+to before setup can force secret resampling while a previously allocated commitment transaction is
+still available for resubmission, resulting in a commitment and local-secret mismatch.
+
+Commit `7126078` originally designed pruning as reorg-aware work queued with its originating block
+and executed only after the block became safe. Commit `424d678` removed that queue and replaced it
+with immediate effects.
+
+The TypeScript implementation also unregisters retired FROST groups immediately, so this is partly
+an inherited protocol risk rather than a pure parity regression.
+
+Required remediation:
+
+- Restore the snapshotted pruning queue.
+- Execute DKG-secret and nonce-tree deletion only after the originating block is at or below the
+  safe boundary.
+- Test reorgs across DKG finalization, DKG failure, epoch rollover, and old-group retirement.
+
+## Medium-severity findings
+
+### 5. Synthetic restart replay duplicates non-idempotent actions
+
+Every Rust restart deliberately replays the most recent `max_reorg_depth` blocks through a
+synthetic reorg. Replayed state transitions reproduce actions, but transaction storage assigns only
+an auto-increment row ID and blindly inserts every encoded request.
+
+This can create a second logical action even when the original canonical transaction was already
+executed. `FROSTCoordinator.sign` is particularly sensitive because each call increments the group
+sequence and opens a new signing ceremony; it does not reject duplicate messages.
+
+Replay duplication is partially bounded by the block deadlines attached to queued actions: a
+replayed action whose `expires_at` has already passed is dropped before submission. It is not
+bounded for `Sign`, whose deadline (six blocks by default) exceeds the replay depth (five blocks
+by default), nor for actions queued without a deadline.
+
+Repeated restarts can therefore:
+
+- Open orphan signing ceremonies.
+- Consume preprocessing sequence numbers and nonce stock.
+- Generate unnecessary fallback and top-up work.
+- Spend validator gas on duplicate calls or expected reverts.
+
+Required remediation:
+
+- Derive a stable action ID from the originating event coordinates and action kind.
+- Upsert or reconcile actions by logical identity.
+- Reuse the existing logical action during reorg recovery instead of appending another row.
+- Add restart tests around every state-generated action, especially `Sign`.
+
+### 6. Restarting during a historical warp can fail deterministically
+
+During a historical warp, state persistence prunes intermediate snapshots to the final block of
+each processed page. The state-machine test explicitly confirms that only the latest snapshot
+survives.
+
+If the process restarts after a sufficiently advanced warp page:
+
+1. The latest committed snapshot is block `S`.
+2. Startup generates a synthetic uncle around `S - max_reorg_depth`.
+3. Reorg restoration requires the uncle's parent snapshot.
+4. That snapshot was deleted during warp pruning.
+5. Snapshot storage returns `MissingSnapshot`, and the driver exits.
+
+This applies both to a restart in the middle of a long warp and to the window between completing a
+warp and building a full set of recent snapshots.
+
+Required remediation:
+
+- Retain at least `max_reorg_depth + 1` snapshots while warping, or
+- Persist a warp checkpoint and resume mode that does not synthesize a reorg until a normal reorg
+  window has been established.
+- Add process-restart tests after every warp page and during recent-block catch-up.
+
+### 7. Event type is not validated against its emitter address
+
+Rust watches the consensus contract, coordinator, and configured oracles in one address filter. The
+union event decoder classifies logs only by topics and data, returning the first ABI interface that
+decodes. Coordinator and consensus transition handlers then ignore the log address; only
+`OracleResult` uses it.
+
+A malicious or upgraded configured oracle can therefore emit a byte-compatible `Sign`,
+`Preprocess`, `EpochStaged`, or other coordinator or consensus event. The validator will process the
+log with authority greater than an oracle is intended to possess.
+
+The TypeScript watcher has the same trust-boundary flaw because it also uses one combined address
+and event filter.
+
+Required remediation:
+
+- Dispatch using both event type and expected emitter address.
+- Prefer separate per-contract decoders or explicit address-to-interface routing.
+- Add tests in which each watched contract emits a topic belonging to another watched contract.
+
+### 8. Default configuration is not mixed-network parity-safe
+
+The implementations use different implicit defaults:
+
+| Setting          |  Rust | TypeScript |
+| ---------------- | ----: | ---------: |
+| Blocks per epoch | 1,440 |     17,280 |
+| Keygen timeout   |   120 |        120 |
+| Signing timeout  |     6 |        120 |
+| Oracle timeout   |    12 |        120 |
+
+Some Rust values match the current beta documentation, so parts of this difference appear
+intentional. Silent defaults remain dangerous in a mixed Rust and TypeScript validator set,
+especially when the oracle timeout changes when validators approve, decline, or submit fallback
+actions.
+
+Staker behavior also differs:
+
+- TypeScript defaults the staker to the validator account.
+- Rust skips staker reconciliation entirely when `staker` is absent.
+
+Required remediation:
+
+- Make consensus-affecting timing explicit and required in production configuration.
+- Publish a parity table and checked-in Rust TOML example.
+- Preserve the TypeScript staker default or document and validate the semantic change.
+- Add mixed-validator tests with default and explicitly configured timeout values.
+
+### 9. Production lifecycle and observability are incomplete
+
+The Rust service has substantially less lifecycle and health instrumentation than the TypeScript
+service:
+
+- Rust waits only for `Ctrl-C`; TypeScript handles both `SIGINT` and `SIGTERM`.
+- Unrecoverable state errors terminate the driver but allow `main` to return success.
+- A Prometheus endpoint is installed, but validator and core code emit no production counters,
+  gauges, or histograms.
+- TypeScript exposes block cursor, event index, reorg, transition, RPC, transaction, cleanup, and
+  process metrics.
+- There is no dedicated Rust validator README, migration runbook, or checked-in example TOML.
+
+Required remediation:
+
+- Handle `SIGTERM` and complete in-flight durable work before shutdown.
+- Propagate unrecoverable failures to a nonzero process exit.
+- Add progress, reorg, transition, effect, transaction-queue, nonce-stock, DKG, and signing metrics.
+- Document configuration, startup state, database backup, migration, and rollback procedures.
+
+## Low-severity finding
+
+### 10. Participant safety threshold can overflow for very large groups
+
+`min_participants` computes `count * 2 / 3 + 1` using `u16`. For a participant count of at least
+32,768, debug builds panic and release builds wrap, potentially violating the required
+greater-than-two-thirds threshold.
+
+Such a validator set is currently impractical, but the threshold is a security invariant and
+should not depend on an implicit deployment-size assumption.
+
+Required remediation:
+
+- Use a wider intermediate or an overflow-safe equivalent such as `count - count / 3`.
+- Add an explicit supported participant-count bound to configuration validation.
+- Test the boundary values of the supported range.
+
+## Improvements over the TypeScript implementation
+
+The Rust implementation contains important improvements that should be preserved while addressing
+the findings:
+
+- It uses the maintained Zcash FROST implementation and includes cross-language parity vectors.
+- It validates generated and public key material more rigorously before accepting a group.
+- Duplicate transaction and oracle proposals do not reset an ongoing signing state, preventing a
+  proposal-based liveness attack.
+- Signature-share participation is tracked per selection root, avoiding attribution across
+  competing signer selections.
+- Nonce top-up considers retained groups and the global sequence behavior rather than only the
+  current active group.
+- The transaction queue persists nonce allocation, fee bumps, execution status, and reorg markers.
+  This is a meaningful architectural improvement once retry and deduplication are corrected.
+- TOML parsing, nonzero timeout types, explicit epoch types, unknown-field rejection, and resolving
+  the coordinator from the consensus contract improve maintainability.
+- Rust correctly rejects delegate-call subtransactions inside `MultiSendCallOnly`. TypeScript
+  supplies its delegate-call policy to both ordinary MultiSend and CallOnly variants. Rust is safer,
+  but a mixed validator set can disagree on the same proposal; the TypeScript policy should be
+  corrected or the difference explicitly versioned.
+
+## Test coverage assessment
+
+The available Rust checks passed during review:
+
+- `cargo fmt --all -- --check`
+- `cargo clippy --package validator --all-targets -- -D warnings`
+- `cargo test --package validator` — 51 tests passed
+- `cargo clippy --package safenet-core --all-targets -- -D warnings`
+- `cargo test --package safenet-core` — 79 tests passed
+- `cargo test --workspace` — 146 tests passed across core, sentinel, and validator
+
+TypeScript tests and the process-level integration scripts could not be run in the review
+environment because Node.js and NPM were unavailable. The all-Rust integration suite is driven by
+the TypeScript test harness and was therefore also unavailable. A coverage run was attempted but
+exhausted the available disk space while compiling; its generated artifacts were removed.
+
+The test-shape difference remains material:
+
+- The Rust validator has 51 tests, but only one direct unit test in the state-transition modules.
+- The TypeScript validator has 67 test files and approximately 506 `it` or `test` cases.
+- The shared process integration file contains four broad cases: keygen timeout, keygen abort,
+  keygen and signing, and oracle signing.
+
+High-value missing scenarios include:
+
+- Transient failure of every effect.
+- Driver failure before and after state persistence and action enqueueing.
+- Cold start after genesis and migration from an active TypeScript deployment.
+- Restart during action submission and deterministic action deduplication.
+- Restart after each historical warp page.
+- Reorg across DKG setup, finalization, failure, and epoch cleanup.
+- Spoofed events from the wrong watched emitter.
+- Delayed, rejected, or missing oracle responses under mixed timeout configuration.
+
+### Required differential consensus test matrix
+
+The existing mixed test demonstrates cryptographic interoperability on a successful path. It does
+not establish state-machine compatibility. A release-grade differential suite should feed the same
+ordered block and event trace to one Rust validator model and one TypeScript validator model, then
+compare their normalized consensus state and intended actions after every transition.
+
+At minimum, the normalized comparison must include:
+
+- Active and target epoch.
+- Active, staged, and in-progress group IDs and participant sets.
+- Packet hash and expected signing group.
+- Current signature ID, phase, signer selection root, and contributing participants.
+- Responsible participant or “everyone” state.
+- The logical action kind, packet, group, and retry generation.
+
+The suite should cover the following traces:
+
+1. Submit duplicate plain and oracle proposals before the first ceremony completes. Both
+   implementations must retain the same signature ID and issue no second oracle request.
+2. Call `FROSTCoordinator.sign` directly with a valid packet but the wrong finalized group while
+   the packet is waiting for a request. Both implementations must reject the event as unrelated.
+3. Exercise invalid DKG commitment encodings, invalid encrypted-share counts, an invalid local
+   encrypted share, and a public verification share that does not match its commitments. Every
+   observer must count the same contributors and derive the same replacement group. Repeat with an
+   off-curve DKG or nonce point before valid logs in the same live block and historical warp page;
+   the valid suffix must still be processed.
+4. Time out every keygen and signing phase with a named responsible participant and with
+   responsibility assigned to everyone. Assert the same action sender set, exclusion set, retry
+   generation, and cleanup block. Hold an action in each queue across its block deadline and assert
+   that neither implementation later submits an obsolete generation.
+5. Submit `SignShared` events under two competing selection roots, including a share under a root
+   that cannot reach threshold. Both implementations must select and retry from the same root.
+6. Complete the signature but make the callback fail for rollover, plain transaction, and oracle
+   packets. Assert identical direct-attestation fallback and cleanup behavior.
+7. Introduce a reorg after each consensus-relevant event class: proposal, `Sign`, `Preprocess`,
+   DKG commitment/share/confirmation, rollover, signature share, and final attestation. Compare
+   state and actions after canonical replay.
+8. Finalize genesis exactly one block before an epoch boundary. Both implementations must derive
+   the same first regular target epoch and group context.
+9. Rotate the active epoch while an old-group ceremony remains live, then force a retry and nonce
+   top-up. Both implementations must replenish and reveal nonces for the event's group. Interleave
+   another participant's `Preprocess` event before the validator's own event and assert that it does
+   not clear or duplicate the validator's pending tree.
+10. Deliver an oracle result immediately before, at, and immediately after the configured
+    deadline. Assert identical acceptance, decline, timeout, and cleanup decisions.
+11. Run a shared Safe-policy corpus through both implementations, including every configured
+    MultiSend and `MultiSendCallOnly` address and delegate-call position, plus plain calls
+    (operation 0) to every policy-listed address. Approval and decline must match exactly.
+12. Start each implementation with omitted, equal, and intentionally unequal timing parameters.
+    Production mode must reject omitted or incompatible consensus settings rather than silently
+    constructing different state machines.
+
+These assertions should compare consensus state, not only eventual on-chain success. A Rust
+majority can hide a TypeScript incompatibility by completing a ceremony that the TypeScript subset
+abandoned, and the reverse can hide a Rust liveness problem. Known intentional Rust fixes should
+be encoded as the required behavior and backported to TypeScript; they should not be accepted as
+permanent “expected differences” in this suite.
+
+## Release recommendation
+
+Before the Rust port is treated as complete or used as a production replacement, require the
+following release gates:
+
+1. Define one validator consensus-behavior version. Backport the Rust duplicate-proposal, public
+   DKG validation, selection-root attribution, expected-group binding, old-group nonce top-up,
+   event-local curve validation, preprocessing ownership, terminal cleanup, oracle fallback,
+   CallOnly policy, and operation-routing policy fixes to TypeScript. Reconcile this list against
+   the divergences already accepted as project decisions (see the compatibility model above).
+2. Align the DKG, signing, timeout-responsibility, reorg, and first-post-genesis transitions. Do not
+   deploy mixed Rust and TypeScript signing groups until the differential matrix passes.
+3. Remove implicit production timing defaults and validate that blocks-per-epoch and all phase
+   deadlines match the network's declared consensus configuration; expire actions by those same
+   block deadlines.
+4. Implement and test live-network bootstrap and migration behavior.
+5. Replace swallowed one-shot effect failures with durable retries.
+6. Introduce an atomic state/action outbox and real update acknowledgement, and retry transient
+   snapshot-commit failures instead of poisoning the state machine.
+7. Restore safe-block-delayed secret and nonce pruning.
+8. Add stable logical action identities for restart and reorg deduplication.
+9. Fix historical-warp checkpoint recovery.
+10. Validate every decoded event against its emitter address.
+11. Add production shutdown, failure exit, metrics, and operator documentation.
+12. Run the TypeScript, all-Rust, and mixed integration suites in CI, including the full
+    differential matrix plus failure, restart, migration, and reorg scenarios.

--- a/epics/2026_07_14_validator_state_machine_flow_test_harness.md
+++ b/epics/2026_07_14_validator_state_machine_flow_test_harness.md
@@ -1,0 +1,581 @@
+# Plan: Validator state-machine flow-test harness
+
+Component: the existing `crates/validator` crate (Cargo package `validator`), with test-only use of
+the `safenet-core` state machine and the real `contracts` Foundry artifacts on a local Anvil chain.
+No `safenet-core` API or production validator runtime changes are expected, apart from a narrowly
+scoped test seam for generating a reduced usable nonce prefix if the first benchmark confirms it is
+needed.
+
+---
+
+## Overview
+
+The validator state machine in `crates/validator/src/state/` has very little end-to-end behavioral
+coverage. Testing transitions by constructing the private `State`, calling a specific transition,
+and asserting the complete `(State, Commands)` result would couple tests to the state machine's
+internal representation. Routine refactors would then require large, low-value test rewrites.
+
+This epic adds declarative **flow tests** around the highest practical test boundary. Each validator
+node runs the real [`ValidatorService`](../crates/validator/src/service/mod.rs),
+[`StateMachine`](../crates/core/src/state/mod.rs), effect handler, secret store, and action encoder.
+The encoded transactions execute against real `FROSTCoordinator`, `Consensus`, and oracle contracts
+on Anvil. Tests assert only observable protocol behavior: mined typed calls, receipts and events,
+contract views, responsible actors, retries, exclusions, and attestations.
+
+The harness deliberately replaces only the production orchestration that would make these tests
+slow or nondeterministic: watcher polling, the durable transaction queue, fee replacement, and the
+open-ended [`Driver::run`](../crates/core/src/driver.rs) loop. A synchronous block pump broadcasts all
+currently queued actions, mines exactly one block, decodes its real logs, and feeds the corresponding
+updates to every online validator. Protocol waits are expressed in bounded block counts; there are no
+wall-clock sleeps or interval mining in a flow.
+
+The work is split into a foundation vertical slice followed by independently reviewable groups of
+flows:
+
+- Anvil lifecycle, contract deployment, node wiring, block pumping, tracing, and a happy genesis DKG.
+- Typed fault injection plus transaction and signing recovery flows.
+- Key generation complaints/timeouts, epoch rollover, membership, and oracle flows.
+- Restart and reorg security flows, followed by a coverage-guided gap audit.
+
+This is not a replacement for the existing process-level integration test. That test remains a small
+smoke test for the real watcher, transaction queue, configuration, startup reconciliation, and runtime
+loop. The new suite is where state-machine behavior receives broad and diagnostic coverage.
+
+---
+
+## Architecture Decision
+
+The harness will be a crate-internal `#[cfg(test)]` module in the validator binary. Keeping it inside
+the crate gives one small adapter access to private validator types without making state-machine
+internals public or first restructuring the binary as a library.
+
+```text
+declarative flow test
+        |
+        v
+ Scenario / TestDriver -----------------------> typed external calls and faults
+        |                                                 |
+        |                                                 v
+        +--> TestNode[]                             TestChain (Anvil)
+        |      |                                          |
+        |      +-- ValidatorService::components()         +-- real contracts
+        |      +-- safenet_core::StateMachine             +-- real receipts/logs/views
+        |      +-- real effects + per-node SQLite          |
+        |      +-- real ActionEncoder <--------------------+
+        |
+        +--> semantic trace + observable assertions
+```
+
+### Test boundary
+
+Every protocol action must cross the same boundaries it crosses in production:
+
+1. A real state transition emits an action.
+2. The production `ActionEncoder` converts it to destination, calldata, gas, and expiry.
+3. The harness decodes the transaction into a semantic call for tracing/fault matching, without
+   changing the bytes by default.
+4. The validator's signer submits it to Anvil.
+5. The real contract accepts or rejects it and emits logs.
+6. The existing validator `Event` decoder turns those raw logs back into state-machine events.
+
+The tests must not synthesize successful `KeyGen`, `Sign`, `SignCompleted`, attestation, or rollover
+events. Those endogenous events have to arise from mined contract calls. Scenarios may introduce only
+exogenous inputs—such as starting genesis, proposing a transaction, resolving a manual oracle, mining
+blocks, stopping a validator, or creating a fork—and explicit faults.
+
+Individual flow tests import a small harness prelude. Only the node/call adapters may import private
+`State`, `Action`, `Effect`, or transition types. A refactor of an internal enum should therefore
+affect at most the adapter, not every test case.
+
+### Synchronous block pump
+
+Anvil runs with automining and interval mining disabled and FIFO mempool ordering. Validator actions
+created while processing block `N` are queued for the next explicit mine. A block step:
+
+1. Takes the encoded validator calls queued by previous updates and any explicitly queued external
+   calls, preserving actor and action order.
+2. Applies semantic fault rules and drops calls whose production expiry is at or before the current
+   head.
+3. Allocates signer nonces only to calls that will actually be broadcast, then submits them without
+   awaiting receipts.
+4. Mines exactly one block, including an empty block when a timeout must advance.
+5. Collects every receipt and fails immediately on an unexpected revert.
+6. Fetches the actual block header and logs, retaining `(block, log index, address)` ordering.
+7. Feeds each online node `Update::Block(BlockUpdate::New { ... })` followed by the matching
+   `Update::Logs`; the core state machine settles effects and resume messages internally.
+8. Encodes newly emitted actions immediately and queues them for the following block.
+
+External transactions default to a documented stable position relative to already queued validator
+calls. Tests that intentionally exercise same-block ordering must construct an explicit ordered block
+plan rather than depend on incidental async scheduling.
+
+### Observable assertions
+
+Assertions are built around three public observation sources:
+
+- Contract state and view calls, for example active/staged epoch, group key, participant key,
+  signature value/verification, and transaction attestation.
+- Decoded receipts and events, including the actor and transaction that caused each event.
+- Decoded outbound calls, including attempt count, selected sender, callback presence, expiry, and
+  whether a call was mined, delayed, dropped, reverted, or expired.
+
+Tests do not compare complete state snapshots, command vectors, exact random group keys/nonces, or
+incidental block numbers. Exact public calldata may be compared only where it is itself the security
+property—for example proving that a DKG commitment is replayed unchanged after a reorg. Assertions
+such as `attested`, `not_attested`, `submitted_by`, `sign_attempts`, and `group_excludes` hide ABI
+details and include the semantic trace in their failure output.
+
+### Typed fault injection
+
+Faults are applied after real action encoding but before nonce allocation and submission. Calls are
+classified by destination and decoded with the generated `Consensus`/`Coordinator` call interfaces,
+yielding a stable `ProtocolCall` enum. Matchers select an actor, call kind, protocol identifier, and/or
+occurrence rather than matching raw bytes.
+
+The initial fault vocabulary is:
+
+- Drop once/always, delay by a bounded number of blocks, or reorder within an explicit block.
+- Mute a node's outbound calls, pause inbound block delivery, resume, and catch up from recorded
+  canonical blocks.
+- Corrupt a typed DKG encrypted share, complaint response, nonce reveal, or signature share before it
+  is re-encoded and signed.
+- Suppress a completion callback by converting a valid `*WithCallback` call to its non-callback
+  equivalent while preserving the valid share/confirmation.
+- Mark a deliberately malformed call as an expected revert; all other reverts fail the test.
+
+Faults are semantic and narrowly scoped. The harness will not provide a general raw-log injection API
+for flow tests, because that would make impossible contract histories easy to create.
+
+### Persistence and reorg model
+
+Each validator has its own temporary SQLite database, matching production isolation. Restart tests
+drop and reconstruct the service components against the same database and replay any canonical blocks
+missed while the node was offline. Restarts occur at fully processed block boundaries; persistence of
+the production transaction queue remains outside this harness.
+
+Reorg tests pair Anvil's `evm_snapshot`/`evm_revert` with the real core
+`BlockUpdate::Uncle { number }`. The state machine rolls its snapshot tables back while the secret
+store tables deliberately remain untouched. The alternate branch is then mined and delivered through
+the normal block pump. This directly exercises the two critical security properties:
+
+- A replayed DKG setup reuses the retained coefficients and publishes the same commitment.
+- A signing nonce burned on the removed branch is not reused for a different message on the alternate
+  branch.
+
+### Alternatives Considered
+
+- **Direct `(State, Message) -> (State, Commands)` tests for every branch.** Rejected as the primary
+  strategy because they encode private state layout and command sequencing. Small direct tests remain
+  appropriate for pure helpers and defensive branches that real contracts cannot produce.
+- **Run the full production `Driver` in every flow.** Rejected for this suite because watcher polling,
+  fee estimation/replacement, durable queue timing, and shutdown make state behavior slower and less
+  diagnostic. Those components already have focused core tests and retain one process-level
+  integration smoke test.
+- **Use a mock RPC chain and script protocol events, matching
+  [`test-exemplar`](../test-exemplar/) literally.** Rejected
+  for endogenous validator events. It would test that the state machine accepts the history written by
+  the test, while missing invalid calldata, callback behavior, contract ordering, proof verification,
+  and reverts. The exemplar's typed scenarios, named actors, presets, and public assertions are kept;
+  its mocked event source is not.
+- **Implement a Rust model of the Coordinator and Consensus contracts.** Rejected because it creates
+  a second protocol implementation that can drift from Solidity. Local Anvil execution is fast enough
+  once mining is explicit.
+- **Use fixed block times and sleep until a condition becomes true.** Rejected because it is slow and
+  flaky. Every eventual assertion has a maximum number of explicitly mined blocks.
+- **Assert seeded cryptographic outputs.** Rejected as the default because commitments and nonces are
+  not the behavior under test, and exact values make harmless cryptographic refactors noisy. Actor
+  keys, scenario inputs, ordering, and group/signature identifiers are already deterministic. A seeded
+  cryptographic RNG can be added later only if it materially improves reproduction of observed
+  failures.
+- **Share one initialized Anvil/database snapshot across all tests.** Deferred. Per-scenario processes
+  provide clean isolation and parallel execution. Shared snapshots will be considered only if measured
+  startup/deployment cost dominates the suite.
+
+---
+
+## Tech Specs
+
+### Proposed source layout
+
+```text
+crates/validator/src/
+  main.rs                         # #[cfg(test)] mod flow_tests;
+  flow_tests/
+    mod.rs                        # test modules and harness prelude
+    harness/
+      mod.rs
+      chain.rs                    # Anvil lifecycle, RPC controls, block/fork history
+      contracts.rs                # artifact loading, deployment, test-only calls/views
+      node.rs                     # ValidatorService components + StateMachine adapter
+      driver.rs                   # block pump, action collection, catch-up orchestration
+      scenario.rs                 # declarative builder, named actors, presets
+      calls.rs                    # ProtocolCall decoding/encoding and matchers
+      faults.rs                   # fault plan and node controls
+      trace.rs                    # semantic calls, receipts, events, branch/block trace
+      fixtures.rs                 # participants, transactions, timeouts, ready-state helpers
+      assertions.rs               # observable protocol assertions
+    genesis.rs
+    transactions.rs
+    signing.rs
+    keygen.rs
+    rollover.rs
+    oracle.rs
+    recovery.rs
+```
+
+The split is intentionally modular, but no implementation PR should add this tree in one change.
+Each phase below introduces fewer than ten files and aims to stay below 300 lines of production/test
+code. Shared harness APIs are stabilized before the independent flow modules are written.
+
+### Core harness types
+
+The exact fields may evolve during implementation, but responsibilities should remain separated:
+
+```rust
+struct TestDriver {
+    chain: TestChain,
+    contracts: Contracts,
+    nodes: Vec<TestNode>,
+    pending: Vec<PendingCall>,
+    faults: FaultPlan,
+    trace: Trace,
+}
+
+struct TestNode {
+    actor: Actor,
+    machine: StateMachine<State, Transition, Handler>,
+    encoder: Encoder,
+    watched_addresses: Vec<Address>,
+    database: TestDatabase,
+    mode: NodeMode,
+}
+
+struct PendingCall {
+    actor: Actor,
+    transaction: safenet_core::tx::Transaction,
+    expires_at: Option<u64>,
+    decoded: ProtocolCall,
+}
+```
+
+`TestNode::new` constructs a real `ValidatorService`, consumes `Service::components()`, builds the
+real `StateMachine` over the node's pool, and retains the production encoder. It does not expose the
+machine's state to a test.
+
+`Scenario` supplies named deterministic actors (for example Alice, Bob, Carol, Dave, proposer, and
+oracle approver), participant epoch windows, short block-based timeouts, allowed oracles, and faults.
+Presets such as `four_validators`, `active_genesis`, and `allowed_transaction` perform real chain
+work; they never inject the successful events that they claim to establish.
+
+A representative test should read at roughly this level:
+
+```rust
+#[tokio::test]
+async fn retries_without_a_validator_that_withholds_nonces() -> Result<()> {
+    let mut flow = Scenario::four_validators()
+        .drop_once(carol(), CallKind::RevealNonceCommitments)
+        .start()
+        .await?;
+    flow.complete_genesis().await?;
+
+    let proposal = flow.propose(allowed_transaction("payment")).await?;
+    flow.run_until(Observed::transaction_attested(proposal), 24)
+        .await?;
+
+    flow.assert().sign_attempts(proposal, 2);
+    flow.assert().attempt_excludes(proposal, 2, carol());
+    Ok(())
+}
+```
+
+### Anvil and contracts
+
+- Spawn one Anvil instance per scenario on an OS-selected random loopback port, with a fixed mnemonic,
+  `--no-mining`, and `--order fifo`. Use an RAII process wrapper so panics and early returns kill it.
+- Use Alloy's Anvil node binding as a validator dev dependency if it provides the required lifecycle
+  and endpoint handling cleanly; otherwise keep a small `std::process::Command` wrapper local to
+  `chain.rs`. Do not add a repository-wide process abstraction for this test-only need.
+- Run `forge build --root contracts --quiet` once per Rust test binary through a shared one-time cell.
+  Foundry artifacts are ignored by Git, so tests must work on a clean checkout and must not rely on a
+  developer's existing `contracts/build/out` directory.
+- Load creation bytecode from the generated JSON and deploy `FROSTCoordinator`, `Consensus`, and
+  `AlwaysApproveOracle` directly through Alloy. Deploy `SimpleOracle` only for scenarios that need a
+  delayed/rejected result. Direct deployment avoids concurrent Forge broadcast files and a process
+  spawn per scenario.
+- Define test-only ABI bindings for external triggers and views not needed by the validator's
+  production bindings: genesis start, transaction/oracle proposal, oracle resolution, group and
+  signature queries, epoch state, and attestation queries.
+- Submit the exact gas limit from the production encoded `Transaction`. An out-of-date gas estimate is
+  therefore observable as a failed flow instead of being hidden by RPC gas estimation.
+
+The normal CI job already installs Foundry 1.5.1 before `cargo test --workspace`. Flow tests are part
+of ordinary `cargo test --package validator`, are not `#[ignore]`d, and fail with an actionable
+message if `forge` or `anvil` is unavailable.
+
+### Log delivery and chain history
+
+The chain wrapper records every canonical block header, receipt, and raw log. It uses the existing
+`safenet_core::index::events::Events` implementation on the validator `Event` type for decoding, and
+constructs real `EventLog`/`EventUpdate` values with the mined address and log index. Per-node watched
+address filtering mirrors production, especially for allowed oracle addresses.
+
+The test block update keeps the safe boundary behind every block needed by the scenario so snapshots
+are not prematurely pruned. Reorg tests explicitly record the fork point and first uncled block;
+ordinary tests never emit synthetic uncle updates.
+
+An offline node receives no updates. On resume, the driver reconstructs it if requested and replays
+the recorded canonical `(New block, Logs)` pairs in order before it may submit new actions. The trace
+marks actions produced during catch-up separately, making accidental stale submissions diagnosable.
+
+### Performance and determinism
+
+- Contract compilation is cached once per test binary; deployment and databases remain per scenario.
+- A global test semaphore caps concurrent Anvil scenarios to avoid oversubscribing CI. The cap is
+  configurable through a test-only environment variable for local profiling.
+- The first vertical slice records Anvil startup, deployment, genesis DKG, nonce preprocessing, and
+  one signing round separately. The target is a low-single-digit-second happy flow and a complete flow
+  suite that remains practical in the normal workspace test and coverage jobs; timing is reported, not
+  asserted against a flaky wall-clock threshold.
+- Nonce generation is expected to dominate: production creates 1024 unique nonce pairs per chunk.
+  The contract requires every inclusion proof to have the full 10-element depth, so the existing
+  smaller-tree `NonceChunk::with_size` helper cannot be used for contract-backed flows. Add a
+  compile-time test-only constructor that generates a small usable prefix (initially 16 unique nonce
+  pairs), pads the leaves to the protocol's full 1024-leaf tree, and stores proofs only for the usable
+  prefix. These remain real, unique FROST nonces with valid offset-dependent 10-element proofs; an
+  offset outside the prefix has no stored secret and safely produces no action. Production remains
+  fixed at 1024 usable nonces. Reduced-prefix scenarios fail fast if they advance beyond the prefix,
+  while preprocessing/top-up and nonce-reorg security tests opt into the production path where
+  relevant.
+- Do not seed the production cryptographic path merely to make snapshots stable. Fixed actors,
+  ordered blocks, semantic matchers, and public observations provide deterministic tests without
+  coupling to random bytes.
+
+### Diagnostics
+
+Each block trace contains:
+
+- Block/fork number and ordered external/protocol calls.
+- Actor, decoded call kind and relevant public protocol IDs.
+- Applied fault, expiry, broadcast hash, receipt status, and decoded revert when available.
+- Ordered decoded events and the actions queued by each node for the following block.
+- Node stop/restart/catch-up boundaries.
+
+Harness errors and assertion failures render the compact trace automatically. Verbose mode may render
+full public calldata and Anvil logs, but must never dump DKG coefficients, signing nonces, signing
+shares from SQLite, private keys, or database contents. Values already published onchain may be shown.
+
+Every eventual helper takes a maximum block count and reports the last observation plus trace when it
+does not converge. Process readiness may use a short bounded RPC probe; protocol progress may not use
+sleep-based polling.
+
+### Flow coverage matrix
+
+The matrix is behavior-driven rather than a promise of 100% line coverage. `P0` flows are required for
+the epic; `P1` flows are added where the coverage audit shows meaningful reachable gaps.
+
+| Area          | Priority | Flow                                                                                      | Observable result                                                                                        |
+| ------------- | -------- | ----------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------- |
+| Genesis       | P0       | Four validators complete commitments, encrypted shares, confirmations, and preprocessing  | Non-zero group/participant keys; every required confirmation and nonce root landed; no unexpected revert |
+| Transaction   | P0       | Allowed external call is proposed and signed                                              | One valid coordinator signature and `TransactionAttested`; Consensus view returns it                     |
+| Transaction   | P0       | Forbidden Safe self-call is proposed                                                      | Validators decline; no nonce reveal, signature share, or attestation for the packet                      |
+| Transaction   | P0       | Duplicate proposal during an active ceremony                                              | One signing ceremony/attestation; duplicate does not reset progress                                      |
+| Transaction   | P1       | Two proposals in the same block                                                           | Independent signing IDs and attestations; no state collision                                             |
+| Signing       | P0       | One validator withholds its nonce reveal                                                  | Timeout opens a later attempt without it; threshold signs and attests                                    |
+| Signing       | P0       | Enough reveals/shares are missing to lose threshold                                       | Bounded retries stop; no invalid attestation is produced                                                 |
+| Signing       | P0       | Valid signature completes but callback is suppressed                                      | `SignCompleted` lands, then direct timeout fallback attests/stages exactly once                          |
+| Signing       | P1       | A corrupted outbound nonce/share reverts or is rejected                                   | Expected failure is traced; honest threshold either recovers or safely stops                             |
+| Keygen        | P0       | One validator withholds commitment, share, or confirmation during non-genesis DKG         | DKG restarts with a new group excluding it and can still stage the epoch                                 |
+| Keygen        | P0       | Too many validators stall                                                                 | No under-threshold group is confirmed or staged; epoch is safely skipped/abandoned                       |
+| Keygen        | P0       | Recipient detects a corrupted encrypted share and receives a valid complaint response     | Complaint and response land; DKG completes with the verified revealed share                              |
+| Keygen        | P0       | Complaint receives a wrong or no response                                                 | Accused validator is excluded on restart; the abandoned group never confirms or stages                   |
+| Rollover      | P0       | Happy epoch DKG, rollover signature, staging, and activation                              | Proposed group is staged with a valid signature and becomes active at the rollover block                 |
+| Rollover      | P1       | Participant joins, leaves, or observes outside its epoch window                           | Onchain group membership and submitted actors match configured windows                                   |
+| Oracle        | P0       | Allowed synchronous and delayed-approved oracle proposals                                 | Signing begins only after the correct result and produces `OracleTransactionAttested`                    |
+| Oracle        | P0       | Allowed oracle rejects or never responds                                                  | No shares/attestation after rejection or timeout; session is eventually dropped                          |
+| Oracle        | P0       | Proposal names a disallowed oracle                                                        | Validators ignore it and emit no signing participation                                                   |
+| Restart       | P0       | Node restarts after a committed block during DKG and during signing                       | It restores/catches up and completes without duplicate or stale protocol calls                           |
+| Reorg         | P0       | Branch containing a DKG setup/commitment is removed and replayed                          | Replayed public commitment is byte-identical because retained secrets are reused                         |
+| Reorg         | P0       | Branch burns a nonce for message A; alternate branch uses the same sequence for message B | The node never emits a second signature share using the burned nonce                                     |
+| Preprocessing | P1       | Remaining nonces cross the top-up threshold                                               | Exactly one pending chunk is registered/linked and later becomes usable                                  |
+
+Contract-impossible or deliberately malformed histories—wrong event fields that Solidity cannot emit,
+events from unwatched addresses, badly sorted updates, or a resume with no matching effect—should not
+be forced through Anvil. After the flow suite is in place, retain or add small direct tests for those
+defensive invariants and for pure transaction-policy/merkle helpers.
+
+### Definition of done
+
+- Flow modules use only the harness prelude and do not construct or inspect validator `State`.
+- Every validator-originated transaction passes through the production `ActionEncoder` and executes
+  against the real contracts.
+- Successful protocol events are mined from real calls; normal flows contain no scripted logs.
+- All eventual behavior is block-bounded, with no protocol sleeps or interval mining.
+- Unexpected reverts and timeouts produce a semantic actor/call/event trace.
+- The P0 matrix passes under normal `cargo test --package validator` and the Rust coverage job.
+- A state enum/layout refactor changes only harness adapters unless observable behavior changes.
+- The existing process integration remains as runtime-infrastructure smoke coverage.
+- Each implementation PR runs `cargo fmt --all`, `cargo clippy --package validator`, and
+  `cargo test --package validator`; the final phase also runs the workspace checks and coverage report.
+- This epic specification is removed once every required phase has merged and the definition of done
+  is satisfied.
+
+---
+
+## Implementation Phases
+
+Each numbered item is a separate PR unless it explicitly lists sub-PRs. PRs have one primary purpose,
+target fewer than 300 changed lines of code and fewer than ten files, and avoid mixing production
+refactors with new flow cases. The current epic specification is its own plan-only PR.
+
+### Phase 1 — Contract-backed chain foundation
+
+Add the test module entry point, Anvil RAII lifecycle, one-time Foundry build, artifact loader, direct
+contract deployment, deterministic actors, and typed external/view bindings. Prove the layer with a
+small deployment/view smoke test; do not add state-machine flows yet.
+
+Expected files: `crates/validator/Cargo.toml`, `Cargo.lock`, `crates/validator/src/main.rs`,
+`flow_tests/mod.rs`, and `flow_tests/harness/{mod,chain,contracts}.rs`.
+
+### Phase 2 — Real node adapter and block pump
+
+Build `TestNode` from `ValidatorService::components()`, a per-node SQLite database, the real
+`StateMachine`, and the real encoder. Add pending-call collection, deterministic submission/mining,
+receipt checking, existing-event decoding, per-node log filtering, and a minimal semantic trace. A
+vertical internal test starts genesis and observes that encoded keygen calls mine and feed back into
+the nodes; it need not complete DKG yet.
+
+Expected files: `flow_tests/harness/{node,driver,calls,trace}.rs` and small updates to
+`flow_tests/harness/mod.rs` and `flow_tests/mod.rs`.
+
+### Phase 3 — Declarative scenario API and happy vertical slice
+
+Add named actors, participant/timeouts builders, Safe transaction fixtures, bounded `run_until`,
+public assertions, and `complete_genesis`. Land the first complete P0 flows: happy genesis DKG plus one
+allowed transaction attestation. This validates the architecture before fault machinery expands it.
+
+Expected files: `flow_tests/harness/{scenario,fixtures,assertions}.rs`, `flow_tests/genesis.rs`,
+`flow_tests/transactions.rs`, and module declarations.
+
+### Phase 4 — Nonce-generation performance seam
+
+Benchmark the Phase 3 slice under normal tests and `cargo llvm-cov`. In a dedicated refactor PR, add a
+test-only nonce constructor that generates 16 unique usable nonce pairs but pads the commitment to the
+full 1024-leaf protocol tree, plus an effect-handler construction path selecting it. Unit tests must
+prove that usable proofs have the contract-required depth, unavailable offsets contain no secret, and
+production construction remains at `SEQUENCE_CHUNK_SIZE`. Wire the flow fixture to this reduced-prefix
+mode, document its scenario limit, and re-run the real contract proof path. Do not introduce repeated
+nonces or a production configuration knob.
+
+Expected files: `crates/validator/src/service/effect.rs`, its focused tests, and
+`flow_tests/harness/node.rs` or `fixtures.rs`. If the benchmark shows the full-size path already meets
+the agreed suite budget, omit this PR and record that decision in the epic PR thread.
+
+### Phase 5 — Typed faults and diagnostics
+
+Add `ProtocolCall`, call matchers, drop/delay/mute/corrupt/callback-suppression rules, explicit expected
+reverts, node controls, and compact trace rendering. Prove each fault primitive with one narrow harness
+test; avoid adding the broad behavior matrix in the same PR.
+
+Expected files: `flow_tests/harness/{calls,faults,driver,trace,assertions}.rs` and a small dedicated
+harness test module.
+
+### Phase 6 — Transaction and signing flows
+
+Split into two sequential test-focused PRs:
+
+- **6A — transaction intake:** forbidden self-call decline, duplicate proposal, and simultaneous
+  proposal flows in `flow_tests/transactions.rs`, with only fixture/assertion extensions needed by
+  those behaviors.
+- **6B — signing recovery:** missing reveal/share, threshold retained/lost, corrupted submission, and
+  callback fallback flows in `flow_tests/signing.rs`, with only fault/assertion extensions needed by
+  those behaviors.
+
+Both depend on Phase 5. The implementation should prefer multiple short tests sharing real setup
+presets over one long test with many unrelated assertions.
+
+### Phase 7 — Key generation and rollover flows
+
+Split along protocol concerns so complaint cryptography is not mixed with timeout policy:
+
+- **7A — DKG timeout policy:** missing commitment/share/confirmation, one-member exclusion, and
+  too-many-members failure in `flow_tests/keygen.rs`.
+- **7B — DKG complaints:** corrupted encrypted share, valid response, invalid response, and missing
+  response in `flow_tests/keygen.rs`. Extend typed corruption only as required.
+- **7C — rollover and membership:** happy stage/activation, callback fallback for staging, join/leave
+  windows, observer behavior, and stale attempt abandonment in `flow_tests/rollover.rs`.
+
+These PRs are sequential where they edit the same test module, but 7C can be developed in parallel
+with 7B once shared assertion APIs are frozen.
+
+### Phase 8 — Oracle flows
+
+Add on-demand `SimpleOracle` deployment and typed approve/reject external calls. Cover allowed
+synchronous approval, delayed approval, rejection, timeout, and disallowed oracle behavior in
+`flow_tests/oracle.rs`. Keep oracle contract helpers test-only; no production allow-list semantics
+should be duplicated in the harness.
+
+Expected files: `flow_tests/harness/{contracts,fixtures,assertions}.rs`, `flow_tests/oracle.rs`, and
+module declarations. This phase can run in parallel with Phase 7 after Phase 5.
+
+### Phase 9 — Restart and reorg recovery
+
+Split persistence and fork mechanics into separate review units:
+
+- **9A — restart/catch-up:** reconstruct nodes over the same database, replay recorded canonical
+  blocks, and cover restarts during DKG and signing.
+- **9B — reorgs:** add snapshot/revert and uncle delivery, then cover DKG commitment reuse and burned
+  nonce non-reuse on an alternate message. These security flows use real/full nonce generation where
+  the reduced fixture could hide the property.
+
+Expected files: `flow_tests/harness/{node,driver,chain,trace}.rs` and `flow_tests/recovery.rs`, divided
+between the two PRs. Do not add a test-only state-inspection method to prove recovery; use calls,
+events, and contract state.
+
+### Phase 10 — Coverage-guided hardening
+
+Run validator line/branch coverage and map uncovered lines back to the behavior matrix. Add P1 flows
+where a reachable protocol behavior is missing. Add narrowly scoped direct tests only for impossible
+defensive inputs or pure helpers, and document why each cannot be reached through real contracts.
+Remove redundant internal-shape tests rather than maintaining two assertions for the same behavior.
+
+Finally, measure the complete validator suite under regular and coverage instrumentation, tune the
+scenario semaphore if necessary, run all required format/lint/test commands, and keep a short module
+doc describing how future contributors add a scenario without reaching into `State`.
+
+After Phases 1–5 stabilize the harness API, Phases 6A, 7A/7C, and 8 can be assigned in parallel. Reorg
+work remains after the block-history abstraction is stable. Each parallel branch should add its own
+fixtures locally first and only promote a helper to the shared harness when at least two flow modules
+need it.
+
+---
+
+## Open Questions and Assumptions
+
+- **Assumption: four validators are the default scenario.** Their threshold permits tests that lose
+  one participant and still complete. Smaller/larger groups are created only when the threshold edge
+  itself is under test.
+- **Assumption: the core `StateMachine` public update API is sufficient.** The harness does not need
+  `Driver::step` to become public and should not add core test hooks unless the Phase 2 vertical slice
+  demonstrates a concrete missing capability.
+- **Assumption: flow tests are ordinary Rust tests.** CI already installs Foundry 1.5.1, so they should
+  not be feature-gated, silently skipped, or moved exclusively to the slower integration workflow.
+- **Assumption: one Anvil per scenario is affordable.** Start with a conservative global concurrency
+  cap. Reconsider shared snapshots only from measurements, not pre-emptively.
+- **Decision gate: reduced usable nonce prefix.** The recommended test prefix is 16 unique nonce
+  pairs in a full 1024-leaf tree, provided every reduced-prefix scenario is bounded below its usable
+  offsets. Phase 3 must validate a 10-element proof against the real contract and benchmark both test
+  and coverage builds before the Phase 4 seam lands.
+- **Assumption: cryptographic RNG seeding is unnecessary.** If a nondeterministic crypto failure is
+  actually observed, add seed injection as its own reviewable change, keep production entropy as the
+  default, print only the seed/public artifacts, and continue asserting semantics rather than exact
+  random values.
+- **Assumption: transaction-queue persistence is out of scope.** The harness applies action expiry and
+  signs/mines encoded calls, but it does not model fee bumping, in-flight limits, durable nonces, or
+  restart recovery of queued transactions. Those remain core queue tests plus the process integration
+  smoke test.
+- **Question for the first coverage audit:** which defensive state branches are impossible to reach
+  through the deployed contracts? The answer should be recorded next to any retained direct test so a
+  future contract change can promote it to a flow.
+- **Question for suite budgeting:** what runtime ceiling should CI enforce socially? Start by
+  recording per-phase timings rather than adding wall-clock assertions; use the data to agree on a
+  budget before considering shared fixtures or more invasive optimizations.


### PR DESCRIPTION
### Context and Motivation

This PR contains 2 plans for additional follow ups for the Rust validator port:

* The first is to add comprehensive flow tests to the state machine and the state transitions. Currently state transitions are not tested _at all_ (beyond the 4 E2E tests). The epic outlines a plan to add declarative high-level tests to ensure that the state machine is working as expected
* I ran a couple agents over the Rust port to try and find issues and it found a few. I took a brief look and some look relevant and worth following up on. I am adding the epic here verbatim so they can be exampled with a bit more care.

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://docs.safefoundation.org/cla).
