### PR TITLE
[A]: Add reason parameter to oracle contract

### DIFF
--- a/contracts/src/SentinelOracleV2.sol
+++ b/contracts/src/SentinelOracleV2.sol
@@ -136,18 +136,18 @@ contract SentinelOracleV2 is IOracle {
         FEE_TOKEN.safeTransferFrom(msg.sender, address(this), bondAmount);
     }
 
-    function reveal(bytes32 requestId, bool approve, bytes32 salt) external {
+    function reveal(bytes32 requestId, bool approve, bytes32 salt, string calldata reason) external {
         SentinelOracleRequest.Request storage req = $requests.get(requestId);
-        $commitments.reveal(requestId, msg.sender, approve, salt);
+        $commitments.reveal(requestId, msg.sender, approve, salt, reason);
         req.applyReveal(approve);
     }
 
-    function hashCommitment(address sentinel, bytes32 requestId, bool approve, bytes32 salt)
+    function hashCommitment(address sentinel, bytes32 requestId, bool approve, bytes32 salt, string calldata reason)
         external
         pure
         returns (bytes32)
     {
-        return SentinelOracleCommitment.computeHash(sentinel, requestId, approve, salt);
+        return SentinelOracleCommitment.computeHash(sentinel, requestId, approve, salt, reason);
     }
 
     // ============================================================

--- a/contracts/src/libraries/SentinelOracleCommitmentsV2.sol
+++ b/contracts/src/libraries/SentinelOracleCommitmentsV2.sol
@@ -41,13 +41,15 @@ library SentinelOracleCommitment {
         self.claimed = true;
     }
 
-    function computeHash(address sentinel, bytes32 requestId, bool approve, bytes32 salt)
+    function computeHash(address sentinel, bytes32 requestId, bool approve, bytes32 salt, string calldata reason)
         internal
         pure
         returns (bytes32)
     {
+        // `reason` is appended last since it's the only variable-length field in the packed
+        // encoding, keeping the preimage unambiguous.
         // forge-lint: disable-next-line(asm-keccak256)
-        return keccak256(abi.encodePacked(approve, salt, sentinel, requestId));
+        return keccak256(abi.encodePacked(approve, salt, sentinel, requestId, reason));
     }
 }
 
@@ -65,7 +67,11 @@ library SentinelOracleCommitmentMap {
     // ============================================================
 
     event Committed(bytes32 indexed requestId, address indexed sentinel, uint256 bondAmount);
-    event Revealed(bytes32 indexed requestId, address indexed sentinel, bool approved, uint256 bondAmount);
+    // `reason` is why this *sentinel* voted the way it did — unrelated to
+    // `SentinelOracleRequest.ResolveReason`, which is why a *request* resolved.
+    event Revealed(
+        bytes32 indexed requestId, address indexed sentinel, bool approved, uint256 bondAmount, string reason
+    );
 
     // ============================================================
     // ERRORS
@@ -92,15 +98,23 @@ library SentinelOracleCommitmentMap {
         emit Committed(requestId, sentinel, bondAmount);
     }
 
-    function reveal(T storage self, bytes32 requestId, address sentinel, bool approve, bytes32 salt) internal {
+    function reveal(
+        T storage self,
+        bytes32 requestId,
+        address sentinel,
+        bool approve,
+        bytes32 salt,
+        string calldata reason
+    ) internal {
         SentinelOracleCommitment.Commitment storage c = self.commitments[requestId][sentinel];
         require(c.vote != SentinelOracleCommitment.Vote.NONE, NotCommitted());
         require(c.vote == SentinelOracleCommitment.Vote.PENDING, AlreadyRevealed());
         require(
-            SentinelOracleCommitment.computeHash(sentinel, requestId, approve, salt) == c.commitHash, InvalidReveal()
+            SentinelOracleCommitment.computeHash(sentinel, requestId, approve, salt, reason) == c.commitHash,
+            InvalidReveal()
         );
         c.vote = approve ? SentinelOracleCommitment.Vote.APPROVED : SentinelOracleCommitment.Vote.DENIED;
-        emit Revealed(requestId, sentinel, approve, c.bondAmount);
+        emit Revealed(requestId, sentinel, approve, c.bondAmount, reason);
     }
 
     function get(T storage self, bytes32 requestId, address sentinel)

--- a/contracts/test/SentinelOracleV2.t.sol
+++ b/contracts/test/SentinelOracleV2.t.sol
@@ -100,14 +100,22 @@ contract SentinelOracleV2Test is Test {
     }
 
     function _commit(address sentinel, bool approve, bytes32 salt) internal {
-        bytes32 hash = oracle.hashCommitment(sentinel, REQUEST_ID, approve, salt);
+        _commit(sentinel, approve, salt, "");
+    }
+
+    function _commit(address sentinel, bool approve, bytes32 salt, string memory reason) internal {
+        bytes32 hash = oracle.hashCommitment(sentinel, REQUEST_ID, approve, salt, reason);
         vm.prank(sentinel);
         oracle.commit(REQUEST_ID, hash);
     }
 
     function _reveal(address sentinel, bool approve, bytes32 salt) internal {
+        _reveal(sentinel, approve, salt, "");
+    }
+
+    function _reveal(address sentinel, bool approve, bytes32 salt, string memory reason) internal {
         vm.prank(sentinel);
-        oracle.reveal(REQUEST_ID, approve, salt);
+        oracle.reveal(REQUEST_ID, approve, salt, reason);
     }
 
     function _advancePastCommitDeadline() internal {
@@ -132,7 +140,7 @@ contract SentinelOracleV2Test is Test {
         _advancePastCommitDeadline();
 
         vm.expectEmit(true, true, false, true);
-        emit SentinelOracleCommitmentMap.Revealed(REQUEST_ID, sentinel1, true, BOND_TARGET);
+        emit SentinelOracleCommitmentMap.Revealed(REQUEST_ID, sentinel1, true, BOND_TARGET, "");
         _reveal(sentinel1, true, SALT_1);
         _reveal(sentinel2, true, SALT_2);
 
@@ -327,6 +335,34 @@ contract SentinelOracleV2Test is Test {
         _reveal(sentinel1, false, SALT_1);
     }
 
+    function test_Reveal_ReasonEmittedVerbatim() public {
+        _postRequest();
+        string memory reason = "destination is blocklisted";
+        _commit(sentinel1, false, SALT_1, reason);
+        _advancePastCommitDeadline();
+
+        vm.expectEmit(true, true, false, true);
+        emit SentinelOracleCommitmentMap.Revealed(REQUEST_ID, sentinel1, false, BOND_TARGET, reason);
+        _reveal(sentinel1, false, SALT_1, reason);
+    }
+
+    function test_Reveal_EmptyReason_Accepted() public {
+        _postRequest();
+        _commit(sentinel1, true, SALT_1, "");
+        _advancePastCommitDeadline();
+
+        _reveal(sentinel1, true, SALT_1, "");
+    }
+
+    function test_Reveal_WrongReason_Reverts() public {
+        _postRequest();
+        _commit(sentinel1, true, SALT_1, "reason A");
+        _advancePastCommitDeadline();
+
+        vm.expectRevert(SentinelOracleCommitmentMap.InvalidReveal.selector);
+        _reveal(sentinel1, true, SALT_1, "reason B");
+    }
+
     function test_Reveal_WithoutCommit_Reverts() public {
         _postRequest();
         _advancePastCommitDeadline();
@@ -341,7 +377,7 @@ contract SentinelOracleV2Test is Test {
 
         // Precompute the hash before arming expectRevert — hashCommitment() is itself an external
         // call, and vm.expectRevert only intercepts the very next one.
-        bytes32 hash = oracle.hashCommitment(sentinel1, REQUEST_ID, true, SALT_1);
+        bytes32 hash = oracle.hashCommitment(sentinel1, REQUEST_ID, true, SALT_1, "");
         vm.expectRevert(SentinelOracleCommitmentMap.AlreadyCommitted.selector);
         vm.prank(sentinel1);
         oracle.commit(REQUEST_ID, hash);

--- a/crates/sentinel/src/bindings.rs
+++ b/crates/sentinel/src/bindings.rs
@@ -31,16 +31,20 @@ pub mod oracle {
                 bytes32 indexed requestId,
                 address indexed sentinel,
                 bool approved,
-                uint256 bondAmount
+                uint256 bondAmount,
+                string reason
             );
             event DisputeResolved(bytes32 indexed requestId, RequestState outcome, uint256 slashed);
 
             function commit(bytes32 requestId, bytes32 commitHash) external;
-            function reveal(bytes32 requestId, bool approve, bytes32 salt) external;
-            function hashCommitment(address sentinel, bytes32 requestId, bool approve, bytes32 salt)
-                external
-                pure
-                returns (bytes32);
+            function reveal(bytes32 requestId, bool approve, bytes32 salt, string calldata reason) external;
+            function hashCommitment(
+                address sentinel,
+                bytes32 requestId,
+                bool approve,
+                bytes32 salt,
+                string calldata reason
+            ) external pure returns (bytes32);
             function finalize(bytes32 requestId) external;
             function claim(bytes32 requestId) external;
         }

--- a/crates/sentinel/src/hashing.rs
+++ b/crates/sentinel/src/hashing.rs
@@ -15,16 +15,21 @@ const REVEAL_SALT_DOMAIN: &[u8] = b"safenet-sentinel-reveal-salt";
 
 /// Computes the blind commit-hash preimage for the sentinel game's commit-reveal vote, mirroring
 /// `SentinelOracleCommitment.computeHash` (`contracts/src/libraries/SentinelOracleCommitmentsV2.sol`):
-/// `keccak256(abi.encodePacked(approve, salt, sentinel, requestId))`. Binding `sentinel` and
-/// `requestId` into the preimage (not just `approve`/`salt`) is load-bearing, not
-/// defense-in-depth — see the epic's Architecture Decision for why.
+/// `keccak256(abi.encodePacked(approve, salt, sentinel, requestId, reason))`. Binding `sentinel`
+/// and `requestId` into the preimage (not just `approve`/`salt`) is load-bearing, not
+/// defense-in-depth — see the epic's Architecture Decision for why. `reason` is hardcoded to
+/// empty here (Phase A); `abi.encodePacked` of an empty string contributes zero bytes, so this
+/// stays bit-identical to the pre-`reason` hash. Phase B threads a real `reason` through this
+/// function.
 #[must_use]
 pub fn commit_hash(sentinel: Address, request_id: B256, approve: bool, salt: B256) -> B256 {
-    let mut preimage = [0u8; 85];
-    preimage[0] = u8::from(approve);
-    preimage[1..33].copy_from_slice(salt.as_slice());
-    preimage[33..53].copy_from_slice(sentinel.as_slice());
-    preimage[53..85].copy_from_slice(request_id.as_slice());
+    const REASON: &[u8] = b"";
+    let mut preimage = Vec::with_capacity(85 + REASON.len());
+    preimage.push(u8::from(approve));
+    preimage.extend_from_slice(salt.as_slice());
+    preimage.extend_from_slice(sentinel.as_slice());
+    preimage.extend_from_slice(request_id.as_slice());
+    preimage.extend_from_slice(REASON);
     keccak256(preimage)
 }
 

--- a/crates/sentinel/src/service.rs
+++ b/crates/sentinel/src/service.rs
@@ -426,6 +426,7 @@ impl SentinelEncoder {
                     requestId: id,
                     approve,
                     salt,
+                    reason: String::new(),
                 }
                 .abi_encode()
                 .into(),
@@ -643,6 +644,7 @@ mod tests {
                 sentinel,
                 approved,
                 bondAmount: bond,
+                reason: String::new(),
             },
         ))
     }


### PR DESCRIPTION
A reason field is added to the vote. This means the commit hash and the reveal method now support a reason string. The reason string is optional, so can be empty.

Minimal adjustments to the sentinel service have been made to avoid breaking of integration tests. Complete sentinel service adjustments will happen in a follow up PR.

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://docs.safefoundation.org/cla).
