### PR TITLE
[Guard - Step 1] Add TransactionAnnouncement library

### DIFF
--- a/contracts/src/libraries/TransactionAnnouncement.sol
+++ b/contracts/src/libraries/TransactionAnnouncement.sol
@@ -121,7 +121,7 @@ library TransactionAnnouncement {
     }
 
     /**
-     * @notice Cancels a pending announcement immediately.
+     * @notice Cancels an existing announcement immediately, whether it is pending, active, or expired.
      * @dev Reverts `AnnouncementNotFound` if none exists for the pair.
      * @param self The storage struct.
      * @param safe The Safe whose announcement is being cancelled.

--- a/contracts/src/libraries/TransactionAnnouncement.sol
+++ b/contracts/src/libraries/TransactionAnnouncement.sol
@@ -1,0 +1,169 @@
+// SPDX-License-Identifier: GPL-3.0-only
+pragma solidity ^0.8.30;
+
+import {Enum} from "@safe/interfaces/Enum.sol";
+
+/**
+ * @title TransactionAnnouncement
+ * @notice Time-windowed transaction announcements — an escape hatch that lets a Safe execute a
+ *         transaction without a Safenet attestation, only inside a bounded `[activeFrom, activeUntil]`.
+ * @dev State is keyed by `(safe, txHash)`, where `txHash` is the nonce-free {hash} of an
+ *      {AnnouncedTransaction} (every `execTransaction` field except the nonce). Keying by the caller
+ *      isolates each Safe. The two bounds pack into one slot via {Window} (two `uint128`), so each
+ *      operation is a single SLOAD/SSTORE; `activeFrom == 0` is the empty sentinel. `announce` embargoes
+ *      by `delay` and rejects durations that would overflow `uint128`; `cancel` is immediate; an expired
+ *      entry is renewable in place while a pending/active one is not. Emits no events — the consumer
+ *      emits its own (the guard's announcement events are chain- and parameter-dependent).
+ */
+library TransactionAnnouncement {
+    // ============================================================
+    // STRUCTS
+    // ============================================================
+
+    /**
+     * @notice The parameters of an announced transaction — every `execTransaction` field except the
+     *         Safe nonce and signatures. Hashed nonce-free by {hash} to key the announcement.
+     */
+    struct AnnouncedTransaction {
+        address to;
+        uint256 value;
+        bytes data;
+        Enum.Operation operation;
+        uint256 safeTxGas;
+        uint256 baseGas;
+        uint256 gasPrice;
+        address gasToken;
+        address refundReceiver;
+    }
+
+    /**
+     * @notice A bounded execution window `[activeFrom, activeUntil]` (both inclusive), packed in one slot.
+     * @custom:param activeFrom Earliest Unix timestamp at which execution is permitted; zero means
+     *               "no announcement".
+     * @custom:param activeUntil Latest Unix timestamp at which execution is permitted.
+     */
+    struct Window {
+        uint128 activeFrom;
+        uint128 activeUntil;
+    }
+
+    /**
+     * @notice The set of pending announcements.
+     * @custom:param entries Maps `(safe, txHash)` to its execution {Window}.
+     */
+    struct T {
+        mapping(address safe => mapping(bytes32 txHash => Window window)) entries;
+    }
+
+    // ============================================================
+    // ERRORS
+    // ============================================================
+
+    /**
+     * @notice Thrown by `announce` when a pending or still-active announcement already exists for this
+     *         `(safe, txHash)`. An expired announcement does not trigger this — it is overwritten.
+     */
+    error AnnouncementAlreadyExists();
+
+    /**
+     * @notice Thrown by `cancel` when no announcement exists for this `(safe, txHash)`.
+     */
+    error AnnouncementNotFound();
+
+    /**
+     * @notice Thrown by `announce` when `activeFrom`/`activeUntil` would not fit in `uint128`.
+     */
+    error WindowOverflow();
+
+    // ============================================================
+    // INTERNAL FUNCTIONS
+    // ============================================================
+
+    /**
+     * @notice The nonce-free announcement hash of `t` — covers every field except the Safe nonce, and
+     *         excludes the Safe (announcements are scoped by the storage key). `data` is pre-hashed.
+     */
+    function hash(AnnouncedTransaction memory t) internal pure returns (bytes32) {
+        // forge-lint: disable-next-line(asm-keccak256)
+        bytes32 dataHash = keccak256(t.data);
+        bytes memory encoded = abi.encode(
+            t.to, t.value, dataHash, t.operation, t.safeTxGas, t.baseGas, t.gasPrice, t.gasToken, t.refundReceiver
+        );
+        // forge-lint: disable-next-line(asm-keccak256)
+        return keccak256(encoded);
+    }
+
+    /**
+     * @notice Announces `txHash` for execution within `[now + delay, that + window]`.
+     * @dev Overwrites an expired entry (renewal) but reverts `AnnouncementAlreadyExists` while an entry
+     *      is pending or active. Reverts `WindowOverflow` if the computed bounds exceed `uint128`.
+     * @param self The storage struct.
+     * @param safe The Safe making the announcement (typically `msg.sender` in the consumer).
+     * @param txHash The identifier to announce.
+     * @param delay Embargo seconds before the hash becomes executable.
+     * @param window Seconds after `activeFrom` during which the hash remains executable.
+     * @return activeFrom The computed earliest execution timestamp.
+     * @return activeUntil The computed latest execution timestamp.
+     */
+    function announce(T storage self, address safe, bytes32 txHash, uint256 delay, uint256 window)
+        internal
+        returns (uint256 activeFrom, uint256 activeUntil)
+    {
+        Window storage existing = self.entries[safe][txHash];
+        require(existing.activeFrom == 0 || block.timestamp > existing.activeUntil, AnnouncementAlreadyExists());
+        activeFrom = block.timestamp + delay;
+        activeUntil = activeFrom + window;
+        // `activeUntil >= activeFrom` (checked add), so bounding `activeUntil` bounds both.
+        require(activeUntil <= type(uint128).max, WindowOverflow());
+        // Single-slot write.
+        // forge-lint: disable-next-line(unsafe-typecast)
+        self.entries[safe][txHash] = Window({activeFrom: uint128(activeFrom), activeUntil: uint128(activeUntil)});
+    }
+
+    /**
+     * @notice Cancels a pending announcement immediately.
+     * @dev Reverts `AnnouncementNotFound` if none exists for the pair.
+     * @param self The storage struct.
+     * @param safe The Safe whose announcement is being cancelled.
+     * @param txHash The identifier whose announcement should be removed.
+     */
+    function cancel(T storage self, address safe, bytes32 txHash) internal {
+        require(self.entries[safe][txHash].activeFrom != 0, AnnouncementNotFound());
+        delete self.entries[safe][txHash];
+    }
+
+    /**
+     * @notice Consumes the announcement for `txHash` iff it exists and `now` is within its window.
+     * @dev Non-reverting: returns `false` when the entry is absent, not yet active, or expired, so the
+     *      consumer can fall through to other authorisation paths. Deletes the entry on success.
+     * @param self The storage struct.
+     * @param safe The Safe attempting execution.
+     * @param txHash The identifier being executed.
+     * @return consumed True if an in-window announcement was found and deleted.
+     */
+    function consume(T storage self, address safe, bytes32 txHash) internal returns (bool consumed) {
+        Window memory w = self.entries[safe][txHash];
+        if (w.activeFrom != 0 && block.timestamp >= w.activeFrom && block.timestamp <= w.activeUntil) {
+            delete self.entries[safe][txHash];
+            return true;
+        }
+        return false;
+    }
+
+    /**
+     * @notice Returns the execution window for a pending announcement, or `(0, 0)` if none exists.
+     * @param self The storage struct.
+     * @param safe The Safe to query.
+     * @param txHash The identifier to query.
+     * @return activeFrom The earliest execution timestamp, or zero.
+     * @return activeUntil The latest execution timestamp, or zero.
+     */
+    function windowOf(T storage self, address safe, bytes32 txHash)
+        internal
+        view
+        returns (uint256 activeFrom, uint256 activeUntil)
+    {
+        Window memory w = self.entries[safe][txHash];
+        return (w.activeFrom, w.activeUntil);
+    }
+}

--- a/contracts/test/libraries/TransactionAnnouncement.t.sol
+++ b/contracts/test/libraries/TransactionAnnouncement.t.sol
@@ -1,0 +1,96 @@
+// SPDX-License-Identifier: GPL-3.0-only
+pragma solidity ^0.8.30;
+
+import {Test} from "@forge-std/Test.sol";
+import {TransactionAnnouncement} from "@/libraries/TransactionAnnouncement.sol";
+
+/**
+ * @title TransactionAnnouncementTest
+ * @notice Unit tests for the `TransactionAnnouncement` state library, exercised on this contract's own
+ *         storage. Reverting paths go through external `this.call*` wrappers (an internal library revert
+ *         is at the cheatcode's own call depth, which `vm.expectRevert` cannot observe). Covers the
+ *         paths the guard no longer reaches after bounding its constructor timing (notably
+ *         `WindowOverflow`), plus the core announce/consume/cancel/renewal lifecycle.
+ */
+contract TransactionAnnouncementTest is Test {
+    using TransactionAnnouncement for TransactionAnnouncement.T;
+
+    TransactionAnnouncement.T internal state;
+
+    address internal constant SAFE = address(0x5AFE);
+    bytes32 internal constant ID = keccak256("announcement-id");
+    uint256 internal constant DELAY = 1 days;
+    uint256 internal constant WINDOW = 3 days;
+
+    // External wrappers so `vm.expectRevert` can observe library reverts at a lower call depth.
+    function callAnnounce(address safe, bytes32 id, uint256 delay, uint256 window) external {
+        state.announce(safe, id, delay, window);
+    }
+
+    function callCancel(address safe, bytes32 id) external {
+        state.cancel(safe, id);
+    }
+
+    function test_announce_setsWindow() public {
+        uint256 t0 = block.timestamp;
+        (uint256 activeFrom, uint256 activeUntil) = state.announce(SAFE, ID, DELAY, WINDOW);
+        assertEq(activeFrom, t0 + DELAY);
+        assertEq(activeUntil, t0 + DELAY + WINDOW);
+        (uint256 storedFrom, uint256 storedUntil) = state.windowOf(SAFE, ID);
+        assertEq(storedFrom, activeFrom);
+        assertEq(storedUntil, activeUntil);
+    }
+
+    function test_announce_revertsWhilePendingOrActive() public {
+        state.announce(SAFE, ID, DELAY, WINDOW);
+        vm.expectRevert(TransactionAnnouncement.AnnouncementAlreadyExists.selector);
+        this.callAnnounce(SAFE, ID, DELAY, WINDOW);
+    }
+
+    function test_announce_renewsExpired() public {
+        state.announce(SAFE, ID, DELAY, WINDOW);
+        vm.warp(block.timestamp + DELAY + WINDOW + 1); // expire
+        (uint256 activeFrom,) = state.announce(SAFE, ID, DELAY, WINDOW); // must not revert
+        assertEq(activeFrom, block.timestamp + DELAY);
+    }
+
+    function test_announce_revertsOnWindowOverflow() public {
+        // delay fits uint256 (no checked-add panic) but pushes activeUntil past uint128.
+        vm.expectRevert(TransactionAnnouncement.WindowOverflow.selector);
+        this.callAnnounce(SAFE, ID, uint256(1) << 128, 0);
+    }
+
+    function test_consume_onlyWithinWindow() public {
+        state.announce(SAFE, ID, DELAY, WINDOW);
+
+        assertFalse(state.consume(SAFE, ID)); // before activeFrom
+        vm.warp(block.timestamp + DELAY - 1);
+        assertFalse(state.consume(SAFE, ID));
+
+        vm.warp(block.timestamp + 1); // exactly activeFrom
+        assertTrue(state.consume(SAFE, ID)); // consumed
+        (uint256 activeFrom,) = state.windowOf(SAFE, ID);
+        assertEq(activeFrom, 0); // deleted
+    }
+
+    function test_consume_falseAfterExpiry() public {
+        state.announce(SAFE, ID, DELAY, WINDOW);
+        vm.warp(block.timestamp + DELAY + WINDOW + 1);
+        assertFalse(state.consume(SAFE, ID));
+        // The stored entry is not auto-cleared on a failed consume.
+        (uint256 activeFrom,) = state.windowOf(SAFE, ID);
+        assertGt(activeFrom, 0);
+    }
+
+    function test_cancel_deletes() public {
+        state.announce(SAFE, ID, DELAY, WINDOW);
+        state.cancel(SAFE, ID);
+        (uint256 activeFrom,) = state.windowOf(SAFE, ID);
+        assertEq(activeFrom, 0);
+    }
+
+    function test_cancel_revertsIfMissing() public {
+        vm.expectRevert(TransactionAnnouncement.AnnouncementNotFound.selector);
+        this.callCancel(SAFE, ID);
+    }
+}


### PR DESCRIPTION
Introduces the `TransactionAnnouncement` library: the nonce-free, time-windowed announcement store that backs the upcoming SafenetGuard escape hatch.

### Context and Motivation

SafenetGuard needs a liveness path so a Safe can still transact if the Safenet attestation service is unavailable. This library owns that mechanism in isolation, before any guard depends on it: it hashes a Safe transaction over every `execTransaction` field except the nonce, and stores a bounded `[activeFrom, activeUntil]` window per `(safe, txHash)`. Keying by nonce-free hash is what makes the escape hatch executable at any nonce.

### Decisions and Tradeoffs

- The window packs into a single storage slot (two `uint128`), so announce/consume are one SLOAD/SSTORE; `activeFrom == 0` is the empty sentinel.
- An expired entry is renewable in place, but a pending/active one reverts `AnnouncementAlreadyExists` — no silent overwrite of a live announcement.
- The library emits no events: the consuming guard emits its own, because the event shape is chain- and parameter-dependent.

### Testing

- `cd contracts && forge test --match-path 'test/libraries/TransactionAnnouncement.t.sol'` — 8 behavioural tests (announce/renew/cancel/consume/window-overflow), using external wrappers so reverts on `internal` library calls are observable.
- `forge fmt --check` and `forge lint --deny notes` pass.

### Stack

- Base: `standalone-guard`. This is the base of the SafenetGuard stack; every other PR is stacked on top of it.
- Previous: none.
- Next: the ISafenetGuard interface PR is stacked directly on this branch — it consumes this library's `AnnouncedTransaction` struct.
