### PR TITLE
[Guard - Step 3] Add AttestationTrailer library

### DIFF
--- a/contracts/src/libraries/AttestationTrailer.sol
+++ b/contracts/src/libraries/AttestationTrailer.sol
@@ -29,9 +29,10 @@ library AttestationTrailer {
     uint256 private constant _PAYLOAD_LENGTH = 192;
 
     /**
-     * @dev Total trailer overhead: 192-byte payload + 32-byte magic.
+     * @dev Total trailer overhead: the payload followed by the 32-byte magic word. Derived from
+     *      `_PAYLOAD_LENGTH` so the two constants cannot drift if the payload layout changes.
      */
-    uint256 private constant _TRAILER_LENGTH = 224;
+    uint256 private constant _TRAILER_LENGTH = _PAYLOAD_LENGTH + 32;
 
     // ============================================================
     // ERRORS

--- a/contracts/src/libraries/AttestationTrailer.sol
+++ b/contracts/src/libraries/AttestationTrailer.sol
@@ -7,11 +7,11 @@ import {Secp256k1} from "@/libraries/Secp256k1.sol";
 /**
  * @title AttestationTrailer
  * @notice Recognises and decodes a Safenet attestation appended to Safe's `signatures` bytes.
- * @dev Layout: `[safe owner signatures][192-byte abi.encode(epoch, groupKey, signature)][32-byte MAGIC]`.
- *      Anchoring at the end leaves Safe's front-to-back signature parser untouched, and the terminal
- *      magic makes detection independent of signature suffixes — a blob not ending in `MAGIC` is simply
- *      "no trailer". The magic embeds the version, so a future format uses a different magic (and this
- *      guard treats it as absent). The library owns recognition, sizing, and the typed decode.
+ * @dev Layout: `[safe owner signatures][192-byte abi.encode(epoch, groupKey, signature)][32-byte TYPE_HASH]`.
+ *      Anchoring at the end leaves Safe's front-to-back signature parser untouched, and the terminal type
+ *      hash makes detection independent of signature suffixes — a blob not ending in `TYPE_HASH` is simply
+ *      "no trailer". The type hash embeds the version, so a future format uses a different type hash (and
+ *      this guard treats it as absent). The library owns recognition, sizing, and the typed decode.
  */
 library AttestationTrailer {
     // ============================================================
@@ -19,9 +19,9 @@ library AttestationTrailer {
     // ============================================================
 
     /**
-     * @notice Tag that must terminate a v1 attestation trailer.
+     * @notice Type hash that must terminate a v1 attestation trailer; doubles as the version tag.
      */
-    bytes32 internal constant MAGIC = keccak256("SafenetGuard.AttestationTrailer.v1");
+    bytes32 internal constant TYPE_HASH = keccak256("SafenetGuard.AttestationTrailer.v1");
 
     /**
      * @dev Payload is `abi.encode(uint64, Secp256k1.Point, FROST.Signature)` = 6 words = 192 bytes.
@@ -29,7 +29,7 @@ library AttestationTrailer {
     uint256 private constant _PAYLOAD_LENGTH = 192;
 
     /**
-     * @dev Total trailer overhead: the payload followed by the 32-byte magic word. Derived from
+     * @dev Total trailer overhead: the payload followed by the 32-byte type hash word. Derived from
      *      `_PAYLOAD_LENGTH` so the two constants cannot drift if the payload layout changes.
      */
     uint256 private constant _TRAILER_LENGTH = _PAYLOAD_LENGTH + 32;
@@ -39,7 +39,7 @@ library AttestationTrailer {
     // ============================================================
 
     /**
-     * @notice Thrown when the magic is present but the blob is too short to hold a v1 trailer.
+     * @notice Thrown when the type hash is present but the blob is too short to hold a v1 trailer.
      */
     error MalformedAttestationTrailer();
 
@@ -49,8 +49,8 @@ library AttestationTrailer {
 
     /**
      * @notice Recognises and decodes an attestation trailer from a `signatures` blob.
-     * @dev Returns `present == false` when the last word is not `MAGIC` (so the consumer falls through
-     *      to other authorisation paths). Reverts `MalformedAttestationTrailer` when the magic is
+     * @dev Returns `present == false` when the last word is not `TYPE_HASH` (so the consumer falls through
+     *      to other authorisation paths). Reverts `MalformedAttestationTrailer` when the type hash is
      *      present but the blob is shorter than a full trailer — a recognised trailer never silently
      *      falls through.
      * @return present True if a trailer was recognised and decoded.
@@ -63,7 +63,7 @@ library AttestationTrailer {
         pure
         returns (bool present, uint64 epoch, Secp256k1.Point memory groupKey, FROST.Signature memory signature)
     {
-        if (signatures.length < 32 || bytes32(signatures[signatures.length - 32:]) != MAGIC) {
+        if (signatures.length < 32 || bytes32(signatures[signatures.length - 32:]) != TYPE_HASH) {
             return (false, 0, groupKey, signature);
         }
         require(signatures.length >= _TRAILER_LENGTH, MalformedAttestationTrailer());

--- a/contracts/src/libraries/AttestationTrailer.sol
+++ b/contracts/src/libraries/AttestationTrailer.sol
@@ -1,0 +1,76 @@
+// SPDX-License-Identifier: GPL-3.0-only
+pragma solidity ^0.8.30;
+
+import {FROST} from "@/libraries/FROST.sol";
+import {Secp256k1} from "@/libraries/Secp256k1.sol";
+
+/**
+ * @title AttestationTrailer
+ * @notice Recognises and decodes a Safenet attestation appended to Safe's `signatures` bytes.
+ * @dev Layout: `[safe owner signatures][192-byte abi.encode(epoch, groupKey, signature)][32-byte MAGIC]`.
+ *      Anchoring at the end leaves Safe's front-to-back signature parser untouched, and the terminal
+ *      magic makes detection independent of signature suffixes — a blob not ending in `MAGIC` is simply
+ *      "no trailer". The magic embeds the version, so a future format uses a different magic (and this
+ *      guard treats it as absent). The library owns recognition, sizing, and the typed decode.
+ */
+library AttestationTrailer {
+    // ============================================================
+    // CONSTANTS
+    // ============================================================
+
+    /**
+     * @notice Tag that must terminate a v1 attestation trailer.
+     */
+    bytes32 internal constant MAGIC = keccak256("SafenetGuard.AttestationTrailer.v1");
+
+    /**
+     * @dev Payload is `abi.encode(uint64, Secp256k1.Point, FROST.Signature)` = 6 words = 192 bytes.
+     */
+    uint256 private constant _PAYLOAD_LENGTH = 192;
+
+    /**
+     * @dev Total trailer overhead: 192-byte payload + 32-byte magic.
+     */
+    uint256 private constant _TRAILER_LENGTH = 224;
+
+    // ============================================================
+    // ERRORS
+    // ============================================================
+
+    /**
+     * @notice Thrown when the magic is present but the blob is too short to hold a v1 trailer.
+     */
+    error MalformedAttestationTrailer();
+
+    // ============================================================
+    // INTERNAL FUNCTIONS
+    // ============================================================
+
+    /**
+     * @notice Recognises and decodes an attestation trailer from a `signatures` blob.
+     * @dev Returns `present == false` when the last word is not `MAGIC` (so the consumer falls through
+     *      to other authorisation paths). Reverts `MalformedAttestationTrailer` when the magic is
+     *      present but the blob is shorter than a full trailer — a recognised trailer never silently
+     *      falls through.
+     * @return present True if a trailer was recognised and decoded.
+     * @return epoch The attested epoch.
+     * @return groupKey The attesting FROST group key.
+     * @return signature The FROST signature.
+     */
+    function decode(bytes calldata signatures)
+        internal
+        pure
+        returns (bool present, uint64 epoch, Secp256k1.Point memory groupKey, FROST.Signature memory signature)
+    {
+        if (signatures.length < 32 || bytes32(signatures[signatures.length - 32:]) != MAGIC) {
+            return (false, 0, groupKey, signature);
+        }
+        require(signatures.length >= _TRAILER_LENGTH, MalformedAttestationTrailer());
+
+        uint256 payloadStart = signatures.length - _TRAILER_LENGTH;
+        (epoch, groupKey, signature) = abi.decode(
+            signatures[payloadStart:payloadStart + _PAYLOAD_LENGTH], (uint64, Secp256k1.Point, FROST.Signature)
+        );
+        present = true;
+    }
+}


### PR DESCRIPTION
Introduces the `AttestationTrailer` library: recognises and decodes the inline attestation blob that SafenetGuard reads off the tail of a Safe's `signatures`.

### Context and Motivation

SafenetGuard carries the FROST attestation `(epoch, groupKey, signature)` as a trailer appended to the standard `signatures` bytes, so no new call surface is needed on `execTransaction`. This library isolates that wire format — recognition, sizing, and typed decode — away from the guard's authorisation logic.

### Decisions and Tradeoffs

- A single `bytes32` magic (`keccak256("SafenetGuard.AttestationTrailer.v1")`) both frames and versions the trailer; there is no separate version byte.
- Recognition is fail-closed: no magic in the final word means "absent" (the guard falls through to other auth paths), but magic present with a too-short blob reverts `MalformedAttestationTrailer` rather than silently falling through.

### Testing

- No dedicated unit test: the decoder is exercised end-to-end by the SafenetGuard integration suite later in the stack (present/absent/malformed trailer paths). A redundant unit test here was avoided to keep the change minimal.
- `cd contracts && forge build`, `forge fmt --check`, and `forge lint --deny notes` pass.

### Stack

- Base: `guard/2-interface` (this PR is stacked on it).
- Previous: the ISafenetGuard interface PR.
- Next: the GuardAutoAllow library PR. This decoder is consumed by `SafenetGuard` later in the stack.
