### PR TITLE
[Guard - Step 4] Add GuardAutoAllow library

### DIFF
--- a/contracts/src/libraries/AttestationTrailer.sol
+++ b/contracts/src/libraries/AttestationTrailer.sol
@@ -29,9 +29,10 @@ library AttestationTrailer {
     uint256 private constant _PAYLOAD_LENGTH = 192;
 
     /**
-     * @dev Total trailer overhead: 192-byte payload + 32-byte magic.
+     * @dev Total trailer overhead: the payload followed by the 32-byte magic word. Derived from
+     *      `_PAYLOAD_LENGTH` so the two constants cannot drift if the payload layout changes.
      */
-    uint256 private constant _TRAILER_LENGTH = 224;
+    uint256 private constant _TRAILER_LENGTH = _PAYLOAD_LENGTH + 32;
 
     // ============================================================
     // ERRORS

--- a/contracts/src/libraries/AttestationTrailer.sol
+++ b/contracts/src/libraries/AttestationTrailer.sol
@@ -1,0 +1,76 @@
+// SPDX-License-Identifier: GPL-3.0-only
+pragma solidity ^0.8.30;
+
+import {FROST} from "@/libraries/FROST.sol";
+import {Secp256k1} from "@/libraries/Secp256k1.sol";
+
+/**
+ * @title AttestationTrailer
+ * @notice Recognises and decodes a Safenet attestation appended to Safe's `signatures` bytes.
+ * @dev Layout: `[safe owner signatures][192-byte abi.encode(epoch, groupKey, signature)][32-byte MAGIC]`.
+ *      Anchoring at the end leaves Safe's front-to-back signature parser untouched, and the terminal
+ *      magic makes detection independent of signature suffixes — a blob not ending in `MAGIC` is simply
+ *      "no trailer". The magic embeds the version, so a future format uses a different magic (and this
+ *      guard treats it as absent). The library owns recognition, sizing, and the typed decode.
+ */
+library AttestationTrailer {
+    // ============================================================
+    // CONSTANTS
+    // ============================================================
+
+    /**
+     * @notice Tag that must terminate a v1 attestation trailer.
+     */
+    bytes32 internal constant MAGIC = keccak256("SafenetGuard.AttestationTrailer.v1");
+
+    /**
+     * @dev Payload is `abi.encode(uint64, Secp256k1.Point, FROST.Signature)` = 6 words = 192 bytes.
+     */
+    uint256 private constant _PAYLOAD_LENGTH = 192;
+
+    /**
+     * @dev Total trailer overhead: 192-byte payload + 32-byte magic.
+     */
+    uint256 private constant _TRAILER_LENGTH = 224;
+
+    // ============================================================
+    // ERRORS
+    // ============================================================
+
+    /**
+     * @notice Thrown when the magic is present but the blob is too short to hold a v1 trailer.
+     */
+    error MalformedAttestationTrailer();
+
+    // ============================================================
+    // INTERNAL FUNCTIONS
+    // ============================================================
+
+    /**
+     * @notice Recognises and decodes an attestation trailer from a `signatures` blob.
+     * @dev Returns `present == false` when the last word is not `MAGIC` (so the consumer falls through
+     *      to other authorisation paths). Reverts `MalformedAttestationTrailer` when the magic is
+     *      present but the blob is shorter than a full trailer — a recognised trailer never silently
+     *      falls through.
+     * @return present True if a trailer was recognised and decoded.
+     * @return epoch The attested epoch.
+     * @return groupKey The attesting FROST group key.
+     * @return signature The FROST signature.
+     */
+    function decode(bytes calldata signatures)
+        internal
+        pure
+        returns (bool present, uint64 epoch, Secp256k1.Point memory groupKey, FROST.Signature memory signature)
+    {
+        if (signatures.length < 32 || bytes32(signatures[signatures.length - 32:]) != MAGIC) {
+            return (false, 0, groupKey, signature);
+        }
+        require(signatures.length >= _TRAILER_LENGTH, MalformedAttestationTrailer());
+
+        uint256 payloadStart = signatures.length - _TRAILER_LENGTH;
+        (epoch, groupKey, signature) = abi.decode(
+            signatures[payloadStart:payloadStart + _PAYLOAD_LENGTH], (uint64, Secp256k1.Point, FROST.Signature)
+        );
+        present = true;
+    }
+}

--- a/contracts/src/libraries/GuardAutoAllow.sol
+++ b/contracts/src/libraries/GuardAutoAllow.sol
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: GPL-3.0-only
+pragma solidity ^0.8.30;
+
+import {Enum} from "@safe/interfaces/Enum.sol";
+
+/**
+ * @title GuardAutoAllow
+ * @notice Structural gate for guard "self-calls" that a Safe may execute without a Safenet
+ *         attestation (the escape-hatch management functions on the guard itself).
+ * @dev This library owns the audit-sensitive structural checks — the call must target the guard,
+ *      carry zero value, use `CALL` (never `DELEGATECALL`, which would run guard functions in the
+ *      Safe's storage context and corrupt Safe state), and contain at least a 4-byte selector.
+ *      The set of *which* selectors are auto-allowed is intrinsically guard-specific, so that
+ *      membership check stays in the consumer: this library returns the extracted selector for a
+ *      structurally valid self-call and lets the guard compare it against its own whitelist.
+ */
+library GuardAutoAllow {
+    // ============================================================
+    // INTERNAL FUNCTIONS
+    // ============================================================
+
+    /**
+     * @notice Returns the call's selector iff it is a structurally valid guard self-call.
+     * @dev Returns `bytes4(0)` when any structural check fails. Because callers compare the result
+     *      against specific non-zero selectors, a zero return can never be mistaken for a match.
+     * @param to The call target.
+     * @param value The call value.
+     * @param data The call data.
+     * @param operation The call operation type.
+     * @param guard The address of the guard contract (the only permitted self-call target).
+     * @return selector The 4-byte selector of a valid self-call, or `bytes4(0)` otherwise.
+     */
+    function selfCallSelector(address to, uint256 value, bytes memory data, Enum.Operation operation, address guard)
+        internal
+        pure
+        returns (bytes4 selector)
+    {
+        if (to != guard) return bytes4(0);
+        if (value != 0) return bytes4(0);
+        if (operation != Enum.Operation.Call) return bytes4(0);
+        if (data.length < 4) return bytes4(0);
+        // forge-lint: disable-next-line(unsafe-typecast)
+        return bytes4(data);
+    }
+}


### PR DESCRIPTION
Introduces the `GuardAutoAllow` library: the structural gate that decides when a Safe may call the guard's own escape-hatch functions without an attestation.

### Context and Motivation

`announceTransaction` and `cancelAnnouncement` are called by the Safe on the guard itself and therefore must bypass attestation — otherwise the escape hatch could never be armed. This library owns the audit-sensitive structural checks for such self-calls, isolated from the guard's selector whitelist.

### Decisions and Tradeoffs

- A valid self-call must target the guard, carry zero value, use `CALL` (never `DELEGATECALL`, which would execute guard code in the Safe's storage context), and include at least a 4-byte selector.
- The library returns the extracted selector and lets the guard compare it against its own whitelist: which selectors are auto-allowed is intrinsically guard-specific, so that membership check stays with the consumer. A `bytes4(0)` return can never be mistaken for a real selector match.

### Testing

- No dedicated unit test: the auto-allow paths (and the delegatecall/value/target rejections) are covered by the SafenetGuard integration suite later in the stack.
- `cd contracts && forge build`, `forge fmt --check`, and `forge lint --deny notes` pass.

### Stack

- Base: `guard/3-attestation-trailer` (this PR is stacked on it).
- Previous: the AttestationTrailer library PR.
- Next: the SafenetGuard contract PR, which consumes all three libraries and the interface below it.
