### PR TITLE
[Guard - Step 7] Add SafenetGuard deployment script

### DIFF
--- a/contracts/.env.sample
+++ b/contracts/.env.sample
@@ -4,7 +4,7 @@
 # 2 = Canonical Deterministic Deployment Factory
 FACTORY=1
 
-# SafenetCosigner Deployment Config
+# SafenetCosigner / SafenetGuard Deployment Config (shared)
 # Chain ID of the Consensus contract (100 = Gnosis Chain)
 CONSENSUS_CHAIN_ID=100
 # Address of the Consensus contract on the consensus chain
@@ -13,8 +13,12 @@ CONSENSUS_ADDRESS=0x223624cBF099e5a8f8cD5aF22aFa424a1d1acEE9
 INITIAL_EPOCH=
 INITIAL_GROUP_KEY_X=
 INITIAL_GROUP_KEY_Y=
-# Delay in seconds before a pre-approved transaction can be executed (default: 60)
-ALLOW_TX_DELAY=60
+# Escape-hatch embargo: seconds before a pre-approved (SafenetCosigner) or announced (SafenetGuard)
+# transaction becomes executable (default: 259200 = 3 days)
+ALLOW_TX_DELAY=259200
+# SafenetGuard only — escape-hatch window: seconds after the embargo during which an announced
+# transaction stays executable (default: 3600)
+ALLOW_TX_WINDOW=3600
 
 # Staking Contract Deployment Config
 # Initial owner of the staking contract, can be set to any address

--- a/contracts/script/DeploySafenetGuard.s.sol
+++ b/contracts/script/DeploySafenetGuard.s.sol
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: GPL-3.0-only
+pragma solidity ^0.8.30;
+
+import {Script, console} from "@forge-std/Script.sol";
+import {SafenetGuard} from "@/guard/SafenetGuard.sol";
+import {Secp256k1} from "@/libraries/Secp256k1.sol";
+import {DeterministicDeployment} from "@script/util/DeterministicDeployment.sol";
+import {getFactory} from "@script/util/GetFactory.sol";
+
+contract DeploySafenetGuardScript is Script {
+    using DeterministicDeployment for DeterministicDeployment.Factory;
+
+    function run() public returns (address guard) {
+        // Required script arguments:
+        uint256 consensusChainId = vm.envUint("CONSENSUS_CHAIN_ID");
+        address consensusAddress = vm.envAddress("CONSENSUS_ADDRESS");
+        uint256 rawEpoch = vm.envUint("INITIAL_EPOCH");
+        require(rawEpoch <= type(uint64).max, "INITIAL_EPOCH overflow: value exceeds uint64");
+        // forge-lint: disable-next-line(unsafe-typecast)
+        uint64 initialEpoch = uint64(rawEpoch);
+        uint256 groupKeyX = vm.envUint("INITIAL_GROUP_KEY_X");
+        uint256 groupKeyY = vm.envUint("INITIAL_GROUP_KEY_Y");
+
+        // Optional script arguments:
+        uint256 allowTxDelay = vm.envOr("ALLOW_TX_DELAY", uint256(3 days));
+        uint256 allowTxWindow = vm.envOr("ALLOW_TX_WINDOW", uint256(1 hours));
+        DeterministicDeployment.Factory factory = getFactory(vm);
+
+        Secp256k1.Point memory initialGroupKey = Secp256k1.Point({x: groupKeyX, y: groupKeyY});
+
+        vm.startBroadcast();
+
+        guard = factory.deployWithArgs(
+            bytes32(0),
+            type(SafenetGuard).creationCode,
+            abi.encode(consensusChainId, consensusAddress, initialEpoch, initialGroupKey, allowTxDelay, allowTxWindow)
+        );
+
+        vm.stopBroadcast();
+
+        console.log("SafenetGuard deployed at:", guard);
+    }
+}


### PR DESCRIPTION
Adds the Forge deployment script for `SafenetGuard` and documents its configuration in `.env.sample`.

### Context and Motivation

Final piece of the stack: a deploy script mirroring the existing `DeployCosigner` script so the guard can be deployed with the same operational conventions. Reads the Consensus chain id/address, genesis epoch and group key, and the escape-hatch delay/window from the environment.

### Decisions and Tradeoffs

- Deliberately kept as thin as the sibling deploy scripts — no extra guardrails beyond what the constructor already enforces — for consistency with the rest of `script/`.
- `.env.sample` documents the shared Cosigner/Guard config plus the guard-only `ALLOW_TX_WINDOW`, with sensible defaults.

### Testing

- `cd contracts && forge build`, `forge fmt --check`, and `forge lint --deny notes` pass. No test file: the repo does not unit-test deploy scripts.

### Stack

- Base: `guard/6-tests` (this PR is stacked on it — the top of the stack).
- Previous: the SafenetGuard test-suite PR.
- Next: the final integration PR merges `standalone-guard` into `main`.
