### PR TITLE
[Phase 1]: Share Safe Tx Crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4006,6 +4006,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "safe-tx"
+version = "0.1.0"
+dependencies = [
+ "alloy",
+ "serde",
+]
+
+[[package]]
 name = "safenet-core"
 version = "0.2.0"
 dependencies = [
@@ -5246,6 +5254,7 @@ dependencies = [
  "rand 0.8.6",
  "rand_chacha 0.3.1",
  "rayon",
+ "safe-tx",
  "safenet-core",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ k256 = { version = "0.13", features = ["hash2curve", "serde"] }
 metrics = "0.24"
 rand = "0.8"
 rand_chacha = "0.3"
+safe-tx = { path = "crates/safe-tx" }
 safenet-core = { path = "crates/core" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/crates/safe-tx/Cargo.toml
+++ b/crates/safe-tx/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "safe-tx"
+version = "0.1.0"
+edition = "2024"
+publish = false
+
+[dependencies]
+alloy.workspace = true
+serde.workspace = true

--- a/crates/safe-tx/src/checks.rs
+++ b/crates/safe-tx/src/checks.rs
@@ -1,7 +1,5 @@
-mod multi_send;
-
-use self::multi_send::{MultiSendVersion, decode_multi_send};
-use crate::bindings::{Operation, SafeTransaction};
+use crate::multi_send::{MultiSendVersion, decode_multi_send};
+use crate::types::{Operation, SafeTransaction};
 use alloy::{
     primitives::{Address, address},
     sol_types::SolCall as _,

--- a/crates/safe-tx/src/lib.rs
+++ b/crates/safe-tx/src/lib.rs
@@ -1,0 +1,6 @@
+//! Shared Safe transaction types and Safenet policy checks, used by both
+//! `validator` and `sentinel`.
+
+pub mod checks;
+pub mod multi_send;
+pub mod types;

--- a/crates/safe-tx/src/multi_send.rs
+++ b/crates/safe-tx/src/multi_send.rs
@@ -1,6 +1,6 @@
 use std::mem;
 
-use crate::bindings::{Operation, SafeTransaction};
+use crate::types::{Operation, SafeTransaction};
 use alloy::primitives::{Address, Bytes, U256};
 
 #[derive(Clone, Copy)]

--- a/crates/safe-tx/src/types.rs
+++ b/crates/safe-tx/src/types.rs
@@ -1,0 +1,33 @@
+//! `sol!`-generated Safe transaction types, shared between `validator` and
+//! `sentinel`.
+
+use alloy::sol;
+use serde::{Deserialize, Serialize};
+
+sol! {
+    /// Safe transaction operation type; mirrors `Enum.Operation` onchain.
+    #[derive(Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+    enum Operation {
+        #[default]
+        CALL,
+        DELEGATECALL,
+    }
+
+    /// A full Safe transaction as carried by the `(Oracle)TransactionProposed`
+    /// events (the 12-field `SafeTransaction.T` tuple).
+    #[derive(Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+    struct SafeTransaction {
+        uint256 chainId;
+        address safe;
+        address to;
+        uint256 value;
+        bytes data;
+        Operation operation;
+        uint256 safeTxGas;
+        uint256 baseGas;
+        uint256 gasPrice;
+        address gasToken;
+        address refundReceiver;
+        uint256 nonce;
+    }
+}

--- a/crates/validator/Cargo.toml
+++ b/crates/validator/Cargo.toml
@@ -13,6 +13,7 @@ k256.workspace = true
 rand.workspace = true
 rand_chacha.workspace = true
 rayon = "1"
+safe-tx.workspace = true
 safenet-core.workspace = true
 serde.workspace = true
 serde_json.workspace = true

--- a/crates/validator/src/bindings.rs
+++ b/crates/validator/src/bindings.rs
@@ -27,6 +27,13 @@ sol! {
     }
 
     /// Safe transaction operation type; mirrors `Enum.Operation` onchain.
+    ///
+    /// `sol!` requires custom types used as event/struct fields to be
+    /// declared in the same macro invocation, so this ABI-decoding copy
+    /// can't be replaced with a `use` of [`safe_tx::types::Operation`] --
+    /// [`From`] converts one into the other at the point an event is
+    /// consumed, so the rest of the validator only ever sees the shared
+    /// `safe-tx` type.
     #[derive(Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
     enum Operation {
         #[default]
@@ -35,7 +42,8 @@ sol! {
     }
 
     /// A full Safe transaction as carried by the `(Oracle)TransactionProposed`
-    /// events (the 12-field `SafeTransaction.T` tuple).
+    /// events (the 12-field `SafeTransaction.T` tuple). See [`Operation`] for
+    /// why this can't just be [`safe_tx::types::SafeTransaction`].
     #[derive(Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
     struct SafeTransaction {
         uint256 chainId;
@@ -261,5 +269,29 @@ sol! {
     #[derive(Debug)]
     contract Oracle {
         event OracleResult(bytes32 indexed requestId, address indexed proposer, bytes result, bool approved);
+    }
+}
+
+impl From<&SafeTransaction> for safe_tx::types::SafeTransaction {
+    fn from(tx: &SafeTransaction) -> Self {
+        let operation = match tx.operation {
+            Operation::CALL => safe_tx::types::Operation::CALL,
+            Operation::DELEGATECALL => safe_tx::types::Operation::DELEGATECALL,
+            Operation::__Invalid => safe_tx::types::Operation::__Invalid,
+        };
+        safe_tx::types::SafeTransaction {
+            chainId: tx.chainId,
+            safe: tx.safe,
+            to: tx.to,
+            value: tx.value,
+            data: tx.data.clone(),
+            operation,
+            safeTxGas: tx.safeTxGas,
+            baseGas: tx.baseGas,
+            gasPrice: tx.gasPrice,
+            gasToken: tx.gasToken,
+            refundReceiver: tx.refundReceiver,
+            nonce: tx.nonce,
+        }
     }
 }

--- a/crates/validator/src/consensus/hashing.rs
+++ b/crates/validator/src/consensus/hashing.rs
@@ -7,15 +7,13 @@
 //! contract lives on, and the contract's own address). The latter hash is
 //! the message a validator group's FROST signature actually attests to.
 
-use crate::{
-    bindings::{Point, SafeTransaction},
-    consensus::epoch::EpochId,
-};
+use crate::{bindings::Point, consensus::epoch::EpochId};
 use alloy::{
     primitives::{Address, B256, U256},
     sol,
     sol_types::{Eip712Domain, SolStruct},
 };
+use safe_tx::types::SafeTransaction;
 use std::num::NonZeroU64;
 
 sol! {
@@ -174,8 +172,8 @@ impl ConsensusDomain {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::bindings::Operation;
     use alloy::primitives::{Bytes, address, b256};
+    use safe_tx::types::Operation;
 
     const TEST_ADDRESS: Address = address!("d8dA6BF26964aF9D7eEd9e03E53415D37aA96045");
     const TEST_DOMAIN: ConsensusDomain = ConsensusDomain::new(1, TEST_ADDRESS);

--- a/crates/validator/src/consensus/mod.rs
+++ b/crates/validator/src/consensus/mod.rs
@@ -1,6 +1,5 @@
 //! Safenet consensus rules.
 
-pub mod checks;
 pub mod epoch;
 pub mod group;
 pub mod hashing;

--- a/crates/validator/src/state/mod.rs
+++ b/crates/validator/src/state/mod.rs
@@ -6,7 +6,7 @@ mod sign;
 mod transactions;
 
 use crate::{
-    bindings::{Consensus, Coordinator, Oracle, Point, SafeTransaction},
+    bindings::{Consensus, Coordinator, Oracle, Point},
     config::ValidatorConfig,
     consensus::{
         epoch::EpochId,
@@ -24,6 +24,7 @@ use crate::{
     service::{Action, Effect, Event, Resume},
 };
 use alloy::primitives::{Address, B256};
+use safe_tx::types::SafeTransaction;
 use safenet_core::state::{Commands, Message, StateTransition};
 use serde::{Deserialize, Serialize};
 use std::{

--- a/crates/validator/src/state/transactions.rs
+++ b/crates/validator/src/state/transactions.rs
@@ -1,10 +1,7 @@
 use std::collections::btree_map;
 
 use super::{Packet, SigningState, State, Transition};
-use crate::{
-    bindings::Consensus,
-    consensus::{checks, epoch::EpochId},
-};
+use crate::{bindings::Consensus, consensus::epoch::EpochId};
 use safenet_core::state::Commands;
 
 impl Transition {
@@ -29,24 +26,21 @@ impl Transition {
             return (state, Vec::new());
         };
 
-        let message = self
-            .consensus
-            .transaction_packet_hash(epoch, &event.transaction);
+        let transaction: safe_tx::types::SafeTransaction = (&event.transaction).into();
+        let message = self.consensus.transaction_packet_hash(epoch, &transaction);
 
         // Prevent duplicate ongoing transaction proposals. This is to prevent
         // malicious parties from blocking transaction attestations from ever
         // being produced by resetting the signing state of honest validators.
         if let btree_map::Entry::Vacant(signing) = state.signing.entry(message) {
-            let packet = Packet::Transaction {
-                epoch,
-                transaction: event.transaction.clone(),
-            };
+            let passed_checks = safe_tx::checks::check_transaction(&transaction);
+            let packet = Packet::Transaction { epoch, transaction };
 
             let signers = participating_epoch.group.participants().clone();
             let deadline = block.saturating_add(self.config.signing_timeout.get());
 
             let group_id = participating_epoch.group.id();
-            let signing_state = if checks::check_transaction(&event.transaction) {
+            let signing_state = if passed_checks {
                 SigningState::WaitingForRequest {
                     key_share: participating_epoch.key_share.clone(),
                     group_id,
@@ -135,9 +129,10 @@ impl Transition {
             return (state, Vec::new());
         }
 
+        let transaction: safe_tx::types::SafeTransaction = (&event.transaction).into();
         let message =
             self.consensus
-                .oracle_transaction_packet_hash(epoch, event.oracle, &event.transaction);
+                .oracle_transaction_packet_hash(epoch, event.oracle, &transaction);
 
         // Prevent duplicate ongoing transaction proposals. This is to prevent
         // malicious parties from blocking transaction attestations from ever
@@ -146,7 +141,7 @@ impl Transition {
             let packet = Packet::OracleTransaction {
                 epoch,
                 oracle: event.oracle,
-                transaction: event.transaction.clone(),
+                transaction,
             };
             let signers = participating_epoch.group.participants().clone();
             let deadline = block.saturating_add(self.config.signing_timeout.get());


### PR DESCRIPTION
Create a shared crate `safe-tx` for Safe transaction related logic that can be shared between validator and sentinel

The biggest change is the move of the checks and multi send decoding from the validator crate to the shared crate. No logic should be touched for this (except import adjustments).

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://docs.safefoundation.org/cla).
