### PR TITLE
Implement Tailnet AI Review

### DIFF
--- a/.github/actions/ai-review/action.yaml
+++ b/.github/actions/ai-review/action.yaml
@@ -28,6 +28,10 @@ inputs:
     description: "The pull request number to review"
     required: false
     default: ${{ github.event.pull_request.number }}
+  title:
+    description: "Title identifying this reviewer, prefixed to the posted review (useful when multiple ai-review workflows run against the same PR)"
+    required: false
+    default: "AI Code Review"
 
 runs:
   using: "composite"
@@ -41,6 +45,7 @@ runs:
         CONTEXT_MODEL: ${{ inputs.context-model }}
         FALLBACK_MODEL: ${{ inputs.fallback-model }}
         PR_NUMBER: ${{ inputs.pr-number }}
+        TITLE: ${{ inputs.title }}
       with:
         github-token: ${{ inputs.github-token }}
         script: |

--- a/.github/actions/ai-review/review.js
+++ b/.github/actions/ai-review/review.js
@@ -2,6 +2,12 @@ const MAX_ADDITIONAL_FILES = 15;
 
 const SYSTEM_PROMPT = `The current year is ${new Date().getFullYear()}. Newer versions of software, GitHub Actions, and model names than you're aware of from training may still be valid and correct. Do not flag version strings, action references (e.g. actions/checkout@vN), or model names as errors solely because they are unfamiliar to you.`;
 
+const REVIEW_INSTRUCTIONS = `Review this PR. Provide a concise overall summary and, where relevant, specific comments referencing a file path and line number from the diff (the line number in the new version of the file).
+
+- Only comment on lines actually changed in the diff.
+- Only leave a comment where the code should be changed, could be improved, or is questionable — do not comment on lines that are already fine just to praise or acknowledge them.
+- Every comment must be an actionable item.`;
+
 const FILES_SCHEMA = {
   type: "object",
   properties: {
@@ -83,6 +89,7 @@ module.exports = async ({ github, context, core }) => {
   const model = process.env.MODEL;
   const contextModel = process.env.CONTEXT_MODEL;
   const fallbackModel = process.env.FALLBACK_MODEL;
+  const title = process.env.TITLE || "AI Code Review";
   const prNumber = parseInt(process.env.PR_NUMBER);
   const { owner, repo } = context.repo;
 
@@ -140,7 +147,7 @@ module.exports = async ({ github, context, core }) => {
       `PR description:\n${description}`,
       `PR diff:\n${diff}`,
       additionalContext && `Additional file contents for context:\n${additionalContext}`,
-      "Review this PR. Provide a concise overall summary and, where relevant, specific comments referencing a file path and line number from the diff (the line number in the new version of the file). Only comment on lines actually changed in the diff.",
+      REVIEW_INSTRUCTIONS,
     ]
       .filter(Boolean)
       .join("\n\n"),
@@ -148,7 +155,7 @@ module.exports = async ({ github, context, core }) => {
     REVIEW_SCHEMA,
   );
 
-  const body = summary || "AI review";
+  const body = `## ${title}\n\n${summary || "AI review"}`;
   const inlineComments = (comments || []).map((c) => ({ path: c.path, line: c.line, body: c.body, side: "RIGHT" }));
 
   try {

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -1,0 +1,78 @@
+# Workflows
+
+## Gemini Code Review (`gemini_review.yml`)
+
+Runs the [`ai-review`](../actions/ai-review) action against Google's Gemini
+OpenAI-compatible endpoint. Triggers automatically when a PR is opened or
+reopened, and can also be run manually via `workflow_dispatch` with a
+`pr-number` input.
+
+### Setup
+
+Add a repository secret:
+
+- `GEMINI_API_KEY` — an API key for the Gemini API, from
+  [Google AI Studio](https://aistudio.google.com/app/apikey).
+
+No other configuration is required; the action defaults to a Gemini model
+and endpoint.
+
+## Tailnet AI Code Review (`tailnet_ai_review.yml`)
+
+Runs the same [`ai-review`](../actions/ai-review) action, but against a
+self-hosted OpenAI-compatible server reachable only inside our Tailscale
+tailnet. The runner joins the tailnet via
+[`tailscale/github-action`](https://github.com/tailscale/github-action)
+before the review step runs. Unlike the Gemini review, it currently (for
+now) also re-runs on every new push to a PR, not just on open/reopen — it
+triggers automatically when a PR is opened, or reopened, and
+can also be run manually via `workflow_dispatch` with a `pr-number` input.
+Since it depends on a private server that may not always be reachable, keep
+an eye on this workflow failing if the tailnet server is down.
+
+### Setup
+
+1. **Create a Tailscale trust credential** in the
+   [Tailscale admin console](https://login.tailscale.com/admin/settings/trust-credentials)
+   configured for [workload identity federation](https://tailscale.com/kb/1581/workload-identity-federation)
+   (OIDC) rather than a client secret, and grant it a tag (e.g. `tag:ci`)
+   that your tailnet ACL policy allows the credential to issue. The runner's
+   ephemeral node will be tagged with this, so make sure your ACLs grant it
+   access to the AI server. This requires the workflow to request the
+   `id-token: write` permission (already set in `tailnet_ai_review.yml`),
+   which is how GitHub Actions issues the OIDC token the credential trusts —
+   no long-lived secret is stored for authentication.
+   - Set the OIDC scope to `repo:safe-research/safenet:*`.
+   - Grant the credential write access to the `Auth Keys` permission,
+     scoped to the tag `tag:ci`.
+2. Add the following repository secrets. Everything here besides the model
+   names is a secret rather than a repository variable — the tailnet
+   hostname/IP and endpoint URL are treated as sensitive, since they reveal
+   internal network layout, so they must not be exposed as plain variables:
+   - `TS_OAUTH_CLIENT_ID` — the client ID of the trust credential created
+     above.
+   - `TS_AUDIENCE` — the audience configured on that trust credential for
+     OIDC federation.
+   - `TAILNET_AI_API_KEY` — the API key expected by your self-hosted
+     OpenAI-compatible server (use any placeholder value if the server
+     doesn't check one).
+   - `TAILNET_AI_ENDPOINT` — the base URL of the server, e.g.
+     `http://your-host.your-tailnet.ts.net:port/v1`. Do **not** include a
+     trailing `/chat/completions`; the action appends that itself.
+   - `TAILNET_AI_HOST` — the bare hostname or IP of the AI server (e.g.
+     `your-host.your-tailnet.ts.net` or `100.x.y.z`, no scheme/port/path).
+     Used by the `tailscale/github-action` step's `ping` input to confirm
+     the runner can actually reach the server over the tailnet before the
+     review step runs, since newly joined nodes can take a moment to
+     propagate to peers.
+3. Add the following repository (or environment) variables — these are just
+   model names, not sensitive, so they don't need to be secrets:
+   - `TAILNET_AI_MODEL` — the model name served by your endpoint.
+   - `TAILNET_AI_CONTEXT_MODEL` — model used to decide whether extra context
+     files are needed (can be the same as `TAILNET_AI_MODEL`).
+   - `TAILNET_AI_FALLBACK_MODEL` — optional; leave unset to disable
+     fallback-on-error retries.
+4. If your tailnet ACLs restrict which tags can reach the AI server, make
+   sure `tag:ci` (or whatever tag you used in step 1) is permitted — update
+   the `tags:` input in `tailnet_ai_review.yml` to match if you used a
+   different tag.

--- a/.github/workflows/gemini_review.yml
+++ b/.github/workflows/gemini_review.yml
@@ -28,3 +28,4 @@ jobs:
         with:
           api-key: ${{ secrets.GEMINI_API_KEY }}
           pr-number: ${{ inputs.pr-number || github.event.pull_request.number }}
+          title: "Gemini Code Review"

--- a/.github/workflows/tailnet_ai_review.yml
+++ b/.github/workflows/tailnet_ai_review.yml
@@ -1,0 +1,44 @@
+name: Tailnet AI Code Review
+
+on:
+  pull_request:
+    types:
+      - opened
+      - reopened
+  workflow_dispatch:
+    inputs:
+      pr-number:
+        description: "The pull request number to review"
+        required: true
+
+permissions:
+  contents: read
+  pull-requests: write
+  id-token: write
+
+jobs:
+  review:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          sparse-checkout: |
+            .github/actions/ai-review
+
+      - name: Connect to Tailscale
+        uses: tailscale/github-action@780049a30b6ff5c378a9e7b389d15ece7a204888 # v4.1.3
+        with:
+          oauth-client-id: ${{ secrets.TS_OAUTH_CLIENT_ID }}
+          audience: ${{ secrets.TS_AUDIENCE }}
+          tags: tag:ci
+          ping: ${{ secrets.TAILNET_AI_HOST }}
+
+      - uses: ./.github/actions/ai-review
+        with:
+          api-key: ${{ secrets.TAILNET_AI_API_KEY }}
+          endpoint: ${{ secrets.TAILNET_AI_ENDPOINT }}
+          model: ${{ vars.TAILNET_AI_MODEL }}
+          context-model: ${{ vars.TAILNET_AI_CONTEXT_MODEL }}
+          fallback-model: ${{ vars.TAILNET_AI_FALLBACK_MODEL }}
+          pr-number: ${{ inputs.pr-number || github.event.pull_request.number }}
+          title: "Tailnet AI Code Review"


### PR DESCRIPTION
Setup tailnet github action integration to utilize our locally running AI for code reviews

Generally the split of model for context information and review should allow us to use smaller models that run in the NPU for the task to identify required files. Sadly the NPU models (FLM based) don't allow to provide a strict response type (it is being dropped). So the response type would have to be encoded into the query. This is a future iteration and will be ignored for now.

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://docs.safefoundation.org/cla).
