### PR TITLE
Safenet Guard

### DIFF
--- a/contracts/.env.sample
+++ b/contracts/.env.sample
@@ -4,7 +4,7 @@
 # 2 = Canonical Deterministic Deployment Factory
 FACTORY=1
 
-# SafenetCosigner Deployment Config
+# SafenetCosigner / SafenetGuard Deployment Config (shared)
 # Chain ID of the Consensus contract (100 = Gnosis Chain)
 CONSENSUS_CHAIN_ID=100
 # Address of the Consensus contract on the consensus chain
@@ -13,8 +13,12 @@ CONSENSUS_ADDRESS=0x223624cBF099e5a8f8cD5aF22aFa424a1d1acEE9
 INITIAL_EPOCH=
 INITIAL_GROUP_KEY_X=
 INITIAL_GROUP_KEY_Y=
-# Delay in seconds before a pre-approved transaction can be executed (default: 60)
-ALLOW_TX_DELAY=60
+# Escape-hatch embargo: seconds before a pre-approved (SafenetCosigner) or announced (SafenetGuard)
+# transaction becomes executable (default: 259200 = 3 days)
+ALLOW_TX_DELAY=259200
+# SafenetGuard only — escape-hatch window: seconds after the embargo during which an announced
+# transaction stays executable (default: 3600)
+ALLOW_TX_WINDOW=3600
 
 # Staking Contract Deployment Config
 # Initial owner of the staking contract, can be set to any address

--- a/contracts/foundry.toml
+++ b/contracts/foundry.toml
@@ -10,6 +10,7 @@ additional_compiler_profiles = [
 compilation_restrictions = [
   { paths = "src/Consensus.sol", via_ir = true },
   { paths = "src/FROSTCoordinator.sol", via_ir = true },
+  { paths = "src/guard/SafenetGuard.sol", via_ir = true },
   { paths = "src/guard/SafenetGuardA.sol", via_ir = true },
   { paths = "src/guard/SafenetGuardB.sol", via_ir = true },
 ]

--- a/contracts/script/DeploySafenetGuard.s.sol
+++ b/contracts/script/DeploySafenetGuard.s.sol
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: GPL-3.0-only
+pragma solidity ^0.8.30;
+
+import {Script, console} from "@forge-std/Script.sol";
+import {SafenetGuard} from "@/guard/SafenetGuard.sol";
+import {Secp256k1} from "@/libraries/Secp256k1.sol";
+import {DeterministicDeployment} from "@script/util/DeterministicDeployment.sol";
+import {getFactory} from "@script/util/GetFactory.sol";
+
+contract DeploySafenetGuardScript is Script {
+    using DeterministicDeployment for DeterministicDeployment.Factory;
+
+    function run() public returns (address guard) {
+        // Required script arguments:
+        uint256 consensusChainId = vm.envUint("CONSENSUS_CHAIN_ID");
+        address consensusAddress = vm.envAddress("CONSENSUS_ADDRESS");
+        uint256 rawEpoch = vm.envUint("INITIAL_EPOCH");
+        require(rawEpoch <= type(uint64).max, "INITIAL_EPOCH overflow: value exceeds uint64");
+        // forge-lint: disable-next-line(unsafe-typecast)
+        uint64 initialEpoch = uint64(rawEpoch);
+        uint256 groupKeyX = vm.envUint("INITIAL_GROUP_KEY_X");
+        uint256 groupKeyY = vm.envUint("INITIAL_GROUP_KEY_Y");
+
+        // Optional script arguments:
+        uint256 allowTxDelay = vm.envOr("ALLOW_TX_DELAY", uint256(3 days));
+        uint256 allowTxWindow = vm.envOr("ALLOW_TX_WINDOW", uint256(1 hours));
+        DeterministicDeployment.Factory factory = getFactory(vm);
+
+        Secp256k1.Point memory initialGroupKey = Secp256k1.Point({x: groupKeyX, y: groupKeyY});
+
+        vm.startBroadcast();
+
+        guard = factory.deployWithArgs(
+            bytes32(0),
+            type(SafenetGuard).creationCode,
+            abi.encode(consensusChainId, consensusAddress, initialEpoch, initialGroupKey, allowTxDelay, allowTxWindow)
+        );
+
+        vm.stopBroadcast();
+
+        console.log("SafenetGuard deployed at:", guard);
+    }
+}

--- a/contracts/src/guard/README.md
+++ b/contracts/src/guard/README.md
@@ -1,6 +1,100 @@
 # Safenet Guards
 
-This directory contains a collection of Safe Guard implementations for Safenet. Each variant explores a different design trade-off in how FROST threshold-signature attestations are delivered, verified, and stored on-chain. The goal is to evaluate approaches across dimensions such as gas cost, tooling compatibility, epoch management, and escape-hatch ergonomics before settling on a production design.
+`SafenetGuard` is the canonical Safe Guard for Safenet. `SafenetGuardA` and `SafenetGuardB` are earlier explorations, retained for comparison and slated for removal once `SafenetGuard` is adopted.
+
+---
+
+## SafenetGuard
+
+**File:** `SafenetGuard.sol`
+
+SafenetGuard is a Safe *transaction* guard, assembled from focused, independently-auditable libraries so that each concern has a single, isolated audit surface. It implements Safe's `BaseTransactionGuard`, and its interface `ISafenetGuard` extends `ITransactionGuard`, so the guard hooks are part of the published ABI. Every owner-signed transaction is gated behind a FROST threshold-signature attestation, except when a matured announcement authorises execution through the nonce-free escape hatch.
+
+**Scope.** This is a *transaction* guard: it gates only owner-signed `execTransaction` calls. Safe module executions do not invoke transaction-guard hooks, so an enabled module can move assets without an attestation or announcement. Deployments must prohibit modules or treat each enabled module as an explicit bypass of this guard's policy.
+
+### What it reuses
+
+- **`EpochRollover`** (`../libraries/EpochRollover.sol`) — the trusted epoch state and FROST-verified rollover, shared with the rest of Safenet rather than reimplemented in the guard.
+- **`TransactionAnnouncement`** (`../libraries/TransactionAnnouncement.sol`) — the escape-hatch announcement type and nonce-free hashing (`AnnouncedTransaction`, `hash`) plus the time-windowed state (`announce` / `cancel` / `consume`).
+- **`AttestationTrailer`** (`../libraries/AttestationTrailer.sol`) — recognising and decoding the inline attestation trailer from Safe's `signatures` bytes.
+
+The structural self-call gate for the escape-hatch functions (target is the guard, zero value, `CALL` not `DELEGATECALL`, 4-byte selector) is kept inline in the guard for explicitness.
+
+### Design
+
+**Epoch forest.** Epoch state is delegated to `EpochRollover`, which tracks a *forest* of trusted `(group key, epoch)` pairs: any trusted pair may sign a rollover to any strictly-greater epoch, an epoch may hold more than one key (reorg branches), and every pair is kept forever. There is no single "active" epoch — `updateEpoch` names the exact `(parentKey, parentEpoch)` to roll over from, and membership is queried with `isKnownEpoch(groupKey, epoch)`.
+
+**Attestation via signature extension.** Because the forest is keyed by key coordinates (there is no reverse "key for epoch N" lookup) and an epoch may hold several keys, the inline attestation carries the key explicitly. It is appended to Safe's `signatures` bytes as a *signature extension* — a fixed 192-byte payload followed by a 32-byte type hash:
+
+```
+[safe owner signatures] [192-byte abi.encode(epoch, Secp256k1.Point groupKey, FROST.Signature)] [32-byte TYPE_HASH]
+```
+
+Anchoring the extension at the end leaves Safe's front-to-back signature parser untouched, and the terminal type hash makes detection independent of signature suffixes — only a blob whose last word equals `TYPE_HASH` is treated as an attestation, so a valid Safe signature ending in an unrelated value (even the number 192) is never mis-parsed. The type hash doubles as an extensible format tag: it embeds the version, so a future format uses a different type hash (which this guard reads as "no trailer"). This is the first canonical guard the Safe project publishes to use signature extension, and the type-hash separator is intended as a reusable convention for future extensions.
+
+`checkTransaction` outcomes: no type hash → falls through to the announcement path; a type hash on a too-short blob → reverts `MalformedAttestationTrailer`; a recognised trailer → the `(groupKey, epoch)` pair must be trusted (else `UntrustedAttestationKey`) and the FROST signature is verified. A recognised trailer never silently falls through. Forest membership already implies a non-zero key, so no separate non-zero check is needed.
+
+**Nonce-free escape hatch.** Announcements are keyed by a **nonce-free** hash covering every `execTransaction` parameter *except* the Safe nonce (`getAnnouncementHash`). Owners call `announceTransaction(AnnouncedTransaction)` with the **full transaction parameters** (not a bare hash), so signers see exactly what they authorise and the guard derives the announcement hash on-chain — guaranteeing it matches what `checkTransaction` reconstructs and removing a class of silent off-chain hash-mismatch bugs. Because the hash excludes the nonce, a queued announcement survives unrelated nonce advances: owners can keep transacting via attestation while an announcement matures, and after the fixed delay any matching transaction executes without an attestation at whatever nonce is current. Announcements are single-use (consumed on execution) and can be revoked immediately, with no delay, via `cancelAnnouncement(hash)`. Both `announceTransaction` and `cancelAnnouncement` are auto-allowed self-calls, so the escape hatch never requires Safenet. A normally-attested transaction whose parameters happen to match a pending announcement takes the attestation path and does not consume the announcement.
+
+**Bounded validity window.** Each announcement is executable only within `[activeFrom, activeUntil]` (both bounds inclusive), where `activeFrom = now + delay` and `activeUntil = activeFrom + window` (both durations fixed at construction). Bounding the tail prevents a "set and forget" announcement from remaining executable indefinitely — a critical transaction that was queued but not used cannot be triggered by a malicious party long afterward. An announcement that expires unused is inert; it can be renewed in place (`announceTransaction` overwrites an expired entry with a fresh full window), while a pending or still-active entry cannot be overwritten. Both timestamps are packed into a single storage slot (two `uint128`); `announce` rejects durations that would overflow `uint128` (`WindowOverflow`).
+
+**Consumption tracks the authorization path, not execution success.** The announcement is consumed in the pre-execution hook along the escape-hatch path, so it records which authorization path was taken rather than whether the inner call succeeded. If the announced parameters set a non-zero `safeTxGas`/`gasPrice`, Safe may catch an inner-call failure and return `false` while the announcement stays consumed; with all-zero gas params the whole call reverts and the consumption rolls back. This is an accepted trade-off (a full lock/finalize/restore state machine across both hooks was considered and deferred).
+
+**Single announcement event.** Announcing (including renewal) emits `TransactionAnnounced(safe, announcementHash, activeFrom, activeUntil)`. The full announced parameters are always recoverable from the `announceTransaction` calldata, so the event itself stays minimal.
+
+**Fixed delay and window.** Both the embargo delay (`allowTransactionDelay`) and the validity window (`allowTransactionWindow`) are fixed at construction (immutable).
+
+### Integration — attestation trailer format (v1)
+
+Relayers that append the inline attestation must build the exact trailer the guard recognises:
+
+```
+[safe owner signatures]
+[192-byte payload]     = abi.encode(uint64 epoch, Secp256k1.Point groupKey, FROST.Signature signature)   // 6 × 32-byte words
+[32-byte TYPE_HASH]    = keccak256("SafenetGuard.AttestationTrailer.v1")
+```
+
+- **TYPE_HASH** = `keccak256("SafenetGuard.AttestationTrailer.v1")`
+  = `0x7574ada57823dfda76df60551fc6a8662abe3441dc7b19194fb2cc08b312e436`
+
+Total trailer overhead is exactly **224 bytes** (192 payload + 32 type hash) appended after the Safe owner signatures. Decoding (`AttestationTrailer.decode`): a blob whose last 32 bytes are not `TYPE_HASH` is *no trailer* (falls through to the announcement path); the type hash on a blob shorter than 224 bytes reverts `MalformedAttestationTrailer`.
+
+### Design decisions
+
+Deliberate choices with their rationale, recorded so reviewers and auditors can distinguish "intended" from "oversight." They are not defects.
+
+**Epoch trust model**
+
+- **Forest of `(groupKey, epoch)` pairs, kept forever, never pruned.** There is no single "active" epoch; multiple keys per epoch (reorg branches) are allowed. *Rationale:* the FROST per-participant secret shares are destroyed/rotated after an epoch, so a historical group key can never be reconstituted; keeping old pairs valid indefinitely is therefore not a practical risk. Storage grows monotonically, but each added pair requires a valid FROST signature.
+- **A recorded historical key may attest future transactions and sign new rollover branches.** Accepted as a direct consequence of the above (shares no longer exist to abuse). It cannot replay past transactions, which the Safe nonce binds.
+- **`updateEpoch` is permissionless** — the FROST signature is the authorization; the caller names the explicit parent pair; re-submitting a known pair is a no-op.
+- **`rolloverBlock` is not checked against local `block.number`** — it is a Gnosis Chain block number, meaningless on the guard's chain, folded into the signed message only.
+
+**Consensus binding**
+
+- **Consensus is Gnosis-only (chain id 100); the guard keeps a local copy of the epoch forest** (cross-chain calls are infeasible). The EIP-712 domain separator is immutable from constructor args; misconfiguration is unrecoverable (redeploy).
+
+**Attestation (owner transactions)**
+
+- **Inline signature-extension trailer carrying `epoch + groupKey + signature` explicitly** (the forest has no epoch→key reverse lookup). The non-standard encoding (wallets must be Safenet-aware) and the larger trailer are accepted trade-offs.
+- **Type-hash trailer framing** (`keccak256("SafenetGuard.AttestationTrailer.v1")`, not length-only) so a valid Safe-signature suffix cannot be mis-parsed; a recognised trailer never falls through to the announcement path.
+- **Replay/ordering come from the Safe nonce** bound into the verified hash; there is no spent-signature registry.
+
+**Escape hatch (announcements)**
+
+- **`announceTransaction` takes the full parameter struct** (not a bare hash) — signers see what they authorize and the guard derives the hash on-chain (so it cannot diverge from `checkTransaction`).
+- **Nonce-free announcement hash** (excludes the Safe nonce and the Safe address; scoped by storage key) — keeps the hatch usable while unrelated transactions advance the Safe nonce.
+- **Bounded, inclusive `[activeFrom, activeUntil]` window**, both durations immutable; packed into one slot (two `uint128`), with `WindowOverflow`/constructor bounds preventing absurd values.
+- **Single-use; expired entries are renewable in place**; pending/active ones cannot be overwritten; `cancelAnnouncement` is immediate.
+- **Consumption tracks the authorization path, not execution success** (a caught inner-call failure with non-zero `safeTxGas`/`gasPrice` still consumes the announcement). A lock/finalize/restore state machine was considered and deferred.
+- **A relayer holding both a valid attestation and a matured announcement can choose the path**; the attestation path takes precedence and does not consume the announcement.
+- **A single `TransactionAnnounced` event** — the full parameters are recoverable from the announce calldata, so the event carries only the hash and window.
+
+**Structure & scope**
+
+- **Module-transaction guarding is intentionally not integrated** — deferred pending product requirements. Enabled Safe modules bypass this guard; deployers must prohibit modules or treat each as an explicit bypass.
+- **The structural self-call gate is inlined** in the guard for explicitness, rather than extracted into a separate library.
+- **Library-composed design** (`EpochRollover`, `TransactionAnnouncement`, `AttestationTrailer`): state/mechanism in libraries, FROST verification and domain events in the guard. `EpochRollover` epoch events are mirrored on `ISafenetGuard` for a single canonical integration ABI (they appear twice in the generated ABI; harmless — same topic).
 
 ---
 

--- a/contracts/src/guard/SafenetGuard.sol
+++ b/contracts/src/guard/SafenetGuard.sol
@@ -1,0 +1,353 @@
+// SPDX-License-Identifier: GPL-3.0-only
+pragma solidity ^0.8.30;
+
+import {AttestationTrailer} from "@/libraries/AttestationTrailer.sol";
+import {ConsensusMessages} from "@/libraries/ConsensusMessages.sol";
+import {EpochRollover} from "@/libraries/EpochRollover.sol";
+import {FROST} from "@/libraries/FROST.sol";
+import {SafeTransaction} from "@/libraries/SafeTransaction.sol";
+import {Secp256k1} from "@/libraries/Secp256k1.sol";
+import {TransactionAnnouncement} from "@/libraries/TransactionAnnouncement.sol";
+import {ISafenetGuard} from "@/interfaces/ISafenetGuard.sol";
+import {Enum} from "@safe/interfaces/Enum.sol";
+import {BaseTransactionGuard, ITransactionGuard} from "@safe/base/GuardManager.sol";
+import {IERC165} from "@safe/interfaces/IERC165.sol";
+import {ISafe} from "@safe/interfaces/ISafe.sol";
+
+/**
+ * @title SafenetGuard
+ * @notice Safe transaction guard that gates every owner-signed `execTransaction` behind a Safenet FROST
+ *         threshold-signature attestation, with a nonce-free time-windowed escape hatch for liveness.
+ * @dev Composed from focused libraries: epoch state ([EpochRollover]), escape-hatch state and hashing
+ *      ([TransactionAnnouncement]), and attestation-trailer decode ([AttestationTrailer]). Design
+ *      rationale and the accepted trust assumptions are documented in `guard/README.md`; the
+ *      security-relevant points:
+ *
+ *      - **Scope:** transaction guard only. Safe module executions bypass it — deployments must forbid
+ *        modules or treat each as an explicit bypass.
+ *      - **Epochs:** a forest of trusted `(group key, epoch)` pairs kept forever (Consensus lives only on
+ *        Gnosis Chain; the guard holds a local copy). Any recorded pair may attest; a compromised
+ *        historical key can attest future transactions (but not replay past ones — the Safe nonce binds).
+ *      - **Attestation:** an inline trailer on `signatures` carrying `(epoch, groupKey, signature)`,
+ *        verified against the full nonce-bound Safe tx hash.
+ *      - **Escape hatch:** `announceTransaction` queues a transaction by its parameters (nonce excluded);
+ *        after `getAllowTxDelay` it executes without attestation within `getAllowTxWindow`, at any nonce.
+ *        Single-use; consumed in the pre-execution hook (so it reflects the authorisation path taken, not
+ *        inner-call success); revocable via `cancelAnnouncement`.
+ */
+contract SafenetGuard is ISafenetGuard, BaseTransactionGuard {
+    using EpochRollover for EpochRollover.T;
+    using TransactionAnnouncement for TransactionAnnouncement.T;
+
+    // ============================================================
+    // IMMUTABLES
+    // ============================================================
+
+    /**
+     * @dev EIP-712 domain separator used to reconstruct Consensus messages; exposed via
+     *      `getConsensusDomainSeparator`.
+     */
+    bytes32 private immutable _CONSENSUS_DOMAIN_SEPARATOR;
+
+    /**
+     * @dev Escape-hatch embargo in seconds; exposed via `getAllowTxDelay`.
+     */
+    uint256 private immutable _ALLOW_TX_DELAY;
+
+    /**
+     * @dev Escape-hatch window in seconds; exposed via `getAllowTxWindow`.
+     */
+    uint256 private immutable _ALLOW_TX_WINDOW;
+
+    // ============================================================
+    // STORAGE VARIABLES
+    // ============================================================
+
+    /**
+     * @dev Trusted `(group key, epoch)` forest; seeded at construction, extended by `updateEpoch`.
+     */
+    // forge-lint: disable-next-line(mixed-case-variable)
+    EpochRollover.T private $epochs;
+
+    /**
+     * @dev Pending nonce-free announcements, keyed by `(safe, announcementHash)`.
+     */
+    // forge-lint: disable-next-line(mixed-case-variable)
+    TransactionAnnouncement.T private $announcements;
+
+    // ============================================================
+    // CONSTRUCTOR
+    // ============================================================
+
+    /**
+     * @notice Deploys SafenetGuard seeded with the Safenet genesis epoch.
+     * @param consensusChainId Chain ID hosting the Consensus contract (100 for Gnosis Chain).
+     * @param consensusAddress Consensus contract address; must be non-zero. With `consensusChainId` it
+     *                         derives the immutable domain separator (uncorrectable post-deploy).
+     * @param initialEpoch Genesis epoch number.
+     * @param initialGroupKey Genesis FROST group key; must be a non-zero secp256k1 point.
+     * @param allowTransactionDelay Escape-hatch embargo (seconds); non-zero, at most `type(uint64).max`.
+     * @param allowTransactionWindow Escape-hatch window (seconds); non-zero, at most `type(uint64).max`.
+     */
+    constructor(
+        uint256 consensusChainId,
+        address consensusAddress,
+        uint64 initialEpoch,
+        Secp256k1.Point memory initialGroupKey,
+        uint256 allowTransactionDelay,
+        uint256 allowTransactionWindow
+    ) {
+        require(consensusAddress != address(0), InvalidAddress());
+        // Reject zero (unusable) and out-of-range durations; the `uint64` bound keeps the packed
+        // announcement window (a timestamp plus these) inside `uint128` for the contract's lifetime.
+        require(
+            allowTransactionDelay != 0 && allowTransactionDelay <= type(uint64).max && allowTransactionWindow != 0
+                && allowTransactionWindow <= type(uint64).max,
+            InvalidParameter()
+        );
+        _CONSENSUS_DOMAIN_SEPARATOR = ConsensusMessages.domain(consensusChainId, consensusAddress);
+        _ALLOW_TX_DELAY = allowTransactionDelay;
+        _ALLOW_TX_WINDOW = allowTransactionWindow;
+        $epochs.initialize(initialEpoch, initialGroupKey); // reverts on a zero key; emits EpochInitialized
+    }
+
+    // ============================================================
+    // EPOCH MANAGEMENT
+    // ============================================================
+
+    /**
+     * @inheritdoc ISafenetGuard
+     * @dev Delegates to [EpochRollover.rollover], which verifies the signature before recording.
+     */
+    function updateEpoch(
+        Secp256k1.Point calldata parentKey,
+        uint64 parentEpoch,
+        uint64 proposedEpoch,
+        uint64 rolloverBlock,
+        Secp256k1.Point calldata newGroupKey,
+        FROST.Signature calldata signature
+    ) external {
+        $epochs.rollover(
+            _CONSENSUS_DOMAIN_SEPARATOR, parentKey, parentEpoch, proposedEpoch, rolloverBlock, newGroupKey, signature
+        );
+    }
+
+    // ============================================================
+    // ANNOUNCEMENT (ESCAPE HATCH)
+    // ============================================================
+
+    /**
+     * @inheritdoc ISafenetGuard
+     */
+    function announceTransaction(TransactionAnnouncement.AnnouncedTransaction calldata announcement) external {
+        bytes32 announcementHash = TransactionAnnouncement.hash(announcement);
+        (uint256 activeFrom, uint256 activeUntil) =
+            $announcements.announce(msg.sender, announcementHash, _ALLOW_TX_DELAY, _ALLOW_TX_WINDOW);
+
+        // The announced parameters are recoverable from this call's calldata, so the event carries only
+        // the hash and window.
+        emit TransactionAnnounced(msg.sender, announcementHash, activeFrom, activeUntil);
+    }
+
+    /**
+     * @inheritdoc ISafenetGuard
+     */
+    function cancelAnnouncement(bytes32 announcementHash) external {
+        $announcements.cancel(msg.sender, announcementHash);
+        emit AnnouncementCancelled(msg.sender, announcementHash);
+    }
+
+    // ============================================================
+    // SAFE TRANSACTION GUARD
+    // ============================================================
+
+    /**
+     * @notice Pre-execution hook. Permits execution when, in order: (1) it is an auto-allowed self-call;
+     *         (2) `signatures` carries an attestation trailer for a trusted `(groupKey, epoch)` verified
+     *         against the full nonce-bound Safe tx hash; or (3) a matured announcement of these exact
+     *         parameters is consumed. Otherwise reverts `AttestationNotFound`.
+     * @dev A recognised trailer commits to the attestation path (an untrusted key, bad signature, or
+     *      malformed trailer reverts rather than falling through), so an attested transaction never
+     *      consumes a matching announcement. Safe pre-increments its nonce, hence `nonce() - 1`; the
+     *      announcement path ignores the nonce. The trailing `msgSender` parameter is intentionally
+     *      unused — authorisation derives from the attestation or announcement, not the executor.
+     * @param to The call target of the Safe transaction.
+     * @param value The native value forwarded by the Safe transaction.
+     * @param data The call data of the Safe transaction.
+     * @param operation The Safe operation type (`CALL` or `DELEGATECALL`).
+     * @param safeTxGas The gas that should be used for the Safe transaction.
+     * @param baseGas The gas costs independent of the transaction execution (refund accounting).
+     * @param gasPrice The gas price used for the refund calculation.
+     * @param gasToken The token used for the refund (`address(0)` for native).
+     * @param refundReceiver The address receiving the gas payment refund.
+     * @param signatures The packed owner signatures, optionally suffixed with an attestation trailer.
+     */
+    function checkTransaction(
+        address to,
+        uint256 value,
+        bytes memory data,
+        Enum.Operation operation,
+        uint256 safeTxGas,
+        uint256 baseGas,
+        uint256 gasPrice,
+        address gasToken,
+        address payable refundReceiver,
+        bytes calldata signatures,
+        address /* msgSender */
+    ) external override(ITransactionGuard) {
+        if (_isAutoAllowed(to, value, data, operation)) return;
+
+        (bool present, uint64 epoch, Secp256k1.Point memory groupKey, FROST.Signature memory signature) =
+            AttestationTrailer.decode(signatures);
+        if (present) {
+            // Cheap forest-membership check first (also implies a non-zero key, enforced on record), so an
+            // untrusted key short-circuits before the more expensive Safe tx hash is computed.
+            require($epochs.isKnown(groupKey, epoch), UntrustedAttestationKey());
+            uint256 nonce = ISafe(payable(msg.sender)).nonce() - 1;
+            bytes32 safeTxHash = SafeTransaction.hash(
+                SafeTransaction.T({
+                    chainId: block.chainid,
+                    safe: msg.sender,
+                    to: to,
+                    value: value,
+                    data: data,
+                    operation: SafeTransaction.Operation(uint8(operation)),
+                    safeTxGas: safeTxGas,
+                    baseGas: baseGas,
+                    gasPrice: gasPrice,
+                    gasToken: gasToken,
+                    refundReceiver: address(refundReceiver),
+                    nonce: nonce
+                })
+            );
+            bytes32 message = ConsensusMessages.transactionProposal(_CONSENSUS_DOMAIN_SEPARATOR, epoch, safeTxHash);
+            FROST.verify(groupKey, signature, message);
+            return;
+        }
+
+        // Escape hatch: match a nonce-free announcement of these exact parameters.
+        bytes32 announcementHash = TransactionAnnouncement.hash(
+            TransactionAnnouncement.AnnouncedTransaction({
+                to: to,
+                value: value,
+                data: data,
+                operation: operation,
+                safeTxGas: safeTxGas,
+                baseGas: baseGas,
+                gasPrice: gasPrice,
+                gasToken: gasToken,
+                refundReceiver: address(refundReceiver)
+            })
+        );
+        if ($announcements.consume(msg.sender, announcementHash)) {
+            emit AnnouncementConsumed(msg.sender, announcementHash);
+            return;
+        }
+
+        revert AttestationNotFound();
+    }
+
+    /**
+     * @notice Post-execution hook. Intentionally empty — all authorisation happens in `checkTransaction`.
+     * @dev Parameters are unnamed as they are unused; Safe passes the transaction hash and success flag.
+     */
+    function checkAfterExecution(bytes32, bool) external pure override(ITransactionGuard) {}
+
+    /**
+     * @inheritdoc IERC165
+     * @dev Advertises `ISafenetGuard`, `ITransactionGuard`, and `IERC165`.
+     */
+    function supportsInterface(bytes4 interfaceId)
+        external
+        pure
+        override(IERC165, BaseTransactionGuard)
+        returns (bool)
+    {
+        return interfaceId == type(ISafenetGuard).interfaceId || interfaceId == type(ITransactionGuard).interfaceId
+            || interfaceId == type(IERC165).interfaceId;
+    }
+
+    // ============================================================
+    // VIEW FUNCTIONS
+    // ============================================================
+
+    /**
+     * @inheritdoc ISafenetGuard
+     */
+    function isKnownEpoch(Secp256k1.Point calldata groupKey, uint64 epoch) external view returns (bool) {
+        return $epochs.isKnown(groupKey, epoch);
+    }
+
+    /**
+     * @inheritdoc ISafenetGuard
+     */
+    function getConsensusDomainSeparator() external view returns (bytes32 domainSeparator) {
+        return _CONSENSUS_DOMAIN_SEPARATOR;
+    }
+
+    /**
+     * @inheritdoc ISafenetGuard
+     */
+    function getAllowTxDelay() external view returns (uint256 delay) {
+        return _ALLOW_TX_DELAY;
+    }
+
+    /**
+     * @inheritdoc ISafenetGuard
+     */
+    function getAllowTxWindow() external view returns (uint256 window) {
+        return _ALLOW_TX_WINDOW;
+    }
+
+    /**
+     * @inheritdoc ISafenetGuard
+     */
+    function getAnnouncementWindow(address safe, bytes32 announcementHash)
+        external
+        view
+        returns (uint256 activeFrom, uint256 activeUntil)
+    {
+        return $announcements.windowOf(safe, announcementHash);
+    }
+
+    /**
+     * @inheritdoc ISafenetGuard
+     */
+    function getAnnouncementHash(TransactionAnnouncement.AnnouncedTransaction calldata announcement)
+        external
+        pure
+        returns (bytes32)
+    {
+        return TransactionAnnouncement.hash(announcement);
+    }
+
+    // ============================================================
+    // PRIVATE HELPERS
+    // ============================================================
+
+    /**
+     * @dev True if the call is a structurally valid self-call to an escape-hatch selector, bypassing
+     *      attestation. A valid self-call targets the guard, carries no value, uses `CALL` (never
+     *      `DELEGATECALL`, which would run guard code in the Safe's storage context), and carries at least
+     *      a 4-byte selector matching one of the escape-hatch functions.
+     * @param to The call target.
+     * @param value The native value forwarded.
+     * @param data The call data.
+     * @param operation The Safe operation type.
+     * @return allowed True if the call is an auto-allowed escape-hatch self-call.
+     */
+    function _isAutoAllowed(address to, uint256 value, bytes memory data, Enum.Operation operation)
+        private
+        view
+        returns (bool allowed)
+    {
+        if (to != address(this) || value != 0 || operation != Enum.Operation.Call || data.length < 4) {
+            return false;
+        }
+        // forge-lint: disable-next-line(unsafe-typecast)
+        bytes4 selector = bytes4(data);
+        return
+            selector == SafenetGuard.announceTransaction.selector
+                || selector == SafenetGuard.cancelAnnouncement.selector;
+    }
+}

--- a/contracts/src/interfaces/ISafenetGuard.sol
+++ b/contracts/src/interfaces/ISafenetGuard.sol
@@ -1,0 +1,191 @@
+// SPDX-License-Identifier: GPL-3.0-only
+pragma solidity ^0.8.30;
+
+import {FROST} from "@/libraries/FROST.sol";
+import {Secp256k1} from "@/libraries/Secp256k1.sol";
+import {TransactionAnnouncement} from "@/libraries/TransactionAnnouncement.sol";
+import {ITransactionGuard} from "@safe/base/GuardManager.sol";
+
+/**
+ * @title SafenetGuard Interface
+ * @notice External surface of the Safenet transaction guard: the Safe guard hooks, epoch management, the
+ *         nonce-free escape hatch, and the associated views, events, and errors.
+ * @dev Extends `ITransactionGuard`, so `checkTransaction` / `checkAfterExecution` are part of this ABI.
+ *      Announcement events are emitted by the guard; epoch events are emitted by `EpochRollover` and
+ *      mirrored here. Library errors (`AnnouncementAlreadyExists`, `AnnouncementNotFound`,
+ *      `WindowOverflow`, `MalformedAttestationTrailer`) are not mirrored — import the relevant library
+ *      to decode them.
+ */
+interface ISafenetGuard is ITransactionGuard {
+    // ============================================================
+    // EVENTS
+    // ============================================================
+
+    /**
+     * @notice Emitted when the genesis `(group key, epoch)` pair is seeded at construction.
+     * @param epoch The genesis epoch.
+     * @param groupKey The genesis FROST group key.
+     */
+    event EpochInitialized(uint64 indexed epoch, Secp256k1.Point groupKey);
+
+    /**
+     * @notice Emitted when a rollover records a new `(group key, epoch)` pair.
+     * @param parentEpoch The epoch of the trusted parent that authorised the rollover.
+     * @param epoch The newly recorded epoch.
+     * @param parentKey The trusted parent group key.
+     * @param groupKey The newly recorded group key.
+     */
+    event EpochRolledOver(
+        uint64 indexed parentEpoch, uint64 indexed epoch, Secp256k1.Point parentKey, Secp256k1.Point groupKey
+    );
+
+    /**
+     * @notice Emitted when a Safe announces a transaction (including renewal).
+     * @dev The announced parameters are recoverable from the `announceTransaction` calldata, so the event
+     *      itself carries only the hash and window.
+     * @param safe The Safe that made the announcement.
+     * @param announcementHash The nonce-free announcement hash.
+     * @param activeFrom The earliest timestamp at which the announcement is executable.
+     * @param activeUntil The latest timestamp at which the announcement is executable.
+     */
+    event TransactionAnnounced(
+        address indexed safe, bytes32 indexed announcementHash, uint256 activeFrom, uint256 activeUntil
+    );
+
+    /**
+     * @notice Emitted when a pending announcement is cancelled.
+     * @param safe The Safe whose announcement was cancelled.
+     * @param announcementHash The nonce-free hash of the cancelled announcement.
+     */
+    event AnnouncementCancelled(address indexed safe, bytes32 indexed announcementHash);
+
+    /**
+     * @notice Emitted when an announcement authorises a transaction and is consumed.
+     * @dev Consumed in the pre-execution hook — signals the authorisation was spent, not that the inner
+     *      Safe call ultimately succeeded.
+     * @param safe The Safe whose announcement was consumed.
+     * @param announcementHash The nonce-free hash of the consumed announcement.
+     */
+    event AnnouncementConsumed(address indexed safe, bytes32 indexed announcementHash);
+
+    // ============================================================
+    // ERRORS
+    // ============================================================
+
+    /**
+     * @notice Thrown by `checkTransaction` when neither a valid attestation nor a matured announcement
+     *         authorises the transaction.
+     */
+    error AttestationNotFound();
+
+    /**
+     * @notice Thrown by `checkTransaction` when an attestation names a `(groupKey, epoch)` pair absent
+     *         from the trusted epoch forest.
+     */
+    error UntrustedAttestationKey();
+
+    /**
+     * @notice Thrown by the constructor when `consensusAddress` is the zero address.
+     */
+    error InvalidAddress();
+
+    /**
+     * @notice Thrown by the constructor when the escape-hatch delay or window is zero or exceeds
+     *         `type(uint64).max`.
+     */
+    error InvalidParameter();
+
+    // ============================================================
+    // EPOCH MANAGEMENT
+    // ============================================================
+
+    /**
+     * @notice Records a new `(group key, epoch)` pair from a FROST-signed rollover of a trusted parent.
+     * @dev Permissionless (the signature is the authorisation); the caller names the parent explicitly;
+     *      re-submitting a known pair is a no-op. `rolloverBlock` is folded into the signed message only.
+     * @param parentKey Trusted parent group key; `(parentKey, parentEpoch)` must already be trusted.
+     * @param parentEpoch Epoch of `parentKey`.
+     * @param proposedEpoch New epoch; must be strictly greater than `parentEpoch`.
+     * @param rolloverBlock Gnosis Chain block number from the signed rollover message.
+     * @param newGroupKey New group key; must be a non-zero secp256k1 point.
+     * @param signature FROST signature from the parent group over the rollover message.
+     */
+    function updateEpoch(
+        Secp256k1.Point calldata parentKey,
+        uint64 parentEpoch,
+        uint64 proposedEpoch,
+        uint64 rolloverBlock,
+        Secp256k1.Point calldata newGroupKey,
+        FROST.Signature calldata signature
+    ) external;
+
+    // ============================================================
+    // ANNOUNCEMENT (ESCAPE HATCH)
+    // ============================================================
+
+    /**
+     * @notice Announces a transaction for nonce-free, time-windowed execution without an attestation.
+     * @dev Auto-allowed self-call. Executable only within `[now + delay, now + delay + window]`, at any
+     *      nonce; single-use. Reverts `AnnouncementAlreadyExists` if a pending/active announcement exists
+     *      for the derived hash (an expired one is renewed), or `WindowOverflow` on absurd durations.
+     * @param announcement The transaction parameters to announce.
+     */
+    function announceTransaction(TransactionAnnouncement.AnnouncedTransaction calldata announcement) external;
+
+    /**
+     * @notice Immediately cancels a pending announcement of this Safe (no delay).
+     * @dev Auto-allowed self-call. Reverts `AnnouncementNotFound` if none exists for this Safe and hash.
+     * @param announcementHash Hash (from `getAnnouncementHash`) whose announcement should be cancelled.
+     */
+    function cancelAnnouncement(bytes32 announcementHash) external;
+
+    // ============================================================
+    // VIEW FUNCTIONS
+    // ============================================================
+
+    /**
+     * @notice Returns whether a `(groupKey, epoch)` pair is trusted (membership is exact on the pair).
+     * @param groupKey The FROST group key to query.
+     * @param epoch The epoch to query.
+     * @return known True if the pair is in the trusted epoch forest.
+     */
+    function isKnownEpoch(Secp256k1.Point calldata groupKey, uint64 epoch) external view returns (bool known);
+
+    /**
+     * @notice Seconds from announcement to `activeFrom` (escape-hatch embargo).
+     * @return delay The escape-hatch embargo in seconds.
+     */
+    function getAllowTxDelay() external view returns (uint256 delay);
+
+    /**
+     * @notice Seconds after `activeFrom` during which an announcement stays executable.
+     * @return window The escape-hatch window in seconds.
+     */
+    function getAllowTxWindow() external view returns (uint256 window);
+
+    /**
+     * @notice The EIP-712 domain separator used to reconstruct Consensus messages.
+     * @return domainSeparator The Consensus EIP-712 domain separator.
+     */
+    function getConsensusDomainSeparator() external view returns (bytes32 domainSeparator);
+
+    /**
+     * @notice Returns the stored `[activeFrom, activeUntil]` for a `(safe, announcementHash)`, or `(0, 0)`.
+     * @dev Raw stored bounds, no time check: an expired-but-uncancelled entry still reports its non-zero
+     *      window. A non-zero `activeFrom` means "exists", not "executable".
+     */
+    function getAnnouncementWindow(address safe, bytes32 announcementHash)
+        external
+        view
+        returns (uint256 activeFrom, uint256 activeUntil);
+
+    /**
+     * @notice Computes the nonce-free announcement hash for `cancelAnnouncement` / off-chain use.
+     * @param announcement The transaction parameters to hash.
+     * @return announcementHash The nonce-free announcement hash.
+     */
+    function getAnnouncementHash(TransactionAnnouncement.AnnouncedTransaction calldata announcement)
+        external
+        pure
+        returns (bytes32 announcementHash);
+}

--- a/contracts/src/libraries/AttestationTrailer.sol
+++ b/contracts/src/libraries/AttestationTrailer.sol
@@ -1,0 +1,77 @@
+// SPDX-License-Identifier: GPL-3.0-only
+pragma solidity ^0.8.30;
+
+import {FROST} from "@/libraries/FROST.sol";
+import {Secp256k1} from "@/libraries/Secp256k1.sol";
+
+/**
+ * @title AttestationTrailer
+ * @notice Recognises and decodes a Safenet attestation appended to Safe's `signatures` bytes.
+ * @dev Layout: `[safe owner signatures][192-byte abi.encode(epoch, groupKey, signature)][32-byte TYPE_HASH]`.
+ *      Anchoring at the end leaves Safe's front-to-back signature parser untouched, and the terminal type
+ *      hash makes detection independent of signature suffixes — a blob not ending in `TYPE_HASH` is simply
+ *      "no trailer". The type hash embeds the version, so a future format uses a different type hash (and
+ *      this guard treats it as absent). The library owns recognition, sizing, and the typed decode.
+ */
+library AttestationTrailer {
+    // ============================================================
+    // CONSTANTS
+    // ============================================================
+
+    /**
+     * @notice Type hash that must terminate a v1 attestation trailer; doubles as the version tag.
+     */
+    bytes32 internal constant TYPE_HASH = keccak256("SafenetGuard.AttestationTrailer.v1");
+
+    /**
+     * @dev Payload is `abi.encode(uint64, Secp256k1.Point, FROST.Signature)` = 6 words = 192 bytes.
+     */
+    uint256 private constant _PAYLOAD_LENGTH = 192;
+
+    /**
+     * @dev Total trailer overhead: the payload followed by the 32-byte type hash word. Derived from
+     *      `_PAYLOAD_LENGTH` so the two constants cannot drift if the payload layout changes.
+     */
+    uint256 private constant _TRAILER_LENGTH = _PAYLOAD_LENGTH + 32;
+
+    // ============================================================
+    // ERRORS
+    // ============================================================
+
+    /**
+     * @notice Thrown when the type hash is present but the blob is too short to hold a v1 trailer.
+     */
+    error MalformedAttestationTrailer();
+
+    // ============================================================
+    // INTERNAL FUNCTIONS
+    // ============================================================
+
+    /**
+     * @notice Recognises and decodes an attestation trailer from a `signatures` blob.
+     * @dev Returns `present == false` when the last word is not `TYPE_HASH` (so the consumer falls through
+     *      to other authorisation paths). Reverts `MalformedAttestationTrailer` when the type hash is
+     *      present but the blob is shorter than a full trailer — a recognised trailer never silently
+     *      falls through.
+     * @return present True if a trailer was recognised and decoded.
+     * @return epoch The attested epoch.
+     * @return groupKey The attesting FROST group key.
+     * @return signature The FROST signature.
+     */
+    function decode(bytes calldata signatures)
+        internal
+        pure
+        returns (bool present, uint64 epoch, Secp256k1.Point memory groupKey, FROST.Signature memory signature)
+    {
+        if (signatures.length < 32 || bytes32(signatures[signatures.length - 32:]) != TYPE_HASH) {
+            return (false, 0, groupKey, signature);
+        }
+        require(signatures.length >= _TRAILER_LENGTH, MalformedAttestationTrailer());
+
+        uint256 payloadStart = signatures.length - _TRAILER_LENGTH;
+        (epoch, groupKey, signature) = abi.decode(
+            signatures[payloadStart:payloadStart + _PAYLOAD_LENGTH], (uint64, Secp256k1.Point, FROST.Signature)
+        );
+        present = true;
+    }
+}

--- a/contracts/src/libraries/TransactionAnnouncement.sol
+++ b/contracts/src/libraries/TransactionAnnouncement.sol
@@ -1,0 +1,169 @@
+// SPDX-License-Identifier: GPL-3.0-only
+pragma solidity ^0.8.30;
+
+import {Enum} from "@safe/interfaces/Enum.sol";
+
+/**
+ * @title TransactionAnnouncement
+ * @notice Time-windowed transaction announcements — an escape hatch that lets a Safe execute a
+ *         transaction without a Safenet attestation, only inside a bounded `[activeFrom, activeUntil]`.
+ * @dev State is keyed by `(safe, txHash)`, where `txHash` is the nonce-free {hash} of an
+ *      {AnnouncedTransaction} (every `execTransaction` field except the nonce). Keying by the caller
+ *      isolates each Safe. The two bounds pack into one slot via {Window} (two `uint128`), so each
+ *      operation is a single SLOAD/SSTORE; `activeFrom == 0` is the empty sentinel. `announce` embargoes
+ *      by `delay` and rejects durations that would overflow `uint128`; `cancel` is immediate; an expired
+ *      entry is renewable in place while a pending/active one is not. Emits no events — the consumer
+ *      emits its own (the guard's announcement events are chain- and parameter-dependent).
+ */
+library TransactionAnnouncement {
+    // ============================================================
+    // STRUCTS
+    // ============================================================
+
+    /**
+     * @notice The parameters of an announced transaction — every `execTransaction` field except the
+     *         Safe nonce and signatures. Hashed nonce-free by {hash} to key the announcement.
+     */
+    struct AnnouncedTransaction {
+        address to;
+        uint256 value;
+        bytes data;
+        Enum.Operation operation;
+        uint256 safeTxGas;
+        uint256 baseGas;
+        uint256 gasPrice;
+        address gasToken;
+        address refundReceiver;
+    }
+
+    /**
+     * @notice A bounded execution window `[activeFrom, activeUntil]` (both inclusive), packed in one slot.
+     * @custom:param activeFrom Earliest Unix timestamp at which execution is permitted; zero means
+     *               "no announcement".
+     * @custom:param activeUntil Latest Unix timestamp at which execution is permitted.
+     */
+    struct Window {
+        uint128 activeFrom;
+        uint128 activeUntil;
+    }
+
+    /**
+     * @notice The set of pending announcements.
+     * @custom:param entries Maps `(safe, txHash)` to its execution {Window}.
+     */
+    struct T {
+        mapping(address safe => mapping(bytes32 txHash => Window window)) entries;
+    }
+
+    // ============================================================
+    // ERRORS
+    // ============================================================
+
+    /**
+     * @notice Thrown by `announce` when a pending or still-active announcement already exists for this
+     *         `(safe, txHash)`. An expired announcement does not trigger this — it is overwritten.
+     */
+    error AnnouncementAlreadyExists();
+
+    /**
+     * @notice Thrown by `cancel` when no announcement exists for this `(safe, txHash)`.
+     */
+    error AnnouncementNotFound();
+
+    /**
+     * @notice Thrown by `announce` when `activeFrom`/`activeUntil` would not fit in `uint128`.
+     */
+    error WindowOverflow();
+
+    // ============================================================
+    // INTERNAL FUNCTIONS
+    // ============================================================
+
+    /**
+     * @notice The nonce-free announcement hash of `t` — covers every field except the Safe nonce, and
+     *         excludes the Safe (announcements are scoped by the storage key). `data` is pre-hashed.
+     */
+    function hash(AnnouncedTransaction memory t) internal pure returns (bytes32) {
+        // forge-lint: disable-next-line(asm-keccak256)
+        bytes32 dataHash = keccak256(t.data);
+        bytes memory encoded = abi.encode(
+            t.to, t.value, dataHash, t.operation, t.safeTxGas, t.baseGas, t.gasPrice, t.gasToken, t.refundReceiver
+        );
+        // forge-lint: disable-next-line(asm-keccak256)
+        return keccak256(encoded);
+    }
+
+    /**
+     * @notice Announces `txHash` for execution within `[now + delay, that + window]`.
+     * @dev Overwrites an expired entry (renewal) but reverts `AnnouncementAlreadyExists` while an entry
+     *      is pending or active. Reverts `WindowOverflow` if the computed bounds exceed `uint128`.
+     * @param self The storage struct.
+     * @param safe The Safe making the announcement (typically `msg.sender` in the consumer).
+     * @param txHash The identifier to announce.
+     * @param delay Embargo seconds before the hash becomes executable.
+     * @param window Seconds after `activeFrom` during which the hash remains executable.
+     * @return activeFrom The computed earliest execution timestamp.
+     * @return activeUntil The computed latest execution timestamp.
+     */
+    function announce(T storage self, address safe, bytes32 txHash, uint256 delay, uint256 window)
+        internal
+        returns (uint256 activeFrom, uint256 activeUntil)
+    {
+        Window storage existing = self.entries[safe][txHash];
+        require(existing.activeFrom == 0 || block.timestamp > existing.activeUntil, AnnouncementAlreadyExists());
+        activeFrom = block.timestamp + delay;
+        activeUntil = activeFrom + window;
+        // `activeUntil >= activeFrom` (checked add), so bounding `activeUntil` bounds both.
+        require(activeUntil <= type(uint128).max, WindowOverflow());
+        // Single-slot write.
+        // forge-lint: disable-next-line(unsafe-typecast)
+        self.entries[safe][txHash] = Window({activeFrom: uint128(activeFrom), activeUntil: uint128(activeUntil)});
+    }
+
+    /**
+     * @notice Cancels an existing announcement immediately, whether it is pending, active, or expired.
+     * @dev Reverts `AnnouncementNotFound` if none exists for the pair.
+     * @param self The storage struct.
+     * @param safe The Safe whose announcement is being cancelled.
+     * @param txHash The identifier whose announcement should be removed.
+     */
+    function cancel(T storage self, address safe, bytes32 txHash) internal {
+        require(self.entries[safe][txHash].activeFrom != 0, AnnouncementNotFound());
+        delete self.entries[safe][txHash];
+    }
+
+    /**
+     * @notice Consumes the announcement for `txHash` iff it exists and `now` is within its window.
+     * @dev Non-reverting: returns `false` when the entry is absent, not yet active, or expired, so the
+     *      consumer can fall through to other authorisation paths. Deletes the entry on success.
+     * @param self The storage struct.
+     * @param safe The Safe attempting execution.
+     * @param txHash The identifier being executed.
+     * @return consumed True if an in-window announcement was found and deleted.
+     */
+    function consume(T storage self, address safe, bytes32 txHash) internal returns (bool consumed) {
+        Window memory w = self.entries[safe][txHash];
+        if (w.activeFrom != 0 && block.timestamp >= w.activeFrom && block.timestamp <= w.activeUntil) {
+            delete self.entries[safe][txHash];
+            return true;
+        }
+        return false;
+    }
+
+    /**
+     * @notice Returns the execution window for a pending announcement, or `(0, 0)` if none exists.
+     * @param self The storage struct.
+     * @param safe The Safe to query.
+     * @param txHash The identifier to query.
+     * @return activeFrom The earliest execution timestamp, or zero.
+     * @return activeUntil The latest execution timestamp, or zero.
+     */
+    function windowOf(T storage self, address safe, bytes32 txHash)
+        internal
+        view
+        returns (uint256 activeFrom, uint256 activeUntil)
+    {
+        Window memory w = self.entries[safe][txHash];
+        return (w.activeFrom, w.activeUntil);
+    }
+}

--- a/contracts/test/SafenetGuard.t.sol
+++ b/contracts/test/SafenetGuard.t.sol
@@ -1,0 +1,1333 @@
+// SPDX-License-Identifier: GPL-3.0-only
+pragma solidity ^0.8.30;
+
+import {Test} from "@forge-std/Test.sol";
+import {ConsensusMessages} from "@/libraries/ConsensusMessages.sol";
+import {EpochRollover} from "@/libraries/EpochRollover.sol";
+import {FROST} from "@/libraries/FROST.sol";
+import {SafeTransaction} from "@/libraries/SafeTransaction.sol";
+import {Secp256k1} from "@/libraries/Secp256k1.sol";
+import {TransactionAnnouncement} from "@/libraries/TransactionAnnouncement.sol";
+import {AttestationTrailer} from "@/libraries/AttestationTrailer.sol";
+import {ISafenetGuard} from "@/interfaces/ISafenetGuard.sol";
+import {Enum} from "@safe/interfaces/Enum.sol";
+import {ISafe} from "@safe/interfaces/ISafe.sol";
+import {IGuardManager} from "@safe/interfaces/IGuardManager.sol";
+import {ITransactionGuard} from "@safe/base/GuardManager.sol";
+import {Safe} from "@safe/Safe.sol";
+import {SafeProxyFactory} from "@safe/proxies/SafeProxyFactory.sol";
+import {SafenetGuard} from "@/guard/SafenetGuard.sol";
+import {ForgeSecp256k1} from "@test/util/ForgeSecp256k1.sol";
+import {MockERC1271} from "@test/util/MockERC1271.sol";
+
+/**
+ * @title SafenetGuardTest
+ * @notice Behavioural tests for `SafenetGuard`. Every happy path drives a real Safe (singleton +
+ *         proxy factory) with the guard actually installed via `setGuard`, and exercises real
+ *         `execTransaction` calls carrying real ECDSA owner signatures. FROST attestations are real at
+ *         the on-chain verifier level — signatures are synthesized from a known aggregate secret via the
+ *         Schnorr equation (`ForgeSecp256k1`), not produced by a multi-party DKG/signing ceremony — so
+ *         the on-chain FROST/EC verification runs end-to-end, but validator interoperability is out of
+ *         scope here.
+ */
+contract SafenetGuardTest is Test {
+    using ForgeSecp256k1 for ForgeSecp256k1.P;
+
+    SafenetGuard public guard;
+
+    // ============================================================
+    // CONSTANTS — DEPLOYMENT
+    // ============================================================
+
+    uint256 public constant CONSENSUS_CHAIN_ID = 100; // Gnosis Chain
+    address public constant CONSENSUS_ADDR = address(0xC01115E1115115);
+    uint256 public constant ALLOW_TX_DELAY_SECONDS = 1 days;
+    uint256 public constant ALLOW_TX_WINDOW_SECONDS = 3 days;
+    uint64 public constant GENESIS_EPOCH = 1;
+    uint64 public constant ROLLOVER_BLOCK = 100;
+
+    address public other = address(0xABCDE);
+
+    // ============================================================
+    // CONSTANTS — KEY PAIRS
+    // Secret keys for ForgeSecp256k1.g(k): public key = k*G
+    // ============================================================
+
+    uint256 public constant GENESIS_SK = 1; // genesis group secret key; public key = G
+    uint256 public constant GENESIS_NK = 2; // genesis signing nonce; R = 2*G
+
+    uint256 public constant EPOCH2_SK = 5; // epoch 2 group secret key
+    uint256 public constant EPOCH2_NK = 6; // epoch 2 signing nonce
+
+    uint256 public constant FORK_SK = 7; // an alternative epoch-2 branch key
+    uint256 public constant FORK_NK = 8;
+
+    uint256 public constant UNKNOWN_SK = 9; // a key never recorded in the forest
+    uint256 public constant UNKNOWN_NK = 10;
+
+    // ============================================================
+    // CONSTANTS — DEFAULT TRANSACTION PARAMETERS
+    // ============================================================
+
+    address public constant TX_TO = address(0xBEEF);
+    uint256 public constant TX_VALUE = 0;
+    bytes public constant TX_DATA = hex"deadbeef";
+    Enum.Operation public constant TX_OP = Enum.Operation.Call;
+
+    // ============================================================
+    // SAFE DEPLOYMENT
+    // ============================================================
+
+    Safe public singleton;
+    SafeProxyFactory public factory;
+    ISafe public safe;
+    uint256 public ownerKey;
+
+    function setUp() public {
+        ownerKey = 0xA11CE;
+
+        singleton = new Safe();
+        factory = new SafeProxyFactory();
+
+        address[] memory owners = new address[](1);
+        owners[0] = vm.addr(ownerKey);
+        bytes memory initializer = abi.encodeCall(
+            Safe.setup, (owners, 1, address(0), bytes(""), address(0), address(0), 0, payable(address(0)))
+        );
+        safe = ISafe(payable(address(factory.createProxyWithNonce(address(singleton), initializer, 0))));
+
+        Secp256k1.Point memory groupKey = ForgeSecp256k1.g(GENESIS_SK).toPoint();
+        guard = new SafenetGuard(
+            CONSENSUS_CHAIN_ID, CONSENSUS_ADDR, GENESIS_EPOCH, groupKey, ALLOW_TX_DELAY_SECONDS, ALLOW_TX_WINDOW_SECONDS
+        );
+
+        // Install transaction guard (no guard active yet — executes directly). This also exercises
+        // Safe's ERC-165 check that the guard implements ITransactionGuard.
+        _execSafeTx(
+            address(safe),
+            0,
+            abi.encodeCall(IGuardManager.setGuard, (address(guard))),
+            Enum.Operation.Call,
+            ExecMode.Direct
+        );
+    }
+
+    // ============================================================
+    // HELPER FUNCTIONS
+    // ============================================================
+
+    enum ExecMode {
+        Direct,
+        Attested
+    }
+
+    /// @dev Computes a valid FROST Schnorr signature for `message` from group `secretKey`.
+    ///      Derivation: z = nonceKey + challenge(R, Y, msg) * secretKey (mod N)
+    function _frostSign(uint256 secretKey, uint256 nonceKey, bytes32 message)
+        internal
+        returns (FROST.Signature memory)
+    {
+        Secp256k1.Point memory r = ForgeSecp256k1.g(nonceKey).toPoint();
+        Secp256k1.Point memory y = ForgeSecp256k1.g(secretKey).toPoint();
+        uint256 c = FROST.challenge(r, y, message);
+        uint256 z = addmod(nonceKey, mulmod(c, secretKey, Secp256k1.N), Secp256k1.N);
+        return FROST.Signature({r: r, z: z});
+    }
+
+    /// @dev Computes the Safe EIP-712 transaction hash for the given parameters and nonce.
+    function _safeTxHash(address to, uint256 value, bytes memory data, Enum.Operation op, uint256 nonce)
+        internal
+        view
+        returns (bytes32)
+    {
+        return SafeTransaction.hash(
+            SafeTransaction.T({
+                chainId: block.chainid,
+                safe: address(safe),
+                to: to,
+                value: value,
+                data: data,
+                operation: SafeTransaction.Operation(uint8(op)),
+                safeTxGas: 0,
+                baseGas: 0,
+                gasPrice: 0,
+                gasToken: address(0),
+                refundReceiver: address(0),
+                nonce: nonce
+            })
+        );
+    }
+
+    /// @dev Produces a packed ECDSA signature from the owner for a Safe transaction hash.
+    function _signSafeTx(bytes32 txHash) internal view returns (bytes memory) {
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(ownerKey, txHash);
+        return abi.encodePacked(r, s, v);
+    }
+
+    /// @dev Builds an inline FROST attestation trailer in the version-1 framing:
+    ///      `[192-byte abi.encode(epoch, groupKey, signature)][32-byte TYPE_HASH (embeds the version)]`.
+    ///      The group key is derived from `sk` so it matches the signing key.
+    function _buildInlineAttestation(bytes32 txHash, uint64 epoch, uint256 sk, uint256 nk)
+        internal
+        returns (bytes memory)
+    {
+        Secp256k1.Point memory groupKey = ForgeSecp256k1.g(sk).toPoint();
+        bytes32 message = ConsensusMessages.transactionProposal(guard.getConsensusDomainSeparator(), epoch, txHash);
+        FROST.Signature memory sig = _frostSign(sk, nk, message);
+        bytes memory payload = abi.encode(epoch, groupKey, sig); // 192 bytes
+        return bytes.concat(payload, AttestationTrailer.TYPE_HASH);
+    }
+
+    /// @dev Signs and executes a Safe transaction. `Attested` appends a genesis-epoch inline FROST
+    ///      attestation trailer; `Direct` omits it (used before the guard is installed or for
+    ///      auto-allowed self-calls).
+    function _execSafeTx(address to, uint256 value, bytes memory data, Enum.Operation op, ExecMode mode) internal {
+        uint256 nonce = safe.nonce();
+        bytes32 txHash = _safeTxHash(to, value, data, op, nonce);
+        bytes memory safeSig = _signSafeTx(txHash);
+        if (mode == ExecMode.Attested) {
+            safeSig = bytes.concat(safeSig, _buildInlineAttestation(txHash, GENESIS_EPOCH, GENESIS_SK, GENESIS_NK));
+        }
+        safe.execTransaction(to, value, data, op, 0, 0, 0, address(0), payable(address(0)), safeSig);
+    }
+
+    /// @dev Like _execSafeTx(Direct) but takes a pre-computed nonce, making safe.execTransaction the
+    ///      only external call. Use when vm.expectRevert is set immediately before, so the nonce read
+    ///      does not consume the cheat code.
+    function _execSafeTxWithNonce(address to, uint256 value, bytes memory data, Enum.Operation op, uint256 nonce)
+        internal
+    {
+        bytes32 txHash = _safeTxHash(to, value, data, op, nonce);
+        safe.execTransaction(to, value, data, op, 0, 0, 0, address(0), payable(address(0)), _signSafeTx(txHash));
+    }
+
+    /// @dev Executes an attested Safe transaction with an explicit epoch/key pair (for tests that
+    ///      attest against non-genesis or untrusted keys). Reads the nonce internally.
+    function _execAttestedWith(uint64 epoch, uint256 sk, uint256 nk) internal {
+        uint256 nonce = safe.nonce();
+        bytes32 txHash = _safeTxHash(TX_TO, TX_VALUE, TX_DATA, TX_OP, nonce);
+        bytes memory combined = bytes.concat(_signSafeTx(txHash), _buildInlineAttestation(txHash, epoch, sk, nk));
+        safe.execTransaction(TX_TO, TX_VALUE, TX_DATA, TX_OP, 0, 0, 0, address(0), payable(address(0)), combined);
+    }
+
+    /// @dev Performs a FROST-verified epoch rollover through the guard's public `updateEpoch`.
+    function _rollover(uint256 parentSk, uint256 parentNk, uint64 parentEpoch, uint64 proposedEpoch, uint256 newSk)
+        internal
+        returns (Secp256k1.Point memory newKey)
+    {
+        Secp256k1.Point memory parentKey = ForgeSecp256k1.g(parentSk).toPoint();
+        newKey = ForgeSecp256k1.g(newSk).toPoint();
+        bytes32 message = ConsensusMessages.epochRollover(
+            guard.getConsensusDomainSeparator(), parentEpoch, proposedEpoch, ROLLOVER_BLOCK, newKey
+        );
+        FROST.Signature memory sig = _frostSign(parentSk, parentNk, message);
+        guard.updateEpoch(parentKey, parentEpoch, proposedEpoch, ROLLOVER_BLOCK, newKey, sig);
+    }
+
+    /// @dev The default announced transaction (the default test tx, all gas fields zero).
+    function _defaultAnnouncement() internal pure returns (TransactionAnnouncement.AnnouncedTransaction memory) {
+        return TransactionAnnouncement.AnnouncedTransaction({
+            to: TX_TO,
+            value: TX_VALUE,
+            data: TX_DATA,
+            operation: TX_OP,
+            safeTxGas: 0,
+            baseGas: 0,
+            gasPrice: 0,
+            gasToken: address(0),
+            refundReceiver: address(0)
+        });
+    }
+
+    /// @dev Hash of the default announced transaction, as the guard derives it.
+    function _defaultAnnouncementHash() internal view returns (bytes32) {
+        return guard.getAnnouncementHash(_defaultAnnouncement());
+    }
+
+    /// @dev An announcement for `to`/`data`/`safeTxGas` with the remaining fields zeroed.
+    function _announcementFor(address to, bytes memory data, uint256 safeTxGas)
+        internal
+        pure
+        returns (TransactionAnnouncement.AnnouncedTransaction memory)
+    {
+        return TransactionAnnouncement.AnnouncedTransaction({
+            to: to,
+            value: 0,
+            data: data,
+            operation: Enum.Operation.Call,
+            safeTxGas: safeTxGas,
+            baseGas: 0,
+            gasPrice: 0,
+            gasToken: address(0),
+            refundReceiver: address(0)
+        });
+    }
+
+    /// @dev The `activeFrom` of the Safe's announcement for `h` (zero if none). Used as the
+    ///      "is there a live announcement" probe in assertions.
+    function _announcedActiveFrom(bytes32 h) internal view returns (uint256 activeFrom) {
+        (activeFrom,) = guard.getAnnouncementWindow(address(safe), h);
+    }
+
+    /// @dev Announces `t` via a real auto-allowed Safe execTransaction. Advances the Safe nonce by one.
+    function _announce(TransactionAnnouncement.AnnouncedTransaction memory t) internal {
+        uint256 nonce = safe.nonce();
+        bytes memory data = abi.encodeCall(SafenetGuard.announceTransaction, (t));
+        _execSafeTxWithNonce(address(guard), 0, data, Enum.Operation.Call, nonce);
+    }
+
+    /// @dev Announces the default transaction; returns its hash.
+    function _announceDefault() internal returns (bytes32 h) {
+        h = _defaultAnnouncementHash();
+        _announce(_defaultAnnouncement());
+    }
+
+    /// @dev Cancels an announcement via a real Safe execTransaction (auto-allowed). Advances the nonce.
+    function _cancelAnnouncement(bytes32 announcementHash) internal {
+        uint256 nonce = safe.nonce();
+        bytes memory data = abi.encodeCall(SafenetGuard.cancelAnnouncement, (announcementHash));
+        _execSafeTxWithNonce(address(guard), 0, data, Enum.Operation.Call, nonce);
+    }
+
+    // ============================================================
+    // CONSTRUCTOR
+    // ============================================================
+
+    function test_constructor_revertsOnZeroConsensusAddress() public {
+        Secp256k1.Point memory key = ForgeSecp256k1.g(GENESIS_SK).toPoint();
+        vm.expectRevert(ISafenetGuard.InvalidAddress.selector);
+        new SafenetGuard(
+            CONSENSUS_CHAIN_ID, address(0), GENESIS_EPOCH, key, ALLOW_TX_DELAY_SECONDS, ALLOW_TX_WINDOW_SECONDS
+        );
+    }
+
+    function test_constructor_revertsOnZeroAllowTxDelay() public {
+        Secp256k1.Point memory key = ForgeSecp256k1.g(GENESIS_SK).toPoint();
+        vm.expectRevert(ISafenetGuard.InvalidParameter.selector);
+        new SafenetGuard(CONSENSUS_CHAIN_ID, CONSENSUS_ADDR, GENESIS_EPOCH, key, 0, ALLOW_TX_WINDOW_SECONDS);
+    }
+
+    function test_constructor_revertsOnZeroAllowTxWindow() public {
+        Secp256k1.Point memory key = ForgeSecp256k1.g(GENESIS_SK).toPoint();
+        vm.expectRevert(ISafenetGuard.InvalidParameter.selector);
+        new SafenetGuard(CONSENSUS_CHAIN_ID, CONSENSUS_ADDR, GENESIS_EPOCH, key, ALLOW_TX_DELAY_SECONDS, 0);
+    }
+
+    function test_constructor_revertsOnInvalidGroupKey() public {
+        vm.expectRevert(Secp256k1.NotOnCurve.selector);
+        new SafenetGuard(
+            CONSENSUS_CHAIN_ID,
+            CONSENSUS_ADDR,
+            GENESIS_EPOCH,
+            Secp256k1.Point({x: 0, y: 0}),
+            ALLOW_TX_DELAY_SECONDS,
+            ALLOW_TX_WINDOW_SECONDS
+        );
+    }
+
+    function test_constructor_seedsGenesisPairInForest() public {
+        Secp256k1.Point memory genesisKey = ForgeSecp256k1.g(GENESIS_SK).toPoint();
+        assertTrue(guard.isKnownEpoch(genesisKey, GENESIS_EPOCH));
+        // The same key at a different epoch is not trusted (membership is exact on the pair).
+        assertFalse(guard.isKnownEpoch(genesisKey, GENESIS_EPOCH + 1));
+        // A key that was never seeded is not trusted at the genesis epoch.
+        assertFalse(guard.isKnownEpoch(ForgeSecp256k1.g(UNKNOWN_SK).toPoint(), GENESIS_EPOCH));
+    }
+
+    function test_constructor_emitsEpochInitialized() public {
+        Secp256k1.Point memory key = ForgeSecp256k1.g(GENESIS_SK).toPoint();
+        vm.expectEmit(true, false, false, true);
+        emit EpochRollover.EpochInitialized(GENESIS_EPOCH, key);
+        new SafenetGuard(
+            CONSENSUS_CHAIN_ID, CONSENSUS_ADDR, GENESIS_EPOCH, key, ALLOW_TX_DELAY_SECONDS, ALLOW_TX_WINDOW_SECONDS
+        );
+    }
+
+    // ============================================================
+    // CHECK TRANSACTION — ATTESTATION
+    // ============================================================
+
+    function test_checkTransaction_revertsWhenNoAttestation() public {
+        uint256 nonce = safe.nonce();
+        vm.expectRevert(ISafenetGuard.AttestationNotFound.selector);
+        _execSafeTxWithNonce(TX_TO, TX_VALUE, TX_DATA, TX_OP, nonce);
+    }
+
+    function test_checkTransaction_passesWithInlineAttestation() public {
+        _execSafeTx(TX_TO, TX_VALUE, TX_DATA, TX_OP, ExecMode.Attested); // must not revert
+    }
+
+    function test_checkTransaction_revertsWithUntrustedKey() public {
+        // A well-formed attestation whose group key was never recorded in the forest.
+        uint256 nonce = safe.nonce();
+        bytes32 txHash = _safeTxHash(TX_TO, TX_VALUE, TX_DATA, TX_OP, nonce);
+        bytes memory combined =
+            bytes.concat(_signSafeTx(txHash), _buildInlineAttestation(txHash, GENESIS_EPOCH, UNKNOWN_SK, UNKNOWN_NK));
+        vm.expectRevert(ISafenetGuard.UntrustedAttestationKey.selector);
+        safe.execTransaction(TX_TO, TX_VALUE, TX_DATA, TX_OP, 0, 0, 0, address(0), payable(address(0)), combined);
+    }
+
+    function test_checkTransaction_revertsWhenGenesisKeyClaimedAtWrongEpoch() public {
+        // Correct genesis key, but paired with an epoch that was never recorded → pair unknown.
+        uint256 nonce = safe.nonce();
+        bytes32 txHash = _safeTxHash(TX_TO, TX_VALUE, TX_DATA, TX_OP, nonce);
+        bytes memory combined = bytes.concat(
+            _signSafeTx(txHash), _buildInlineAttestation(txHash, GENESIS_EPOCH + 1, GENESIS_SK, GENESIS_NK)
+        );
+        vm.expectRevert(ISafenetGuard.UntrustedAttestationKey.selector);
+        safe.execTransaction(TX_TO, TX_VALUE, TX_DATA, TX_OP, 0, 0, 0, address(0), payable(address(0)), combined);
+    }
+
+    function test_checkTransaction_replayProtectedByNonce() public {
+        // Build a valid attestation for the current nonce and execute it.
+        uint256 nonce = safe.nonce();
+        bytes32 txHash = _safeTxHash(TX_TO, TX_VALUE, TX_DATA, TX_OP, nonce);
+        bytes memory trailer = _buildInlineAttestation(txHash, GENESIS_EPOCH, GENESIS_SK, GENESIS_NK);
+        safe.execTransaction(
+            TX_TO,
+            TX_VALUE,
+            TX_DATA,
+            TX_OP,
+            0,
+            0,
+            0,
+            address(0),
+            payable(address(0)),
+            bytes.concat(_signSafeTx(txHash), trailer)
+        );
+
+        // Re-submitting the identical trailer at the new nonce fails: the attestation is bound to the
+        // old safeTxHash, so FROST verification runs against the wrong message and the EC witness check fails.
+        uint256 nonce2 = safe.nonce();
+        bytes32 txHash2 = _safeTxHash(TX_TO, TX_VALUE, TX_DATA, TX_OP, nonce2);
+        vm.expectRevert(Secp256k1.InvalidMulMulAddWitness.selector);
+        safe.execTransaction(
+            TX_TO,
+            TX_VALUE,
+            TX_DATA,
+            TX_OP,
+            0,
+            0,
+            0,
+            address(0),
+            payable(address(0)),
+            bytes.concat(_signSafeTx(txHash2), trailer)
+        );
+    }
+
+    function test_integration_inlineAttestation_revertsWithTamperedSignature() public {
+        uint256 nonce = safe.nonce();
+        bytes32 txHash = _safeTxHash(TX_TO, TX_VALUE, TX_DATA, TX_OP, nonce);
+        bytes32 message =
+            ConsensusMessages.transactionProposal(guard.getConsensusDomainSeparator(), GENESIS_EPOCH, txHash);
+        FROST.Signature memory sig = _frostSign(GENESIS_SK, GENESIS_NK, message);
+        sig.z = addmod(sig.z, 1, Secp256k1.N); // tamper
+        bytes memory payload = abi.encode(GENESIS_EPOCH, ForgeSecp256k1.g(GENESIS_SK).toPoint(), sig);
+        bytes memory combined = bytes.concat(_signSafeTx(txHash), payload, AttestationTrailer.TYPE_HASH);
+        vm.expectRevert(Secp256k1.InvalidMulMulAddWitness.selector);
+        safe.execTransaction(TX_TO, TX_VALUE, TX_DATA, TX_OP, 0, 0, 0, address(0), payable(address(0)), combined);
+    }
+
+    // ============================================================
+    // CHECK TRANSACTION — AUTO-ALLOW GATES
+    // ============================================================
+
+    function test_checkTransaction_autoAllowsAnnounceTransactionCall() public {
+        bytes32 anyHash = _defaultAnnouncementHash();
+        assertEq(_announcedActiveFrom(anyHash), 0);
+        bytes memory data = abi.encodeCall(SafenetGuard.announceTransaction, (_defaultAnnouncement()));
+        _execSafeTx(address(guard), 0, data, Enum.Operation.Call, ExecMode.Direct); // auto-allowed, no attestation
+        // The announceTransaction body ran with msg.sender == safe — announcement must be registered.
+        assertGt(_announcedActiveFrom(anyHash), 0);
+    }
+
+    function test_checkTransaction_autoAllowsCancelAnnouncementCall() public {
+        bytes32 anyHash = _defaultAnnouncementHash();
+        _announce(_defaultAnnouncement());
+        bytes memory data = abi.encodeCall(SafenetGuard.cancelAnnouncement, (anyHash));
+        _execSafeTx(address(guard), 0, data, Enum.Operation.Call, ExecMode.Direct); // auto-allowed
+        assertEq(_announcedActiveFrom(anyHash), 0);
+    }
+
+    function test_checkTransaction_doesNotAutoAllowDelegatecall() public {
+        bytes memory data = abi.encodeCall(SafenetGuard.announceTransaction, (_defaultAnnouncement()));
+        uint256 nonce = safe.nonce();
+        vm.expectRevert(ISafenetGuard.AttestationNotFound.selector);
+        _execSafeTxWithNonce(address(guard), 0, data, Enum.Operation.DelegateCall, nonce);
+    }
+
+    function test_checkTransaction_doesNotAutoAllowNonZeroValue() public {
+        bytes memory data = abi.encodeCall(SafenetGuard.announceTransaction, (_defaultAnnouncement()));
+        uint256 nonce = safe.nonce();
+        vm.expectRevert(ISafenetGuard.AttestationNotFound.selector);
+        _execSafeTxWithNonce(address(guard), 1, data, Enum.Operation.Call, nonce);
+    }
+
+    function test_checkTransaction_doesNotAutoAllowShortData() public {
+        uint256 nonce = safe.nonce();
+        vm.expectRevert(ISafenetGuard.AttestationNotFound.selector);
+        _execSafeTxWithNonce(address(guard), 0, hex"aabbcc", Enum.Operation.Call, nonce); // 3 bytes < 4
+    }
+
+    function test_checkTransaction_doesNotAutoAllowOtherSelectors() public {
+        // updateEpoch targets the guard but is not on the auto-allow whitelist.
+        bytes memory data = abi.encodeWithSelector(SafenetGuard.updateEpoch.selector);
+        uint256 nonce = safe.nonce();
+        vm.expectRevert(ISafenetGuard.AttestationNotFound.selector);
+        _execSafeTxWithNonce(address(guard), 0, data, Enum.Operation.Call, nonce);
+    }
+
+    // ============================================================
+    // ESCAPE HATCH — NONCE-FREE ANNOUNCEMENTS
+    // ============================================================
+
+    function test_announcement_passesAfterDelay() public {
+        _announce(_defaultAnnouncement());
+        vm.warp(block.timestamp + ALLOW_TX_DELAY_SECONDS);
+        _execSafeTx(TX_TO, TX_VALUE, TX_DATA, TX_OP, ExecMode.Direct); // must not revert
+    }
+
+    function test_announcement_revertsBeforeDelay() public {
+        _announce(_defaultAnnouncement());
+        uint256 nonce = safe.nonce();
+        vm.warp(block.timestamp + ALLOW_TX_DELAY_SECONDS - 1);
+        vm.expectRevert(ISafenetGuard.AttestationNotFound.selector);
+        _execSafeTxWithNonce(TX_TO, TX_VALUE, TX_DATA, TX_OP, nonce);
+    }
+
+    function test_announcement_consumedOnUse() public {
+        bytes32 h = _defaultAnnouncementHash();
+        _announce(_defaultAnnouncement());
+        vm.warp(block.timestamp + ALLOW_TX_DELAY_SECONDS);
+        _execSafeTx(TX_TO, TX_VALUE, TX_DATA, TX_OP, ExecMode.Direct);
+        assertEq(_announcedActiveFrom(h), 0);
+    }
+
+    function test_announcement_emitsExecutedViaAllowance() public {
+        bytes32 h = _defaultAnnouncementHash();
+        _announce(_defaultAnnouncement());
+        vm.warp(block.timestamp + ALLOW_TX_DELAY_SECONDS);
+        vm.expectEmit(true, true, false, false);
+        emit ISafenetGuard.AnnouncementConsumed(address(safe), h);
+        _execSafeTx(TX_TO, TX_VALUE, TX_DATA, TX_OP, ExecMode.Direct);
+    }
+
+    function test_announceTransaction_emitsEvent() public {
+        bytes32 h = _defaultAnnouncementHash();
+        uint256 expectedFrom = block.timestamp + ALLOW_TX_DELAY_SECONDS;
+        uint256 expectedUntil = expectedFrom + ALLOW_TX_WINDOW_SECONDS;
+        vm.expectEmit(true, true, false, true);
+        emit ISafenetGuard.TransactionAnnounced(address(safe), h, expectedFrom, expectedUntil);
+        _announce(_defaultAnnouncement());
+    }
+
+    function test_announceTransaction_revertsOnDuplicate() public {
+        _announce(_defaultAnnouncement());
+        uint256 nonce = safe.nonce();
+        bytes memory data = abi.encodeCall(SafenetGuard.announceTransaction, (_defaultAnnouncement()));
+        vm.expectRevert(TransactionAnnouncement.AnnouncementAlreadyExists.selector);
+        _execSafeTxWithNonce(address(guard), 0, data, Enum.Operation.Call, nonce);
+    }
+
+    function test_cancelAnnouncement_revertsIfNotPending() public {
+        bytes32 h = _defaultAnnouncementHash();
+        uint256 nonce = safe.nonce();
+        bytes memory data = abi.encodeCall(SafenetGuard.cancelAnnouncement, (h));
+        vm.expectRevert(TransactionAnnouncement.AnnouncementNotFound.selector);
+        _execSafeTxWithNonce(address(guard), 0, data, Enum.Operation.Call, nonce);
+    }
+
+    function test_cancelAnnouncement_externalCallerCannotCancelSafesAnnouncement() public {
+        bytes32 h = _defaultAnnouncementHash();
+        _announce(_defaultAnnouncement()); // registered under address(safe)
+        // An unrelated EOA calling the guard directly is keyed under its own address, so it finds no
+        // announcement and cannot touch the Safe's entry.
+        vm.expectRevert(TransactionAnnouncement.AnnouncementNotFound.selector);
+        vm.prank(other);
+        guard.cancelAnnouncement(h);
+        assertGt(_announcedActiveFrom(h), 0);
+    }
+
+    /// @notice Announcements are scoped by the executing Safe: a second Safe cannot consume another
+    ///         Safe's announcement even though the (nonce-free) announcement hash is identical.
+    function test_announcement_cannotBeConsumedByAnotherSafe() public {
+        // Safe A announces the default transaction.
+        bytes32 h = _defaultAnnouncementHash();
+        _announce(_defaultAnnouncement());
+
+        // A second guarded Safe B attempts the same-parameter transaction, unattested, after the delay.
+        ISafe safeB = _deploySafeWithGuard(1);
+        vm.warp(block.timestamp + ALLOW_TX_DELAY_SECONDS);
+        uint256 nonceB = safeB.nonce();
+        bytes32 txHashB = _safeTxHashFor(address(safeB), TX_TO, TX_VALUE, TX_DATA, TX_OP, nonceB);
+        bytes memory sigB = _signSafeTx(txHashB);
+        vm.expectRevert(ISafenetGuard.AttestationNotFound.selector);
+        safeB.execTransaction(TX_TO, TX_VALUE, TX_DATA, TX_OP, 0, 0, 0, address(0), payable(address(0)), sigB);
+
+        // Safe A's announcement is untouched.
+        assertGt(_announcedActiveFrom(h), 0);
+    }
+
+    /// @notice The core feature: an announcement survives unrelated transactions advancing the Safe
+    ///         nonce, then executes at whatever nonce is current — without any attestation.
+    function test_announcement_survivesNonceAdvanceAndExecutesNonceFree() public {
+        bytes32 h = _defaultAnnouncementHash();
+        _announce(_defaultAnnouncement());
+
+        // Other, unrelated attested transactions run and keep advancing the Safe nonce.
+        _execSafeTx(TX_TO, TX_VALUE, TX_DATA, TX_OP, ExecMode.Attested);
+        _execSafeTx(TX_TO, TX_VALUE, TX_DATA, TX_OP, ExecMode.Attested);
+
+        // After the delay, the announced transaction executes via the escape hatch at the current
+        // (much later) nonce — the nonce-bound version of this hatch could never have matched here.
+        vm.warp(block.timestamp + ALLOW_TX_DELAY_SECONDS);
+        _execSafeTx(TX_TO, TX_VALUE, TX_DATA, TX_OP, ExecMode.Direct); // must not revert
+        assertEq(_announcedActiveFrom(h), 0);
+    }
+
+    /// @notice An attested execution of a transaction whose params match a pending announcement takes
+    ///         the attestation path and must NOT consume the announcement.
+    function test_announcement_notConsumedByAttestedExecution() public {
+        bytes32 h = _defaultAnnouncementHash();
+        _announce(_defaultAnnouncement());
+        vm.warp(block.timestamp + ALLOW_TX_DELAY_SECONDS); // even matured...
+        _execSafeTx(TX_TO, TX_VALUE, TX_DATA, TX_OP, ExecMode.Attested); // ...attested path wins
+        assertGt(_announcedActiveFrom(h), 0);
+    }
+
+    /// @notice Cancellation is immediate: a cancelled announcement cannot execute even after the delay.
+    function test_announcement_cancelIsImmediateAndBlocksExecution() public {
+        bytes32 h = _defaultAnnouncementHash();
+        _announce(_defaultAnnouncement());
+        _cancelAnnouncement(h); // no warp — cancellation is not delayed
+        assertEq(_announcedActiveFrom(h), 0);
+
+        vm.warp(block.timestamp + ALLOW_TX_DELAY_SECONDS);
+        uint256 nonce = safe.nonce();
+        vm.expectRevert(ISafenetGuard.AttestationNotFound.selector);
+        _execSafeTxWithNonce(TX_TO, TX_VALUE, TX_DATA, TX_OP, nonce);
+    }
+
+    function test_integration_announcementFullFlow() public {
+        bytes32 h = _defaultAnnouncementHash();
+        _announce(_defaultAnnouncement());
+
+        // Before the delay: guard reverts, Safe propagates it, nonce unchanged.
+        uint256 nonce1 = safe.nonce();
+        vm.expectRevert(ISafenetGuard.AttestationNotFound.selector);
+        _execSafeTxWithNonce(TX_TO, TX_VALUE, TX_DATA, TX_OP, nonce1);
+
+        // After the delay: passes, consumes the announcement, nonce increments.
+        vm.warp(block.timestamp + ALLOW_TX_DELAY_SECONDS);
+        uint256 nonce2 = safe.nonce();
+        _execSafeTxWithNonce(TX_TO, TX_VALUE, TX_DATA, TX_OP, nonce2);
+        assertEq(_announcedActiveFrom(h), 0);
+
+        // Single-use: a subsequent identical transaction (no attestation) has no announcement → fails.
+        uint256 nonce3 = safe.nonce();
+        vm.expectRevert(ISafenetGuard.AttestationNotFound.selector);
+        _execSafeTxWithNonce(TX_TO, TX_VALUE, TX_DATA, TX_OP, nonce3);
+    }
+
+    // ============================================================
+    // ESCAPE HATCH — VALIDITY WINDOW (activeUntil)
+    // ============================================================
+
+    function test_getAnnouncementWindow_returnsBothBounds() public {
+        bytes32 h = _defaultAnnouncementHash();
+        uint256 at = block.timestamp; // announce happens at the current timestamp (no warp)
+        _announce(_defaultAnnouncement());
+        (uint256 activeFrom, uint256 activeUntil) = guard.getAnnouncementWindow(address(safe), h);
+        assertEq(activeFrom, at + ALLOW_TX_DELAY_SECONDS);
+        assertEq(activeUntil, at + ALLOW_TX_DELAY_SECONDS + ALLOW_TX_WINDOW_SECONDS);
+    }
+
+    /// @notice Executable at the exact end of the window (`activeUntil` is inclusive).
+    function test_announcement_executableAtWindowEnd() public {
+        _announce(_defaultAnnouncement());
+        vm.warp(block.timestamp + ALLOW_TX_DELAY_SECONDS + ALLOW_TX_WINDOW_SECONDS); // exactly activeUntil
+        _execSafeTx(TX_TO, TX_VALUE, TX_DATA, TX_OP, ExecMode.Direct); // must not revert
+    }
+
+    /// @notice The core of this feature: once `activeUntil` has passed the announcement is inert, so a
+    ///         stale critical transaction cannot be executed long after it was queued.
+    function test_announcement_revertsAfterWindowExpires() public {
+        bytes32 h = _defaultAnnouncementHash();
+        _announce(_defaultAnnouncement());
+        vm.warp(block.timestamp + ALLOW_TX_DELAY_SECONDS + ALLOW_TX_WINDOW_SECONDS + 1); // one second past activeUntil
+
+        // The entry is not auto-cleared: the stored window persists but is now expired.
+        (uint256 activeFrom, uint256 activeUntil) = guard.getAnnouncementWindow(address(safe), h);
+        assertGt(activeFrom, 0);
+        assertGt(block.timestamp, activeUntil);
+
+        uint256 nonce = safe.nonce();
+        vm.expectRevert(ISafenetGuard.AttestationNotFound.selector);
+        _execSafeTxWithNonce(TX_TO, TX_VALUE, TX_DATA, TX_OP, nonce);
+    }
+
+    /// @notice D-02: an expired announcement is renewable in place — re-announcing overwrites it with
+    ///         a fresh, full window, with no separate cancellation needed.
+    function test_announcement_expiredIsRenewableInPlace() public {
+        bytes32 h = _defaultAnnouncementHash();
+        _announce(_defaultAnnouncement());
+        (uint256 firstFrom,) = guard.getAnnouncementWindow(address(safe), h);
+
+        // Expire it, then re-announce without cancelling — must not revert.
+        vm.warp(block.timestamp + ALLOW_TX_DELAY_SECONDS + ALLOW_TX_WINDOW_SECONDS + 1);
+        _announce(_defaultAnnouncement());
+
+        (uint256 secondFrom, uint256 secondUntil) = guard.getAnnouncementWindow(address(safe), h);
+        assertGt(secondFrom, firstFrom); // fresh, later embargo
+        assertEq(secondUntil - secondFrom, ALLOW_TX_WINDOW_SECONDS); // full new window
+    }
+
+    /// @notice A pending or still-active announcement cannot be overwritten (only expired ones renew).
+    function test_announcement_activeCannotBeOverwritten() public {
+        _announce(_defaultAnnouncement());
+        vm.warp(block.timestamp + ALLOW_TX_DELAY_SECONDS); // matured, still within window
+
+        uint256 nonce = safe.nonce();
+        bytes memory data = abi.encodeCall(SafenetGuard.announceTransaction, (_defaultAnnouncement()));
+        vm.expectRevert(TransactionAnnouncement.AnnouncementAlreadyExists.selector);
+        _execSafeTxWithNonce(address(guard), 0, data, Enum.Operation.Call, nonce);
+    }
+
+    // ============================================================
+    // UPDATE EPOCH — FOREST SEMANTICS
+    // ============================================================
+
+    function test_updateEpoch_recordsNewPairAndAcceptsItsAttestation() public {
+        Secp256k1.Point memory newKey = _rollover(GENESIS_SK, GENESIS_NK, GENESIS_EPOCH, GENESIS_EPOCH + 1, EPOCH2_SK);
+        assertTrue(guard.isKnownEpoch(newKey, GENESIS_EPOCH + 1));
+        // A transaction attested by the new epoch's key now executes.
+        _execAttestedWith(GENESIS_EPOCH + 1, EPOCH2_SK, EPOCH2_NK);
+    }
+
+    function test_updateEpoch_keepsHistoricKeysValid() public {
+        // Roll forward to epoch 2, then attest with the *genesis* key — the forest never prunes, so
+        // it must still be accepted.
+        _rollover(GENESIS_SK, GENESIS_NK, GENESIS_EPOCH, GENESIS_EPOCH + 1, EPOCH2_SK);
+        _execAttestedWith(GENESIS_EPOCH, GENESIS_SK, GENESIS_NK); // must not revert
+    }
+
+    function test_updateEpoch_supportsForkedBranches() public {
+        // Two distinct rollovers from the same genesis parent to the same epoch number but different
+        // keys (a reorg fork). Both branches must be independently trusted.
+        Secp256k1.Point memory branchA = _rollover(GENESIS_SK, GENESIS_NK, GENESIS_EPOCH, GENESIS_EPOCH + 1, EPOCH2_SK);
+        Secp256k1.Point memory branchB = _rollover(GENESIS_SK, GENESIS_NK, GENESIS_EPOCH, GENESIS_EPOCH + 1, FORK_SK);
+
+        assertTrue(guard.isKnownEpoch(branchA, GENESIS_EPOCH + 1));
+        assertTrue(guard.isKnownEpoch(branchB, GENESIS_EPOCH + 1));
+        _execAttestedWith(GENESIS_EPOCH + 1, EPOCH2_SK, EPOCH2_NK);
+        _execAttestedWith(GENESIS_EPOCH + 1, FORK_SK, FORK_NK);
+    }
+
+    function test_updateEpoch_skippedEpochNeverBecomesTrusted() public {
+        // Jump genesis (1) → 3, skipping 2. Epoch 2 was never recorded, so an attestation naming any
+        // key at epoch 2 is rejected.
+        _rollover(GENESIS_SK, GENESIS_NK, GENESIS_EPOCH, GENESIS_EPOCH + 2, EPOCH2_SK);
+        uint256 nonce = safe.nonce();
+        bytes32 txHash = _safeTxHash(TX_TO, TX_VALUE, TX_DATA, TX_OP, nonce);
+        bytes memory combined =
+            bytes.concat(_signSafeTx(txHash), _buildInlineAttestation(txHash, GENESIS_EPOCH + 1, EPOCH2_SK, EPOCH2_NK));
+        vm.expectRevert(ISafenetGuard.UntrustedAttestationKey.selector);
+        safe.execTransaction(TX_TO, TX_VALUE, TX_DATA, TX_OP, 0, 0, 0, address(0), payable(address(0)), combined);
+    }
+
+    function test_updateEpoch_revertsUnknownParent() public {
+        // Parent pair (unknown key at genesis epoch) was never recorded.
+        Secp256k1.Point memory unknownParent = ForgeSecp256k1.g(UNKNOWN_SK).toPoint();
+        Secp256k1.Point memory newKey = ForgeSecp256k1.g(EPOCH2_SK).toPoint();
+        bytes32 message = ConsensusMessages.epochRollover(
+            guard.getConsensusDomainSeparator(), GENESIS_EPOCH, GENESIS_EPOCH + 1, ROLLOVER_BLOCK, newKey
+        );
+        FROST.Signature memory sig = _frostSign(UNKNOWN_SK, UNKNOWN_NK, message);
+        vm.expectRevert(EpochRollover.UnknownParent.selector);
+        guard.updateEpoch(unknownParent, GENESIS_EPOCH, GENESIS_EPOCH + 1, ROLLOVER_BLOCK, newKey, sig);
+    }
+
+    function test_updateEpoch_revertsWhenNotAdvancing() public {
+        Secp256k1.Point memory parentKey = ForgeSecp256k1.g(GENESIS_SK).toPoint();
+        Secp256k1.Point memory newKey = ForgeSecp256k1.g(EPOCH2_SK).toPoint();
+        // proposedEpoch == parentEpoch (not strictly greater).
+        bytes32 message = ConsensusMessages.epochRollover(
+            guard.getConsensusDomainSeparator(), GENESIS_EPOCH, GENESIS_EPOCH, ROLLOVER_BLOCK, newKey
+        );
+        FROST.Signature memory sig = _frostSign(GENESIS_SK, GENESIS_NK, message);
+        vm.expectRevert(EpochRollover.EpochNotAdvancing.selector);
+        guard.updateEpoch(parentKey, GENESIS_EPOCH, GENESIS_EPOCH, ROLLOVER_BLOCK, newKey, sig);
+    }
+
+    function test_updateEpoch_revertsOnInvalidNewKey() public {
+        Secp256k1.Point memory parentKey = ForgeSecp256k1.g(GENESIS_SK).toPoint();
+        FROST.Signature memory dummySig = FROST.Signature({r: ForgeSecp256k1.g(GENESIS_NK).toPoint(), z: 1});
+        // Known parent + advancing epoch, but a zero new key → requireNonZero reverts before verify.
+        vm.expectRevert(Secp256k1.NotOnCurve.selector);
+        guard.updateEpoch(
+            parentKey, GENESIS_EPOCH, GENESIS_EPOCH + 1, ROLLOVER_BLOCK, Secp256k1.Point({x: 0, y: 0}), dummySig
+        );
+    }
+
+    function test_updateEpoch_isPermissionless() public {
+        Secp256k1.Point memory parentKey = ForgeSecp256k1.g(GENESIS_SK).toPoint();
+        Secp256k1.Point memory newKey = ForgeSecp256k1.g(EPOCH2_SK).toPoint();
+        bytes32 message = ConsensusMessages.epochRollover(
+            guard.getConsensusDomainSeparator(), GENESIS_EPOCH, GENESIS_EPOCH + 1, ROLLOVER_BLOCK, newKey
+        );
+        FROST.Signature memory sig = _frostSign(GENESIS_SK, GENESIS_NK, message);
+        vm.prank(other); // an arbitrary caller holding the rollover signature
+        guard.updateEpoch(parentKey, GENESIS_EPOCH, GENESIS_EPOCH + 1, ROLLOVER_BLOCK, newKey, sig);
+        assertTrue(guard.isKnownEpoch(newKey, GENESIS_EPOCH + 1));
+    }
+
+    function test_updateEpoch_emitsRolledOver() public {
+        Secp256k1.Point memory parentKey = ForgeSecp256k1.g(GENESIS_SK).toPoint();
+        Secp256k1.Point memory newKey = ForgeSecp256k1.g(EPOCH2_SK).toPoint();
+        bytes32 message = ConsensusMessages.epochRollover(
+            guard.getConsensusDomainSeparator(), GENESIS_EPOCH, GENESIS_EPOCH + 1, ROLLOVER_BLOCK, newKey
+        );
+        FROST.Signature memory sig = _frostSign(GENESIS_SK, GENESIS_NK, message);
+        vm.expectEmit(true, true, false, true);
+        emit EpochRollover.EpochRolledOver(GENESIS_EPOCH, GENESIS_EPOCH + 1, parentKey, newKey);
+        guard.updateEpoch(parentKey, GENESIS_EPOCH, GENESIS_EPOCH + 1, ROLLOVER_BLOCK, newKey, sig);
+    }
+
+    function test_integration_updateEpoch_revertsWithTamperedSignature() public {
+        Secp256k1.Point memory parentKey = ForgeSecp256k1.g(GENESIS_SK).toPoint();
+        Secp256k1.Point memory newKey = ForgeSecp256k1.g(EPOCH2_SK).toPoint();
+        bytes32 message = ConsensusMessages.epochRollover(
+            guard.getConsensusDomainSeparator(), GENESIS_EPOCH, GENESIS_EPOCH + 1, ROLLOVER_BLOCK, newKey
+        );
+        FROST.Signature memory sig = _frostSign(GENESIS_SK, GENESIS_NK, message);
+        sig.z = addmod(sig.z, 1, Secp256k1.N); // tamper
+        vm.expectRevert(Secp256k1.InvalidMulMulAddWitness.selector);
+        guard.updateEpoch(parentKey, GENESIS_EPOCH, GENESIS_EPOCH + 1, ROLLOVER_BLOCK, newKey, sig);
+    }
+
+    // ============================================================
+    // ATTESTATION TRAILER DECODING
+    // ============================================================
+
+    function test_trailer_noMagicTreatedAsAbsent() public {
+        // A trailing word without the magic prefix is not a trailer → falls through → no announcement.
+        uint256 nonce = safe.nonce();
+        bytes32 txHash = _safeTxHash(TX_TO, TX_VALUE, TX_DATA, TX_OP, nonce);
+        bytes memory combined = bytes.concat(_signSafeTx(txHash), bytes32(0));
+        vm.expectRevert(ISafenetGuard.AttestationNotFound.selector);
+        safe.execTransaction(TX_TO, TX_VALUE, TX_DATA, TX_OP, 0, 0, 0, address(0), payable(address(0)), combined);
+    }
+
+    /// @notice A valid signature blob whose final word merely equals 192 (the old length framing) is
+    ///         not mistaken for a trailer under magic framing.
+    function test_trailer_signatureEndingIn192TreatedAsAbsent() public {
+        uint256 nonce = safe.nonce();
+        bytes32 txHash = _safeTxHash(TX_TO, TX_VALUE, TX_DATA, TX_OP, nonce);
+        bytes memory combined = bytes.concat(_signSafeTx(txHash), bytes32(uint256(192)));
+        vm.expectRevert(ISafenetGuard.AttestationNotFound.selector);
+        safe.execTransaction(TX_TO, TX_VALUE, TX_DATA, TX_OP, 0, 0, 0, address(0), payable(address(0)), combined);
+    }
+
+    /// @notice A recognised v1 magic with a too-short blob reverts as malformed (no announcement fallback).
+    function test_trailer_malformedTruncatedReverts() public {
+        uint256 nonce = safe.nonce();
+        bytes32 txHash = _safeTxHash(TX_TO, TX_VALUE, TX_DATA, TX_OP, nonce);
+        // 65-byte owner sig + 32-byte v1 tag = 97 bytes < 224 required.
+        bytes memory combined = bytes.concat(_signSafeTx(txHash), AttestationTrailer.TYPE_HASH);
+        vm.expectRevert(AttestationTrailer.MalformedAttestationTrailer.selector);
+        safe.execTransaction(TX_TO, TX_VALUE, TX_DATA, TX_OP, 0, 0, 0, address(0), payable(address(0)), combined);
+    }
+
+    // ============================================================
+    // SIGNATURE ENCODINGS — REAL SAFE, MULTIPLE OWNER TYPES
+    // ============================================================
+
+    function test_checkTransaction_twoOfThreePassesWithAttestation() public {
+        uint256 keyA = 0xB2;
+        uint256 keyB = 0xC3;
+        uint256 keyC = 0xA1;
+
+        // Owner order is irrelevant to `Safe.setup`, and `_sign2of3` orders the two signatures Safe
+        // verifies, so no sorting is needed here.
+        address[] memory owners = new address[](3);
+        owners[0] = vm.addr(keyA);
+        owners[1] = vm.addr(keyB);
+        owners[2] = vm.addr(keyC);
+
+        bytes memory initializer = abi.encodeCall(
+            Safe.setup, (owners, 2, address(0), bytes(""), address(0), address(0), 0, payable(address(0)))
+        );
+        ISafe safe2 = ISafe(payable(address(factory.createProxyWithNonce(address(singleton), initializer, 1))));
+
+        // Install the guard using two owners (no guard active yet — direct execution).
+        bytes memory guardData = abi.encodeCall(IGuardManager.setGuard, (address(guard)));
+        bytes32 setupHash = _safeTxHashFor(address(safe2), address(safe2), 0, guardData, Enum.Operation.Call, 0);
+        safe2.execTransaction(
+            address(safe2),
+            0,
+            guardData,
+            Enum.Operation.Call,
+            0,
+            0,
+            0,
+            address(0),
+            payable(address(0)),
+            _sign2of3(setupHash, keyA, keyB)
+        );
+
+        // Execute an attested transaction through the 2-of-3 Safe.
+        bytes32 txHash = _safeTxHashFor(address(safe2), TX_TO, TX_VALUE, TX_DATA, TX_OP, safe2.nonce());
+        bytes memory combined = bytes.concat(
+            _sign2of3(txHash, keyA, keyB), _buildInlineAttestation(txHash, GENESIS_EPOCH, GENESIS_SK, GENESIS_NK)
+        );
+        safe2.execTransaction(TX_TO, TX_VALUE, TX_DATA, TX_OP, 0, 0, 0, address(0), payable(address(0)), combined);
+    }
+
+    function test_checkTransaction_approvedHashPassesWithAttestation() public {
+        uint256 nonce = safe.nonce();
+        bytes32 txHash = _safeTxHash(TX_TO, TX_VALUE, TX_DATA, TX_OP, nonce);
+        // v=1 approved-hash encoding: r=owner address, s=0, v=1. Safe accepts it when executor == owner.
+        bytes memory v1sig = abi.encodePacked(bytes32(uint256(uint160(vm.addr(ownerKey)))), bytes32(0), uint8(1));
+        bytes memory combined =
+            bytes.concat(v1sig, _buildInlineAttestation(txHash, GENESIS_EPOCH, GENESIS_SK, GENESIS_NK));
+        vm.prank(vm.addr(ownerKey));
+        safe.execTransaction(TX_TO, TX_VALUE, TX_DATA, TX_OP, 0, 0, 0, address(0), payable(address(0)), combined);
+    }
+
+    function test_checkTransaction_contractSignaturePassesWithAttestation() public {
+        // A 1-of-1 Safe whose sole owner is an ERC-1271 contract.
+        MockERC1271 mock = new MockERC1271();
+        address[] memory owners = new address[](1);
+        owners[0] = address(mock);
+
+        bytes memory initializer = abi.encodeCall(
+            Safe.setup, (owners, 1, address(0), bytes(""), address(0), address(0), 0, payable(address(0)))
+        );
+        ISafe safe2 = ISafe(payable(address(factory.createProxyWithNonce(address(singleton), initializer, 1))));
+
+        // v=0 contract signature (97 bytes): r=owner, s=offset(65), v=0, then a zero-length payload.
+        bytes memory contractSig =
+            abi.encodePacked(bytes32(uint256(uint160(address(mock)))), bytes32(uint256(65)), uint8(0), bytes32(0));
+
+        bytes memory guardData = abi.encodeCall(IGuardManager.setGuard, (address(guard)));
+        safe2.execTransaction(
+            address(safe2), 0, guardData, Enum.Operation.Call, 0, 0, 0, address(0), payable(address(0)), contractSig
+        );
+
+        bytes32 txHash = _safeTxHashFor(address(safe2), TX_TO, TX_VALUE, TX_DATA, TX_OP, safe2.nonce());
+        bytes memory combined =
+            bytes.concat(contractSig, _buildInlineAttestation(txHash, GENESIS_EPOCH, GENESIS_SK, GENESIS_NK));
+        safe2.execTransaction(TX_TO, TX_VALUE, TX_DATA, TX_OP, 0, 0, 0, address(0), payable(address(0)), combined);
+    }
+
+    /// @notice Attested execution with non-default gas/refund fields (which the default helpers leave
+    ///         zero) — guards against a future arg-order regression in the guard's hash reconstruction.
+    function test_checkTransaction_attestedWithNonDefaultGasFields() public {
+        uint256 safeTxGas = 50_000;
+        uint256 baseGas = 21_000;
+        address refundReceiver = address(0xFEE); // harmless with gasPrice == 0 (no refund transfer)
+        uint256 nonce = safe.nonce();
+        bytes32 txHash = SafeTransaction.hash(
+            SafeTransaction.T({
+                chainId: block.chainid,
+                safe: address(safe),
+                to: TX_TO,
+                value: TX_VALUE,
+                data: TX_DATA,
+                operation: SafeTransaction.Operation(uint8(TX_OP)),
+                safeTxGas: safeTxGas,
+                baseGas: baseGas,
+                gasPrice: 0,
+                gasToken: address(0),
+                refundReceiver: refundReceiver,
+                nonce: nonce
+            })
+        );
+        bytes memory combined =
+            bytes.concat(_signSafeTx(txHash), _buildInlineAttestation(txHash, GENESIS_EPOCH, GENESIS_SK, GENESIS_NK));
+        safe.execTransaction(
+            TX_TO, TX_VALUE, TX_DATA, TX_OP, safeTxGas, baseGas, 0, address(0), payable(refundReceiver), combined
+        ); // must not revert
+    }
+
+    /// @notice A single threshold Safe combining an ECDSA owner, a `v=1` approved-hash owner, and an
+    ///         ERC-1271 owner with a non-empty dynamic payload — with the attestation trailer appended
+    ///         after that dynamic payload. Exercises the trailer alongside overlapping exotic encodings.
+    function test_checkTransaction_mixedOwnerEncodingsWithTrailer() public {
+        uint256 keyA = 0xA1;
+        uint256 keyB = 0xB2;
+        MockERC1271 mock = new MockERC1271();
+
+        address[] memory owners = new address[](3);
+        owners[0] = vm.addr(keyA);
+        owners[1] = vm.addr(keyB);
+        owners[2] = address(mock);
+        bytes memory initializer = abi.encodeCall(
+            Safe.setup, (owners, 3, address(0), bytes(""), address(0), address(0), 0, payable(address(0)))
+        );
+        ISafe safe3 = ISafe(payable(address(factory.createProxyWithNonce(address(singleton), initializer, 2))));
+
+        // Install the guard (no guard active yet — three-owner direct execution).
+        bytes memory guardData = abi.encodeCall(IGuardManager.setGuard, (address(guard)));
+        bytes32 setupHash = _safeTxHashFor(address(safe3), address(safe3), 0, guardData, Enum.Operation.Call, 0);
+        safe3.execTransaction(
+            address(safe3),
+            0,
+            guardData,
+            Enum.Operation.Call,
+            0,
+            0,
+            0,
+            address(0),
+            payable(address(0)),
+            _mixedOwnerSig(safe3, setupHash, keyA, keyB, address(mock))
+        );
+
+        // Attested execution: mixed 3-owner signature + trailer.
+        bytes32 txHash = _safeTxHashFor(address(safe3), TX_TO, TX_VALUE, TX_DATA, TX_OP, safe3.nonce());
+        bytes memory combined = bytes.concat(
+            _mixedOwnerSig(safe3, txHash, keyA, keyB, address(mock)),
+            _buildInlineAttestation(txHash, GENESIS_EPOCH, GENESIS_SK, GENESIS_NK)
+        );
+        safe3.execTransaction(TX_TO, TX_VALUE, TX_DATA, TX_OP, 0, 0, 0, address(0), payable(address(0)), combined);
+    }
+
+    // ============================================================
+    // ERC-165
+    // ============================================================
+
+    function test_supportsInterface() public view {
+        assertTrue(guard.supportsInterface(type(ISafenetGuard).interfaceId));
+        assertTrue(guard.supportsInterface(type(ITransactionGuard).interfaceId)); // 0xe6d7a83a
+        assertTrue(guard.supportsInterface(0x01ffc9a7)); // ERC-165
+        assertFalse(guard.supportsInterface(0xffffffff)); // ERC-165 requires false
+        assertFalse(guard.supportsInterface(0xdeadbeef));
+    }
+
+    // ============================================================
+    // SCOPE PREMISE — NO MODULES
+    // ============================================================
+
+    /// @notice This guard is transaction-guard only; the test Safe must have no modules enabled, so the
+    ///         suite genuinely reflects the "modules out of scope" security premise (see DD / F-05).
+    function test_setup_noModulesEnabled() public view {
+        (address[] memory modules,) = Safe(payable(address(safe))).getModulesPaginated(address(0x1), 10);
+        assertEq(modules.length, 0);
+    }
+
+    // ============================================================
+    // CONSTRUCTOR TIMING BOUNDS (L-01 / F-02)
+    // ============================================================
+
+    /// @notice The constructor rejects durations above `uint64.max`, so a guard whose escape hatch
+    ///         could never be used (window would overflow the packed `uint128`) cannot be deployed.
+    function test_constructor_revertsOnOversizedDelay() public {
+        Secp256k1.Point memory key = ForgeSecp256k1.g(GENESIS_SK).toPoint();
+        vm.expectRevert(ISafenetGuard.InvalidParameter.selector);
+        new SafenetGuard(
+            CONSENSUS_CHAIN_ID,
+            CONSENSUS_ADDR,
+            GENESIS_EPOCH,
+            key,
+            uint256(type(uint64).max) + 1,
+            ALLOW_TX_WINDOW_SECONDS
+        );
+    }
+
+    function test_constructor_revertsOnOversizedWindow() public {
+        Secp256k1.Point memory key = ForgeSecp256k1.g(GENESIS_SK).toPoint();
+        vm.expectRevert(ISafenetGuard.InvalidParameter.selector);
+        new SafenetGuard(
+            CONSENSUS_CHAIN_ID,
+            CONSENSUS_ADDR,
+            GENESIS_EPOCH,
+            key,
+            ALLOW_TX_DELAY_SECONDS,
+            uint256(type(uint64).max) + 1
+        );
+    }
+
+    function test_constructor_acceptsMaxUint64Timing() public {
+        Secp256k1.Point memory key = ForgeSecp256k1.g(GENESIS_SK).toPoint();
+        // Boundary: exactly uint64.max for both is accepted.
+        new SafenetGuard(CONSENSUS_CHAIN_ID, CONSENSUS_ADDR, GENESIS_EPOCH, key, type(uint64).max, type(uint64).max);
+    }
+
+    // ============================================================
+    // FOREST TRUST ASSUMPTION (F-01)
+    // ============================================================
+
+    /// @notice Documents the accepted policy: a historical key attests newly created future
+    ///         transactions, not only replays of historical ones.
+    function test_forest_historicalKeySignsFutureTransaction() public {
+        _rollover(GENESIS_SK, GENESIS_NK, GENESIS_EPOCH, GENESIS_EPOCH + 1, EPOCH2_SK);
+        _rollover(EPOCH2_SK, EPOCH2_NK, GENESIS_EPOCH + 1, GENESIS_EPOCH + 2, FORK_SK);
+        // The genesis key still attests a brand-new transaction at the current nonce.
+        _execAttestedWith(GENESIS_EPOCH, GENESIS_SK, GENESIS_NK); // must not revert
+    }
+
+    /// @notice Documents the accepted policy: a historical parent can sign a brand-new far-future
+    ///         rollover branch, which is then usable for attestation.
+    function test_forest_historicalParentCreatesFutureBranch() public {
+        _rollover(GENESIS_SK, GENESIS_NK, GENESIS_EPOCH, GENESIS_EPOCH + 1, EPOCH2_SK);
+        Secp256k1.Point memory branchKey = _rollover(GENESIS_SK, GENESIS_NK, GENESIS_EPOCH, 1000, UNKNOWN_SK);
+        assertTrue(guard.isKnownEpoch(branchKey, 1000));
+        _execAttestedWith(1000, UNKNOWN_SK, UNKNOWN_NK); // must not revert
+    }
+
+    // ============================================================
+    // ANNOUNCEMENT CONSUMPTION vs EXECUTION SUCCESS (F-03)
+    // ============================================================
+
+    /// @notice Documented F-03 behavior: with non-zero `safeTxGas`, Safe catches an inner-call failure
+    ///         and returns `false`, yet the announcement is still consumed (spent on the attempt).
+    function test_announcement_consumedEvenWhenInnerCallFails() public {
+        Reverter reverter = new Reverter();
+        uint256 safeTxGas = 100_000;
+        TransactionAnnouncement.AnnouncedTransaction memory t = _announcementFor(address(reverter), "", safeTxGas);
+        bytes32 h = guard.getAnnouncementHash(t);
+        _announce(t);
+        vm.warp(block.timestamp + ALLOW_TX_DELAY_SECONDS);
+
+        uint256 nonce = safe.nonce();
+        bytes32 txHash = SafeTransaction.hash(
+            SafeTransaction.T({
+                chainId: block.chainid,
+                safe: address(safe),
+                to: address(reverter),
+                value: 0,
+                data: "",
+                operation: SafeTransaction.Operation(uint8(Enum.Operation.Call)),
+                safeTxGas: safeTxGas,
+                baseGas: 0,
+                gasPrice: 0,
+                gasToken: address(0),
+                refundReceiver: address(0),
+                nonce: nonce
+            })
+        );
+        bool ok = safe.execTransaction(
+            address(reverter),
+            0,
+            "",
+            Enum.Operation.Call,
+            safeTxGas,
+            0,
+            0,
+            address(0),
+            payable(address(0)),
+            _signSafeTx(txHash)
+        );
+        assertFalse(ok); // inner revert caught because safeTxGas != 0
+        (uint256 af,) = guard.getAnnouncementWindow(address(safe), h);
+        assertEq(af, 0); // consumed despite failure
+    }
+
+    /// @notice Control: with all-zero gas params, an inner revert bubbles and the whole call reverts,
+    ///         so the consumption is rolled back and the announcement survives.
+    function test_announcement_zeroGasInnerRevertRollsBackConsumption() public {
+        Reverter reverter = new Reverter();
+        TransactionAnnouncement.AnnouncedTransaction memory t = _announcementFor(address(reverter), "", 0);
+        bytes32 h = guard.getAnnouncementHash(t);
+        _announce(t);
+        vm.warp(block.timestamp + ALLOW_TX_DELAY_SECONDS);
+
+        uint256 nonce = safe.nonce();
+        bytes32 txHash = _safeTxHash(address(reverter), 0, "", Enum.Operation.Call, nonce);
+        vm.expectRevert();
+        safe.execTransaction(
+            address(reverter), 0, "", Enum.Operation.Call, 0, 0, 0, address(0), payable(address(0)), _signSafeTx(txHash)
+        );
+
+        (uint256 af,) = guard.getAnnouncementWindow(address(safe), h);
+        assertGt(af, 0); // consumption rolled back with the revert
+    }
+
+    /// @notice One announcement authorises at most one execution: a target that reenters the Safe with
+    ///         an identical-parameter transaction at the next nonce cannot reuse the (already deleted)
+    ///         announcement.
+    function test_announcement_singleUseUnderReentrancy() public {
+        Reenterer reenterer = new Reenterer();
+        TransactionAnnouncement.AnnouncedTransaction memory t = _announcementFor(address(reenterer), "", 0);
+        bytes32 h = guard.getAnnouncementHash(t);
+        _announce(t);
+        vm.warp(block.timestamp + ALLOW_TX_DELAY_SECONDS);
+
+        uint256 outerNonce = safe.nonce();
+        // Reentrant call reuses identical params at the next nonce (the nonce active at reentry).
+        bytes32 reentHash =
+            _safeTxHashFor(address(safe), address(reenterer), 0, "", Enum.Operation.Call, outerNonce + 1);
+        bytes memory reentData = abi.encodeCall(
+            ISafe.execTransaction,
+            (
+                address(reenterer),
+                0,
+                "",
+                Enum.Operation.Call,
+                0,
+                0,
+                0,
+                address(0),
+                payable(address(0)),
+                _signSafeTx(reentHash)
+            )
+        );
+        reenterer.configure(safe, reentData);
+
+        bytes32 outerHash = _safeTxHashFor(address(safe), address(reenterer), 0, "", Enum.Operation.Call, outerNonce);
+        safe.execTransaction(
+            address(reenterer),
+            0,
+            "",
+            Enum.Operation.Call,
+            0,
+            0,
+            0,
+            address(0),
+            payable(address(0)),
+            _signSafeTx(outerHash)
+        );
+
+        assertTrue(reenterer.attempted());
+        assertFalse(reenterer.reentrantSucceeded()); // second use blocked by the guard
+        (uint256 af,) = guard.getAnnouncementWindow(address(safe), h);
+        assertEq(af, 0); // consumed exactly once
+    }
+
+    // ============================================================
+    // AUTO-ALLOW SELECTOR SENTINEL (D-04)
+    // ============================================================
+
+    function test_autoAllowSelectorsAreNonZero() public pure {
+        assertTrue(SafenetGuard.announceTransaction.selector != bytes4(0));
+        assertTrue(SafenetGuard.cancelAnnouncement.selector != bytes4(0));
+    }
+
+    // ============================================================
+    // HELPERS FOR ALTERNATE SAFES
+    // ============================================================
+
+    /// @dev Safe EIP-712 tx hash for an arbitrary Safe address (the default helpers assume `safe`).
+    function _safeTxHashFor(
+        address safeAddr,
+        address to,
+        uint256 value,
+        bytes memory data,
+        Enum.Operation op,
+        uint256 nonce
+    ) internal view returns (bytes32) {
+        return SafeTransaction.hash(
+            SafeTransaction.T({
+                chainId: block.chainid,
+                safe: safeAddr,
+                to: to,
+                value: value,
+                data: data,
+                operation: SafeTransaction.Operation(uint8(op)),
+                safeTxGas: 0,
+                baseGas: 0,
+                gasPrice: 0,
+                gasToken: address(0),
+                refundReceiver: address(0),
+                nonce: nonce
+            })
+        );
+    }
+
+    /// @dev Two 65-byte ECDSA blocks sorted in ascending address order, as Safe requires.
+    function _sign2of3(bytes32 txHash, uint256 keyA, uint256 keyB) internal pure returns (bytes memory) {
+        if (vm.addr(keyA) > vm.addr(keyB)) (keyA, keyB) = (keyB, keyA);
+        (uint8 v1, bytes32 r1, bytes32 s1) = vm.sign(keyA, txHash);
+        (uint8 v2, bytes32 r2, bytes32 s2) = vm.sign(keyB, txHash);
+        return abi.encodePacked(r1, s1, v1, r2, s2, v2);
+    }
+
+    /// @dev A Safe `signatures` blob for a 3-of-3 Safe over `txHash` combining an ECDSA owner (`keyA`),
+    ///      a `v=1` approved-hash owner (`keyB`, pre-approved here), and a `v=0` ERC-1271 contract owner
+    ///      (`mock`) with a non-empty dynamic payload. Static slots are sorted by owner address; the
+    ///      contract slot's `s` points at the dynamic section that follows all three static slots.
+    function _mixedOwnerSig(ISafe s, bytes32 txHash, uint256 keyA, uint256 keyB, address mock)
+        internal
+        returns (bytes memory)
+    {
+        vm.prank(vm.addr(keyB));
+        s.approveHash(txHash); // authorises the v=1 slot without needing the executor to be the owner
+
+        (uint8 vA, bytes32 rA, bytes32 sA) = vm.sign(keyA, txHash);
+        address[] memory ownerAddrs = new address[](3);
+        bytes[] memory slots = new bytes[](3);
+        ownerAddrs[0] = vm.addr(keyA);
+        slots[0] = abi.encodePacked(rA, sA, vA);
+        ownerAddrs[1] = vm.addr(keyB);
+        slots[1] = abi.encodePacked(bytes32(uint256(uint160(vm.addr(keyB)))), bytes32(0), uint8(1));
+        ownerAddrs[2] = mock;
+        // Contract slot: r = owner, s = offset to the dynamic section (3 static slots = 195 bytes), v = 0.
+        slots[2] = abi.encodePacked(bytes32(uint256(uint160(mock))), bytes32(uint256(195)), uint8(0));
+
+        // Sort (owner, slot) pairs ascending by owner address — Safe requires ordered signatures.
+        for (uint256 i = 0; i < 3; i++) {
+            for (uint256 j = i + 1; j < 3; j++) {
+                if (ownerAddrs[j] < ownerAddrs[i]) {
+                    (ownerAddrs[i], ownerAddrs[j]) = (ownerAddrs[j], ownerAddrs[i]);
+                    (slots[i], slots[j]) = (slots[j], slots[i]);
+                }
+            }
+        }
+
+        // [static A|B|C][dynamic: 32-byte length + non-empty payload]; MockERC1271 ignores the content.
+        bytes memory dynamicPart = abi.encodePacked(bytes32(uint256(32)), bytes32(uint256(0xC0FFEE)));
+        return bytes.concat(slots[0], slots[1], slots[2], dynamicPart);
+    }
+
+    /// @dev Deploys a fresh 1-of-1 Safe owned by `ownerKey` with this guard installed.
+    function _deploySafeWithGuard(uint256 saltNonce) internal returns (ISafe s) {
+        address[] memory owners = new address[](1);
+        owners[0] = vm.addr(ownerKey);
+        bytes memory initializer = abi.encodeCall(
+            Safe.setup, (owners, 1, address(0), bytes(""), address(0), address(0), 0, payable(address(0)))
+        );
+        s = ISafe(payable(address(factory.createProxyWithNonce(address(singleton), initializer, saltNonce))));
+
+        bytes memory guardData = abi.encodeCall(IGuardManager.setGuard, (address(guard)));
+        bytes32 setupHash = _safeTxHashFor(address(s), address(s), 0, guardData, Enum.Operation.Call, 0);
+        s.execTransaction(
+            address(s),
+            0,
+            guardData,
+            Enum.Operation.Call,
+            0,
+            0,
+            0,
+            address(0),
+            payable(address(0)),
+            _signSafeTx(setupHash)
+        );
+    }
+}
+
+/// @dev A target that always reverts, for exercising Safe's caught-failure path.
+contract Reverter {
+    fallback() external {
+        revert("Reverter");
+    }
+}
+
+/// @dev A target that, when called, reenters the Safe once with a pre-configured `execTransaction`
+///      call and records whether that reentrant call succeeded.
+contract Reenterer {
+    ISafe public safe;
+    bytes public reentryData;
+    bool public attempted;
+    bool public reentrantSucceeded;
+
+    function configure(ISafe safe_, bytes calldata reentryData_) external {
+        safe = safe_;
+        reentryData = reentryData_;
+    }
+
+    fallback() external {
+        attempted = true;
+        (bool ok,) = address(safe).call(reentryData);
+        reentrantSucceeded = ok;
+    }
+}

--- a/contracts/test/libraries/TransactionAnnouncement.t.sol
+++ b/contracts/test/libraries/TransactionAnnouncement.t.sol
@@ -1,0 +1,96 @@
+// SPDX-License-Identifier: GPL-3.0-only
+pragma solidity ^0.8.30;
+
+import {Test} from "@forge-std/Test.sol";
+import {TransactionAnnouncement} from "@/libraries/TransactionAnnouncement.sol";
+
+/**
+ * @title TransactionAnnouncementTest
+ * @notice Unit tests for the `TransactionAnnouncement` state library, exercised on this contract's own
+ *         storage. Reverting paths go through external `this.call*` wrappers (an internal library revert
+ *         is at the cheatcode's own call depth, which `vm.expectRevert` cannot observe). Covers the
+ *         paths the guard no longer reaches after bounding its constructor timing (notably
+ *         `WindowOverflow`), plus the core announce/consume/cancel/renewal lifecycle.
+ */
+contract TransactionAnnouncementTest is Test {
+    using TransactionAnnouncement for TransactionAnnouncement.T;
+
+    TransactionAnnouncement.T internal state;
+
+    address internal constant SAFE = address(0x5AFE);
+    bytes32 internal constant ID = keccak256("announcement-id");
+    uint256 internal constant DELAY = 1 days;
+    uint256 internal constant WINDOW = 3 days;
+
+    // External wrappers so `vm.expectRevert` can observe library reverts at a lower call depth.
+    function callAnnounce(address safe, bytes32 id, uint256 delay, uint256 window) external {
+        state.announce(safe, id, delay, window);
+    }
+
+    function callCancel(address safe, bytes32 id) external {
+        state.cancel(safe, id);
+    }
+
+    function test_announce_setsWindow() public {
+        uint256 t0 = block.timestamp;
+        (uint256 activeFrom, uint256 activeUntil) = state.announce(SAFE, ID, DELAY, WINDOW);
+        assertEq(activeFrom, t0 + DELAY);
+        assertEq(activeUntil, t0 + DELAY + WINDOW);
+        (uint256 storedFrom, uint256 storedUntil) = state.windowOf(SAFE, ID);
+        assertEq(storedFrom, activeFrom);
+        assertEq(storedUntil, activeUntil);
+    }
+
+    function test_announce_revertsWhilePendingOrActive() public {
+        state.announce(SAFE, ID, DELAY, WINDOW);
+        vm.expectRevert(TransactionAnnouncement.AnnouncementAlreadyExists.selector);
+        this.callAnnounce(SAFE, ID, DELAY, WINDOW);
+    }
+
+    function test_announce_renewsExpired() public {
+        state.announce(SAFE, ID, DELAY, WINDOW);
+        vm.warp(block.timestamp + DELAY + WINDOW + 1); // expire
+        (uint256 activeFrom,) = state.announce(SAFE, ID, DELAY, WINDOW); // must not revert
+        assertEq(activeFrom, block.timestamp + DELAY);
+    }
+
+    function test_announce_revertsOnWindowOverflow() public {
+        // delay fits uint256 (no checked-add panic) but pushes activeUntil past uint128.
+        vm.expectRevert(TransactionAnnouncement.WindowOverflow.selector);
+        this.callAnnounce(SAFE, ID, uint256(1) << 128, 0);
+    }
+
+    function test_consume_onlyWithinWindow() public {
+        state.announce(SAFE, ID, DELAY, WINDOW);
+
+        assertFalse(state.consume(SAFE, ID)); // before activeFrom
+        vm.warp(block.timestamp + DELAY - 1);
+        assertFalse(state.consume(SAFE, ID));
+
+        vm.warp(block.timestamp + 1); // exactly activeFrom
+        assertTrue(state.consume(SAFE, ID)); // consumed
+        (uint256 activeFrom,) = state.windowOf(SAFE, ID);
+        assertEq(activeFrom, 0); // deleted
+    }
+
+    function test_consume_falseAfterExpiry() public {
+        state.announce(SAFE, ID, DELAY, WINDOW);
+        vm.warp(block.timestamp + DELAY + WINDOW + 1);
+        assertFalse(state.consume(SAFE, ID));
+        // The stored entry is not auto-cleared on a failed consume.
+        (uint256 activeFrom,) = state.windowOf(SAFE, ID);
+        assertGt(activeFrom, 0);
+    }
+
+    function test_cancel_deletes() public {
+        state.announce(SAFE, ID, DELAY, WINDOW);
+        state.cancel(SAFE, ID);
+        (uint256 activeFrom,) = state.windowOf(SAFE, ID);
+        assertEq(activeFrom, 0);
+    }
+
+    function test_cancel_revertsIfMissing() public {
+        vm.expectRevert(TransactionAnnouncement.AnnouncementNotFound.selector);
+        this.callCancel(SAFE, ID);
+    }
+}


### PR DESCRIPTION
Adds SafenetGuard: a standalone Safe transaction guard that gates every owner-signed `execTransaction` behind a Safenet FROST threshold-signature attestation, with a nonce-free, time-windowed escape hatch for liveness.

### Context and Motivation

This lands the reviewed `standalone-guard` stack as a single change. The feature was built as a linear stack of small, individually reviewed PRs - TransactionAnnouncement library (#600), ISafenetGuard interface (#601), AttestationTrailer library (#602), the SafenetGuard contract (#604), its test suite (#605), the deploy script (#606), and the README (#611) - so each concern had a focused review surface.

How it works:
- **Attestation via signature extension.** The FROST attestation `(epoch, groupKey, signature)` rides as a trailer appended to Safe's `signatures`, framed by a terminal type hash (`keccak256("SafenetGuard.AttestationTrailer.v1")`) that also tags the format version. `checkTransaction` verifies it against the full nonce-bound Safe tx hash. This is the first canonical guard the Safe project publishes to use signature extension.
- **Epoch forest.** Trusted `(group key, epoch)` pairs are tracked via the shared `EpochRollover` library; rollovers are permissionless (the FROST signature is the authorization).
- **Nonce-free escape hatch.** `announceTransaction` queues a transaction by its parameters minus the nonce; after a fixed delay it executes without an attestation inside a bounded `[activeFrom, activeUntil]` window, at any nonce. Single-use, revocable immediately via `cancelAnnouncement`.

### Decisions and Tradeoffs

- **Scope is transaction-guard only** - Safe module executions bypass it. Deployments must forbid modules or treat each as an explicit bypass.
- `ISafenetGuard` extends `ITransactionGuard`, so the guard hooks are part of the published ABI.
- The forest keeps historical `(groupKey, epoch)` pairs forever: post-rollover FROST shares are destroyed, so retaining old keys is not a practical risk (a historical key cannot replay past transactions - the Safe nonce binds them).
- Announcing emits a single `TransactionAnnounced` event; the full parameters are recoverable from the announce calldata.
- The structural self-call gate for the escape-hatch functions is kept inline in the guard for explicitness (the earlier `GuardAutoAllow` library was folded in, #603).
- SafenetGuard requires `via_ir` (added to `foundry.toml`); full rationale and accepted design decisions live in `src/guard/README.md`.

### Testing

- `cd contracts && forge test` - full suite green (SafenetGuard: 65 tests with a real Safe and real FROST signing; TransactionAnnouncement: 8 tests).
- `forge build`, `forge fmt --check`, and `forge lint --deny notes` pass.
