### PR TITLE
[Phase 7b]: Multi send decoding refactor

### DIFF
--- a/crates/safe-tx/src/checks.rs
+++ b/crates/safe-tx/src/checks.rs
@@ -1,4 +1,4 @@
-use crate::multi_send::{decode_multi_send, known_deployment};
+use crate::multi_send::decode_multi_send_call;
 use crate::rule::RuleId;
 use crate::types::{Operation, SafeTransaction};
 use alloy::{
@@ -214,18 +214,7 @@ fn check_delegate_calls(tx: &SafeTransaction) -> bool {
 /// `bool`, which is a bigger change than a MultiSend-only fix warrants
 /// right now.
 fn check_multi_send(tx: &SafeTransaction) -> bool {
-    if tx.operation != Operation::DELEGATECALL {
-        return false;
-    }
-    let Ok(call) = bindings::multiSendCall::abi_decode(&tx.data) else {
-        return false;
-    };
-
-    let Some((version, allows_delegate_calls)) = known_deployment(tx.to) else {
-        return false;
-    };
-
-    let Some(sub_txs) = decode_multi_send(tx.safe, &call.transactions, version) else {
+    let Some((sub_txs, allows_delegate_calls)) = decode_multi_send_call(tx) else {
         return false;
     };
 

--- a/crates/safe-tx/src/multi_send.rs
+++ b/crates/safe-tx/src/multi_send.rs
@@ -1,7 +1,10 @@
 use std::mem;
 
-use crate::types::{Operation, SafeTransaction};
-use alloy::primitives::{Address, Bytes, U256, address};
+use crate::types::{Operation, SafeTransaction, multi_send_bindings};
+use alloy::{
+    primitives::{Address, Bytes, U256, address},
+    sol_types::SolCall,
+};
 
 #[derive(Clone, Copy)]
 pub enum MultiSendVersion {
@@ -124,6 +127,23 @@ pub fn decode_multi_send(
     }
 
     Some(result)
+}
+
+/// Decodes `tx` as a whole MultiSend call: `None` unless `tx` is a
+/// delegatecall to a known MultiSend deployment carrying a valid
+/// `multiSend(bytes)` call whose packed `transactions` blob itself decodes
+/// cleanly. On success, returns the individual sub-transactions plus
+/// whether that deployment allows delegate calls among them — combining
+/// `known_deployment`, decoding the outer `multiSend(bytes)` call, and
+/// `decode_multi_send`, the three steps every caller needs together.
+pub fn decode_multi_send_call(tx: &SafeTransaction) -> Option<(Vec<SafeTransaction>, bool)> {
+    if tx.operation != Operation::DELEGATECALL {
+        return None;
+    }
+    let (version, allows_delegate_calls) = known_deployment(tx.to)?;
+    let call = multi_send_bindings::multiSendCall::abi_decode(&tx.data).ok()?;
+    let sub_txs = decode_multi_send(tx.safe, &call.transactions, version)?;
+    Some((sub_txs, allows_delegate_calls))
 }
 
 struct Cursor<'a>(&'a [u8]);

--- a/crates/safe-tx/src/target_effects.rs
+++ b/crates/safe-tx/src/target_effects.rs
@@ -4,8 +4,8 @@
 //! here — see `crate::checks` for the existing base-guarantee policy, and
 //! future `Check`s (elsewhere) that will consume this output.
 
-use crate::multi_send::{decode_multi_send, known_deployment};
-use crate::types::{Operation, SafeTransaction, erc20, erc721, erc1155, multi_send_bindings};
+use crate::multi_send::decode_multi_send_call;
+use crate::types::{SafeTransaction, erc20, erc721, erc1155};
 use alloy::{
     primitives::{Address, U256},
     sol_types::SolCall as _,
@@ -43,15 +43,8 @@ pub enum EffectKind {
 /// Decodes the target effects of a Safe transaction, recursing through
 /// MultiSend so each batched sub-call is decoded individually.
 pub fn decode_target_effects(tx: &SafeTransaction) -> Vec<TargetEffect> {
-    if tx.operation == Operation::DELEGATECALL
-        && let Some((version, _)) = known_deployment(tx.to)
-        && let Ok(call) = multi_send_bindings::multiSendCall::abi_decode(&tx.data)
-    {
-        return decode_multi_send(tx.safe, &call.transactions, version)
-            .unwrap_or_default()
-            .iter()
-            .flat_map(decode_target_effects)
-            .collect();
+    if let Some((sub_txs, _)) = decode_multi_send_call(tx) {
+        return sub_txs.iter().flat_map(decode_target_effects).collect();
     }
 
     decode_call(tx)
@@ -140,6 +133,7 @@ fn decode_call(tx: &SafeTransaction) -> Vec<TargetEffect> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::types::{Operation, multi_send_bindings};
     use alloy::primitives::{Bytes, address};
 
     fn tx(


### PR DESCRIPTION
The multi send decoding logic has been duplicated in multiple places. Namely the check of operation, detection of known deployments, abi decoding of bytes, and the decoding into sub transactions. These steps are now combined in a single shared method that can be easily reused.

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://docs.safefoundation.org/cla).
