### PR TITLE
[Guard] Split AttestationTrailer into hasTrailer/decode + data calldata

### DIFF
--- a/contracts/src/guard/SafenetGuard.sol
+++ b/contracts/src/guard/SafenetGuard.sol
@@ -185,7 +185,7 @@ contract SafenetGuard is ISafenetGuard, BaseTransactionGuard {
     function checkTransaction(
         address to,
         uint256 value,
-        bytes memory data,
+        bytes calldata data,
         Enum.Operation operation,
         uint256 safeTxGas,
         uint256 baseGas,
@@ -197,9 +197,9 @@ contract SafenetGuard is ISafenetGuard, BaseTransactionGuard {
     ) external override(ITransactionGuard) {
         if (_isAutoAllowed(to, value, data, operation)) return;
 
-        (bool present, uint64 epoch, Secp256k1.Point memory groupKey, FROST.Signature memory signature) =
-            AttestationTrailer.decode(signatures);
-        if (present) {
+        if (AttestationTrailer.hasTrailer(signatures)) {
+            (uint64 epoch, Secp256k1.Point memory groupKey, FROST.Signature memory signature) =
+                AttestationTrailer.decode(signatures);
             // Cheap forest-membership check first (also implies a non-zero key, enforced on record), so an
             // untrusted key short-circuits before the more expensive Safe tx hash is computed.
             require($epochs.isKnown(groupKey, epoch), UntrustedAttestationKey());
@@ -336,7 +336,7 @@ contract SafenetGuard is ISafenetGuard, BaseTransactionGuard {
      * @param operation The Safe operation type.
      * @return allowed True if the call is an auto-allowed escape-hatch self-call.
      */
-    function _isAutoAllowed(address to, uint256 value, bytes memory data, Enum.Operation operation)
+    function _isAutoAllowed(address to, uint256 value, bytes calldata data, Enum.Operation operation)
         private
         view
         returns (bool allowed)

--- a/contracts/src/libraries/AttestationTrailer.sol
+++ b/contracts/src/libraries/AttestationTrailer.sol
@@ -48,12 +48,21 @@ library AttestationTrailer {
     // ============================================================
 
     /**
-     * @notice Recognises and decodes an attestation trailer from a `signatures` blob.
-     * @dev Returns `present == false` when the last word is not `TYPE_HASH` (so the consumer falls through
-     *      to other authorisation paths). Reverts `MalformedAttestationTrailer` when the type hash is
-     *      present but the blob is shorter than a full trailer — a recognised trailer never silently
-     *      falls through.
-     * @return present True if a trailer was recognised and decoded.
+     * @notice Returns whether `signatures` carries an attestation trailer (ends with `TYPE_HASH`).
+     * @dev Non-reverting: a blob shorter than a word, or not ending in `TYPE_HASH`, is simply "no
+     *      trailer", so the consumer can fall through to other authorisation paths.
+     * @param signatures The Safe `signatures` blob, optionally suffixed with a trailer.
+     * @return present True if the blob ends with `TYPE_HASH`.
+     */
+    function hasTrailer(bytes calldata signatures) internal pure returns (bool present) {
+        return signatures.length >= 32 && bytes32(signatures[signatures.length - 32:]) == TYPE_HASH;
+    }
+
+    /**
+     * @notice Decodes the attestation payload from a trailer-bearing `signatures` blob.
+     * @dev Call only once {hasTrailer} is true. Reverts `MalformedAttestationTrailer` if the blob is too
+     *      short to hold a full v1 trailer, so a recognised trailer never yields partial data.
+     * @param signatures The Safe `signatures` blob ending in a v1 attestation trailer.
      * @return epoch The attested epoch.
      * @return groupKey The attesting FROST group key.
      * @return signature The FROST signature.
@@ -61,17 +70,12 @@ library AttestationTrailer {
     function decode(bytes calldata signatures)
         internal
         pure
-        returns (bool present, uint64 epoch, Secp256k1.Point memory groupKey, FROST.Signature memory signature)
+        returns (uint64 epoch, Secp256k1.Point memory groupKey, FROST.Signature memory signature)
     {
-        if (signatures.length < 32 || bytes32(signatures[signatures.length - 32:]) != TYPE_HASH) {
-            return (false, 0, groupKey, signature);
-        }
         require(signatures.length >= _TRAILER_LENGTH, MalformedAttestationTrailer());
-
         uint256 payloadStart = signatures.length - _TRAILER_LENGTH;
         (epoch, groupKey, signature) = abi.decode(
             signatures[payloadStart:payloadStart + _PAYLOAD_LENGTH], (uint64, Secp256k1.Point, FROST.Signature)
         );
-        present = true;
     }
 }

--- a/contracts/test/libraries/AttestationTrailer.t.sol
+++ b/contracts/test/libraries/AttestationTrailer.t.sol
@@ -1,0 +1,83 @@
+// SPDX-License-Identifier: GPL-3.0-only
+pragma solidity ^0.8.30;
+
+import {Test} from "@forge-std/Test.sol";
+import {AttestationTrailer} from "@/libraries/AttestationTrailer.sol";
+import {FROST} from "@/libraries/FROST.sol";
+import {Secp256k1} from "@/libraries/Secp256k1.sol";
+
+/**
+ * @title AttestationTrailerTest
+ * @notice Unit tests for the `AttestationTrailer` wire-format library. `hasTrailer` is pure recognition;
+ *         `decode` extracts the payload and reverts `MalformedAttestationTrailer` on a too-short blob.
+ *         Both take `calldata`, so they are exercised through external `this.call*` wrappers (which also
+ *         lets `vm.expectRevert` observe the internal revert at a lower call depth).
+ */
+contract AttestationTrailerTest is Test {
+    uint64 internal constant EPOCH = 7;
+
+    function callHasTrailer(bytes calldata signatures) external pure returns (bool) {
+        return AttestationTrailer.hasTrailer(signatures);
+    }
+
+    function callDecode(bytes calldata signatures)
+        external
+        pure
+        returns (uint64 epoch, Secp256k1.Point memory groupKey, FROST.Signature memory signature)
+    {
+        return AttestationTrailer.decode(signatures);
+    }
+
+    function _key() internal pure returns (Secp256k1.Point memory) {
+        return Secp256k1.Point({x: 111, y: 222});
+    }
+
+    function _sig() internal pure returns (FROST.Signature memory) {
+        return FROST.Signature({r: Secp256k1.Point({x: 333, y: 444}), z: 555});
+    }
+
+    // A full, well-formed trailer: [owner sigs][192-byte payload][32-byte TYPE_HASH].
+    function _trailer(bytes memory ownerSigs) internal pure returns (bytes memory) {
+        bytes memory payload = abi.encode(EPOCH, _key(), _sig());
+        return bytes.concat(ownerSigs, payload, AttestationTrailer.TYPE_HASH);
+    }
+
+    function test_hasTrailer_trueForWellFormed() public view {
+        assertTrue(this.callHasTrailer(_trailer(hex"aabbcc")));
+    }
+
+    function test_hasTrailer_falseWhenNoTypeHash() public view {
+        // A plausible Safe signature blob ending in an unrelated word (even the number 192).
+        bytes memory sigs = bytes.concat(hex"aabbcc", bytes32(uint256(192)));
+        assertFalse(this.callHasTrailer(sigs));
+    }
+
+    function test_hasTrailer_falseWhenShorterThanWord() public view {
+        assertFalse(this.callHasTrailer(hex"deadbeef"));
+        assertFalse(this.callHasTrailer(""));
+    }
+
+    function test_decode_roundTrips() public view {
+        (uint64 epoch, Secp256k1.Point memory k, FROST.Signature memory s) = this.callDecode(_trailer(hex"aabbcc"));
+        assertEq(epoch, EPOCH);
+        assertEq(k.x, 111);
+        assertEq(k.y, 222);
+        assertEq(s.r.x, 333);
+        assertEq(s.r.y, 444);
+        assertEq(s.z, 555);
+    }
+
+    function test_decode_ignoresOwnerSignatureLength() public view {
+        // Payload is sliced from the tail, so any owner-signature prefix decodes to the same values.
+        (uint64 epoch,,) = this.callDecode(_trailer(hex""));
+        assertEq(epoch, EPOCH);
+        (uint64 epoch2,,) = this.callDecode(_trailer(hex"0102030405060708090a0b0c0d0e0f"));
+        assertEq(epoch2, EPOCH);
+    }
+
+    function test_decode_revertsWhenTooShort() public {
+        // Type hash present but the blob is shorter than a full 224-byte trailer.
+        vm.expectRevert(AttestationTrailer.MalformedAttestationTrailer.selector);
+        this.callDecode(bytes.concat(AttestationTrailer.TYPE_HASH));
+    }
+}


### PR DESCRIPTION
Splits attestation-trailer recognition from decoding, wires the guard to the new API, narrows `data` to calldata, and adds the missing library unit tests.

### Context and Motivation

`AttestationTrailer.decode` previously returned a `bool present` alongside zeroed values when no trailer was found (Richard, #602). It's now two focused functions: `hasTrailer` (non-reverting recognition) and `decode` (payload extraction, reverts `MalformedAttestationTrailer` on a too-short blob). `SafenetGuard.checkTransaction` calls `hasTrailer` then `decode`, preserving the exact fail-closed semantics. `checkTransaction`/`_isAutoAllowed` take `data` as `calldata` (G1), matching `signatures`.

### Decisions and Tradeoffs

- `decode` assumes `hasTrailer` was checked; it validates length so a recognised trailer never yields partial data.
- Adds `test/libraries/AttestationTrailer.t.sol` — the library had no isolated coverage (Richard's audit-readiness ask).

### Testing
- `forge build`, `forge test` (guard suite behaviour unchanged), `forge fmt --check`, `forge lint --deny notes` pass.