### PR TITLE
[Guard] Add SignatureExtension library (generic signature-extension envelope)

### DIFF
--- a/contracts/src/libraries/SignatureExtension.sol
+++ b/contracts/src/libraries/SignatureExtension.sol
@@ -1,0 +1,90 @@
+// SPDX-License-Identifier: GPL-3.0-only
+pragma solidity ^0.8.30;
+
+/**
+ * @title SignatureExtension
+ * @notice A reusable format for appending typed, variable-length data after a Safe's owner signatures.
+ * @dev A *signature extension* is a self-describing envelope appended to Safe's `signatures` bytes.
+ *      Safe's own signature parser reads owner signatures front-to-back and ignores trailing bytes, so a
+ *      consumer (e.g. a transaction guard) can carry extra authorisation data in the tail and recover it
+ *      here without disturbing Safe's parse.
+ *
+ *      Envelope layout:
+ *
+ *          [safe owner signatures] [payload: N bytes] [uint256 payloadLength = N] [bytes32 typeHash]
+ *
+ *      - The **type hash** is the terminal 32-byte word. It both identifies the extension type and pins
+ *        its version, by the registry convention `typeHash = keccak256("<Owner>.<Name>.v<N>")` (e.g.
+ *        `SafenetGuard.AttestationTrailer.v1`). Anchoring the discriminator at the end makes detection
+ *        independent of any owner-signature suffix, and a consumer of a different type simply does not
+ *        recognise it. A future, post-release format change bumps to a new type hash, which older
+ *        consumers read as "no extension".
+ *      - The **length word** precedes the type hash and gives the payload size, so the payload may be any
+ *        length and is sliceable from the tail in O(1). Total envelope overhead is a fixed 64 bytes.
+ *      - The owner-signature/payload boundary is not exposed: the guard does not need it (Safe parses the
+ *        front independently), and a consumer that does can derive it as
+ *        `signatures.length - payloadLength - {ENVELOPE_OVERHEAD}`.
+ *
+ *      This library is the transport only — payload-agnostic. A typed consumer holds its own `typeHash`
+ *      and decodes the returned payload bytes into its own schema. At most one extension per blob;
+ *      nesting is not supported (a future need would be a new format/version).
+ */
+library SignatureExtension {
+    // ============================================================
+    // CONSTANTS
+    // ============================================================
+
+    /**
+     * @dev Fixed envelope overhead: the `uint256 payloadLength` word (32 bytes) plus the terminal
+     *      `bytes32 typeHash` word (32 bytes).
+     */
+    uint256 private constant _ENVELOPE_OVERHEAD = 64;
+
+    // ============================================================
+    // ERRORS
+    // ============================================================
+
+    /**
+     * @notice Thrown when a blob carries the expected type hash but is not a well-formed envelope — too
+     *         short to hold `[payloadLength][typeHash]`, or a payload length that runs past the front.
+     */
+    error MalformedSignatureExtension();
+
+    // ============================================================
+    // INTERNAL FUNCTIONS
+    // ============================================================
+
+    /**
+     * @notice Returns whether `signatures` carries an extension of type `typeHash` (ends with it).
+     * @dev Non-reverting recognition: a blob shorter than a word, or not ending in `typeHash`, is simply
+     *      "no extension of this type", so the consumer can fall through to other authorisation paths.
+     *      This is detection only; {payload} performs the full well-formedness validation.
+     * @param signatures The Safe `signatures` blob, optionally suffixed with an extension.
+     * @param typeHash The extension type to look for.
+     * @return present True if the blob ends with `typeHash`.
+     */
+    function has(bytes calldata signatures, bytes32 typeHash) internal pure returns (bool present) {
+        return signatures.length >= 32 && bytes32(signatures[signatures.length - 32:]) == typeHash;
+    }
+
+    /**
+     * @notice Extracts the payload of a `typeHash` extension from `signatures`.
+     * @dev Self-verifying, so it is safe to call standalone without a preceding {has}: reverts
+     *      `MalformedSignatureExtension` if the blob is too short to hold `[payloadLength][typeHash]`, if
+     *      the terminal word is not `typeHash`, or if the encoded payload length runs past the front of
+     *      the blob. The returned slice is a `calldata` view (no copy).
+     * @param signatures The Safe `signatures` blob ending in a `typeHash` extension.
+     * @param typeHash The expected extension type; the terminal word must equal it.
+     * @return payloadData The extension payload (`payloadLength` bytes preceding the length word).
+     */
+    function payload(bytes calldata signatures, bytes32 typeHash) internal pure returns (bytes calldata payloadData) {
+        require(
+            signatures.length >= _ENVELOPE_OVERHEAD && bytes32(signatures[signatures.length - 32:]) == typeHash,
+            MalformedSignatureExtension()
+        );
+        uint256 end = signatures.length - _ENVELOPE_OVERHEAD; // index just past the payload
+        uint256 payloadLength = uint256(bytes32(signatures[end:end + 32]));
+        require(payloadLength <= end, MalformedSignatureExtension());
+        return signatures[end - payloadLength:end];
+    }
+}

--- a/contracts/test/libraries/SignatureExtension.t.sol
+++ b/contracts/test/libraries/SignatureExtension.t.sol
@@ -1,0 +1,94 @@
+// SPDX-License-Identifier: GPL-3.0-only
+pragma solidity ^0.8.30;
+
+import {Test} from "@forge-std/Test.sol";
+import {SignatureExtension} from "@/libraries/SignatureExtension.sol";
+
+/**
+ * @title SignatureExtensionTest
+ * @notice Unit tests for the generic `SignatureExtension` envelope: terminal-type-hash recognition and
+ *         length-prefixed payload extraction across payload sizes, plus the malformed/overrun reverts.
+ *         Both functions take `calldata`, so they are exercised through external `this.call*` wrappers
+ *         (which also lets `vm.expectRevert` observe the internal revert at a lower call depth).
+ */
+contract SignatureExtensionTest is Test {
+    bytes32 internal constant TYPE_HASH = keccak256("Test.Extension.v1");
+    bytes32 internal constant OTHER_TYPE_HASH = keccak256("Test.Other.v1");
+
+    function callHas(bytes calldata signatures, bytes32 typeHash) external pure returns (bool) {
+        return SignatureExtension.has(signatures, typeHash);
+    }
+
+    function callPayload(bytes calldata signatures, bytes32 typeHash) external pure returns (bytes memory) {
+        return SignatureExtension.payload(signatures, typeHash);
+    }
+
+    /// @dev Build a well-formed envelope: [ownerSigs][payload][uint256 payload.length][typeHash].
+    function _envelope(bytes memory ownerSigs, bytes memory payload_, bytes32 typeHash)
+        internal
+        pure
+        returns (bytes memory)
+    {
+        return bytes.concat(ownerSigs, payload_, abi.encode(payload_.length), typeHash);
+    }
+
+    // ----------------------------------------------------------------
+    // has
+    // ----------------------------------------------------------------
+
+    function test_has_trueForMatchingTypeHash() public view {
+        bytes memory sigs = _envelope(hex"aabbcc", hex"1122334455", TYPE_HASH);
+        assertTrue(this.callHas(sigs, TYPE_HASH));
+    }
+
+    function test_has_falseForDifferentTypeHash() public view {
+        bytes memory sigs = _envelope(hex"aabbcc", hex"1122334455", TYPE_HASH);
+        assertFalse(this.callHas(sigs, OTHER_TYPE_HASH));
+    }
+
+    function test_has_falseWhenShorterThanWord() public view {
+        assertFalse(this.callHas(hex"deadbeef", TYPE_HASH));
+        assertFalse(this.callHas("", TYPE_HASH));
+    }
+
+    // ----------------------------------------------------------------
+    // payload
+    // ----------------------------------------------------------------
+
+    function test_payload_roundTripsAcrossSizes() public view {
+        // Empty payload, a 5-byte (non-word-multiple) payload, and a full 32-byte word.
+        bytes memory empty = this.callPayload(_envelope(hex"aabb", "", TYPE_HASH), TYPE_HASH);
+        assertEq(empty.length, 0);
+
+        bytes memory five = hex"0102030405";
+        assertEq(this.callPayload(_envelope(hex"aabb", five, TYPE_HASH), TYPE_HASH), five);
+
+        bytes memory word = hex"1111111111111111111111111111111111111111111111111111111111111111";
+        assertEq(this.callPayload(_envelope(hex"", word, TYPE_HASH), TYPE_HASH), word);
+    }
+
+    function test_payload_ignoresOwnerSignatureLength() public view {
+        bytes memory p = hex"cafebabe";
+        assertEq(this.callPayload(_envelope(hex"", p, TYPE_HASH), TYPE_HASH), p);
+        assertEq(this.callPayload(_envelope(hex"00112233445566778899", p, TYPE_HASH), TYPE_HASH), p);
+    }
+
+    function test_payload_revertsWhenTooShort() public {
+        // Only a type-hash word (32 bytes): shorter than the 64-byte minimum envelope.
+        vm.expectRevert(SignatureExtension.MalformedSignatureExtension.selector);
+        this.callPayload(bytes.concat(TYPE_HASH), TYPE_HASH);
+    }
+
+    function test_payload_revertsOnTypeHashMismatch() public {
+        bytes memory sigs = _envelope(hex"aabb", hex"1122", TYPE_HASH);
+        vm.expectRevert(SignatureExtension.MalformedSignatureExtension.selector);
+        this.callPayload(sigs, OTHER_TYPE_HASH);
+    }
+
+    function test_payload_revertsWhenLengthOverrunsFront() public {
+        // Well-formed framing, but payloadLength claims more bytes than precede the length word.
+        bytes memory sigs = bytes.concat(hex"1122", abi.encode(uint256(64)), TYPE_HASH);
+        vm.expectRevert(SignatureExtension.MalformedSignatureExtension.selector);
+        this.callPayload(sigs, TYPE_HASH);
+    }
+}


### PR DESCRIPTION
Implements the reusable signature-extension transport from the epic (#639) — Phase 1. Standalone library + tests; no consumer wired up yet.

### Context and Motivation
Generic, payload-agnostic envelope `[payload][uint256 payloadLength][bytes32 typeHash]` parsed from the tail of Safe's `signatures`: `has(sigs, typeHash)` (non-reverting detection) and self-verifying `payload(sigs, typeHash)`. Canonical format spec lives in the NatSpec.

### Decisions and Tradeoffs
Per the epic: `payload` takes `typeHash` (self-verifying), payload-only (boundary derivable), single-extension, fail-closed bounds. Fixed 64-byte overhead.

### Testing
`forge test` — 8 new tests (detection, variable-size round-trips, malformed/overrun reverts); full suite green.
