### PR TITLE
[Guard] Phase 2: migrate AttestationTrailer onto SignatureExtension

### DIFF
--- a/contracts/src/libraries/AttestationTrailer.sol
+++ b/contracts/src/libraries/AttestationTrailer.sol
@@ -3,15 +3,17 @@ pragma solidity ^0.8.30;
 
 import {FROST} from "@/libraries/FROST.sol";
 import {Secp256k1} from "@/libraries/Secp256k1.sol";
+import {SignatureExtension} from "@/libraries/SignatureExtension.sol";
 
 /**
  * @title AttestationTrailer
- * @notice Recognises and decodes a Safenet attestation appended to Safe's `signatures` bytes.
- * @dev Layout: `[safe owner signatures][192-byte abi.encode(epoch, groupKey, signature)][32-byte TYPE_HASH]`.
- *      Anchoring at the end leaves Safe's front-to-back signature parser untouched, and the terminal type
- *      hash makes detection independent of signature suffixes — a blob not ending in `TYPE_HASH` is simply
- *      "no trailer". The type hash embeds the version, so a future format uses a different type hash (and
- *      this guard treats it as absent). The library owns recognition, sizing, and the typed decode.
+ * @notice Recognises and decodes a Safenet attestation carried as a {SignatureExtension} on Safe's
+ *         `signatures` bytes.
+ * @dev The attestation is a typed signature extension: its payload is the fixed 192-byte
+ *      `abi.encode(uint64 epoch, Secp256k1.Point groupKey, FROST.Signature signature)`, tagged by the
+ *      terminal `TYPE_HASH`. The envelope framing (length word + type hash, tail-anchored so Safe's
+ *      front-to-back signature parser is untouched) is owned by {SignatureExtension}; this library owns
+ *      only the guard-specific type hash and payload schema.
  */
 library AttestationTrailer {
     // ============================================================
@@ -19,7 +21,7 @@ library AttestationTrailer {
     // ============================================================
 
     /**
-     * @notice Type hash that must terminate a v1 attestation trailer; doubles as the version tag.
+     * @notice Type hash identifying an attestation trailer; the terminal word of the signature extension.
      */
     bytes32 internal constant TYPE_HASH = keccak256("SafenetGuard.AttestationTrailer.v1");
 
@@ -28,18 +30,12 @@ library AttestationTrailer {
      */
     uint256 private constant _PAYLOAD_LENGTH = 192;
 
-    /**
-     * @dev Total trailer overhead: the payload followed by the 32-byte type hash word. Derived from
-     *      `_PAYLOAD_LENGTH` so the two constants cannot drift if the payload layout changes.
-     */
-    uint256 private constant _TRAILER_LENGTH = _PAYLOAD_LENGTH + 32;
-
     // ============================================================
     // ERRORS
     // ============================================================
 
     /**
-     * @notice Thrown when the type hash is present but the blob is too short to hold a v1 trailer.
+     * @notice Thrown when a recognised trailer's payload is not the expected 192-byte attestation.
      */
     error MalformedAttestationTrailer();
 
@@ -49,20 +45,20 @@ library AttestationTrailer {
 
     /**
      * @notice Returns whether `signatures` carries an attestation trailer (ends with `TYPE_HASH`).
-     * @dev Non-reverting: a blob shorter than a word, or not ending in `TYPE_HASH`, is simply "no
-     *      trailer", so the consumer can fall through to other authorisation paths.
+     * @dev Non-reverting; the consumer falls through to other authorisation paths when absent.
      * @param signatures The Safe `signatures` blob, optionally suffixed with a trailer.
      * @return present True if the blob ends with `TYPE_HASH`.
      */
     function hasTrailer(bytes calldata signatures) internal pure returns (bool present) {
-        return signatures.length >= 32 && bytes32(signatures[signatures.length - 32:]) == TYPE_HASH;
+        return SignatureExtension.has(signatures, TYPE_HASH);
     }
 
     /**
-     * @notice Decodes the attestation payload from a trailer-bearing `signatures` blob.
-     * @dev Call only once {hasTrailer} is true. Reverts `MalformedAttestationTrailer` if the blob is too
-     *      short to hold a full v1 trailer, so a recognised trailer never yields partial data.
-     * @param signatures The Safe `signatures` blob ending in a v1 attestation trailer.
+     * @notice Decodes the attestation from a trailer-bearing `signatures` blob.
+     * @dev Self-verifying via {SignatureExtension.payload}: reverts `MalformedSignatureExtension` if the
+     *      envelope itself is malformed, and `MalformedAttestationTrailer` if the payload is not the fixed
+     *      192-byte attestation — a recognised trailer never yields partial or wrongly-sized data.
+     * @param signatures The Safe `signatures` blob ending in an attestation trailer.
      * @return epoch The attested epoch.
      * @return groupKey The attesting FROST group key.
      * @return signature The FROST signature.
@@ -72,10 +68,8 @@ library AttestationTrailer {
         pure
         returns (uint64 epoch, Secp256k1.Point memory groupKey, FROST.Signature memory signature)
     {
-        require(signatures.length >= _TRAILER_LENGTH, MalformedAttestationTrailer());
-        uint256 payloadStart = signatures.length - _TRAILER_LENGTH;
-        (epoch, groupKey, signature) = abi.decode(
-            signatures[payloadStart:payloadStart + _PAYLOAD_LENGTH], (uint64, Secp256k1.Point, FROST.Signature)
-        );
+        bytes calldata payloadData = SignatureExtension.payload(signatures, TYPE_HASH);
+        require(payloadData.length == _PAYLOAD_LENGTH, MalformedAttestationTrailer());
+        (epoch, groupKey, signature) = abi.decode(payloadData, (uint64, Secp256k1.Point, FROST.Signature));
     }
 }

--- a/contracts/test/SafenetGuard.t.sol
+++ b/contracts/test/SafenetGuard.t.sol
@@ -9,6 +9,7 @@ import {SafeTransaction} from "@/libraries/SafeTransaction.sol";
 import {Secp256k1} from "@/libraries/Secp256k1.sol";
 import {TransactionAnnouncement} from "@/libraries/TransactionAnnouncement.sol";
 import {AttestationTrailer} from "@/libraries/AttestationTrailer.sol";
+import {SignatureExtension} from "@/libraries/SignatureExtension.sol";
 import {ISafenetGuard} from "@/interfaces/ISafenetGuard.sol";
 import {Enum} from "@safe/interfaces/Enum.sol";
 import {ISafe} from "@safe/interfaces/ISafe.sol";
@@ -164,8 +165,8 @@ contract SafenetGuardTest is Test {
         return abi.encodePacked(r, s, v);
     }
 
-    /// @dev Builds an inline FROST attestation trailer in the version-1 framing:
-    ///      `[192-byte abi.encode(epoch, groupKey, signature)][32-byte TYPE_HASH (embeds the version)]`.
+    /// @dev Builds an inline FROST attestation as a signature extension:
+    ///      `[192-byte abi.encode(epoch, groupKey, signature)][uint256 payloadLength = 192][32-byte TYPE_HASH]`.
     ///      The group key is derived from `sk` so it matches the signing key.
     function _buildInlineAttestation(bytes32 txHash, uint64 epoch, uint256 sk, uint256 nk)
         internal
@@ -175,7 +176,7 @@ contract SafenetGuardTest is Test {
         bytes32 message = ConsensusMessages.transactionProposal(guard.getConsensusDomainSeparator(), epoch, txHash);
         FROST.Signature memory sig = _frostSign(sk, nk, message);
         bytes memory payload = abi.encode(epoch, groupKey, sig); // 192 bytes
-        return bytes.concat(payload, AttestationTrailer.TYPE_HASH);
+        return bytes.concat(payload, abi.encode(payload.length), AttestationTrailer.TYPE_HASH);
     }
 
     /// @dev Signs and executes a Safe transaction. `Attested` appends a genesis-epoch inline FROST
@@ -423,7 +424,8 @@ contract SafenetGuardTest is Test {
         FROST.Signature memory sig = _frostSign(GENESIS_SK, GENESIS_NK, message);
         sig.z = addmod(sig.z, 1, Secp256k1.N); // tamper
         bytes memory payload = abi.encode(GENESIS_EPOCH, ForgeSecp256k1.g(GENESIS_SK).toPoint(), sig);
-        bytes memory combined = bytes.concat(_signSafeTx(txHash), payload, AttestationTrailer.TYPE_HASH);
+        bytes memory combined =
+            bytes.concat(_signSafeTx(txHash), payload, abi.encode(payload.length), AttestationTrailer.TYPE_HASH);
         vm.expectRevert(Secp256k1.InvalidMulMulAddWitness.selector);
         safe.execTransaction(TX_TO, TX_VALUE, TX_DATA, TX_OP, 0, 0, 0, address(0), payable(address(0)), combined);
     }
@@ -812,13 +814,14 @@ contract SafenetGuardTest is Test {
         safe.execTransaction(TX_TO, TX_VALUE, TX_DATA, TX_OP, 0, 0, 0, address(0), payable(address(0)), combined);
     }
 
-    /// @notice A recognised v1 magic with a too-short blob reverts as malformed (no announcement fallback).
+    /// @notice A recognised type hash with no valid envelope behind it reverts as malformed — the guard
+    ///         fails closed rather than falling through to the announcement path.
     function test_trailer_malformedTruncatedReverts() public {
         uint256 nonce = safe.nonce();
         bytes32 txHash = _safeTxHash(TX_TO, TX_VALUE, TX_DATA, TX_OP, nonce);
-        // 65-byte owner sig + 32-byte v1 tag = 97 bytes < 224 required.
+        // Owner sig + bare type hash: ends in TYPE_HASH but has no valid [payloadLength][typeHash] envelope.
         bytes memory combined = bytes.concat(_signSafeTx(txHash), AttestationTrailer.TYPE_HASH);
-        vm.expectRevert(AttestationTrailer.MalformedAttestationTrailer.selector);
+        vm.expectRevert(SignatureExtension.MalformedSignatureExtension.selector);
         safe.execTransaction(TX_TO, TX_VALUE, TX_DATA, TX_OP, 0, 0, 0, address(0), payable(address(0)), combined);
     }
 

--- a/contracts/test/libraries/AttestationTrailer.t.sol
+++ b/contracts/test/libraries/AttestationTrailer.t.sol
@@ -3,15 +3,17 @@ pragma solidity ^0.8.30;
 
 import {Test} from "@forge-std/Test.sol";
 import {AttestationTrailer} from "@/libraries/AttestationTrailer.sol";
+import {SignatureExtension} from "@/libraries/SignatureExtension.sol";
 import {FROST} from "@/libraries/FROST.sol";
 import {Secp256k1} from "@/libraries/Secp256k1.sol";
 
 /**
  * @title AttestationTrailerTest
- * @notice Unit tests for the `AttestationTrailer` wire-format library. `hasTrailer` is pure recognition;
- *         `decode` extracts the payload and reverts `MalformedAttestationTrailer` on a too-short blob.
- *         Both take `calldata`, so they are exercised through external `this.call*` wrappers (which also
- *         lets `vm.expectRevert` observe the internal revert at a lower call depth).
+ * @notice Unit tests for the typed attestation codec layered on `SignatureExtension`: recognition,
+ *         round-trip decode of the fixed 192-byte payload, and the two reverts — a well-formed envelope
+ *         whose payload is the wrong size (`MalformedAttestationTrailer`) and a malformed envelope
+ *         (`MalformedSignatureExtension`, surfaced from the transport layer). Both functions take
+ *         `calldata`, so they run through external `this.call*` wrappers.
  */
 contract AttestationTrailerTest is Test {
     uint64 internal constant EPOCH = 7;
@@ -28,37 +30,29 @@ contract AttestationTrailerTest is Test {
         return AttestationTrailer.decode(signatures);
     }
 
-    function _key() internal pure returns (Secp256k1.Point memory) {
-        return Secp256k1.Point({x: 111, y: 222});
+    function _attestationPayload() internal pure returns (bytes memory) {
+        // abi.encode(uint64, Secp256k1.Point, FROST.Signature) = 192 bytes.
+        return abi.encode(
+            EPOCH, Secp256k1.Point({x: 111, y: 222}), FROST.Signature({r: Secp256k1.Point({x: 333, y: 444}), z: 555})
+        );
     }
 
-    function _sig() internal pure returns (FROST.Signature memory) {
-        return FROST.Signature({r: Secp256k1.Point({x: 333, y: 444}), z: 555});
-    }
-
-    // A full, well-formed trailer: [owner sigs][192-byte payload][32-byte TYPE_HASH].
-    function _trailer(bytes memory ownerSigs) internal pure returns (bytes memory) {
-        bytes memory payload = abi.encode(EPOCH, _key(), _sig());
-        return bytes.concat(ownerSigs, payload, AttestationTrailer.TYPE_HASH);
+    /// @dev Well-formed trailer: [ownerSigs][payload][uint256 payload.length][TYPE_HASH].
+    function _trailer(bytes memory ownerSigs, bytes memory payload) internal pure returns (bytes memory) {
+        return bytes.concat(ownerSigs, payload, abi.encode(payload.length), AttestationTrailer.TYPE_HASH);
     }
 
     function test_hasTrailer_trueForWellFormed() public view {
-        assertTrue(this.callHasTrailer(_trailer(hex"aabbcc")));
+        assertTrue(this.callHasTrailer(_trailer(hex"aabbcc", _attestationPayload())));
     }
 
-    function test_hasTrailer_falseWhenNoTypeHash() public view {
-        // A plausible Safe signature blob ending in an unrelated word (even the number 192).
-        bytes memory sigs = bytes.concat(hex"aabbcc", bytes32(uint256(192)));
-        assertFalse(this.callHasTrailer(sigs));
-    }
-
-    function test_hasTrailer_falseWhenShorterThanWord() public view {
-        assertFalse(this.callHasTrailer(hex"deadbeef"));
-        assertFalse(this.callHasTrailer(""));
+    function test_hasTrailer_falseWhenAbsent() public view {
+        assertFalse(this.callHasTrailer(bytes.concat(hex"aabbcc", bytes32(uint256(192)))));
     }
 
     function test_decode_roundTrips() public view {
-        (uint64 epoch, Secp256k1.Point memory k, FROST.Signature memory s) = this.callDecode(_trailer(hex"aabbcc"));
+        (uint64 epoch, Secp256k1.Point memory k, FROST.Signature memory s) =
+            this.callDecode(_trailer(hex"aabbcc", _attestationPayload()));
         assertEq(epoch, EPOCH);
         assertEq(k.x, 111);
         assertEq(k.y, 222);
@@ -67,17 +61,15 @@ contract AttestationTrailerTest is Test {
         assertEq(s.z, 555);
     }
 
-    function test_decode_ignoresOwnerSignatureLength() public view {
-        // Payload is sliced from the tail, so any owner-signature prefix decodes to the same values.
-        (uint64 epoch,,) = this.callDecode(_trailer(hex""));
-        assertEq(epoch, EPOCH);
-        (uint64 epoch2,,) = this.callDecode(_trailer(hex"0102030405060708090a0b0c0d0e0f"));
-        assertEq(epoch2, EPOCH);
+    function test_decode_revertsOnWrongPayloadSize() public {
+        // A well-formed envelope whose payload is not the fixed 192-byte attestation.
+        vm.expectRevert(AttestationTrailer.MalformedAttestationTrailer.selector);
+        this.callDecode(_trailer(hex"aabb", hex"1122334455667788"));
     }
 
-    function test_decode_revertsWhenTooShort() public {
-        // Type hash present but the blob is shorter than a full 224-byte trailer.
-        vm.expectRevert(AttestationTrailer.MalformedAttestationTrailer.selector);
+    function test_decode_revertsOnMalformedEnvelope() public {
+        // Ends in TYPE_HASH but has no valid [payloadLength][typeHash] envelope behind it.
+        vm.expectRevert(SignatureExtension.MalformedSignatureExtension.selector);
         this.callDecode(bytes.concat(AttestationTrailer.TYPE_HASH));
     }
 }


### PR DESCRIPTION
Rebuilds `AttestationTrailer` as a thin typed codec over `SignatureExtension` (Phase 2). Keeps the `...v1` type hash — the format is unreleased, so this is not a breaking change.

### Context and Motivation
`hasTrailer`/`decode` now delegate framing to `SignatureExtension`; `AttestationTrailer` owns only the type hash + the fixed 192-byte payload schema, asserting the size explicitly (`MalformedAttestationTrailer`) and surfacing `MalformedSignatureExtension` for a malformed envelope. `SafenetGuard` itself is unchanged (the `hasTrailer`/`decode` signatures are stable).

### Decisions and Tradeoffs
Two layers on purpose (transport vs. typed codec) — rationale in the epic's "Why two layers". Explicit 192-byte assertion.

### Testing
`forge test` — updated `AttestationTrailer.t.sol` (round-trip + wrong-size + malformed-envelope) and the guard suite's envelope helper; full suite green (244).
