### PR TITLE
Fix SQLite connection

### DIFF
--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -17,5 +17,6 @@ pub mod observability;
 pub mod serialization;
 pub mod state;
 pub mod tx;
+pub mod utils;
 
 pub use self::driver::Driver;

--- a/crates/core/src/utils.rs
+++ b/crates/core/src/utils.rs
@@ -1,0 +1,30 @@
+//! Miscellaneous utilities shared across Safenet services that don't belong
+//! to any single component.
+
+use sqlx::sqlite::{SqliteConnectOptions, SqlitePool, SqlitePoolOptions};
+
+/// Connects a `SqlitePool`, for use as [`Driver::new`](crate::Driver::new)'s
+/// `pool` argument (or anywhere else a service needs a SQLite pool).
+///
+/// This disables sqlx's default connection recycling (`idle_timeout` and
+/// `max_lifetime`), which is critical for a `sqlite::memory:` database: an
+/// in-memory database only exists for as long as at least one connection to
+/// it is open, but sqlx's pool otherwise periodically closes and reopens even
+/// a lone remaining connection to enforce those limits. The instant that
+/// happens, the (named, potentially shared-cache) in-memory database is
+/// destroyed, and the next query transparently opens a fresh, empty one in
+/// its place — surfacing as spurious "no such table" errors with no apparent
+/// cause. A file-backed database has no such failure mode, but there is no
+/// upside to recycling a long-lived, single-process SQLite connection either,
+/// so this is disabled unconditionally rather than only for `:memory:`.
+///
+/// Note that `min_connections` does not help here: sqlx's reaper still closes
+/// and reopens a connection to enforce `idle_timeout`/`max_lifetime` even
+/// while maintaining a minimum pool size, so both must be disabled outright.
+pub async fn connect_sqlite(options: SqliteConnectOptions) -> Result<SqlitePool, sqlx::Error> {
+    SqlitePoolOptions::new()
+        .idle_timeout(None)
+        .max_lifetime(None)
+        .connect_with(options)
+        .await
+}

--- a/crates/sentinel/src/main.rs
+++ b/crates/sentinel/src/main.rs
@@ -20,8 +20,7 @@ use alloy::{
     providers::{Provider, ProviderBuilder},
 };
 use argh::FromArgs;
-use safenet_core::{Driver, observability};
-use sqlx::sqlite::SqlitePool;
+use safenet_core::{Driver, observability, utils};
 use std::{error::Error, path::PathBuf};
 
 #[derive(Debug, FromArgs)]
@@ -49,7 +48,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
     tracing::debug!(config_file = %options.config_file.display(), "sentinel configuration loaded");
 
     let provider = ProviderBuilder::new().connect(config.rpc.as_str()).await?;
-    let pool = SqlitePool::connect_with(config.database).await?;
+    let pool = utils::connect_sqlite(config.database).await?;
     let chain_id = U256::from(provider.get_chain_id().await?);
 
     let service = SentinelService::new(

--- a/crates/validator/src/main.rs
+++ b/crates/validator/src/main.rs
@@ -14,8 +14,7 @@ use self::{
 };
 use alloy::providers::{Provider, ProviderBuilder};
 use argh::FromArgs;
-use safenet_core::{Driver, observability};
-use sqlx::sqlite::SqlitePool;
+use safenet_core::{Driver, observability, utils};
 use std::{error::Error, path::PathBuf};
 
 #[derive(Debug, FromArgs)]
@@ -43,7 +42,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
     tracing::debug!(config_file = %options.config_file.display(), "validator configuration loaded");
 
     let provider = ProviderBuilder::new().connect(config.rpc.as_str()).await?;
-    let pool = SqlitePool::connect_with(config.database).await?;
+    let pool = utils::connect_sqlite(config.database).await?;
 
     let consensus = config.validator.consensus;
     let coordinator = Consensus::new(consensus, &provider)


### PR DESCRIPTION
In-memory SQLite databases are only kept while a connection to the database is open. As connections have a maximum lifetime this might happen even if there is constant activity (as there is potentially a short time where there is no connection). This caused tables to be unavailable, preventing any further process.

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://docs.safefoundation.org/cla).
