### PR TITLE
Fix retry of failed transitions

### DIFF
--- a/crates/core/src/driver.rs
+++ b/crates/core/src/driver.rs
@@ -32,14 +32,6 @@ pub struct Config {
     pub transactions: tx::Config,
 }
 
-/// Whether the [`Driver::run`] loop should keep processing updates or stop.
-enum Loop {
-    /// Continue with the next iteration.
-    Continue,
-    /// Stop the run loop, for example after a shutdown signal.
-    Break,
-}
-
 /// Error produced by the [`Driver`].
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
@@ -65,7 +57,7 @@ pub trait ActionEncoder<Action> {
 /// A Safenet service definition.
 pub trait Service {
     type State: Default + DeserializeOwned + Serialize;
-    type Event: Debug + Events;
+    type Event: Clone + Debug + Events;
 
     type Transition: StateTransition<Self::State, Event = Self::Event>;
     type Effects: EffectHandler<
@@ -148,8 +140,12 @@ where
     /// Runs the service, processing indexer updates until a shutdown signal
     /// (such as Ctrl-C) is received or an unrecoverable error occurs.
     ///
-    /// A failed step is retried on the next iteration rather than stopping the
-    /// service.
+    /// Each iteration first obtains an update via [`Driver::next_update`] —
+    /// `self.pending`, if a previous [`Driver::step`] left one, otherwise a
+    /// new one from the watcher — then processes it. A failed step is retried
+    /// on the next iteration rather than stopping the service; if the update
+    /// it failed on can be safely retried as-is (see [`Driver::step`]), the
+    /// retry reuses it instead of fetching a new one from the watcher.
     pub async fn run(mut self) {
         let shutdown = async {
             if let Err(err) = tokio::signal::ctrl_c().await {
@@ -158,22 +154,57 @@ where
         };
         tokio::pin!(shutdown);
 
+        let mut pending: Option<Update<S::Event>> = None;
         loop {
-            match self.step(shutdown.as_mut()).await {
-                Ok(Loop::Continue) => {}
-                Ok(Loop::Break) => {
+            let update = match self.next_update(shutdown.as_mut(), pending.take()).await {
+                Ok(Some(update)) => update,
+                Ok(None) => {
                     tracing::info!("received shutdown signal; stopping service");
                     break;
                 }
+                Err(err) => {
+                    tracing::warn!(
+                        ?err,
+                        "failed to fetch the next update; retrying after delay"
+                    );
+                    tokio::time::sleep(STEP_RETRY_DELAY).await;
+                    continue;
+                }
+            };
+
+            // TODO: evaluate with nlordell if there is a better way that does not clone on each update
+            match self.step(update.clone()).await {
+                Ok(()) => {}
                 Err(Error::State(err)) => {
                     tracing::error!(?err, "unrecoverable state transition error; exiting");
                     break;
                 }
                 Err(err) => {
                     tracing::warn!(?err, "service step failed; retrying after delay");
+                    pending = Some(update);
                     tokio::time::sleep(STEP_RETRY_DELAY).await;
                 }
             }
+        }
+    }
+
+    /// Returns the next update for [`Driver::step`] to process: `self.pending`,
+    /// if a previous call to `step` left one (see its docs), otherwise the
+    /// next one from the watcher. Returns `Ok(None)` on a shutdown signal,
+    /// which only races fetching a *new* update — a pending update is always
+    /// returned immediately.
+    async fn next_update(
+        &mut self,
+        shutdown: Pin<&mut impl Future<Output = ()>>,
+        pending: Option<Update<S::Event>>,
+    ) -> Result<Option<Update<S::Event>>, Error> {
+        match pending {
+            Some(update) => Ok(Some(update)),
+            None => tokio::select! {
+                biased;
+                _ = shutdown => Ok(None),
+                update = self.watcher.next() => update.map(Some).map_err(Error::from),
+            },
         }
     }
 
@@ -181,15 +212,19 @@ where
     /// transaction queue, advancing the state machine, and queuing the
     /// transactions its actions encode to.
     ///
-    /// Only the wait for the next update races `shutdown`; once an update
-    /// arrives it is processed to completion so its state transition and queued
-    /// transactions are committed before the loop can stop.
-    async fn step(&mut self, shutdown: Pin<&mut impl Future<Output = ()>>) -> Result<Loop, Error> {
-        let update = tokio::select! {
-            biased;
-            _ = shutdown => return Ok(Loop::Break),
-            update = self.watcher.next() => update?,
-        };
+    /// On failure, `self.pending` is set to the update to retry, if any, for
+    /// [`Driver::next_update`] to hand back on the next call. A `Block` update
+    /// that fails the transaction queue's per-block housekeeping is stashed
+    /// there so the exact same update can be retried: the watcher's
+    /// event-fetching side has already (irreversibly) moved on to this
+    /// block's logs regardless of whether this call succeeds, so the state
+    /// machine — which has not yet seen this update — must eventually see
+    /// this exact one to stay in step with it, not a fresh one that skips it.
+    /// Once `self.state.handle_update` is reached, either it or the
+    /// subsequent action submission failing has nothing to retry: the state
+    /// machine has already committed (or would redundantly recommit) this
+    /// update, so `self.pending` is left as `None`.
+    async fn step(&mut self, update: Update<S::Event>) -> Result<(), Error> {
         tracing::trace!(?update, "received watcher update");
 
         // Block updates drive the transaction queue's per-block housekeeping
@@ -211,6 +246,6 @@ where
             self.transactions.queue(transactions).await?;
         }
 
-        Ok(Loop::Continue)
+        Ok(())
     }
 }

--- a/crates/core/src/index/events.rs
+++ b/crates/core/src/index/events.rs
@@ -561,6 +561,7 @@ macro_rules! watcher_events {
         }
     ) => {
         $(#[$meta])*
+        #[derive(Clone)]
         $vis enum $name {
             $($variant($events)),*
         }

--- a/crates/core/src/state/mod.rs
+++ b/crates/core/src/state/mod.rs
@@ -121,6 +121,7 @@ pub struct StateMachine<S, T, E> {
     effects: E,
 }
 
+#[derive(Debug)]
 enum Status {
     Initialized,
     BlockPending { pending: u64 },
@@ -193,10 +194,10 @@ where
     ///
     /// The state machine halts if it returns an error, as it can no longer
     /// correctly progress.
-    pub async fn handle_update(
-        &mut self,
-        update: Update<T::Event>,
-    ) -> Result<Vec<T::Action>, Error> {
+    pub async fn handle_update(&mut self, update: Update<T::Event>) -> Result<Vec<T::Action>, Error>
+    where
+        T::Event: std::fmt::Debug,
+    {
         let mut lock = self.inner.lock().await;
         let (state, status) = mem::take(&mut *lock).ok_or(Error::Poisoned)?;
         let (state, status, actions) = match update {
@@ -239,9 +240,17 @@ where
                 // We are extra defensive with the updates that we pass to the
                 // state machine, so ensure that the logs are in strictly sorted
                 // and in the update's block range.
-                if !logs.is_sorted_by(|a, b| (a.block, a.index) < (b.block, b.index))
-                    || logs.iter().any(|log| !blocks.contains(&log.block))
-                {
+                let sorted = logs.is_sorted_by(|a, b| (a.block, a.index) < (b.block, b.index));
+                let in_range = logs.iter().all(|log| blocks.contains(&log.block));
+                if !sorted || !in_range {
+                    tracing::error!(
+                        ?status,
+                        ?blocks,
+                        sorted,
+                        in_range,
+                        logs_len = logs.len(),
+                        "rejecting Logs update: entries must be strictly sorted by (block, index) and fall within the update's block range"
+                    );
                     return Err(Error::BadUpdate);
                 }
 
@@ -279,7 +288,14 @@ where
 
                 (state, status, actions)
             }
-            _ => return Err(Error::BadUpdate),
+            _ => {
+                tracing::error!(
+                    ?status,
+                    ?update,
+                    "rejecting update: it does not match any expected transition for the current status"
+                );
+                return Err(Error::BadUpdate);
+            }
         };
         *lock = Some((state, status));
         Ok(actions)
@@ -351,7 +367,14 @@ fn block_range(from: u64, to: u64) -> Result<RangeInclusive<u64>, Error> {
     (from <= to)
         .then_some(from..=to)
         .map(RangeInclusive::from)
-        .ok_or(Error::BadUpdate)
+        .ok_or_else(|| {
+            tracing::error!(
+                from,
+                to,
+                "rejecting update: block range's `from` is after `to`"
+            );
+            Error::BadUpdate
+        })
 }
 
 fn is_next_in_range(range: impl Into<RangeInclusive<u64>>, sub: RangeInclusive<u64>) -> bool {

--- a/crates/core/src/tx/mod.rs
+++ b/crates/core/src/tx/mod.rs
@@ -89,6 +89,7 @@ pub struct TransactionQueue<P> {
     balance_cache: Option<U256>,
 }
 
+#[derive(Clone, Copy, Debug)]
 enum Block {
     Initialized,
     Latest { block: u64 },
@@ -145,45 +146,58 @@ where
         self.balance_cache = None;
         match update {
             BlockUpdate::New { number, safe, .. } => {
-                if self.next_block()?.is_some_and(|next| next != number) || safe > number {
+                let next = self.next_block()?;
+                if next.is_some_and(|next| next != number) || safe > number {
+                    tracing::error!(
+                        block = ?self.block,
+                        number,
+                        safe,
+                        next = ?next,
+                        "rejecting New block update: does not follow the expected block sequence, or `safe` is ahead of `number`"
+                    );
                     return Err(Error::BadUpdate);
                 }
+                let previous_block = self.block;
                 self.block = Block::Latest { block: number };
-
-                // The signer nonce is an RPC round-trip needed only to mark
-                // executed transactions and to assign nonces to queued ones;
-                // both are moot unless a transaction is still outstanding, so
-                // skip it (and the work that needs it) otherwise. Pruning needs
-                // no nonce and always runs, before submission so expired
-                // transactions are dropped rather than broadcast.
-                let outstanding = self.storage.count_outstanding(number).await? > 0;
-                if outstanding {
-                    let nonce = self.nonce().await?;
-                    self.storage
-                        .mark_executed(Status {
-                            block: number,
-                            nonce,
-                        })
-                        .await?;
-                }
-
-                self.storage.prune(safe).await?;
-                if outstanding {
-                    self.resubmit_stale(number).await?;
-                    self.submit_pending().await?;
+                if let Err(err) = self.handle_new_block(number, safe).await {
+                    self.block = previous_block;
+                    return Err(err);
                 }
             }
             BlockUpdate::Uncle { number } => {
-                if self.latest_block().is_some_and(|latest| latest < number) {
+                let latest = self.latest_block();
+                if latest.is_some_and(|latest| latest < number) {
+                    tracing::warn!(
+                        block = ?self.block,
+                        number,
+                        latest = ?latest,
+                        "rejecting Uncle update: the uncled block is ahead of the last observed latest block"
+                    );
                     return Err(Error::BadUpdate);
                 }
-                self.block = Block::Latest {
-                    block: number.checked_sub(1).ok_or(Error::BadUpdate)?,
-                };
+                let block = number.checked_sub(1).ok_or_else(|| {
+                    tracing::warn!(
+                        number,
+                        "rejecting Uncle update: block 0 has no parent block to roll back to"
+                    );
+                    Error::BadUpdate
+                })?;
+                // Unlike `New` above, nothing here needs `self.block` updated
+                // ahead of time, so it's simplest (and safe to retry) to only
+                // commit it once the fallible work has actually succeeded.
                 self.storage.unmark_executed(number).await?;
+                self.block = Block::Latest { block };
             }
             BlockUpdate::Warp { from, to } => {
-                if self.next_block()?.is_some_and(|next| next != from) || to < from {
+                let next = self.next_block()?;
+                if next.is_some_and(|next| next != from) || to < from {
+                    tracing::warn!(
+                        block = ?self.block,
+                        from,
+                        to,
+                        next = ?next,
+                        "rejecting Warp update: `from` does not follow the expected block sequence, or `to` is before `from`"
+                    );
                     return Err(Error::BadUpdate);
                 }
 
@@ -198,6 +212,36 @@ where
                 self.block = Block::Warping { to };
             }
         }
+        Ok(())
+    }
+
+    /// Performs the per-block housekeeping for a `New` block update once
+    /// `self.block` already reflects it: marking executed transactions,
+    /// pruning finalized and expired ones, and resubmitting/submitting.
+    async fn handle_new_block(&mut self, number: u64, safe: u64) -> Result<(), Error> {
+        // The signer nonce is an RPC round-trip needed only to mark executed
+        // transactions and to assign nonces to queued ones; both are moot
+        // unless a transaction is still outstanding, so skip it (and the work
+        // that needs it) otherwise. Pruning needs no nonce and always runs,
+        // before submission so expired transactions are dropped rather than
+        // broadcast.
+        let outstanding = self.storage.count_outstanding(number).await? > 0;
+        if outstanding {
+            let nonce = self.nonce().await?;
+            self.storage
+                .mark_executed(Status {
+                    block: number,
+                    nonce,
+                })
+                .await?;
+        }
+
+        self.storage.prune(safe).await?;
+        if outstanding {
+            self.resubmit_stale(number).await?;
+            self.submit_pending().await?;
+        }
+
         Ok(())
     }
 
@@ -504,6 +548,32 @@ mod tests {
             queue.handle_block_update(new_block(block)).await.unwrap();
             assert!(asserter.read_q().is_empty());
         }
+    }
+
+    #[tokio::test]
+    async fn restores_the_latest_block_if_new_block_housekeeping_fails() {
+        let asserter = Asserter::new();
+        let mut queue = queue(&asserter).await;
+        queue.queue([(tx("0x01"), Some(1000))]).await.unwrap();
+
+        // No RPC response is queued for the nonce fetch this housekeeping
+        // needs (since the queued transaction is outstanding), so it fails.
+        assert!(queue.handle_block_update(new_block(10)).await.is_err());
+
+        // The failed attempt must not have left `self.block` advanced to 10:
+        // a caller retrying the identical update needs to see the same
+        // starting state it did on the first attempt, not one that already
+        // believes it advanced.
+        assert_eq!(queue.latest_block(), None);
+
+        // Retrying the identical update, this time with the RPC responses it
+        // needs, succeeds and correctly advances to block 10.
+        asserter.push_success(&U64::from(0)); // signer transaction count
+        asserter.push_success(&fee_history()); // fee estimate
+        asserter.push_success(&B256::ZERO); // transaction hash from submission
+        queue.handle_block_update(new_block(10)).await.unwrap();
+        assert_eq!(queue.latest_block(), Some(10));
+        assert!(asserter.read_q().is_empty());
     }
 
     #[tokio::test]


### PR DESCRIPTION
When a transitions fails then in many case it is possible to try again. But the current logic consumed the updated, therefore skipping it in case of an error rather than retrying it. To fix this the current update is retained and reused in case of an error, to ensure that each update is applied before proceeding to the next.

This also means that within the handlers state should only be updated on success (i.e. when updating the last processed block). Error logging has been added to all BadUpdate pathts to make such issue more visible.

Due to this bug there were case where a failed sqlite update caused a new block update to be skipped, and therefore raising a non recoverable error on the next logs update, as the transition to the new block was missing.

## Alternative that should be discussed

It would also be possible to remove the retry logic (at least for the path were updates are applied, so the transition). Generally most of the paths should try to recover internally from the error, and if this is not possible cause a hard failure.

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://docs.safefoundation.org/cla).
