### PR TITLE
[Phase 1]: Implement Oracle Addresses in Settings

### DIFF
--- a/explorer/.env.sample
+++ b/explorer/.env.sample
@@ -29,6 +29,11 @@
 # Default signing timeout in blocks.
 # VITE_DEFAULT_SIGNING_TIMEOUT=12
 
+# Default oracle allow-list (comma-separated addresses). Oracle-checked transaction
+# proposals are only recognized when their oracle is in this list; when empty, trust
+# falls back to oracles that already have an attested transaction on chain.
+# VITE_DEFAULT_ORACLES=
+
 # Canonical public URL of the app (no trailing slash). Used in og:url, og:image, and
 # twitter:image meta tags for social link previews. When unset, those tags render with
 # an empty URL and are ignored by social crawlers.

--- a/explorer/src/components/settings/ConsensusSettingsForm.test.tsx
+++ b/explorer/src/components/settings/ConsensusSettingsForm.test.tsx
@@ -15,6 +15,7 @@ const DEFAULT_SETTINGS: Settings = {
 	refetchInterval: 10000,
 	blocksPerEpoch: 1440,
 	signingTimeout: 12,
+	oracles: [],
 };
 
 const mockUpdateSettings = vi.hoisted(() => vi.fn());
@@ -43,6 +44,7 @@ describe("ConsensusSettingsForm", () => {
 		expect(screen.getByLabelText("Validator Info Url")).toBeTruthy();
 		expect(screen.getByLabelText("Refetch Interval (0 to disable refetching)")).toBeTruthy();
 		expect(screen.getByLabelText("Signing Timeout (blocks)")).toBeTruthy();
+		expect(screen.getByLabelText("Oracle Addresses (comma-separated)")).toBeTruthy();
 	});
 
 	it("displays default values from settings", () => {
@@ -117,6 +119,38 @@ describe("ConsensusSettingsForm", () => {
 		fireEvent.submit(input.closest("form") as HTMLFormElement);
 		await waitFor(() => {
 			expect(screen.getByText(/too small/i)).toBeTruthy();
+		});
+	});
+
+	it("parses comma-separated oracle addresses into a list on submit", async () => {
+		const oracleA = "0x49Db717Adec0D22235A73C3a9c2ea57AB0bC2353";
+		const oracleB = "0x223624cBF099e5a8f8cD5aF22aFa424a1d1acEE9";
+		render(<ConsensusSettingsForm />);
+		const input = screen.getByLabelText("Oracle Addresses (comma-separated)") as HTMLInputElement;
+		fireEvent.change(input, { target: { value: `${oracleA}, ${oracleB}` } });
+		fireEvent.submit(input.closest("form") as HTMLFormElement);
+		await waitFor(() => {
+			expect(mockUpdateSettings).toHaveBeenCalledWith(expect.objectContaining({ oracles: [oracleA, oracleB] }));
+		});
+	});
+
+	it("treats an empty oracle addresses field as an empty list", async () => {
+		render(<ConsensusSettingsForm />);
+		const input = screen.getByLabelText("Oracle Addresses (comma-separated)") as HTMLInputElement;
+		fireEvent.change(input, { target: { value: "" } });
+		fireEvent.submit(input.closest("form") as HTMLFormElement);
+		await waitFor(() => {
+			expect(mockUpdateSettings).toHaveBeenCalledWith(expect.objectContaining({ oracles: [] }));
+		});
+	});
+
+	it("shows a validation error for an invalid oracle address", async () => {
+		render(<ConsensusSettingsForm />);
+		const input = screen.getByLabelText("Oracle Addresses (comma-separated)") as HTMLInputElement;
+		fireEvent.change(input, { target: { value: "not-an-address" } });
+		fireEvent.submit(input.closest("form") as HTMLFormElement);
+		await waitFor(() => {
+			expect(screen.getByText(/invalid address format or checksum/i)).toBeTruthy();
 		});
 	});
 });

--- a/explorer/src/components/settings/ConsensusSettingsForm.tsx
+++ b/explorer/src/components/settings/ConsensusSettingsForm.tsx
@@ -11,6 +11,21 @@ const numberOrStringAsNumber = z
 	.union([z.string(), z.number()])
 	.transform((val) => (val === "" ? undefined : Number(val)));
 
+// Accepts the already-parsed Address[] from Settings (used as react-hook-form's
+// defaultValues) or the raw comma-separated text the user edits it as. Validation
+// issues are reported on the field itself (not per-address) so FormItem can render them.
+const addressListOrStringAsAddressList = z.union([z.array(checkedAddressSchema), z.string()]).transform((val, ctx) => {
+	const addresses = (Array.isArray(val) ? val : val.split(","))
+		.map((address) => address.trim())
+		.filter((address) => address !== "");
+	const parsed = z.array(checkedAddressSchema).safeParse(addresses);
+	if (!parsed.success) {
+		ctx.addIssue({ code: "custom", message: parsed.error.issues[0]?.message ?? "Invalid oracle address" });
+		return z.NEVER;
+	}
+	return parsed.data;
+});
+
 const settingsFormSchema = z.object({
 	consensus: emptyToUndefined(checkedAddressSchema),
 	decoder: emptyToUndefined(z.url()),
@@ -21,6 +36,7 @@ const settingsFormSchema = z.object({
 	refetchInterval: numberOrStringAsNumber.pipe(z.number().int().nonnegative().optional()),
 	blocksPerEpoch: numberOrStringAsNumber.pipe(z.number().int().positive().optional()),
 	signingTimeout: numberOrStringAsNumber.pipe(z.number().int().positive().optional()),
+	oracles: addressListOrStringAsAddressList.optional(),
 });
 
 type SettingsFormInput = z.input<typeof settingsFormSchema>;
@@ -78,6 +94,14 @@ function ConsensusSettingsForm({ onSubmitted }: { onSubmitted?: () => void }) {
 				label="Signing Timeout (blocks)"
 			/>
 			<FormItem id="validatorInfo" register={register} error={errors.validatorInfo} label="Validator Info Url" />
+
+			<FormItem
+				id="oracles"
+				register={register}
+				error={errors.oracles}
+				label="Oracle Addresses (comma-separated)"
+				placeholder="0x…, 0x…"
+			/>
 
 			<FormItem
 				id="refetchInterval"

--- a/explorer/src/hooks/useSafeTransactionProposals.test.ts
+++ b/explorer/src/hooks/useSafeTransactionProposals.test.ts
@@ -23,6 +23,7 @@ const DEFAULT_SETTINGS: Settings = {
 	refetchInterval: 0,
 	blocksPerEpoch: 1440,
 	signingTimeout: 12,
+	oracles: [],
 };
 
 vi.mock("@/hooks/useSettings", () => ({

--- a/explorer/src/lib/settings.test.ts
+++ b/explorer/src/lib/settings.test.ts
@@ -49,4 +49,22 @@ describe("loadSettings", () => {
 		expect(settings.signingTimeout).toBe(12);
 		expect(settings.blocksPerEpoch).toBe(1440);
 	});
+
+	it("oracles defaults to an empty array when nothing is stored", () => {
+		const settings = loadSettings();
+		expect(settings.oracles).toEqual([]);
+	});
+
+	it("oracles is read from stored settings", () => {
+		const oracle = "0x49Db717Adec0D22235A73C3a9c2ea57AB0bC2353";
+		localStorage.setItem(STORAGE_KEY, JSON.stringify({ oracles: [oracle] }));
+		const settings = loadSettings();
+		expect(settings.oracles).toEqual([oracle]);
+	});
+
+	it("falls back to defaults when a stored oracle address is invalid", () => {
+		localStorage.setItem(STORAGE_KEY, JSON.stringify({ oracles: ["not-an-address"] }));
+		const settings = loadSettings();
+		expect(settings.oracles).toEqual([]);
+	});
 });

--- a/explorer/src/lib/settings.ts
+++ b/explorer/src/lib/settings.ts
@@ -16,6 +16,7 @@ const DEFAULT_SETTINGS = {
 	blocksPerEpoch: __DEFAULT_BLOCKS_PER_EPOCH__,
 	signingTimeout: __DEFAULT_SIGNING_TIMEOUT__,
 	relayer: __DEFAULT_RELAYER__ || undefined,
+	oracles: __DEFAULT_ORACLES__ as Address[],
 };
 
 const settingsSchema = z.object({
@@ -28,6 +29,9 @@ const settingsSchema = z.object({
 	refetchInterval: z.number().int().nonnegative().default(DEFAULT_SETTINGS.refetchInterval),
 	blocksPerEpoch: z.number().int().positive().default(DEFAULT_SETTINGS.blocksPerEpoch),
 	signingTimeout: z.number().int().positive().default(DEFAULT_SETTINGS.signingTimeout),
+	// Oracle allow-list. Empty means trust falls back to on-chain attested oracles
+	// instead of hiding or blindly trusting every oracle-checked proposal.
+	oracles: z.array(checkedAddressSchema).default(DEFAULT_SETTINGS.oracles),
 });
 
 export type Settings = z.output<typeof settingsSchema>;

--- a/explorer/src/vite-env.d.ts
+++ b/explorer/src/vite-env.d.ts
@@ -17,3 +17,4 @@ declare const __DEFAULT_VALIDATOR_INFO__: string;
 declare const __DEFAULT_REFETCH_INTERVAL__: number;
 declare const __DEFAULT_BLOCKS_PER_EPOCH__: number;
 declare const __DEFAULT_SIGNING_TIMEOUT__: number;
+declare const __DEFAULT_ORACLES__: string[];

--- a/explorer/vite.config.js
+++ b/explorer/vite.config.js
@@ -4,6 +4,8 @@ import { tanstackRouter } from "@tanstack/router-plugin/vite";
 import viteReact from "@vitejs/plugin-react";
 import { defineConfig, loadEnv } from "vite";
 
+const ETHEREUM_ADDRESS_REGEX = /^0x[0-9a-fA-F]{40}$/;
+
 // https://vitejs.dev/config/
 export default defineConfig(({ mode }) => {
 	// Load environment variables and set base path for nested routes
@@ -25,7 +27,7 @@ export default defineConfig(({ mode }) => {
 	}
 
 	// Validate VITE_DEFAULT_* overrides at build time (only when explicitly set)
-	if (env.VITE_DEFAULT_CONSENSUS && !/^0x[0-9a-fA-F]{40}$/.test(env.VITE_DEFAULT_CONSENSUS)) {
+	if (env.VITE_DEFAULT_CONSENSUS && !ETHEREUM_ADDRESS_REGEX.test(env.VITE_DEFAULT_CONSENSUS)) {
 		throw new Error(`VITE_DEFAULT_CONSENSUS is not a valid Ethereum address: ${env.VITE_DEFAULT_CONSENSUS}`);
 	}
 	for (const key of [
@@ -50,6 +52,15 @@ export default defineConfig(({ mode }) => {
 	]) {
 		if (env[key] && !Number.isInteger(Number(env[key]))) {
 			throw new Error(`${key} is not a valid integer: ${env[key]}`);
+		}
+	}
+	const defaultOracles = (env.VITE_DEFAULT_ORACLES || "")
+		.split(",")
+		.map((address) => address.trim())
+		.filter(Boolean);
+	for (const address of defaultOracles) {
+		if (!ETHEREUM_ADDRESS_REGEX.test(address)) {
+			throw new Error(`VITE_DEFAULT_ORACLES contains an invalid Ethereum address: ${address}`);
 		}
 	}
 
@@ -107,6 +118,7 @@ export default defineConfig(({ mode }) => {
 			__DEFAULT_REFETCH_INTERVAL__: Number(env.VITE_DEFAULT_REFETCH_INTERVAL) || 10000,
 			__DEFAULT_BLOCKS_PER_EPOCH__: Number(env.VITE_DEFAULT_BLOCKS_PER_EPOCH) || 1440,
 			__DEFAULT_SIGNING_TIMEOUT__: Number(env.VITE_DEFAULT_SIGNING_TIMEOUT) || 12,
+			__DEFAULT_ORACLES__: JSON.stringify(defaultOracles),
 		},
 	};
 });

--- a/explorer/vitest.config.ts
+++ b/explorer/vitest.config.ts
@@ -19,6 +19,7 @@ export default defineConfig({
 		__DEFAULT_REFETCH_INTERVAL__: 10000,
 		__DEFAULT_BLOCKS_PER_EPOCH__: 1440,
 		__DEFAULT_SIGNING_TIMEOUT__: 12,
+		__DEFAULT_ORACLES__: JSON.stringify([]),
 	},
 	test: {
 		coverage: {


### PR DESCRIPTION
Allow to set a list of trusted oracles in the settings. Custom error handling is implemented for a comma separated address list to display a proper error for an invalid input.

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://docs.safefoundation.org/cla).
