### PR TITLE
[Phase 2]: Add support for oracle consensus events

### DIFF
--- a/explorer/src/components/transaction/SafeTxProposals.test.tsx
+++ b/explorer/src/components/transaction/SafeTxProposals.test.tsx
@@ -56,6 +56,7 @@ const makeProposal = (overrides?: Partial<TransactionProposalWithStatus>): Trans
 	chainId: 8453n,
 	safeTxHash: SAFE_TX_HASH,
 	epoch: 1n,
+	oracle: null,
 	transaction: makeTransaction(),
 	proposedAt: { block: 100n, tx: "0xabc" as Hex },
 	attestedAt: null,

--- a/explorer/src/components/transaction/TransactionProposalsList.test.tsx
+++ b/explorer/src/components/transaction/TransactionProposalsList.test.tsx
@@ -23,6 +23,7 @@ const makeProposal = (safeTxHash: string, epoch = 1n): TransactionProposalWithSt
 	chainId: 1n,
 	safeTxHash: safeTxHash as Hex,
 	epoch,
+	oracle: null,
 	transaction: {
 		chainId: 1n,
 		safe: "0x0000000000000000000000000000000000000001" as Address,

--- a/explorer/src/hooks/useProposalsForTransaction.tsx
+++ b/explorer/src/hooks/useProposalsForTransaction.tsx
@@ -17,6 +17,7 @@ export function useProposalsForTransaction(proposalTxHash: Hex) {
 			proposalTxHash,
 			settings.maxBlockRange,
 			settings.signingTimeout,
+			settings.oracles,
 		],
 		queryFn: () =>
 			getConsensusWorker().loadTransactionProposals({
@@ -25,6 +26,7 @@ export function useProposalsForTransaction(proposalTxHash: Hex) {
 				safeTxHash: proposalTxHash,
 				maxBlockRange: BigInt(settings.maxBlockRange),
 				signingTimeout: settings.signingTimeout,
+				oracles: settings.oracles,
 			}),
 		select: (data) => data.proposals,
 		initialData: { proposals: [], fromBlock: 0n, toBlock: 0n },

--- a/explorer/src/hooks/useRecentTransactionProposals.tsx
+++ b/explorer/src/hooks/useRecentTransactionProposals.tsx
@@ -10,13 +10,20 @@ export function useRecentTransactionProposals(autoRefresh = true) {
 	const [settings] = useSettings();
 
 	return useQuery<LoadTransactionProposalsResult, Error, TransactionProposalWithStatus[]>({
-		queryKey: ["recentProposals", settings.consensus, settings.maxBlockRange, settings.signingTimeout],
+		queryKey: [
+			"recentProposals",
+			settings.consensus,
+			settings.maxBlockRange,
+			settings.signingTimeout,
+			settings.oracles,
+		],
 		queryFn: () =>
 			getConsensusWorker().loadTransactionProposals({
 				rpc: settings.rpc,
 				consensus: settings.consensus,
 				maxBlockRange: BigInt(settings.maxBlockRange),
 				signingTimeout: settings.signingTimeout,
+				oracles: settings.oracles,
 			}),
 		select: (data) => data.proposals,
 		refetchInterval: () => (autoRefresh && settings.refetchInterval > 0 ? settings.refetchInterval : false),

--- a/explorer/src/hooks/useSafeTransactionProposals.ts
+++ b/explorer/src/hooks/useSafeTransactionProposals.ts
@@ -32,6 +32,7 @@ export function useSafeTransactionProposals({
 			settings.consensus,
 			settings.maxBlockRange,
 			settings.signingTimeout,
+			settings.oracles,
 		],
 		refetchInterval: autoRefresh ? settings.refetchInterval : false,
 		// pageParam is the toBlock for this window. undefined on the first page so
@@ -45,6 +46,7 @@ export function useSafeTransactionProposals({
 				toBlock,
 				maxBlockRange: BigInt(settings.maxBlockRange),
 				signingTimeout: settings.signingTimeout,
+				oracles: settings.oracles,
 			}),
 		initialPageParam: undefined,
 		// The next window ends one block before where the previous one started.

--- a/explorer/src/lib/consensus/abi.ts
+++ b/explorer/src/lib/consensus/abi.ts
@@ -9,13 +9,15 @@ export const consensusAbi = parseAbi([
 	"function getTransactionAttestationByHash(uint64 epoch, bytes32 safeTxHash) external view returns (((uint256 x, uint256 y) r, uint256 z) signature)",
 	"event TransactionProposed(bytes32 indexed safeTxHash, uint256 indexed chainId, address indexed safe, uint64 epoch, (uint256 chainId, address safe, address to, uint256 value, bytes data, uint8 operation, uint256 safeTxGas, uint256 baseGas, uint256 gasPrice, address gasToken, address refundReceiver, uint256 nonce) transaction)",
 	"event TransactionAttested(bytes32 indexed safeTxHash, uint256 indexed chainId, address indexed safe, uint64 epoch, bytes32 signatureId, ((uint256 x, uint256 y) r, uint256 z) attestation)",
+	"event OracleTransactionProposed(bytes32 indexed safeTxHash, uint256 indexed chainId, address indexed safe, uint64 epoch, address oracle, (uint256 chainId, address safe, address to, uint256 value, bytes data, uint8 operation, uint256 safeTxGas, uint256 baseGas, uint256 gasPrice, address gasToken, address refundReceiver, uint256 nonce) transaction)",
+	"event OracleTransactionAttested(bytes32 indexed safeTxHash, uint256 indexed chainId, address indexed safe, uint64 epoch, address oracle, bytes32 signatureId, ((uint256 x, uint256 y) r, uint256 z) attestation)",
 	"event EpochProposed(uint64 indexed activeEpoch, uint64 indexed proposedEpoch, uint64 rolloverBlock, bytes32 groupId, (uint256 x, uint256 y) groupKey)",
 	"event EpochStaged(uint64 indexed activeEpoch, uint64 indexed proposedEpoch, uint64 rolloverBlock, bytes32 groupId, (uint256 x, uint256 y) groupKey, bytes32 signatureId, ((uint256 x, uint256 y) r, uint256 z) attestation)",
 ]);
 
-const [proposedEventSelector, attestedEventSelector] = [
+export const transactionEventSelectors = [
 	"TransactionProposed" as const,
 	"TransactionAttested" as const,
+	"OracleTransactionProposed" as const,
+	"OracleTransactionAttested" as const,
 ].map((eventName) => toEventSelector(getAbiItem({ abi: consensusAbi, name: eventName })));
-
-export const transactionEventSelectors = [proposedEventSelector, attestedEventSelector];

--- a/explorer/src/lib/consensus/consensus.test.ts
+++ b/explorer/src/lib/consensus/consensus.test.ts
@@ -1,6 +1,7 @@
 import type { Address, Hex, PublicClient } from "viem";
-import { numberToHex } from "viem";
+import { encodeAbiParameters, encodeEventTopics, getAbiItem, numberToHex } from "viem";
 import { describe, expect, it, vi } from "vitest";
+import { consensusAbi } from "./abi";
 import { loadEpochRolloverHistory, loadEpochsState } from "./epochs";
 import { loadTransactionProposals } from "./transactions";
 
@@ -35,7 +36,7 @@ describe("loadTransactionProposals", () => {
 			expect((provider.request as ReturnType<typeof vi.fn>).mock.calls).toHaveLength(1);
 		});
 
-		it("passes both event selectors as an OR filter in topic[0]", async () => {
+		it("passes all four event selectors as an OR filter in topic[0]", async () => {
 			const provider = makeProvider();
 			await loadTransactionProposals({
 				provider,
@@ -44,7 +45,7 @@ describe("loadTransactionProposals", () => {
 				signingTimeout: SIGNING_TIMEOUT,
 			});
 			expect(Array.isArray(firstCall(provider).topics[0])).toBe(true);
-			expect(firstCall(provider).topics[0]).toHaveLength(2);
+			expect(firstCall(provider).topics[0]).toHaveLength(4);
 		});
 
 		it("uses null for topic[1] when safeTxHash is not provided", async () => {
@@ -134,6 +135,208 @@ describe("loadTransactionProposals", () => {
 			expect(result.toBlock).toBe(6000n);
 			expect(result.proposals).toEqual([]);
 		});
+	});
+});
+
+// biome-ignore lint/suspicious/noExplicitAny: viem's ABI input types don't always include the `indexed` property
+const nonIndexedInputs = (inputs: readonly any[]) => inputs.filter((i: any) => !i.indexed);
+
+const ORACLE_TX = {
+	chainId: 1n,
+	safe: SAFE_ADDRESS,
+	to: SAFE_ADDRESS,
+	value: 0n,
+	data: "0x" as Hex,
+	operation: 0,
+	safeTxGas: 0n,
+	baseGas: 0n,
+	gasPrice: 0n,
+	gasToken: "0x0000000000000000000000000000000000000000" as Address,
+	refundReceiver: "0x0000000000000000000000000000000000000000" as Address,
+	nonce: 0n,
+};
+
+const makeRawConsensusLog = ({
+	eventName,
+	indexedArgs,
+	nonIndexedValues,
+	blockNumber,
+	logIndex = 0,
+}: {
+	eventName: "TransactionProposed" | "TransactionAttested" | "OracleTransactionProposed" | "OracleTransactionAttested";
+	indexedArgs: Record<string, unknown>;
+	nonIndexedValues: unknown[];
+	blockNumber: bigint;
+	logIndex?: number;
+}) => {
+	const topics = encodeEventTopics({ abi: consensusAbi, eventName, args: indexedArgs });
+	const abiItem = getAbiItem({ abi: consensusAbi, name: eventName }) as { inputs: readonly unknown[] };
+	const data = encodeAbiParameters(nonIndexedInputs(abiItem.inputs), nonIndexedValues);
+	return {
+		address: CONSENSUS,
+		topics,
+		data,
+		blockNumber: numberToHex(blockNumber),
+		logIndex: numberToHex(logIndex),
+		transactionHash: `0x${"00".repeat(32)}`,
+		blockHash: `0x${"00".repeat(32)}`,
+		transactionIndex: "0x0",
+		removed: false,
+	};
+};
+
+const makeProposedLog = ({ safeTxHash, epoch, blockNumber }: { safeTxHash: Hex; epoch: bigint; blockNumber: bigint }) =>
+	makeRawConsensusLog({
+		eventName: "TransactionProposed",
+		indexedArgs: { safeTxHash, chainId: 1n, safe: SAFE_ADDRESS },
+		nonIndexedValues: [epoch, ORACLE_TX],
+		blockNumber,
+	});
+
+const makeOracleProposedLog = ({
+	safeTxHash,
+	epoch,
+	oracle,
+	blockNumber,
+}: {
+	safeTxHash: Hex;
+	epoch: bigint;
+	oracle: Address;
+	blockNumber: bigint;
+}) =>
+	makeRawConsensusLog({
+		eventName: "OracleTransactionProposed",
+		indexedArgs: { safeTxHash, chainId: 1n, safe: SAFE_ADDRESS },
+		nonIndexedValues: [epoch, oracle, ORACLE_TX],
+		blockNumber,
+	});
+
+const makeOracleAttestedLog = ({
+	safeTxHash,
+	epoch,
+	oracle,
+	blockNumber,
+	logIndex = 1,
+}: {
+	safeTxHash: Hex;
+	epoch: bigint;
+	oracle: Address;
+	blockNumber: bigint;
+	logIndex?: number;
+}) =>
+	makeRawConsensusLog({
+		eventName: "OracleTransactionAttested",
+		indexedArgs: { safeTxHash, chainId: 1n, safe: SAFE_ADDRESS },
+		nonIndexedValues: [epoch, oracle, `0x${"00".repeat(32)}`, { r: { x: 0n, y: 0n }, z: 0n }],
+		blockNumber,
+		logIndex,
+	});
+
+const makeProviderWithLogs = (logs: ReturnType<typeof makeRawConsensusLog>[]): PublicClient =>
+	({
+		getBlockNumber: vi.fn().mockResolvedValue(CURRENT_BLOCK),
+		request: vi.fn().mockResolvedValue(logs),
+	}) as unknown as PublicClient;
+
+describe("loadTransactionProposals oracle recognition", () => {
+	const ORACLE = "0x3333333333333333333333333333333333333333" as Address;
+	const OTHER_ORACLE = "0x4444444444444444444444444444444444444444" as Address;
+
+	it("discards an oracle proposal whose oracle is not in the allow-list", async () => {
+		const provider = makeProviderWithLogs([
+			makeOracleProposedLog({ safeTxHash: SAFE_TX_HASH, epoch: 1n, oracle: ORACLE, blockNumber: CURRENT_BLOCK }),
+		]);
+		const result = await loadTransactionProposals({
+			provider,
+			consensus: CONSENSUS,
+			maxBlockRange: MAX_BLOCK_RANGE,
+			signingTimeout: SIGNING_TIMEOUT,
+			oracles: [OTHER_ORACLE],
+		});
+		expect(result.proposals).toEqual([]);
+	});
+
+	it("keeps and tags an oracle proposal whose oracle is in the allow-list", async () => {
+		const provider = makeProviderWithLogs([
+			makeOracleProposedLog({ safeTxHash: SAFE_TX_HASH, epoch: 1n, oracle: ORACLE, blockNumber: CURRENT_BLOCK }),
+		]);
+		const result = await loadTransactionProposals({
+			provider,
+			consensus: CONSENSUS,
+			maxBlockRange: MAX_BLOCK_RANGE,
+			signingTimeout: SIGNING_TIMEOUT,
+			oracles: [ORACLE],
+		});
+		expect(result.proposals).toHaveLength(1);
+		expect(result.proposals[0].oracle).toBe(ORACLE);
+	});
+
+	it("drops an oracle proposal from an unattested, unlisted oracle when no allow-list is configured", async () => {
+		const provider = makeProviderWithLogs([
+			makeOracleProposedLog({ safeTxHash: SAFE_TX_HASH, epoch: 1n, oracle: ORACLE, blockNumber: CURRENT_BLOCK }),
+		]);
+		const result = await loadTransactionProposals({
+			provider,
+			consensus: CONSENSUS,
+			maxBlockRange: MAX_BLOCK_RANGE,
+			signingTimeout: SIGNING_TIMEOUT,
+		});
+		expect(result.proposals).toEqual([]);
+	});
+
+	it("derives trust from an OracleTransactionAttested log when no allow-list is configured", async () => {
+		const provider = makeProviderWithLogs([
+			makeOracleProposedLog({ safeTxHash: SAFE_TX_HASH, epoch: 1n, oracle: ORACLE, blockNumber: CURRENT_BLOCK }),
+			makeOracleAttestedLog({ safeTxHash: SAFE_TX_HASH, epoch: 1n, oracle: ORACLE, blockNumber: CURRENT_BLOCK }),
+		]);
+		const result = await loadTransactionProposals({
+			provider,
+			consensus: CONSENSUS,
+			maxBlockRange: MAX_BLOCK_RANGE,
+			signingTimeout: SIGNING_TIMEOUT,
+		});
+		expect(result.proposals).toHaveLength(1);
+		expect(result.proposals[0].oracle).toBe(ORACLE);
+		expect(result.proposals[0].status).toBe("ATTESTED");
+	});
+
+	it("does not cross-match a plain proposal's attestation with an oracle-checked one sharing the same safeTxHash and epoch", async () => {
+		const provider = makeProviderWithLogs([
+			makeProposedLog({ safeTxHash: SAFE_TX_HASH, epoch: 1n, blockNumber: CURRENT_BLOCK }),
+			makeOracleAttestedLog({ safeTxHash: SAFE_TX_HASH, epoch: 1n, oracle: ORACLE, blockNumber: CURRENT_BLOCK }),
+		]);
+		const result = await loadTransactionProposals({
+			provider,
+			consensus: CONSENSUS,
+			maxBlockRange: MAX_BLOCK_RANGE,
+			signingTimeout: SIGNING_TIMEOUT,
+			oracles: [ORACLE],
+		});
+		expect(result.proposals).toHaveLength(1);
+		expect(result.proposals[0].oracle).toBeNull();
+		expect(result.proposals[0].status).toBe("PROPOSED");
+	});
+
+	it("matches a lower-cased allow-list address against the checksummed address decoded from logs", async () => {
+		// Mixed-case (unlike ORACLE/OTHER_ORACLE above) so lower-casing actually changes it.
+		const CHECKSUMMED_ORACLE = "0xabCDEF1234567890ABcDEF1234567890aBCDeF12" as Address;
+		const provider = makeProviderWithLogs([
+			makeOracleProposedLog({
+				safeTxHash: SAFE_TX_HASH,
+				epoch: 1n,
+				oracle: CHECKSUMMED_ORACLE,
+				blockNumber: CURRENT_BLOCK,
+			}),
+		]);
+		const result = await loadTransactionProposals({
+			provider,
+			consensus: CONSENSUS,
+			maxBlockRange: MAX_BLOCK_RANGE,
+			signingTimeout: SIGNING_TIMEOUT,
+			oracles: [CHECKSUMMED_ORACLE.toLowerCase() as Address],
+		});
+		expect(result.proposals).toHaveLength(1);
+		expect(result.proposals[0].oracle).toBe(CHECKSUMMED_ORACLE);
 	});
 });
 

--- a/explorer/src/lib/consensus/transactions.ts
+++ b/explorer/src/lib/consensus/transactions.ts
@@ -2,6 +2,7 @@ import {
 	type Address,
 	formatLog,
 	getAbiItem,
+	getAddress,
 	type Hex,
 	numberToHex,
 	type PublicClient,
@@ -39,6 +40,7 @@ export type TransactionProposal = {
 	chainId: bigint;
 	safeTxHash: Hex;
 	epoch: bigint;
+	oracle: Address | null;
 	transaction: SafeTransaction;
 	proposedAt: ExecutionLink;
 	attestedAt: ExecutionLink | null;
@@ -90,6 +92,7 @@ export const loadTransactionProposals = async ({
 	toBlock: referenceBlock,
 	maxBlockRange,
 	signingTimeout,
+	oracles = [],
 }: {
 	provider: PublicClient;
 	consensus: Address;
@@ -98,6 +101,7 @@ export const loadTransactionProposals = async ({
 	toBlock?: bigint;
 	maxBlockRange: bigint;
 	signingTimeout: number;
+	oracles?: Address[];
 }): Promise<LoadTransactionProposalsResult> => {
 	const { fromBlock, toBlock } = await getBlockRange(provider, maxBlockRange, referenceBlock);
 	const blockRange = { fromBlock: numberToHex(fromBlock), toBlock: numberToHex(toBlock) };
@@ -115,7 +119,7 @@ export const loadTransactionProposals = async ({
 			},
 		],
 	});
-	const eventLogs = mostRecentFirst(
+	const allEventLogs = mostRecentFirst(
 		parseEventLogs({
 			// <https://github.com/wevm/viem/issues/4340>
 			logs: rawLogs.map((log) => formatLog(log)),
@@ -124,16 +128,34 @@ export const loadTransactionProposals = async ({
 		}),
 	);
 
-	const attestationKey = (log: { args: { safeTxHash: Hex; epoch: bigint } }) =>
-		`${log.args.safeTxHash}:${log.args.epoch}`;
+	// `oracle` isn't an indexed topic on either oracle event, so it can't be filtered via
+	// eth_getLogs topics; trust is resolved here, after decoding. With no explicit allow-list,
+	// an oracle is trusted once it has an `OracleTransactionAttested` log in this same batch.
+	// Addresses are compared via their checksummed form: `oracles` comes from user settings and
+	// may not be checksummed, while addresses decoded from logs by viem always are.
+	const trustedOracles = new Set(
+		(oracles.length > 0
+			? oracles
+			: allEventLogs.filter((log) => log.eventName === "OracleTransactionAttested").map((log) => log.args.oracle)
+		).map((oracle) => getAddress(oracle)),
+	);
+	const eventLogs = allEventLogs.filter((log) => {
+		if (log.eventName !== "OracleTransactionProposed" && log.eventName !== "OracleTransactionAttested") {
+			return true;
+		}
+		return trustedOracles.has(getAddress(log.args.oracle));
+	});
+
+	const attestationKey = (log: { args: { safeTxHash: Hex; epoch: bigint; oracle?: Address } }) =>
+		`${log.args.safeTxHash}:${log.args.epoch}:${log.args.oracle ? getAddress(log.args.oracle) : "plain"}`;
 	const attestations = new Map(
 		eventLogs
-			.filter((log) => log.eventName === "TransactionAttested")
+			.filter((log) => log.eventName === "TransactionAttested" || log.eventName === "OracleTransactionAttested")
 			.map((log) => [attestationKey(log), { block: log.blockNumber, tx: log.transactionHash }] as const),
 	);
 	const proposals = eventLogs
 		.map((log) => {
-			if (log.eventName !== "TransactionProposed") {
+			if (log.eventName !== "TransactionProposed" && log.eventName !== "OracleTransactionProposed") {
 				return undefined;
 			}
 
@@ -142,6 +164,7 @@ export const loadTransactionProposals = async ({
 				return undefined;
 			}
 
+			const oracle = log.eventName === "OracleTransactionProposed" ? log.args.oracle : null;
 			const attestedAt = attestations.get(attestationKey(log)) ?? null;
 			const proposedAt = { block: log.blockNumber, tx: log.transactionHash };
 			const status: ProposalStatus =
@@ -154,6 +177,7 @@ export const loadTransactionProposals = async ({
 				chainId: log.args.chainId,
 				safeTxHash: log.args.safeTxHash,
 				epoch: log.args.epoch,
+				oracle,
 				transaction: transaction.data,
 				proposedAt,
 				attestedAt,

--- a/explorer/src/lib/consensus/worker.ts
+++ b/explorer/src/lib/consensus/worker.ts
@@ -16,6 +16,7 @@ const workerApi = {
 		toBlock?: bigint;
 		maxBlockRange: bigint;
 		signingTimeout: number;
+		oracles?: Address[];
 	}) => loadTransactionProposals({ ...params, provider: createRpcClient(rpc) }),
 
 	loadConsensusState: ({ rpc, consensus }: { rpc: string; consensus: Address }) =>

--- a/explorer/src/routes/safe.test.tsx
+++ b/explorer/src/routes/safe.test.tsx
@@ -84,6 +84,7 @@ const makeProposal = (safeTxHash: string): TransactionProposal => ({
 	chainId: 1n,
 	safeTxHash: safeTxHash as Hex,
 	epoch: 1n,
+	oracle: null,
 	transaction: {
 		chainId: 1n,
 		safe: "0x0000000000000000000000000000000000000001" as Address,


### PR DESCRIPTION
Adjust the proposal and attestation events to also cover the events with oracle information. The current version support both proposal paths. The detailed tracking of oracle events (including sentinel votes) will happen in a separate PR.

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://docs.safefoundation.org/cla).
