### PR TITLE
[Phase 5c]: Wire up Votes UI

### DIFF
--- a/explorer/src/components/transaction/SafeTxProposals.test.tsx
+++ b/explorer/src/components/transaction/SafeTxProposals.test.tsx
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
 
 import type { DefinedUseQueryResult } from "@tanstack/react-query";
-import { cleanup, render, screen } from "@testing-library/react";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import type { Address, Hex } from "viem";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { SafeTransaction, TransactionProposalWithStatus } from "@/lib/consensus";
@@ -26,12 +26,22 @@ vi.mock("@/hooks/useSigningProgress", () => ({
 	useAttestationStatus: vi.fn(() => ({ data: null, isFetching: false })),
 }));
 
+vi.mock("@/hooks/useVotingStatus", () => ({
+	useVotingStatus: vi.fn(() => ({ data: null })),
+}));
+
+vi.mock("@/hooks/useSentinelVotes", () => ({
+	useSentinelVotes: vi.fn(() => ({ data: [] })),
+}));
+
 vi.mock("../common/Info", () => ({
 	InlineBlockInfo: ({ block }: { block: bigint }) => <span>{block.toString()}</span>,
 	InlineExplorerTxLink: ({ children }: { children: React.ReactNode }) => <span>{children}</span>,
 }));
 
 import { useProposalsForTransaction } from "@/hooks/useProposalsForTransaction";
+import { useSentinelVotes } from "@/hooks/useSentinelVotes";
+import { useVotingStatus } from "@/hooks/useVotingStatus";
 
 afterEach(cleanup);
 
@@ -104,5 +114,40 @@ describe("SafeTxProposals", () => {
 		vi.mocked(useProposalsForTransaction).mockReturnValue(mockQueryResult([]));
 		render(<SafeTxProposals safeTxHash={SAFE_TX_HASH} transaction={makeTransaction(99999n)} />);
 		expect(screen.getByText(/No proposals found for this SafeTxHash on chain 99999/)).toBeTruthy();
+	});
+
+	it("shows an Oracle row with the derived status for an oracle proposal", () => {
+		vi.mocked(useVotingStatus).mockReturnValue({ data: { kind: "generic", approved: true } } as never);
+		vi.mocked(useProposalsForTransaction).mockReturnValue(
+			mockQueryResult([makeProposal({ oracle: "0x0000000000000000000000000000000000000099" as Address })]),
+		);
+		render(<SafeTxProposals safeTxHash={SAFE_TX_HASH} transaction={makeTransaction()} />);
+		expect(screen.getByText("Oracle")).toBeTruthy();
+		expect(screen.getByText("APPROVED")).toBeTruthy();
+		expect(screen.queryByText("0x0000…0011 ⏳")).toBeNull();
+	});
+
+	it("shows the per-sentinel vote list for a sentinel oracle request", () => {
+		vi.mocked(useVotingStatus).mockReturnValue({
+			data: { kind: "sentinel", state: "PENDING", approveCount: 1n, denyCount: 0n },
+		} as never);
+		vi.mocked(useSentinelVotes).mockReturnValue({
+			data: [
+				{ sentinel: "0x0000000000000000000000000000000000000011" as Address, state: "committed" },
+				{
+					sentinel: "0x0000000000000000000000000000000000000022" as Address,
+					state: "approved",
+					reason: "looks fine",
+				},
+			],
+		} as never);
+		vi.mocked(useProposalsForTransaction).mockReturnValue(
+			mockQueryResult([makeProposal({ oracle: "0x0000000000000000000000000000000000000099" as Address })]),
+		);
+		render(<SafeTxProposals safeTxHash={SAFE_TX_HASH} transaction={makeTransaction()} />);
+		expect(screen.getByText("0x0000…0011 ⏳")).toBeTruthy();
+		expect(screen.getByText("0x0000…0022 ✅")).toBeTruthy();
+		fireEvent.click(screen.getByText("0x0000…0022 ✅"));
+		expect(screen.getByText("looks fine")).toBeTruthy();
 	});
 });

--- a/explorer/src/components/transaction/SafeTxProposals.tsx
+++ b/explorer/src/components/transaction/SafeTxProposals.tsx
@@ -1,5 +1,5 @@
 import { InformationCircleIcon } from "@heroicons/react/24/outline";
-import type { Hex } from "viem";
+import type { Address, Hex } from "viem";
 import { CopyButton } from "@/components/common/CopyButton";
 import { InfoPopover } from "@/components/common/InfoPopover";
 import { InlineHash } from "@/components/common/InlineHash";
@@ -7,12 +7,16 @@ import { StatusBadge } from "@/components/common/StatusBadge";
 import { Box, BoxTitle } from "@/components/Groups";
 import { Skeleton } from "@/components/Skeleton";
 import { useProposalsForTransaction } from "@/hooks/useProposalsForTransaction";
+import { useSentinelVotes } from "@/hooks/useSentinelVotes";
 import { useAttestationStatus } from "@/hooks/useSigningProgress";
 import { useSubmitProposal } from "@/hooks/useSubmitProposal";
+import { useVotingStatus } from "@/hooks/useVotingStatus";
 import { SAFE_SERVICE_CHAINS } from "@/lib/chains";
 import type { SafeTransaction, TransactionProposal, TransactionProposalWithStatus } from "@/lib/consensus";
 import { InlineBlockInfo, InlineExplorerTxLink } from "../common/Info";
 import { SafeTxAttestationStatus } from "./SafeTxAttestationStatus";
+import { SentinelVoteList } from "./SentinelVoteList";
+import { VotingStatusBadge } from "./VotingStatusBadge";
 
 export function SafeTxProposals({ safeTxHash, transaction }: { safeTxHash: Hex; transaction: SafeTransaction }) {
 	const proposals = useProposalsForTransaction(safeTxHash);
@@ -38,6 +42,7 @@ function ProposalInfoButton({ proposal }: { proposal: TransactionProposal }) {
 		proposal.epoch,
 		proposal.proposedAt.block,
 		proposal.attestedAt?.block ?? null,
+		proposal.oracle,
 	);
 	if (status.data === null) return null;
 
@@ -68,6 +73,30 @@ function ProposalInfoButton({ proposal }: { proposal: TransactionProposal }) {
 	);
 }
 
+function SafeTxProposalVoting({ oracle, proposal }: { oracle: Address; proposal: TransactionProposal }) {
+	const votingStatus = useVotingStatus(oracle, proposal.epoch, proposal.safeTxHash);
+	const isSentinel = votingStatus.data?.kind === "sentinel";
+	const sentinelVotes = useSentinelVotes(oracle, proposal.epoch, proposal.safeTxHash, isSentinel);
+	return (
+		<div className="space-y-2">
+			<div className="md:flex md:justify-between">
+				<div className="flex items-center gap-2">
+					<p className="font-semibold">Oracle</p>
+					<InfoPopover trigger={<InformationCircleIcon className="h-4 w-4 text-muted" />}>
+						<div className="flex items-center gap-1 whitespace-nowrap">
+							<InlineHash hash={oracle} />
+							<CopyButton value={oracle} />
+						</div>
+					</InfoPopover>
+					<p className="font-semibold">:</p>
+				</div>
+				<VotingStatusBadge status={votingStatus.data} />
+			</div>
+			{isSentinel && <SentinelVoteList votes={sentinelVotes.data} />}
+		</div>
+	);
+}
+
 function SafeTxProposal({ proposal, number }: { proposal: TransactionProposalWithStatus; number: number }) {
 	return (
 		<Box className="space-y-2">
@@ -79,6 +108,7 @@ function SafeTxProposal({ proposal, number }: { proposal: TransactionProposalWit
 				<p>Status:</p>
 				<StatusBadge status={proposal.status} />
 			</div>
+			{proposal.oracle != null && <SafeTxProposalVoting oracle={proposal.oracle} proposal={proposal} />}
 			<div className="md:flex md:justify-between">
 				<p className="mr-2">Proposed:</p>
 				<p>

--- a/explorer/src/hooks/useSentinelVotes.tsx
+++ b/explorer/src/hooks/useSentinelVotes.tsx
@@ -3,18 +3,32 @@ import type { Address, Hex } from "viem";
 import { useSettings } from "@/hooks/useSettings";
 import { getOracleWorker, type SentinelVote } from "@/lib/oracle";
 
-export function useSentinelVotes(oracle: Address, requestId: Hex) {
+// `enabled` should be false until the caller knows the oracle is `SentinelOracleV2`-shaped
+// (i.e. `useVotingStatus(...).data?.kind === "sentinel"`) — a generic `IOracle` has no
+// `Committed`/`Revealed` events to read, so querying it is pure wasted RPC traffic.
+export function useSentinelVotes(oracle: Address, epoch: bigint, safeTxHash: Hex, enabled = false) {
 	const [settings] = useSettings();
 	return useQuery<SentinelVote[], Error>({
-		queryKey: ["sentinelVotes", settings.rpc, oracle, requestId, settings.maxBlockRange],
+		queryKey: [
+			"sentinelVotes",
+			settings.rpc,
+			oracle,
+			settings.consensus,
+			epoch.toString(),
+			safeTxHash,
+			settings.maxBlockRange,
+		],
 		queryFn: () =>
 			getOracleWorker().loadSentinelVotes({
 				rpc: settings.rpc,
 				oracle,
-				requestId,
+				consensus: settings.consensus,
+				epoch,
+				safeTxHash,
 				maxBlockRange: BigInt(settings.maxBlockRange),
 			}),
 		initialData: [],
+		enabled,
 		refetchInterval: () => (settings.refetchInterval > 0 ? settings.refetchInterval : false),
 	});
 }

--- a/explorer/src/hooks/useVotingStatus.tsx
+++ b/explorer/src/hooks/useVotingStatus.tsx
@@ -3,17 +3,28 @@ import type { Address, Hex } from "viem";
 import { useSettings } from "@/hooks/useSettings";
 import { getOracleWorker, type VotingStatus } from "@/lib/oracle";
 
-export function useVotingStatus(oracle: Address, requestId: Hex) {
+export function useVotingStatus(oracle: Address, epoch: bigint, safeTxHash: Hex) {
 	const [settings] = useSettings();
 	return useQuery<VotingStatus, Error>({
-		queryKey: ["votingStatus", settings.rpc, oracle, requestId, settings.maxBlockRange],
+		queryKey: [
+			"votingStatus",
+			settings.rpc,
+			oracle,
+			settings.consensus,
+			epoch.toString(),
+			safeTxHash,
+			settings.maxBlockRange,
+		],
 		queryFn: () =>
 			getOracleWorker().loadVotingStatus({
 				rpc: settings.rpc,
 				oracle,
-				requestId,
+				consensus: settings.consensus,
+				epoch,
+				safeTxHash,
 				maxBlockRange: BigInt(settings.maxBlockRange),
 			}),
+		initialData: null,
 		refetchInterval: () => (settings.refetchInterval > 0 ? settings.refetchInterval : false),
 	});
 }

--- a/explorer/src/lib/consensus/epochs.ts
+++ b/explorer/src/lib/consensus/epochs.ts
@@ -1,5 +1,5 @@
 import { type Address, getAbiItem, type Hex, type PublicClient } from "viem";
-import { getBlockRange, mostRecentFirst } from "@/lib/utils";
+import { getBlockRange, loadChainId, mostRecentFirst } from "@/lib/utils";
 import { consensusAbi } from "./abi";
 
 export type ConsensusState = {
@@ -7,18 +7,6 @@ export type ConsensusState = {
 	currentEpoch: bigint;
 	currentGroupId: Hex;
 	currentBlock: bigint;
-};
-
-let cachedChainId: { provider: PublicClient; chainId: Promise<number> } | undefined;
-
-const loadChainId = async (provider: PublicClient): Promise<number> => {
-	if (provider !== cachedChainId?.provider) {
-		cachedChainId = {
-			provider,
-			chainId: provider.getChainId(),
-		};
-	}
-	return cachedChainId.chainId;
 };
 
 export const loadConsensusState = async (provider: PublicClient, consensus: Address): Promise<ConsensusState> => {

--- a/explorer/src/lib/oracle/votes.test.ts
+++ b/explorer/src/lib/oracle/votes.test.ts
@@ -9,12 +9,31 @@ import {
 } from "viem";
 import { describe, expect, it, vi } from "vitest";
 import { sentinelOracleV2Abi } from "./abi";
+import { oracleRequestId } from "./hashing";
 import { loadSentinelVotes } from "./votes";
 
 const ORACLE: Address = "0x1234567890123456789012345678901234567890";
-const REQUEST_ID: Hex = `0x${"ab".repeat(32)}`;
+const CONSENSUS: Address = "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045";
+const EPOCH = 1n;
+const SAFE_TX_HASH: Hex = "0xfe8b85e8d090b16fe8f142d3c9292dc1fc77daf9eb4af8f7cf4a7707d95f4028";
+const CHAIN_ID = 1;
+const REQUEST_ID: Hex = oracleRequestId({
+	chainId: CHAIN_ID,
+	consensus: CONSENSUS,
+	epoch: EPOCH,
+	oracle: ORACLE,
+	safeTxHash: SAFE_TX_HASH,
+});
 const SENTINEL_A: Address = "0x1111111111111111111111111111111111111111";
 const SENTINEL_B: Address = "0x2222222222222222222222222222222222222222";
+
+const commonParams = {
+	oracle: ORACLE,
+	consensus: CONSENSUS,
+	epoch: EPOCH,
+	safeTxHash: SAFE_TX_HASH,
+	maxBlockRange: 500n,
+};
 
 // biome-ignore lint/suspicious/noExplicitAny: viem's ABI input types don't always include the `indexed` property
 const nonIndexedInputs = (inputs: readonly any[]) => inputs.filter((i: any) => !i.indexed);
@@ -70,13 +89,14 @@ const makeProvider = (logs: unknown[]): PublicClient =>
 	({
 		getBlockNumber: vi.fn().mockResolvedValue(1000n),
 		request: vi.fn().mockResolvedValue(logs),
+		getChainId: vi.fn().mockResolvedValue(CHAIN_ID),
 	}) as unknown as PublicClient;
 
 describe("loadSentinelVotes", () => {
-	it("makes a single eth_getLogs request filtered by requestId", async () => {
+	it("makes a single eth_getLogs request filtered by the derived requestId", async () => {
 		const provider = makeProvider([]);
 
-		await loadSentinelVotes({ provider, oracle: ORACLE, requestId: REQUEST_ID, maxBlockRange: 500n });
+		await loadSentinelVotes({ provider, ...commonParams });
 
 		const requestMock = provider.request as unknown as ReturnType<typeof vi.fn>;
 		expect(requestMock).toHaveBeenCalledTimes(1);
@@ -90,7 +110,7 @@ describe("loadSentinelVotes", () => {
 	it("returns an empty array when nobody has voted", async () => {
 		const provider = makeProvider([]);
 
-		const result = await loadSentinelVotes({ provider, oracle: ORACLE, requestId: REQUEST_ID, maxBlockRange: 500n });
+		const result = await loadSentinelVotes({ provider, ...commonParams });
 
 		expect(result).toEqual([]);
 	});
@@ -98,7 +118,7 @@ describe("loadSentinelVotes", () => {
 	it("marks a sentinel as committed when it hasn't revealed yet", async () => {
 		const provider = makeProvider([makeCommittedLog(SENTINEL_A, 1n)]);
 
-		const result = await loadSentinelVotes({ provider, oracle: ORACLE, requestId: REQUEST_ID, maxBlockRange: 500n });
+		const result = await loadSentinelVotes({ provider, ...commonParams });
 
 		expect(result).toEqual([{ sentinel: SENTINEL_A, state: "committed" }]);
 	});
@@ -109,7 +129,7 @@ describe("loadSentinelVotes", () => {
 			makeRevealedLog(SENTINEL_A, true, "looks good", 2n),
 		]);
 
-		const result = await loadSentinelVotes({ provider, oracle: ORACLE, requestId: REQUEST_ID, maxBlockRange: 500n });
+		const result = await loadSentinelVotes({ provider, ...commonParams });
 
 		expect(result).toEqual([{ sentinel: SENTINEL_A, state: "approved", reason: "looks good" }]);
 	});
@@ -120,7 +140,7 @@ describe("loadSentinelVotes", () => {
 			makeRevealedLog(SENTINEL_A, false, "suspicious payload", 2n),
 		]);
 
-		const result = await loadSentinelVotes({ provider, oracle: ORACLE, requestId: REQUEST_ID, maxBlockRange: 500n });
+		const result = await loadSentinelVotes({ provider, ...commonParams });
 
 		expect(result).toEqual([{ sentinel: SENTINEL_A, state: "denied", reason: "suspicious payload" }]);
 	});
@@ -133,7 +153,7 @@ describe("loadSentinelVotes", () => {
 			makeRevealedLog(SENTINEL_B, false, "no", 6n, 1),
 		]);
 
-		const result = await loadSentinelVotes({ provider, oracle: ORACLE, requestId: REQUEST_ID, maxBlockRange: 500n });
+		const result = await loadSentinelVotes({ provider, ...commonParams });
 
 		expect(result).toEqual([
 			{ sentinel: SENTINEL_A, state: "approved", reason: "ok" },

--- a/explorer/src/lib/oracle/votes.ts
+++ b/explorer/src/lib/oracle/votes.ts
@@ -1,6 +1,7 @@
 import { type Address, formatLog, type Hex, numberToHex, type PublicClient, parseEventLogs } from "viem";
-import { getBlockRange } from "@/lib/utils";
+import { getBlockRange, loadChainId } from "@/lib/utils";
 import { sentinelOracleV2Abi, sentinelVoteEventSelectors } from "./abi";
+import { oracleRequestId } from "./hashing";
 
 export type SentinelVote =
 	| { sentinel: Address; state: "committed" }
@@ -13,14 +14,20 @@ export type SentinelVote =
 export const loadSentinelVotes = async ({
 	provider,
 	oracle,
-	requestId,
+	consensus,
+	epoch,
+	safeTxHash,
 	maxBlockRange,
 }: {
 	provider: PublicClient;
 	oracle: Address;
-	requestId: Hex;
+	consensus: Address;
+	epoch: bigint;
+	safeTxHash: Hex;
 	maxBlockRange: bigint;
 }): Promise<SentinelVote[]> => {
+	const chainId = await loadChainId(provider);
+	const requestId = oracleRequestId({ chainId, consensus, epoch, oracle, safeTxHash });
 	const { fromBlock, toBlock } = await getBlockRange(provider, maxBlockRange);
 
 	// A single `eth_getLogs` here, in order to filter on the `requestId` topic while still

--- a/explorer/src/lib/oracle/votingStatus.test.ts
+++ b/explorer/src/lib/oracle/votingStatus.test.ts
@@ -5,7 +5,19 @@ import { loadVotingStatus } from "./votingStatus";
 
 const ORACLE: Address = "0x1234567890123456789012345678901234567890";
 const PROPOSER: Address = "0x9999999999999999999999999999999999999999";
+const CONSENSUS: Address = "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045";
+const EPOCH = 1n;
+const SAFE_TX_HASH: Hex = "0xfe8b85e8d090b16fe8f142d3c9292dc1fc77daf9eb4af8f7cf4a7707d95f4028";
 const REQUEST_ID: Hex = `0x${"ab".repeat(32)}`;
+const CHAIN_ID = 1;
+
+const commonParams = {
+	oracle: ORACLE,
+	consensus: CONSENSUS,
+	epoch: EPOCH,
+	safeTxHash: SAFE_TX_HASH,
+	maxBlockRange: 500n,
+};
 
 const makeSentinelProvider = (request: {
 	proposer?: Address;
@@ -30,6 +42,7 @@ const makeSentinelProvider = (request: {
 			revealedCount: 0n,
 			...request,
 		}),
+		getChainId: vi.fn().mockResolvedValue(CHAIN_ID),
 	}) as unknown as PublicClient;
 
 const makeGenericProvider = (logs: unknown[] = []): PublicClient =>
@@ -37,6 +50,7 @@ const makeGenericProvider = (logs: unknown[] = []): PublicClient =>
 		readContract: vi.fn().mockRejectedValue(new Error("function selector not recognized")),
 		getBlockNumber: vi.fn().mockResolvedValue(1000n),
 		getLogs: vi.fn().mockResolvedValue(logs),
+		getChainId: vi.fn().mockResolvedValue(CHAIN_ID),
 	}) as unknown as PublicClient;
 
 const makeOracleResultLog = (approved: boolean, blockNumber = 1n, logIndex = 0) => ({
@@ -55,7 +69,7 @@ describe("loadVotingStatus", () => {
 	] as const)("maps SentinelOracleRequest.State ordinal %i to %s", async (state, name) => {
 		const provider = makeSentinelProvider({ state, approveSentinelCount: 3n, denySentinelCount: 1n });
 
-		const result = await loadVotingStatus({ provider, oracle: ORACLE, requestId: REQUEST_ID, maxBlockRange: 500n });
+		const result = await loadVotingStatus({ provider, ...commonParams });
 
 		expect(result).toEqual({ kind: "sentinel", state: name, approveCount: 3n, denyCount: 1n });
 	});
@@ -68,7 +82,7 @@ describe("loadVotingStatus", () => {
 			denySentinelCount: 0n,
 		});
 
-		const result = await loadVotingStatus({ provider, oracle: ORACLE, requestId: REQUEST_ID, maxBlockRange: 500n });
+		const result = await loadVotingStatus({ provider, ...commonParams });
 
 		expect(result).toBeNull();
 	});
@@ -76,7 +90,7 @@ describe("loadVotingStatus", () => {
 	it("falls back to OracleResult logs when getRequest reverts", async () => {
 		const provider = makeGenericProvider([makeOracleResultLog(true)]);
 
-		const result = await loadVotingStatus({ provider, oracle: ORACLE, requestId: REQUEST_ID, maxBlockRange: 500n });
+		const result = await loadVotingStatus({ provider, ...commonParams });
 
 		expect(result).toEqual({ kind: "generic", approved: true });
 	});
@@ -84,7 +98,7 @@ describe("loadVotingStatus", () => {
 	it("returns null when getRequest reverts and no OracleResult log exists yet", async () => {
 		const provider = makeGenericProvider([]);
 
-		const result = await loadVotingStatus({ provider, oracle: ORACLE, requestId: REQUEST_ID, maxBlockRange: 500n });
+		const result = await loadVotingStatus({ provider, ...commonParams });
 
 		expect(result).toBeNull();
 	});

--- a/explorer/src/lib/oracle/votingStatus.ts
+++ b/explorer/src/lib/oracle/votingStatus.ts
@@ -1,6 +1,7 @@
 import { type Address, getAbiItem, type Hex, type PublicClient, zeroAddress } from "viem";
-import { getBlockRange, mostRecentFirst } from "@/lib/utils";
+import { getBlockRange, loadChainId, mostRecentFirst } from "@/lib/utils";
 import { oracleAbi, sentinelOracleV2Abi } from "./abi";
+import { oracleRequestId } from "./hashing";
 
 const sentinelRequestStates = ["PENDING", "FROZEN", "RESOLVED_APPROVED", "RESOLVED_DENIED", "TIMED_OUT"] as const;
 
@@ -14,14 +15,21 @@ export type VotingStatus =
 export const loadVotingStatus = async ({
 	provider,
 	oracle,
-	requestId,
+	consensus,
+	epoch,
+	safeTxHash,
 	maxBlockRange,
 }: {
 	provider: PublicClient;
 	oracle: Address;
-	requestId: Hex;
+	consensus: Address;
+	epoch: bigint;
+	safeTxHash: Hex;
 	maxBlockRange: bigint;
 }): Promise<VotingStatus> => {
+	const chainId = await loadChainId(provider);
+	const requestId = oracleRequestId({ chainId, consensus, epoch, oracle, safeTxHash });
+
 	// `getRequest` is a bare mapping read on `SentinelOracleV2` — it never reverts, even for an
 	// unknown requestId, instead returning a zero-initialized struct. The catch below only fires
 	// for oracles that don't implement `getRequest` at all (a plain `IOracle` like

--- a/explorer/src/lib/oracle/worker.ts
+++ b/explorer/src/lib/oracle/worker.ts
@@ -4,10 +4,19 @@ import { createRpcClient } from "@/lib/rpc";
 import { loadSentinelVotes } from "./votes";
 import { loadVotingStatus } from "./votingStatus";
 
+type LoadVotesParams = {
+	rpc: string;
+	oracle: Address;
+	consensus: Address;
+	epoch: bigint;
+	safeTxHash: Hex;
+	maxBlockRange: bigint;
+};
+
 const workerApi = {
-	loadVotingStatus: ({ rpc, ...params }: { rpc: string; oracle: Address; requestId: Hex; maxBlockRange: bigint }) =>
+	loadVotingStatus: ({ rpc, ...params }: LoadVotesParams) =>
 		loadVotingStatus({ ...params, provider: createRpcClient(rpc) }),
-	loadSentinelVotes: ({ rpc, ...params }: { rpc: string; oracle: Address; requestId: Hex; maxBlockRange: bigint }) =>
+	loadSentinelVotes: ({ rpc, ...params }: LoadVotesParams) =>
 		loadSentinelVotes({ ...params, provider: createRpcClient(rpc) }),
 };
 

--- a/explorer/src/lib/utils.ts
+++ b/explorer/src/lib/utils.ts
@@ -47,3 +47,15 @@ export const mostRecentFirst = <T extends Pick<Log<bigint, number, false>, "bloc
 		}
 		return right.logIndex - left.logIndex;
 	});
+
+let cachedChainId: { provider: PublicClient; chainId: Promise<number> } | undefined;
+
+export const loadChainId = async (provider: PublicClient): Promise<number> => {
+	if (provider !== cachedChainId?.provider) {
+		cachedChainId = {
+			provider,
+			chainId: provider.getChainId(),
+		};
+	}
+	return cachedChainId.chainId;
+};


### PR DESCRIPTION
Wire up the fetched oracle vote details to the UI. This will display a voting badge and the detailed votes with reasons.

Uses the new vote information components in the SafeTxProposal. Some adjustments have been made to the oracle related functions, as for correct request id calculation it is necessary to load the consensus chain id. This was not considered before.

## Testing

Use the feature branch deployment (https://feat-senex-5c.safenet-explorer-staging.pages.dev/) and set the rpc node to `https://research-node.tailadcc60.ts.net:8443/` and the consensus to `0x551F797aB5D24f1Cd6DBf2D684cd5946B2CfD95b`. It is also recommended to update the validator info path to an invalid value to avoid loading of validator info (if the value is cleared it falls back to the default).

Transaction proposal has to be done manually, by following the [devnet guide](https://github.com/safe-research/safenet/blob/7d8094c1bd9ea58cc3dc4f2603decbc23167f828/docs/devnet.md)

## Screenshots

### Pending/ Committed
<img width="871" height="337" alt="image" src="https://github.com/user-attachments/assets/4e1229d7-ac9c-4f2c-9a51-8cebb58a9b72" />

### Approved
<img width="837" height="343" alt="image" src="https://github.com/user-attachments/assets/32ddc174-fd11-41e1-adf3-84273977f25f" />

### Denied
<img width="867" height="393" alt="image" src="https://github.com/user-attachments/assets/3445d285-f58c-4713-8c51-bc9fe6bc1fed" />

### Attested
<img width="847" height="394" alt="image" src="https://github.com/user-attachments/assets/f410be09-ca61-4943-bec1-b9d6594a58dc" />


---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://docs.safefoundation.org/cla).
