### PR TITLE
[Phase 6b]: Fix ChainId caching

### DIFF
--- a/explorer/src/lib/utils.test.ts
+++ b/explorer/src/lib/utils.test.ts
@@ -1,6 +1,6 @@
 import type { PublicClient } from "viem";
 import { describe, expect, it, vi } from "vitest";
-import { getBlockRange, mostRecentFirst } from "./utils";
+import { getBlockRange, loadChainId, mostRecentFirst } from "./utils";
 
 const CURRENT_BLOCK = 10000n;
 const MAX_BLOCK_RANGE = 1000n;
@@ -81,5 +81,41 @@ describe("mostRecentFirst", () => {
 			{ blockNumber: 100n, logIndex: 5 },
 			{ blockNumber: 100n, logIndex: 2 },
 		]);
+	});
+});
+
+describe("loadChainId", () => {
+	const makeChainProvider = (chainId = 1) =>
+		({ getChainId: vi.fn().mockResolvedValue(chainId) }) as unknown as PublicClient;
+
+	it("fetches and returns the chain id", async () => {
+		const provider = makeChainProvider(5);
+		await expect(loadChainId(provider)).resolves.toBe(5);
+	});
+
+	it("caches the result for the same provider instance", async () => {
+		const provider = makeChainProvider(5);
+		await loadChainId(provider);
+		await loadChainId(provider);
+		expect(provider.getChainId).toHaveBeenCalledOnce();
+	});
+
+	it("refetches when called with a different provider instance", async () => {
+		const providerA = makeChainProvider(1);
+		const providerB = makeChainProvider(2);
+		await expect(loadChainId(providerA)).resolves.toBe(1);
+		await expect(loadChainId(providerB)).resolves.toBe(2);
+		expect(providerA.getChainId).toHaveBeenCalledOnce();
+		expect(providerB.getChainId).toHaveBeenCalledOnce();
+	});
+
+	it("does not cache a rejected lookup, so a later call retries", async () => {
+		const provider = {
+			getChainId: vi.fn().mockRejectedValueOnce(new Error("network error")).mockResolvedValueOnce(7),
+		} as unknown as PublicClient;
+
+		await expect(loadChainId(provider)).rejects.toThrow("network error");
+		await expect(loadChainId(provider)).resolves.toBe(7);
+		expect(provider.getChainId).toHaveBeenCalledTimes(2);
 	});
 });

--- a/explorer/src/lib/utils.ts
+++ b/explorer/src/lib/utils.ts
@@ -52,10 +52,17 @@ let cachedChainId: { provider: PublicClient; chainId: Promise<number> } | undefi
 
 export const loadChainId = async (provider: PublicClient): Promise<number> => {
 	if (provider !== cachedChainId?.provider) {
-		cachedChainId = {
+		const entry: { provider: PublicClient; chainId: Promise<number> } = {
 			provider,
-			chainId: provider.getChainId(),
+			chainId: provider.getChainId().catch((error) => {
+				// Don't cache errors
+				if (cachedChainId === entry) {
+					cachedChainId = undefined;
+				}
+				throw error;
+			}),
 		};
+		cachedChainId = entry;
 	}
 	return cachedChainId.chainId;
 };


### PR DESCRIPTION
When encountering an error fetching the chain id, the cached value should be reset. Tests for this logic have also been added, as this is an important logic part required in many paths.

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://docs.safefoundation.org/cla).
