### PR TITLE
Closes #657: Dispute reason

### DIFF
--- a/contracts/src/SentinelOracle.sol
+++ b/contracts/src/SentinelOracle.sol
@@ -22,7 +22,12 @@ contract SentinelOracle is IOracle {
     // EVENTS
     // ============================================================
 
-    event DisputeResolved(bytes32 indexed requestId, SentinelOracleRequest.State outcome, uint256 slashed);
+    // `context` is the arbitrator's rationale for this ruling (free-form text, or e.g. an IPFS
+    // CID pointing to a longer writeup) -- unrelated to a sentinel's vote `reason` and to
+    // `SentinelOracleRequest.ResolveReason`, which is why a *request* resolved.
+    event DisputeResolved(
+        bytes32 indexed requestId, SentinelOracleRequest.State outcome, uint256 slashed, string context
+    );
     event Claimed(bytes32 indexed requestId, address indexed sentinel, uint256 bondReturn, uint256 feeReward);
 
     // ============================================================
@@ -167,7 +172,7 @@ contract SentinelOracle is IOracle {
     // ARBITRATION
     // ============================================================
 
-    function resolveDispute(bytes32 requestId, bool approveWins) external onlyArbitrator {
+    function resolveDispute(bytes32 requestId, bool approveWins, string calldata context) external onlyArbitrator {
         SentinelOracleRequest.Request storage req = $requests.get(requestId);
         address proposer = req.proposer;
         uint256 slashed = req.resolveDispute(approveWins);
@@ -176,7 +181,7 @@ contract SentinelOracle is IOracle {
         req.fee = 0;
         FEE_TOKEN.safeTransfer(proposer, refundFee);
         FEE_TOKEN.safeTransfer(ARBITRATOR, slashed - refundFee);
-        emit DisputeResolved(requestId, outcome, slashed);
+        emit DisputeResolved(requestId, outcome, slashed, context);
         emit OracleResult(requestId, proposer, abi.encode(SentinelOracleRequest.ResolveReason.ARBITRATION), approveWins);
     }
 

--- a/contracts/src/SentinelOracleV2.sol
+++ b/contracts/src/SentinelOracleV2.sol
@@ -24,7 +24,12 @@ contract SentinelOracleV2 is IOracle {
     // EVENTS
     // ============================================================
 
-    event DisputeResolved(bytes32 indexed requestId, SentinelOracleRequest.State outcome, uint256 slashed);
+    // `context` is the arbitrator's rationale for this ruling (free-form text, or e.g. an IPFS
+    // CID pointing to a longer writeup) -- unrelated to a sentinel's `reveal` vote `reason` and
+    // to `SentinelOracleRequest.ResolveReason`, which is why a *request* resolved.
+    event DisputeResolved(
+        bytes32 indexed requestId, SentinelOracleRequest.State outcome, uint256 slashed, string context
+    );
     event Claimed(bytes32 indexed requestId, address indexed sentinel, uint256 bondReturn, uint256 feeReward);
 
     // ============================================================
@@ -206,7 +211,7 @@ contract SentinelOracleV2 is IOracle {
     // ARBITRATION
     // ============================================================
 
-    function resolveDispute(bytes32 requestId, bool approveWins) external onlyArbitrator {
+    function resolveDispute(bytes32 requestId, bool approveWins, string calldata context) external onlyArbitrator {
         SentinelOracleRequest.Request storage req = $requests.get(requestId);
         address proposer = req.proposer;
         uint256 slashed = req.resolveDispute(approveWins);
@@ -214,7 +219,7 @@ contract SentinelOracleV2 is IOracle {
         uint256 refundFee = req.fee;
         FEE_TOKEN.safeTransfer(proposer, refundFee);
         FEE_TOKEN.safeTransfer(ARBITRATOR, slashed - refundFee);
-        emit DisputeResolved(requestId, outcome, slashed);
+        emit DisputeResolved(requestId, outcome, slashed, context);
         emit OracleResult(requestId, proposer, abi.encode(SentinelOracleRequest.ResolveReason.ARBITRATION), approveWins);
     }
 

--- a/contracts/test/SentinelOracle.t.sol
+++ b/contracts/test/SentinelOracle.t.sol
@@ -212,15 +212,19 @@ contract SentinelOracleTest is Test {
         // Arbitrator resolves: approve wins.
         uint256 arbitratorBalBefore = token.balanceOf(arbitrator);
 
+        string memory context = "sentinel1's evidence was conclusive";
+
         vm.expectEmit(true, false, false, true);
-        emit SentinelOracle.DisputeResolved(REQUEST_ID, SentinelOracleRequest.State.RESOLVED_APPROVED, BOND_TARGET);
+        emit SentinelOracle.DisputeResolved(
+            REQUEST_ID, SentinelOracleRequest.State.RESOLVED_APPROVED, BOND_TARGET, context
+        );
         vm.expectEmit(true, true, false, true);
         emit IOracle.OracleResult(
             REQUEST_ID, proposer, abi.encode(SentinelOracleRequest.ResolveReason.ARBITRATION), true
         );
 
         vm.prank(arbitrator);
-        oracle.resolveDispute(REQUEST_ID, true);
+        oracle.resolveDispute(REQUEST_ID, true, context);
 
         // Fee is refunded to proposer from slashed amount; arbitrator receives the remainder.
         assertEq(token.balanceOf(proposer), proposerBalBefore, "proposer balance fully restored");

--- a/contracts/test/SentinelOracleV2.t.sol
+++ b/contracts/test/SentinelOracleV2.t.sol
@@ -259,16 +259,19 @@ contract SentinelOracleV2Test is Test {
         // ---- Phase 2: arbitration ----
 
         uint256 arbitratorBalBefore = token.balanceOf(arbitrator);
+        string memory context = "sentinel1's evidence was conclusive";
 
         vm.expectEmit(true, false, false, true);
-        emit SentinelOracleV2.DisputeResolved(REQUEST_ID, SentinelOracleRequest.State.RESOLVED_APPROVED, BOND_TARGET);
+        emit SentinelOracleV2.DisputeResolved(
+            REQUEST_ID, SentinelOracleRequest.State.RESOLVED_APPROVED, BOND_TARGET, context
+        );
         vm.expectEmit(true, true, false, true);
         emit IOracle.OracleResult(
             REQUEST_ID, proposer, abi.encode(SentinelOracleRequest.ResolveReason.ARBITRATION), true
         );
 
         vm.prank(arbitrator);
-        oracle.resolveDispute(REQUEST_ID, true);
+        oracle.resolveDispute(REQUEST_ID, true, context);
 
         assertEq(token.balanceOf(proposer), proposerBalBefore, "proposer balance fully restored");
         assertEq(
@@ -292,6 +295,19 @@ contract SentinelOracleV2Test is Test {
         vm.prank(sentinel2);
         oracle.claim(REQUEST_ID);
         assertEq(token.balanceOf(sentinel2), s2Before, "sentinel2 bond slashed");
+    }
+
+    function test_ResolveDispute_EmptyContext_Accepted() public {
+        _postRequest();
+        _commit(sentinel1, true, SALT_1);
+        _commit(sentinel2, false, SALT_2);
+        _advancePastCommitDeadline();
+        _reveal(sentinel1, true, SALT_1);
+        _reveal(sentinel2, false, SALT_2);
+        oracle.finalize(REQUEST_ID);
+
+        vm.prank(arbitrator);
+        oracle.resolveDispute(REQUEST_ID, true, "");
     }
 
     // ============================================================

--- a/crates/sentinel/src/bindings.rs
+++ b/crates/sentinel/src/bindings.rs
@@ -34,7 +34,7 @@ pub mod oracle {
                 uint256 bondAmount,
                 string reason
             );
-            event DisputeResolved(bytes32 indexed requestId, RequestState outcome, uint256 slashed);
+            event DisputeResolved(bytes32 indexed requestId, RequestState outcome, uint256 slashed, string context);
 
             function commit(bytes32 requestId, bytes32 commitHash) external;
             function reveal(bytes32 requestId, bool approve, bytes32 salt, string calldata reason) external;

--- a/crates/sentinel/src/service.rs
+++ b/crates/sentinel/src/service.rs
@@ -863,6 +863,7 @@ mod tests {
                 requestId: id,
                 outcome,
                 slashed,
+                context: String::new(),
             },
         ))
     }


### PR DESCRIPTION
Closes #657

Add a context string to the dispute resolution which is emitted as part of the event. It is not persisted in contract storage.

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://docs.safefoundation.org/cla).
