### PR TITLE
Update workflow to build docker images

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -8,12 +8,24 @@ on:
     branches:
       - main
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   docker:
     runs-on: ubuntu-latest
     permissions:
       contents: read
       packages: write
+
+    strategy:
+      matrix:
+        include:
+          - image: validator
+            dockerfile: crates/validator/Dockerfile
+          - image: sentinel
+            dockerfile: crates/sentinel/Dockerfile
 
     steps:
       - uses: actions/checkout@v5
@@ -29,12 +41,7 @@ jobs:
       - id: meta
         uses: docker/metadata-action@v5
         with:
-          images: ghcr.io/safe-research/safenet-validator
-          tags: |
-            type=ref,event=branch
-            type=ref,event=tag
-            # create beta tags on new releases
-            type=raw,value=beta,enable=${{ startsWith(github.ref, 'refs/tags/v') }}
+          images: ghcr.io/safe-research/safenet-${{ matrix.image }}
           flavor: |
             latest=false
 
@@ -44,8 +51,8 @@ jobs:
       - uses: docker/build-push-action@v6
         with:
           context: .
-          file: validator/Dockerfile
-          platforms: linux/amd64,linux/arm64
+          file: ${{ matrix.dockerfile }}
+          platforms: ${{ github.event_name == 'pull_request' && 'linux/amd64' || 'linux/amd64,linux/arm64' }}
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
- Build the rust based validator
- Add build for rust based sentinel

The same image names are kept. This is important to note as the new versions come with breaking changes. The `beta` tag is removed, as the new versions are not compatible with Safenet Beta.

Building the arm64 images for the Rust based sentinel and validator takes significant time. Therefore these will only be build for tags and the main branch. Also to avoid stacking of long running actions, we create a concurrency group to cancel the running workflow when new changes are pushed. 

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://docs.safefoundation.org/cla).
