### PR TITLE
Improve Driver Error Handling

### DIFF
--- a/crates/core/src/driver.rs
+++ b/crates/core/src/driver.rs
@@ -181,10 +181,13 @@ where
     /// Only the wait for the next update races `shutdown`; once an update
     /// arrives it is processed to completion so its state transition and queued
     /// transactions are committed before the loop can stop.
-    async fn step(&mut self, shutdown: Pin<&mut impl Future<Output = ()>>) -> Result<Loop, Error> {
+    async fn step(
+        &mut self,
+        mut shutdown: Pin<&mut impl Future<Output = ()>>,
+    ) -> Result<Loop, Error> {
         let update = tokio::select! {
             biased;
-            _ = shutdown => return Ok(Loop::Break),
+            _ = shutdown.as_mut() => return Ok(Loop::Break),
             update = self.watcher.next() => update,
         };
 
@@ -200,8 +203,11 @@ where
                     ?err,
                     "failed to get next blockchain update; retrying after delay"
                 );
-                tokio::time::sleep(STEP_RETRY_DELAY).await;
-                return Ok(Loop::Continue);
+                return tokio::select! {
+                    biased;
+                    _ = shutdown.as_mut() => Ok(Loop::Break),
+                    _ = tokio::time::sleep(STEP_RETRY_DELAY) => Ok(Loop::Continue),
+                };
             }
         };
 

--- a/crates/core/src/driver.rs
+++ b/crates/core/src/driver.rs
@@ -148,8 +148,9 @@ where
     /// Runs the service, processing indexer updates until a shutdown signal
     /// (such as Ctrl-C) is received or an unrecoverable error occurs.
     ///
-    /// A failed step is retried on the next iteration rather than stopping the
-    /// service.
+    /// Failures while waiting for the next indexer update are retried after a
+    /// short delay. Errors encountered after an update has been received are
+    /// handled according to their component's recovery policy.
     pub async fn run(mut self) {
         let shutdown = async {
             if let Err(err) = tokio::signal::ctrl_c().await {
@@ -160,18 +161,14 @@ where
 
         loop {
             match self.step(shutdown.as_mut()).await {
-                Ok(Loop::Continue) => {}
+                Ok(Loop::Continue) => continue,
                 Ok(Loop::Break) => {
                     tracing::info!("received shutdown signal; stopping service");
                     break;
                 }
-                Err(Error::State(err)) => {
-                    tracing::error!(?err, "unrecoverable state transition error; exiting");
-                    break;
-                }
                 Err(err) => {
-                    tracing::warn!(?err, "service step failed; retrying after delay");
-                    tokio::time::sleep(STEP_RETRY_DELAY).await;
+                    tracing::error!(?err, "unrecoverable driver error; exiting");
+                    break;
                 }
             }
         }
@@ -188,16 +185,41 @@ where
         let update = tokio::select! {
             biased;
             _ = shutdown => return Ok(Loop::Break),
-            update = self.watcher.next() => update?,
+            update = self.watcher.next() => update,
         };
-        tracing::trace!(?update, "received watcher update");
+
+        // Make sure that getting the next watcher update was successful. If not
+        // log and continue the loop after a short delay.
+        let update = match update {
+            Ok(update) => {
+                tracing::trace!(?update, "received watcher update");
+                update
+            }
+            Err(err) => {
+                tracing::warn!(
+                    ?err,
+                    "failed to get next blockchain update; retrying after delay"
+                );
+                tokio::time::sleep(STEP_RETRY_DELAY).await;
+                return Ok(Loop::Continue);
+            }
+        };
 
         // Block updates drive the transaction queue's per-block housekeeping
         // (marking executed transactions, pruning, resubmitting and submitting).
         // Do this before advancing the state machine so freshly queued
         // transactions are submitted against the current block.
         if let Update::Block(block) = &update {
-            self.transactions.handle_block_update(block.clone()).await?;
+            // If we encounter an intermittent error handling block updates in
+            // the transaction queue - log and continue; things will naturally
+            // get a chance to recover.
+            let result = self.transactions.handle_block_update(block.clone()).await;
+            if let Err(err) = tx::lift_intermittent_error(result)? {
+                tracing::warn!(
+                    ?err,
+                    "transaction queue failed to handle new block; will continue"
+                );
+            }
         }
 
         // Perform a state transition for the next update.
@@ -208,7 +230,14 @@ where
             let transactions = actions
                 .into_iter()
                 .map(|action| self.actions.encode_action(action));
-            self.transactions.queue(transactions).await?;
+            // Same for queued transactions.
+            let result = self.transactions.queue(transactions).await;
+            if let Err(err) = tx::lift_intermittent_error(result)? {
+                tracing::warn!(
+                    ?err,
+                    "transaction queue failed to queue transactions; will continue"
+                );
+            }
         }
 
         Ok(Loop::Continue)

--- a/crates/core/src/tx/mod.rs
+++ b/crates/core/src/tx/mod.rs
@@ -49,6 +49,30 @@ pub enum Error {
     BadUpdate,
 }
 
+impl Error {
+    /// Returns whether or not a transaction queue error is an intermittent
+    /// error that can be recovered from naturally.
+    fn is_intermittent(&self) -> bool {
+        // Note that we only consider RPC errors as transient - everything else
+        // including SQLite errors (which only happen if you are in a pretty
+        // borked FS situation or there is a bug in the SQL logic) and signing
+        // errors (which indicate some issue with the signer configuration) are
+        // considered more serious.
+        matches!(self, Self::Rpc(_))
+    }
+}
+
+/// Lifts an intermittent transaction queue error.
+pub(crate) fn lift_intermittent_error<T>(
+    result: Result<T, Error>,
+) -> Result<Result<T, Error>, Error> {
+    match result {
+        Ok(ok) => Ok(Ok(ok)),
+        Err(err) if err.is_intermittent() => Ok(Err(err)),
+        Err(err) => Err(err),
+    }
+}
+
 /// Transaction queue configuration.
 #[derive(Clone, Debug, Deserialize, PartialEq)]
 #[serde(default, deny_unknown_fields)]


### PR DESCRIPTION
Improve driver error handling so failures cannot cause an already-fetched chain update to be skipped. Watcher failures are retried, transaction queue intermittent failures are ignored, and all other errors are considered unrecoverable and stop the driver.

Supersedes #654 

### Context and Motivation

The driver previously retried most step errors by starting a new iteration. If an error occurred after the watcher produced an update but before the state machine processed it, the next iteration requested a subsequent update and could desynchronize the state machine. This could happen with an intermittent RPC error while resubmitting stale transactions for example. Error handling now depends on where the failure occurs.

### Decisions and Tradeoffs

- Watcher failures are handled before an update is consumed and retried after a short delay. This matches the existing behaviour for watcher errors.
- Transaction queue RPC errors are treated as intermittent. They are logged while state processing continues, allowing transaction housekeeping and submission to recover naturally on later blocks.
- All other errors (some of which were previously retried) are now considered fatal.
- State transitions and action enqueueing remain separate operations. The protocol's consensus and timeout mechanisms provide recovery if an action is not submitted because of an intermittent failure.

### Testing

For now, we've omitted tests (since we didn't have existing driver tests, and the happy path is already verified as part of the integration tests).

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://docs.safefoundation.org/cla).
