### PR TITLE
Publish contract docker image

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -26,6 +26,8 @@ jobs:
             dockerfile: crates/validator/Dockerfile
           - image: sentinel
             dockerfile: crates/sentinel/Dockerfile
+          - image: contracts
+            dockerfile: contracts/Dockerfile
 
     steps:
       - uses: actions/checkout@v5


### PR DESCRIPTION
Builds and publishes the contracts docker image. This makes it easier to execute the scripts for contract interaction and deployment on a dedicated, non-dev machine.

### Testing

- Check that the workflow successfully build the docker image

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://docs.safefoundation.org/cla).
