### PR TITLE
Update Transaction Queue on Latest Known Block

### DIFF
--- a/crates/core/src/driver.rs
+++ b/crates/core/src/driver.rs
@@ -8,7 +8,7 @@
 //! for submission.
 
 use crate::{
-    index::{self, Update, Watcher, events::Events},
+    index::{self, Watcher, events::Events},
     state::{self, EffectHandler, StateMachine, StateTransition},
     tx::{self, Signer, Transaction, TransactionQueue},
 };
@@ -210,26 +210,24 @@ where
                 };
             }
         };
+        let block_status = self.watcher.block_status();
 
-        // Block updates drive the transaction queue's per-block housekeeping
-        // (marking executed transactions, pruning, resubmitting and submitting).
-        // Do this before advancing the state machine so freshly queued
-        // transactions are submitted against the current block.
-        if let Update::Block(block) = &update {
-            // If we encounter an intermittent error handling block updates in
-            // the transaction queue - log and continue; things will naturally
-            // get a chance to recover.
-            let result = self.transactions.handle_block_update(block.clone()).await;
-            if let Err(err) = tx::lift_intermittent_error(result)? {
-                tracing::warn!(
-                    ?err,
-                    "transaction queue failed to handle new block; will continue"
-                );
-            }
+        // Reconcile the transaction queue against the block watcher's current
+        // chain view before advancing the state machine, so freshly queued
+        // transactions are submitted against the latest known block. If we
+        // encounter an intermittent error - log and continue; things will
+        // naturally get a chance to recover.
+        let result = self.transactions.update_block_status(block_status).await;
+        if let Err(err) = tx::lift_intermittent_error(result)? {
+            tracing::warn!(
+                ?err,
+                "transaction queue failed to handle new block; will continue"
+            );
         }
 
         // Perform a state transition for the next update.
         let actions = self.state.handle_update(update).await?;
+        self.state.prune(block_status.safe).await?;
 
         // Submit transactions for execution onchain.
         if !actions.is_empty() {

--- a/crates/core/src/index/blocks.rs
+++ b/crates/core/src/index/blocks.rs
@@ -76,10 +76,16 @@ pub enum BlockUpdate {
         number: u64,
         hash: B256,
         logs_bloom: Bloom,
-        /// The highest block that can no longer reorg. State at or below it is
-        /// final, so older snapshots may be pruned.
-        safe: u64,
     },
+}
+
+/// The block watcher's current view of the chain.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct BlockStatus {
+    /// The latest canonical block known to the watcher.
+    pub latest: u64,
+    /// The highest block outside the configured reorg window.
+    pub safe: u64,
 }
 
 /// Error produced by the block watcher.
@@ -266,7 +272,6 @@ where
                 number: block.header.number,
                 hash: block.header.hash,
                 logs_bloom: block.header.logs_bloom,
-                safe,
             });
         }
 
@@ -276,6 +281,19 @@ where
     /// Retrieves all ready updates without blocking.
     pub fn ready(&mut self) -> impl Iterator<Item = BlockUpdate> + '_ {
         self.queue.drain(..)
+    }
+
+    /// Returns the watcher's current view of the latest and reorg-safe blocks.
+    pub fn status(&self) -> BlockStatus {
+        BlockStatus {
+            latest: self.pending.number.saturating_sub(1),
+            safe: self
+                .recent
+                .front()
+                .map(|block| block.header.number)
+                .unwrap_or(self.pending.number)
+                .saturating_sub(1),
+        }
     }
 
     /// Retrieves the next block update from the watcher. This will block and
@@ -346,20 +364,11 @@ where
             self.recent.pop_front();
         }
 
-        // Compute the updated safe block
-        let safe = self
-            .recent
-            .front()
-            .map(|block| block.header.number)
-            .unwrap_or(self.pending.number)
-            .saturating_sub(1);
-
-        tracing::trace!(number, hash = %hash, safe, "new canonical block");
+        tracing::trace!(number, %hash, "new canonical block");
         Ok(BlockUpdate::New {
             number,
             hash,
             logs_bloom,
-            safe,
         })
     }
 
@@ -538,9 +547,16 @@ mod tests {
         assert_eq!(
             blocks.ready().collect::<Vec<_>>(),
             [
-                new_block_update(&block(999), 998),
-                new_block_update(&block(1000), 998)
+                new_block_update(&block(999)),
+                new_block_update(&block(1000))
             ]
+        );
+        assert_eq!(
+            blocks.status(),
+            BlockStatus {
+                latest: 1000,
+                safe: 998,
+            }
         );
         assert!(asserter.read_q().is_empty());
     }
@@ -560,8 +576,8 @@ mod tests {
             [
                 BlockUpdate::Uncle { number: 899 },
                 BlockUpdate::Warp { from: 899, to: 998 },
-                new_block_update(&block(999), 998),
-                new_block_update(&block(1000), 998),
+                new_block_update(&block(999)),
+                new_block_update(&block(1000)),
             ]
         );
         assert!(asserter.read_q().is_empty());
@@ -588,8 +604,8 @@ mod tests {
             blocks.ready().collect::<Vec<_>>(),
             [
                 BlockUpdate::Warp { from: 900, to: 998 },
-                new_block_update(&block(999), 998),
-                new_block_update(&block(1000), 998),
+                new_block_update(&block(999)),
+                new_block_update(&block(1000)),
             ]
         );
         assert!(asserter.read_q().is_empty());
@@ -615,8 +631,8 @@ mod tests {
         assert_eq!(
             blocks.ready().collect::<Vec<_>>(),
             [
-                new_block_update(&block(999), 998),
-                new_block_update(&block(1000), 998)
+                new_block_update(&block(999)),
+                new_block_update(&block(1000))
             ]
         );
     }
@@ -640,7 +656,7 @@ mod tests {
 
         assert_eq!(
             blocks.ready().collect::<Vec<_>>(),
-            [new_block_update(&block(1000), 998)]
+            [new_block_update(&block(1000))]
         );
     }
 
@@ -699,9 +715,9 @@ mod tests {
         assert_eq!(
             blocks.ready().collect::<Vec<_>>(),
             [
-                new_block_update(&block(998), 997),
-                new_block_update(&block(999), 997),
-                new_block_update(&block(1000), 997),
+                new_block_update(&block(998)),
+                new_block_update(&block(999)),
+                new_block_update(&block(1000)),
             ]
         );
         assert!(asserter.read_q().is_empty());
@@ -718,7 +734,7 @@ mod tests {
         asserter.push_success(&next_block.clone());
 
         let update = blocks.next().await.unwrap();
-        assert_eq!(update, new_block_update(&next_block, 999));
+        assert_eq!(update, new_block_update(&next_block));
         assert_eq!(
             start.elapsed(),
             Duration::from_millis(blocks.block_time + config.block_propagation_delay)
@@ -740,7 +756,7 @@ mod tests {
         asserter.push_success(&block(1002));
 
         let update = blocks.next().await.unwrap();
-        assert_eq!(update, new_block_update(&block(1001), 999));
+        assert_eq!(update, new_block_update(&block(1001)));
         assert_eq!(
             start.elapsed(),
             Duration::from_millis(
@@ -752,7 +768,7 @@ mod tests {
         );
 
         let update = blocks.next().await.unwrap();
-        assert_eq!(update, new_block_update(&block(1002), 1000));
+        assert_eq!(update, new_block_update(&block(1002)));
         // This is a bit counter-intuitive, but delays are relative to a
         // _target_ block time. This means that for the second block, since we
         // only needed to retry once, we will be at start plus two block times
@@ -786,7 +802,7 @@ mod tests {
         asserter.push_success(&block(1001));
 
         let update = blocks.next().await.unwrap();
-        assert_eq!(update, new_block_update(&block(1001), 999));
+        assert_eq!(update, new_block_update(&block(1001)));
         assert_eq!(
             start.elapsed(),
             Duration::from_millis(
@@ -851,13 +867,10 @@ mod tests {
             blocks.next().await.unwrap(),
             BlockUpdate::Uncle { number: 998 }
         );
+        assert_eq!(blocks.next().await.unwrap(), new_block_update(&reorg_998));
         assert_eq!(
             blocks.next().await.unwrap(),
-            new_block_update(&reorg_998, 995)
-        );
-        assert_eq!(
-            blocks.next().await.unwrap(),
-            new_block_update(&canonical_999, 995)
+            new_block_update(&canonical_999)
         );
         assert!(asserter.read_q().is_empty());
     }
@@ -923,14 +936,8 @@ mod tests {
         .await
         .unwrap();
 
-        assert_eq!(
-            blocks.next().await.unwrap(),
-            new_block_update(&block(998), 997)
-        );
-        assert_eq!(
-            blocks.next().await.unwrap(),
-            new_block_update(&block(999), 997)
-        );
+        assert_eq!(blocks.next().await.unwrap(), new_block_update(&block(998)));
+        assert_eq!(blocks.next().await.unwrap(), new_block_update(&block(999)));
 
         asserter.push_success(&block_with(999, |header| {
             header.hash = keccak256("new999");
@@ -963,9 +970,13 @@ mod tests {
 
         // With no reorg window, the latest block is final immediately.
         asserter.push_success(&block(1001));
+        assert_eq!(blocks.next().await.unwrap(), new_block_update(&block(1001)));
         assert_eq!(
-            blocks.next().await.unwrap(),
-            new_block_update(&block(1001), 1001)
+            blocks.status(),
+            BlockStatus {
+                latest: 1001,
+                safe: 1001,
+            }
         );
     }
 
@@ -1007,12 +1018,11 @@ mod tests {
         Block::empty(header)
     }
 
-    fn new_block_update(block: &Block, safe: u64) -> BlockUpdate {
+    fn new_block_update(block: &Block) -> BlockUpdate {
         BlockUpdate::New {
             number: block.header.number,
             hash: block.header.hash,
             logs_bloom: block.header.logs_bloom,
-            safe,
         }
     }
 

--- a/crates/core/src/index/events.rs
+++ b/crates/core/src/index/events.rs
@@ -608,7 +608,6 @@ mod tests {
 
     const WATCHED: Address = address!("0x1111111111111111111111111111111111111111");
     const OTHER: Address = address!("0x2222222222222222222222222222222222222222");
-    const UNUSED: u64 = u64::MAX;
 
     sol! {
         #[derive(Debug, Default, Eq, PartialEq)]
@@ -1296,7 +1295,6 @@ mod tests {
                 number: 1337,
                 hash: B256::repeat_byte(0x13),
                 logs_bloom: Bloom::ZERO,
-                safe: UNUSED,
             })
             .unwrap();
 
@@ -1365,7 +1363,6 @@ mod tests {
                 number: 1337,
                 hash: B256::repeat_byte(0x13),
                 logs_bloom: bloom::compute_logs_bloom(&block_logs),
-                safe: UNUSED,
             })
             .unwrap();
         asserter.push_success(&block_logs);
@@ -1403,7 +1400,6 @@ mod tests {
                 number: 1337,
                 hash: B256::repeat_byte(0x13),
                 logs_bloom: Bloom::ZERO,
-                safe: UNUSED,
             })
             .unwrap();
 
@@ -1466,7 +1462,6 @@ mod tests {
                 number: 1337,
                 hash,
                 logs_bloom: Bloom::ZERO,
-                safe: UNUSED,
             })
             .unwrap();
 
@@ -1513,7 +1508,6 @@ mod tests {
                 number: 1337,
                 hash: B256::repeat_byte(0x13),
                 logs_bloom: Bloom::ZERO,
-                safe: UNUSED,
             })
             .unwrap();
 

--- a/crates/core/src/index/mod.rs
+++ b/crates/core/src/index/mod.rs
@@ -12,7 +12,7 @@ use blocks::BlockWatcher;
 use events::{EventWatcher, Events};
 use serde::Deserialize;
 
-pub use blocks::BlockUpdate;
+pub use blocks::{BlockStatus, BlockUpdate};
 pub use events::{EventLog, EventUpdate};
 
 /// Watcher configuration, aggregating the block and event watcher configs.
@@ -94,6 +94,11 @@ where
             self.events.on_block_update(update.clone())?;
             Ok(Update::Block(update))
         }
+    }
+
+    /// Returns the block watcher's current view of the chain.
+    pub fn block_status(&self) -> BlockStatus {
+        self.blocks.status()
     }
 
     /// Fetches the next batch of logs, recovering from a node that exposed a
@@ -273,7 +278,14 @@ mod tests {
             logs_update(948..=997, [weth_deposit(2)])
         );
 
-        assert_eq!(watcher.next().await.unwrap(), new_block_update(998, 997));
+        assert_eq!(watcher.next().await.unwrap(), new_block_update(998));
+        assert_eq!(
+            watcher.block_status(),
+            BlockStatus {
+                latest: 1000,
+                safe: 997,
+            }
+        );
 
         asserter.push_success(&vec![log((998, 0), weth_deposit(3))]);
         assert_eq!(
@@ -281,7 +293,7 @@ mod tests {
             logs_update(998..=998, [weth_deposit(3)])
         );
 
-        assert_eq!(watcher.next().await.unwrap(), new_block_update(999, 997));
+        assert_eq!(watcher.next().await.unwrap(), new_block_update(999));
 
         asserter.push_success(&vec![log((999, 0), weth_deposit(4))]);
         assert_eq!(
@@ -289,7 +301,14 @@ mod tests {
             logs_update(999..=999, [weth_deposit(4)])
         );
 
-        assert_eq!(watcher.next().await.unwrap(), new_block_update(1000, 997));
+        assert_eq!(watcher.next().await.unwrap(), new_block_update(1000));
+        assert_eq!(
+            watcher.block_status(),
+            BlockStatus {
+                latest: 1000,
+                safe: 997,
+            }
+        );
 
         asserter.push_success(&vec![log((1000, 0), weth_deposit(5))]);
         assert_eq!(
@@ -299,7 +318,14 @@ mod tests {
 
         // Fetch another block from the RPC node.
         asserter.push_success(&block(1001));
-        assert_eq!(watcher.next().await.unwrap(), new_block_update(1001, 998));
+        assert_eq!(watcher.next().await.unwrap(), new_block_update(1001));
+        assert_eq!(
+            watcher.block_status(),
+            BlockStatus {
+                latest: 1001,
+                safe: 998,
+            }
+        );
 
         asserter.push_success(&vec![log((1001, 0), weth_deposit(6))]);
         assert_eq!(
@@ -333,7 +359,6 @@ mod tests {
                 number: 1000,
                 hash: block_hash(1000),
                 logs_bloom: block_bloom(1000),
-                safe: 999,
             })
         );
 
@@ -384,12 +409,11 @@ mod tests {
         Bloom::from(bytes)
     }
 
-    fn new_block_update<E>(number: u64, safe: u64) -> Update<E> {
+    fn new_block_update<E>(number: u64) -> Update<E> {
         Update::Block(BlockUpdate::New {
             number,
             hash: block_hash(number),
             logs_bloom: block_bloom(number),
-            safe,
         })
     }
 

--- a/crates/core/src/state/mod.rs
+++ b/crates/core/src/state/mod.rs
@@ -124,7 +124,7 @@ pub struct StateMachine<S, T, E> {
 enum Status {
     Initialized,
     BlockPending { pending: u64 },
-    BlockEvents { latest: u64, safe: u64 },
+    BlockEvents { latest: u64 },
     WarpEvents { range: RangeInclusive<u64> },
 }
 
@@ -184,7 +184,7 @@ where
             // block returned by `snapshots.current` without round-tripping to
             // the database. Note that the `WarpEvents` status's starting block
             // gets updated as event updates are processed.
-            Status::BlockEvents { latest, .. } => latest.checked_sub(1),
+            Status::BlockEvents { latest } => latest.checked_sub(1),
             Status::WarpEvents { range } => range.start.checked_sub(1),
         }
     }
@@ -211,13 +211,13 @@ where
             }
             Update::Block(BlockUpdate::Uncle { number })
                 if matches!(status, Status::BlockPending { pending } if number < pending)
-                    || matches!(status, Status::BlockEvents { latest, .. } if number <= latest) =>
+                    || matches!(status, Status::BlockEvents { latest } if number <= latest) =>
             {
                 let (_, state) = self.snapshots.reorg(number).await?;
                 let status = Status::BlockPending { pending: number };
                 (state, status, vec![])
             }
-            Update::Block(BlockUpdate::New { number, safe, .. })
+            Update::Block(BlockUpdate::New { number, .. })
                 if matches!(status, Status::Initialized)
                     || matches!(status, Status::BlockPending { pending } if pending == number) =>
             {
@@ -226,14 +226,11 @@ where
                         .apply(Message::NewBlock(number))
                         .await
                         .finish();
-                let status = Status::BlockEvents {
-                    latest: number,
-                    safe,
-                };
+                let status = Status::BlockEvents { latest: number };
                 (state, status, actions)
             }
             Update::Logs(EventUpdate { blocks, logs })
-                if matches!(status, Status::BlockEvents { latest, .. } if is_next_in_range(latest..=latest, blocks))
+                if matches!(status, Status::BlockEvents { latest } if is_next_in_range(latest..=latest, blocks))
                     || matches!(status, Status::WarpEvents { range } if is_next_in_range(range, blocks)) =>
             {
                 // We are extra defensive with the updates that we pass to the
@@ -251,16 +248,6 @@ where
                 }
                 let (state, actions) = batch.finish();
 
-                // Prune only after committing the state for the update. In
-                // particular, a new block's safe boundary must not be applied
-                // before its logs are committed: if the service stops between
-                // those updates, restart recovery still needs the parent of
-                // the last committed block for its synthetic reorg.
-                let prune = match &status {
-                    Status::BlockEvents { safe, .. } => Some(*safe),
-                    Status::WarpEvents { .. } => Some(blocks.last),
-                    _ => None,
-                };
                 let status = match status {
                     Status::WarpEvents { range } if blocks.last < range.last => {
                         let range = block_range(next_block(blocks.last)?, range.last)?;
@@ -273,9 +260,6 @@ where
                 };
 
                 self.snapshots.commit(blocks.last, &state).await?;
-                if let Some(safe) = prune {
-                    self.snapshots.prune(safe).await?;
-                }
 
                 (state, status, actions)
             }
@@ -283,6 +267,12 @@ where
         };
         *lock = Some((state, status));
         Ok(actions)
+    }
+
+    /// Prunes state snapshots older than `safe`, retaining the latest snapshot.
+    pub async fn prune(&self, safe: u64) -> Result<(), Error> {
+        self.snapshots.prune(safe).await?;
+        Ok(())
     }
 }
 
@@ -449,15 +439,10 @@ mod tests {
     }
 
     fn new_block(number: u64) -> Update<u64> {
-        new_block_with_safe(number, 0)
-    }
-
-    fn new_block_with_safe(number: u64, safe: u64) -> Update<u64> {
         Update::Block(BlockUpdate::New {
             number,
             hash: Default::default(),
             logs_bloom: Default::default(),
-            safe,
         })
     }
 
@@ -552,23 +537,18 @@ mod tests {
         // Model a one-block reorg window through block 6. Processing block 6
         // retains block 5 as the safe rollback snapshot.
         for block in 1..=6 {
-            machine
-                .handle_update(new_block_with_safe(block, block.saturating_sub(1)))
-                .await
-                .unwrap();
+            machine.handle_update(new_block(block)).await.unwrap();
             machine
                 .handle_update(logs(block..=block, []))
                 .await
                 .unwrap();
+            machine.prune(block.saturating_sub(1)).await.unwrap();
         }
 
         // Observe block 7, but stop before its logs and snapshot are committed.
         // Its newer safe boundary must not prune the rollback state needed by
         // the watcher when it resumes from the last committed block (6).
-        machine
-            .handle_update(new_block_with_safe(7, 6))
-            .await
-            .unwrap();
+        machine.handle_update(new_block(7)).await.unwrap();
         assert_eq!(machine.last_block().await, Some(6));
         drop(machine);
 
@@ -623,19 +603,33 @@ mod tests {
         let pool = pool().await;
         let mut machine = new_machine(&pool).await;
 
-        // Warp ahead, then apply the warped range's events. The block transition
-        // does not run for warped blocks; the state is committed at the end of
-        // the range and the older snapshots are pruned.
         assert_eq!(machine.handle_update(warp(1, 6)).await.unwrap(), vec![]);
+
+        // Apply the first chunk of warped events and prune on the Safe block
+        // (which is the block at the end of the warp).
         assert_eq!(
             machine.handle_update(logs(1..=3, [10])).await.unwrap(),
             vec![Action::Event(10)]
         );
+        machine.prune(6).await.unwrap();
+        assert_eq!(
+            committed(&pool).await,
+            Some((
+                3,
+                TestState {
+                    blocks: vec![],
+                    events: vec![10],
+                },
+            ))
+        );
+        assert_eq!(snapshot_count(&pool).await, 1);
+
+        // Continue with the next chunk of events from the warp.
         assert_eq!(
             machine.handle_update(logs(4..=6, [40])).await.unwrap(),
             vec![Action::Event(40)]
         );
-
+        machine.prune(6).await.unwrap();
         assert_eq!(
             committed(&pool).await,
             Some((
@@ -646,7 +640,6 @@ mod tests {
                 },
             ))
         );
-        // Only the latest snapshot survives the prune.
         assert_eq!(snapshot_count(&pool).await, 1);
     }
 }

--- a/crates/core/src/tx/mod.rs
+++ b/crates/core/src/tx/mod.rs
@@ -18,7 +18,7 @@ use self::{
     types::AllocatedTransaction,
 };
 pub use self::{signer::Signer, types::Transaction};
-use crate::index::BlockUpdate;
+use crate::index::BlockStatus;
 use alloy::{
     eips::{BlockId, eip1559::Eip1559Estimation},
     primitives::U256,
@@ -40,13 +40,6 @@ pub enum Error {
     /// A transaction could not be signed.
     #[error(transparent)]
     Signing(#[from] SigningError),
-    /// We have reached the end of the block chain and cannot continue handling
-    /// updates.
-    #[error("end of chain")]
-    EndOfChain,
-    /// A block update arrived out of order or has unexpected or invalid data.
-    #[error("bad block update")]
-    BadUpdate,
 }
 
 impl Error {
@@ -107,16 +100,10 @@ pub struct TransactionQueue<P> {
     signer: Signer,
     storage: TransactionStorage,
     config: Config,
-    block: Block,
+    block_status: Option<BlockStatus>,
     nonce_cache: Option<u64>,
     fee_cache: Option<Eip1559Estimation>,
     balance_cache: Option<U256>,
-}
-
-enum Block {
-    Initialized,
-    Latest { block: u64 },
-    Warping { to: u64 },
 }
 
 impl<P> TransactionQueue<P>
@@ -140,7 +127,7 @@ where
             signer,
             storage,
             config,
-            block: Block::Initialized,
+            block_status: None,
             nonce_cache: None,
             fee_cache: None,
             balance_cache: None,
@@ -156,85 +143,75 @@ where
         transactions: impl IntoIterator<Item = (Transaction, Option<u64>)>,
     ) -> Result<(), Error> {
         self.storage.enqueue(transactions).await?;
-        self.submit_pending().await
+        if let Some(status) = self.block_status {
+            self.submit_pending(status.latest).await?;
+        }
+        Ok(())
     }
 
-    /// Handles an indexer [`BlockUpdate`], performing the queue's per-block
-    /// housekeeping: invalidating cached chain state, marking executed
-    /// transactions, pruning finalized and expired ones, resubmitting stale
-    /// transactions and submitting newly queued ones.
-    pub async fn handle_block_update(&mut self, update: BlockUpdate) -> Result<(), Error> {
-        self.nonce_cache = None;
-        self.fee_cache = None;
-        self.balance_cache = None;
-        match update {
-            BlockUpdate::New { number, safe, .. } => {
-                if self.next_block()?.is_some_and(|next| next != number) || safe > number {
-                    return Err(Error::BadUpdate);
-                }
-                self.block = Block::Latest { block: number };
-
-                // The signer nonce is an RPC round-trip needed only to mark
-                // executed transactions and to assign nonces to queued ones;
-                // both are moot unless a transaction is still outstanding, so
-                // skip it (and the work that needs it) otherwise. Pruning needs
-                // no nonce and always runs, before submission so expired
-                // transactions are dropped rather than broadcast.
-                let outstanding = self.storage.count_outstanding(number).await? > 0;
-                if outstanding {
-                    let nonce = self.nonce().await?;
-                    self.storage
-                        .mark_executed(Status {
-                            block: number,
-                            nonce,
-                        })
-                        .await?;
-                }
-
-                self.storage.prune(safe).await?;
-                if outstanding {
-                    self.resubmit_stale(number).await?;
-                    self.submit_pending().await?;
-                }
-            }
-            BlockUpdate::Uncle { number } => {
-                if self.latest_block().is_some_and(|latest| latest < number) {
-                    return Err(Error::BadUpdate);
-                }
-                self.block = Block::Latest {
-                    block: number.checked_sub(1).ok_or(Error::BadUpdate)?,
-                };
-                self.storage.unmark_executed(number).await?;
-            }
-            BlockUpdate::Warp { from, to } => {
-                if self.next_block()?.is_some_and(|next| next != from) || to < from {
-                    return Err(Error::BadUpdate);
-                }
-
-                // We do not handle warping (it gets weird with transaction
-                // submission and getting transaction counts). It is not worth
-                // it either as warping is historic and most transactions are
-                // too far in the past to execute anyway. Put us into the state
-                // where we are waiting for the next new block update, so queued
-                // transactions do not execute right away. This ensures that
-                // transactions that are queued already expired while warping do
-                // execute.
-                self.block = Block::Warping { to };
-            }
+    /// Updates the queue's view of the chain, reconciling executed transactions
+    /// and performing submission housekeeping when the latest block advances.
+    pub async fn update_block_status(&mut self, status: BlockStatus) -> Result<(), Error> {
+        let previous = self.block_status;
+        if previous == Some(status) {
+            return Ok(());
         }
+
+        // Update the block status immediately, so the last observed block
+        // status is stored even in case of an intermittent error.
+        self.block_status = Some(status);
+
+        // Invalidate our caches if necessary.
+        if previous.is_none_or(|previous| previous.latest != status.latest) {
+            self.nonce_cache = None;
+            self.fee_cache = None;
+            self.balance_cache = None;
+        }
+
+        // Prune the transaction storage if necessary.
+        if previous.is_none_or(|previous| previous.safe != status.safe) {
+            self.storage.prune(status.safe).await?;
+        }
+
+        // Invalidate execution markers for transactions as necessary.
+        if let Some(block) = match previous {
+            // On startup, conservatively invalidate all transactions executed
+            // past the `safe` block, as there may have been reorgs.
+            None => status.safe.checked_add(1),
+            // In case of a reorg (where the status has a latest block before
+            // the last status we've seen) indicates a reorg to `latest`, so
+            // invalidate markers accordingly.
+            Some(previous) if previous.latest > status.latest => status.latest.checked_add(1),
+            // In all other cases, there are no markers to invalidate.
+            _ => None,
+        } {
+            self.storage.unmark_executed(block).await?;
+        }
+
+        // The signer nonce is an RPC round-trip needed both to mark executed
+        // transactions and to assign nonces to queued ones. Skip it and the
+        // remaining work when there is no new inclusion possibilities (either
+        // there is no new latest block, or there are no outstanding txs).
+        if previous.is_none_or(|previous| previous.latest < status.latest)
+            && self.storage.count_outstanding(status.latest).await? > 0
+        {
+            let nonce = self.nonce().await?;
+            self.storage
+                .mark_executed(Status {
+                    block: status.latest,
+                    nonce,
+                })
+                .await?;
+            self.resubmit_stale(status.latest).await?;
+            self.submit_pending(status.latest).await?;
+        }
+
         Ok(())
     }
 
     /// Submits queued transactions while fewer than
     /// `config.max_in_flight_transactions` are in flight.
-    ///
-    /// Does nothing until the first block update is observed, since a submission
-    /// is stamped with the current block.
-    async fn submit_pending(&mut self) -> Result<(), Error> {
-        let Some(block) = self.latest_block() else {
-            return Ok(());
-        };
-
+    async fn submit_pending(&mut self, block: u64) -> Result<(), Error> {
         let in_flight = self.storage.count_in_flight().await?;
         for _ in in_flight..self.config.max_in_flight_transactions {
             let nonce = self.nonce().await?;
@@ -339,41 +316,20 @@ where
         Ok(())
     }
 
-    /// Returns the latest block received from block updates, or `None` if no
-    /// updates have been received or during warping.
-    fn latest_block(&self) -> Option<u64> {
-        match self.block {
-            Block::Latest { block } => Some(block),
-            _ => None,
-        }
-    }
-
-    /// Returns the expected next block for block updates, or `None` if no block
-    /// updates have been received.
-    fn next_block(&self) -> Result<Option<u64>, Error> {
-        match self.block {
-            Block::Latest { block } | Block::Warping { to: block } => {
-                let next = block.checked_add(1).ok_or(Error::EndOfChain)?;
-                Ok(Some(next))
-            }
-            _ => Ok(None),
-        }
-    }
-
-    /// Returns the signer's onchain nonce (its transaction count), fetched from
-    /// the chain on a cache miss and cached until the next block update.
+    /// Returns the signer's onchain nonce at the latest block, fetched from
+    /// the chain on a cache miss and cached until the block status changes.
     async fn nonce(&mut self) -> Result<u64, Error> {
         match self.nonce_cache {
             Some(nonce) => Ok(nonce),
             None => {
+                let block_id = self
+                    .block_status
+                    .map(|block_status| BlockId::from(block_status.latest))
+                    .unwrap_or_else(BlockId::latest);
                 let nonce = self
                     .provider
                     .get_transaction_count(self.signer.address())
-                    .block_id(
-                        self.latest_block()
-                            .map(BlockId::from)
-                            .unwrap_or_else(BlockId::latest),
-                    )
+                    .block_id(block_id)
                     .await?;
                 self.nonce_cache = Some(nonce);
                 Ok(nonce)
@@ -383,7 +339,7 @@ where
 
     /// Returns the current EIP-1559 fee estimate, with the configured priority
     /// fee cap applied, fetched from the chain on a cache miss and cached until
-    /// the next block update.
+    /// the block status changes.
     async fn fees(&mut self) -> Result<Eip1559Estimation, Error> {
         match self.fee_cache {
             Some(fees) => Ok(fees),
@@ -409,8 +365,9 @@ where
         }
     }
 
-    /// Returns the cached account balance, used to detect whether or not a
-    /// submitted transaction was rejected because of insufficient fees.
+    /// Returns the account balance cached until the block status changes, used
+    /// to detect whether a submission was rejected because of insufficient
+    /// funds.
     async fn balance(&mut self) -> Result<U256, Error> {
         match self.balance_cache {
             Some(balance) => Ok(balance),
@@ -427,7 +384,7 @@ where
 mod tests {
     use super::*;
     use alloy::{
-        primitives::{Address, B256, Bloom, U64, U256, address, keccak256},
+        primitives::{Address, B256, U64, U256, address, keccak256},
         providers::{ProviderBuilder, RootProvider},
         rpc::types::FeeHistory,
         transports::mock::Asserter,
@@ -458,14 +415,8 @@ mod tests {
         }
     }
 
-    /// A new-block update at `number`, finalizing state up to `safe`.
-    fn new_block(number: u64) -> BlockUpdate {
-        BlockUpdate::New {
-            number,
-            hash: B256::ZERO,
-            logs_bloom: Bloom::ZERO,
-            safe: 0,
-        }
+    fn block_status(latest: u64) -> BlockStatus {
+        BlockStatus { latest, safe: 0 }
     }
 
     /// A fee-history response yielding an estimate of a 210 max fee and 10
@@ -479,6 +430,58 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn processes_each_block_status_once() {
+        let asserter = Asserter::new();
+        let mut queue = queue(&asserter).await;
+        queue.queue([(tx("0x01"), None)]).await.unwrap();
+
+        // The initial status submits the queued transaction against the block
+        // watcher's already-known head.
+        asserter.push_success(&U64::from(0)); // signer transaction count
+        asserter.push_success(&fee_history()); // fee estimate
+        asserter.push_success(&B256::ZERO); // transaction hash from submission
+        queue.update_block_status(block_status(10)).await.unwrap();
+
+        // Replayed watcher updates carry the same status and do not repeat any
+        // transaction RPC requests.
+        queue.update_block_status(block_status(10)).await.unwrap();
+        queue.update_block_status(block_status(10)).await.unwrap();
+        assert!(asserter.read_q().is_empty());
+    }
+
+    #[tokio::test]
+    async fn initial_status_reconciles_executions_in_the_reorg_window() {
+        let asserter = Asserter::new();
+        let mut queue = queue(&asserter).await;
+        queue.queue([(tx("0x01"), None)]).await.unwrap();
+
+        // Submit at block 10, then observe the nonce advance at block 11 and
+        // mark the transaction executed there.
+        asserter.push_success(&U64::from(0));
+        asserter.push_success(&fee_history());
+        asserter.push_success(&B256::ZERO);
+        queue.update_block_status(block_status(10)).await.unwrap();
+        asserter.push_success(&U64::from(1));
+        queue.update_block_status(block_status(11)).await.unwrap();
+        assert_eq!(queue.storage.count_in_flight().await.unwrap(), 0);
+
+        // Simulate restarting after an offline reorg of block 11. The initial
+        // status invalidates execution markers above the safe block and then
+        // reconciles them against the latest canonical nonce.
+        queue.block_status = None;
+        asserter.push_success(&U64::from(0));
+        queue
+            .update_block_status(BlockStatus {
+                latest: 11,
+                safe: 10,
+            })
+            .await
+            .unwrap();
+        assert_eq!(queue.storage.count_in_flight().await.unwrap(), 1);
+        assert!(asserter.read_q().is_empty());
+    }
+
+    #[tokio::test]
     async fn submits_queued_transactions_with_reorg_awareness() {
         let asserter = Asserter::new();
         let mut queue = queue(&asserter).await;
@@ -487,45 +490,44 @@ mod tests {
         asserter.push_success(&U64::from(0)); // signer transaction count
         asserter.push_success(&fee_history()); // fee estimate
         asserter.push_success(&B256::ZERO); // transaction hash from submission
-        queue.handle_block_update(new_block(10)).await.unwrap();
+        queue.update_block_status(block_status(10)).await.unwrap();
 
         // At block 11 the signer nonce has advanced to 1, so nonce 0 executed.
-        // The safe block (5) is below the execution, so it is marked but not
-        // pruned. No transaction is broadcast, so only the nonce is fetched.
+        // No transaction is broadcast, so only the nonce is fetched.
         asserter.push_success(&U64::from(1));
-        queue.handle_block_update(new_block(11)).await.unwrap();
+        queue.update_block_status(block_status(11)).await.unwrap();
         assert!(asserter.read_q().is_empty());
 
         // Block 11 is uncled, reverting the execution: the transaction is in
         // flight again.
-        queue
-            .handle_block_update(BlockUpdate::Uncle { number: 11 })
-            .await
-            .unwrap();
+        queue.update_block_status(block_status(10)).await.unwrap();
         assert!(asserter.read_q().is_empty());
 
         // We update up to block 12, where the nonce stays the same. This means
         // that it is not submitted and gets resubmitted (since it did not get
         // executed on the new canonical chain since the reorg).
         asserter.push_success(&U64::from(0)); // signer transaction count
-        queue.handle_block_update(new_block(11)).await.unwrap();
+        queue.update_block_status(block_status(11)).await.unwrap();
         assert!(asserter.read_q().is_empty());
 
         asserter.push_success(&U64::from(0)); // signer transaction count
         asserter.push_success(&fee_history()); // fee estimate
         asserter.push_success(&B256::ZERO); // transaction hash from submission
-        queue.handle_block_update(new_block(12)).await.unwrap();
+        queue.update_block_status(block_status(12)).await.unwrap();
         assert!(asserter.read_q().is_empty());
 
         // Now the transaction gets picked up, and since there are no remaining
         // outstanding transactions we avoid any additional RPC requests on
         // future blocks.
         asserter.push_success(&U64::from(1)); // signer transaction count
-        queue.handle_block_update(new_block(13)).await.unwrap();
+        queue.update_block_status(block_status(13)).await.unwrap();
         assert!(asserter.read_q().is_empty());
 
         for block in 14..=20 {
-            queue.handle_block_update(new_block(block)).await.unwrap();
+            queue
+                .update_block_status(block_status(block))
+                .await
+                .unwrap();
             assert!(asserter.read_q().is_empty());
         }
     }
@@ -552,7 +554,7 @@ mod tests {
         queue.queue([(tx("0xf1"), Some(12))]).await.unwrap();
 
         // Observe a block to submit some of the transactions.
-        queue.handle_block_update(new_block(10)).await.unwrap();
+        queue.update_block_status(block_status(10)).await.unwrap();
         assert!(asserter.read_q().is_empty());
 
         // At block 11, the nonce advances by 1, opening up one more transaction
@@ -560,7 +562,7 @@ mod tests {
         asserter.push_success(&U64::from(1)); // signer transaction count
         asserter.push_success(&fee_history()); // fee estimate
         asserter.push_success(&B256::ZERO); // transaction hash from submission
-        queue.handle_block_update(new_block(11)).await.unwrap();
+        queue.update_block_status(block_status(11)).await.unwrap();
         assert!(asserter.read_q().is_empty());
 
         // At block 12, another transaction gets mined, but the outstanding
@@ -573,39 +575,32 @@ mod tests {
         for _ in 2..queue.config.max_in_flight_transactions {
             asserter.push_success(&B256::ZERO); // transaction hash from submission
         }
-        queue.handle_block_update(new_block(12)).await.unwrap();
+        queue.update_block_status(block_status(12)).await.unwrap();
         assert!(asserter.read_q().is_empty());
 
         // At block 13, all the remaining transactions get mined, the second
         // transaction was already expired and does not resubmit.
         asserter.push_success(&U64::from(queue.config.max_in_flight_transactions + 1)); // signer transaction count
-        queue.handle_block_update(new_block(13)).await.unwrap();
+        queue.update_block_status(block_status(13)).await.unwrap();
         assert!(asserter.read_q().is_empty());
 
         // At block 14, there are no outstanding transactions and therefore no
         // RPC requests are made.
-        queue.handle_block_update(new_block(14)).await.unwrap();
+        queue.update_block_status(block_status(14)).await.unwrap();
         assert!(asserter.read_q().is_empty());
     }
 
     #[tokio::test]
-    async fn expired_transactions_while_warping_are_ignored() {
+    async fn transactions_expired_before_the_initial_status_are_ignored() {
         let asserter = Asserter::new();
         let mut queue = queue(&asserter).await;
 
-        // Observe a warp update.
-        queue
-            .handle_block_update(BlockUpdate::Warp { from: 0, to: 1000 })
-            .await
-            .unwrap();
-        assert!(asserter.read_q().is_empty());
-
-        // queue a transaction long expired.
+        // Queue a transaction before the block watcher provides its status.
         queue.queue([(tx("0x01"), Some(42))]).await.unwrap();
 
-        // now queue a block update, the transaction is not submitted as it is
-        // expired and was never submitted to an RPC node.
-        queue.handle_block_update(new_block(1001)).await.unwrap();
+        // Once the status is available, the transaction is already expired and
+        // is never submitted to the RPC node.
+        queue.update_block_status(block_status(1001)).await.unwrap();
         assert!(asserter.read_q().is_empty());
     }
 
@@ -640,7 +635,7 @@ mod tests {
         asserter.push_failure_msg("no connection"); // cheap submission fails
         asserter.push_success(&U256::from(100_000_000)); // signer balance
         asserter.push_failure_msg("insufficient funds"); // expensive submission fails
-        queue.handle_block_update(new_block(10)).await.unwrap();
+        queue.update_block_status(block_status(10)).await.unwrap();
         assert!(asserter.read_q().is_empty());
 
         // At block 11 neither transaction executed (the nonce is unchanged), so
@@ -652,7 +647,7 @@ mod tests {
         asserter.push_success(&fee_history()); // fee estimate
         asserter.push_success(&B256::ZERO); // cheap resubmission
         asserter.push_success(&B256::ZERO); // expensive resubmission
-        queue.handle_block_update(new_block(11)).await.unwrap();
+        queue.update_block_status(block_status(11)).await.unwrap();
         assert!(asserter.read_q().is_empty());
     }
 }


### PR DESCRIPTION
Fixes #269.

Drive transaction submission and pruning from the block watcher's current chain status instead of individual block updates. This prevents startup history from making newly submitted transactions appear stale and triggering duplicate `eth_sendRawTransaction` calls.

### Context and Motivation

During startup, the block watcher replays the reorg window while already knowing the RPC node's latest block. Treating each replayed block as new submission progress could immediately mark a freshly submitted transaction as stale and attempt to resubmit the identical transaction with cached fees. The transaction queue needs the watcher's actual latest and safe blocks.

### Decisions and Tradeoffs

- Introduce `BlockStatus { latest, safe }`, derived from the block watcher's existing internal state. This prevents duplicate RPC calls (even in the transaction queue).
- Reconcile the transaction queue from `BlockStatus` instead of block updates.
- Remove the `safe` from block updates. State and transaction pruning now use `BlockStatus::safe`; It was a code smell that polluted the `BlockUpdate::New` value anyway (as state transitions should never consider the `safe` block anyway, evidence of this being a code smell are the `UNUSED` values that are now gone).

### Testing

Added some new unit tests for the new transaction queue logic.

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://docs.safefoundation.org/cla).
