### PR TITLE
Resume indexing from retained snapshots

### DIFF
--- a/crates/core/src/driver.rs
+++ b/crates/core/src/driver.rs
@@ -117,7 +117,7 @@ where
             provider.clone(),
             config.index,
             addresses,
-            state.last_block().await,
+            state.block_status().await?,
         )
         .await?;
         let transactions =

--- a/crates/core/src/index/blocks.rs
+++ b/crates/core/src/index/blocks.rs
@@ -138,15 +138,14 @@ where
 {
     /// Creates and initializes a block watcher.
     ///
-    /// When `last_indexed_block` is set, the watcher resumes from it, replaying
-    /// the last `max_reorg_depth` blocks via a deliberate "fake" reorg so any
-    /// reorg that happened while the service was down is re-indexed. Otherwise,
-    /// when `Config::start_block` is set, it back-fills from there via a warp
-    /// without a (fake) reorg.
+    /// When `indexed` is set, the watcher resumes from the persisted snapshot
+    /// range, replaying everything after its safe rollback anchor via a
+    /// synthetic reorg. Otherwise, when `Config::start_block` is set, it
+    /// back-fills from there via a warp without a fake reorg.
     pub async fn new(
         provider: P,
         config: Config,
-        last_indexed_block: Option<u64>,
+        indexed: Option<BlockStatus>,
     ) -> Result<Self, Error> {
         let block_time = resolve_block_time(&provider, config.block_time).await?;
         let mut watcher = Self {
@@ -161,7 +160,7 @@ where
             recent: VecDeque::new(),
             queue: VecDeque::new(),
         };
-        watcher.initialize(last_indexed_block).await?;
+        watcher.initialize(indexed).await?;
         Ok(watcher)
     }
 
@@ -175,7 +174,7 @@ where
             .ok_or(Error::MissingBlock(id))
     }
 
-    async fn initialize(&mut self, last_indexed_block: Option<u64>) -> Result<(), Error> {
+    async fn initialize(&mut self, indexed: Option<BlockStatus>) -> Result<(), Error> {
         let latest = self.require_block(BlockId::latest()).await?;
         let safe = latest
             .header
@@ -184,26 +183,31 @@ where
         tracing::debug!(
             latest = latest.header.number,
             safe,
-            resume = ?last_indexed_block,
+            resume = ?indexed,
             "initializing block watcher"
         );
 
         self.update_next_pending_block(latest.header.number, latest.header.timestamp);
 
-        if let Some(last_indexed_block) = last_indexed_block {
-            // To guard against a reorg of a block right as the service restarted,
-            // we always create a "fake" reorg `max_reorg_depth` deep to re-index
-            // the last blocks before shutdown. Queue an uncle for the block right
-            // after the last reorg-safe indexed block.
-            let uncle = (last_indexed_block + 1).saturating_sub(self.config.max_reorg_depth);
-            if uncle <= last_indexed_block {
+        if let Some(indexed) = indexed {
+            // The earliest retained snapshot is the rollback anchor. Replay
+            // everything after it, but only emit an uncle when there are newer
+            // snapshots to discard. A pruned warp may retain only its latest
+            // snapshot, in which case we can continue directly from the next
+            // block without a synthetic reorg.
+            let uncle = indexed.safe.checked_add(1);
+            if let Some(uncle) = uncle
+                && uncle <= indexed.latest
+            {
                 self.queue.push_back(BlockUpdate::Uncle { number: uncle });
             }
 
             // If possible, warp up to the reorg-safe block to allow bulk log
             // queries. We cannot warp to the latest block, as a range query
             // could then return data for a block that later gets uncled.
-            if uncle <= safe {
+            if let Some(uncle) = uncle
+                && uncle <= safe
+            {
                 self.queue.push_back(BlockUpdate::Warp {
                     from: uncle,
                     to: safe,
@@ -259,14 +263,24 @@ where
             }
         }
 
-        // Queue new-block updates for the recent blocks. When starting from a
-        // configured block, only emit those at or after it; earlier blocks (which
-        // occur when `start_block` is within the reorg window) are still retained
-        // for reorg detection.
+        // Queue new-block updates for the recent blocks. Earlier blocks are
+        // still retained for reorg detection, but updates before the persisted
+        // rollback boundary (or configured start block on a fresh start) have
+        // already been processed and must not be emitted.
         for block in self.recent.iter().filter(|block| {
-            self.config
-                .start_block
-                .is_none_or(|start_block| block.header.number >= start_block)
+            indexed.map_or_else(
+                || {
+                    self.config
+                        .start_block
+                        .is_none_or(|start_block| block.header.number >= start_block)
+                },
+                |indexed| {
+                    indexed
+                        .safe
+                        .checked_add(1)
+                        .is_some_and(|from| block.header.number >= from)
+                },
+            )
         }) {
             self.queue.push_back(BlockUpdate::New {
                 number: block.header.number,
@@ -562,14 +576,21 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn initializes_from_last_indexed_block() {
+    async fn initializes_from_persisted_snapshot_range() {
         let asserter = Asserter::new();
         asserter.push_success(&block(1000));
         asserter.push_success(&block(999));
 
-        let mut blocks = BlockWatcher::new(mock_provider(&asserter), config(), Some(900))
-            .await
-            .unwrap();
+        let mut blocks = BlockWatcher::new(
+            mock_provider(&asserter),
+            config(),
+            Some(BlockStatus {
+                latest: 900,
+                safe: 898,
+            }),
+        )
+        .await
+        .unwrap();
 
         assert_eq!(
             blocks.ready().collect::<Vec<_>>(),
@@ -580,6 +601,55 @@ mod tests {
                 new_block_update(&block(1000)),
             ]
         );
+        assert!(asserter.read_q().is_empty());
+    }
+
+    #[tokio::test]
+    async fn resumes_after_a_single_pruned_snapshot_without_a_fake_reorg() {
+        let asserter = Asserter::new();
+        asserter.push_success(&block(1000));
+        asserter.push_success(&block(999));
+
+        let mut blocks = BlockWatcher::new(
+            mock_provider(&asserter),
+            config(),
+            Some(BlockStatus {
+                latest: 900,
+                safe: 900,
+            }),
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(
+            blocks.ready().collect::<Vec<_>>(),
+            [
+                BlockUpdate::Warp { from: 901, to: 998 },
+                new_block_update(&block(999)),
+                new_block_update(&block(1000)),
+            ]
+        );
+        assert!(asserter.read_q().is_empty());
+    }
+
+    #[tokio::test]
+    async fn does_not_reemit_recent_blocks_at_or_before_the_persisted_snapshot() {
+        let asserter = Asserter::new();
+        asserter.push_success(&block(1000));
+        asserter.push_success(&block(999));
+
+        let mut blocks = BlockWatcher::new(
+            mock_provider(&asserter),
+            config(),
+            Some(BlockStatus {
+                latest: 1000,
+                safe: 1000,
+            }),
+        )
+        .await
+        .unwrap();
+
+        assert!(blocks.ready().next().is_none());
         assert!(asserter.read_q().is_empty());
     }
 
@@ -671,7 +741,10 @@ mod tests {
                 max_reorg_depth: 0,
                 ..config()
             },
-            Some(900),
+            Some(BlockStatus {
+                latest: 900,
+                safe: 900,
+            }),
         )
         .await
         .unwrap();

--- a/crates/core/src/index/mod.rs
+++ b/crates/core/src/index/mod.rs
@@ -65,15 +65,15 @@ where
     E: Events,
 {
     /// Creates and initializes a watcher for the events `E` emitted by
-    /// `addresses`, resuming from `last_indexed_block` (see
+    /// `addresses`, resuming from the persisted snapshot range (see
     /// [`BlockWatcher::new`]).
     pub async fn new(
         provider: P,
         config: Config,
         addresses: Vec<Address>,
-        last_indexed_block: Option<u64>,
+        indexed: Option<BlockStatus>,
     ) -> Result<Self, Error> {
-        let blocks = BlockWatcher::new(provider.clone(), config.blocks, last_indexed_block).await?;
+        let blocks = BlockWatcher::new(provider.clone(), config.blocks, indexed).await?;
         let events = EventWatcher::new(provider, config.events, addresses);
         Ok(Self { blocks, events })
     }
@@ -238,10 +238,10 @@ mod tests {
     async fn watcher(
         asserter: &Asserter,
         config: Config,
-        last_indexed_block: Option<u64>,
+        indexed: Option<BlockStatus>,
     ) -> Watcher<RootProvider, Weth::WethEvents> {
         let provider = ProviderBuilder::default().connect_mocked_client(asserter.clone());
-        Watcher::new(provider, config, vec![WATCHED], last_indexed_block)
+        Watcher::new(provider, config, vec![WATCHED], indexed)
             .await
             .unwrap()
     }
@@ -253,7 +253,15 @@ mod tests {
         asserter.push_success(&block(1000));
         asserter.push_success(&block(998));
         asserter.push_success(&block(999));
-        let mut watcher = watcher(&asserter, config(), Some(850)).await;
+        let mut watcher = watcher(
+            &asserter,
+            config(),
+            Some(BlockStatus {
+                latest: 850,
+                safe: 847,
+            }),
+        )
+        .await;
 
         assert_eq!(
             watcher.next().await.unwrap(),

--- a/crates/core/src/state/mod.rs
+++ b/crates/core/src/state/mod.rs
@@ -7,7 +7,7 @@
 pub mod storage;
 
 use self::storage::SnapshotStore;
-use crate::index::{BlockUpdate, EventLog, EventUpdate, Update};
+use crate::index::{BlockStatus, BlockUpdate, EventLog, EventUpdate, Update};
 use serde::{Serialize, de::DeserializeOwned};
 use sqlx::SqlitePool;
 use std::{collections::VecDeque, convert::Infallible, mem, range::RangeInclusive};
@@ -170,23 +170,13 @@ where
         })
     }
 
-    /// Returns the last block that was fully processed by the state machine.
-    /// Note that this only counts fully processed blocks.
-    pub async fn last_block(&self) -> Option<u64> {
-        let lock = self.inner.lock().await;
-        let (_, status) = lock.as_ref()?;
-        match status {
-            Status::Initialized => None,
-            Status::BlockPending { pending } => pending.checked_sub(1),
-            // This is a bit counter-intuitive, but if we observed the latest
-            // block `N` and are waiting for its events, then we have only
-            // completely processed block `N-1`. This should correspond to the
-            // block returned by `snapshots.current` without round-tripping to
-            // the database. Note that the `WarpEvents` status's starting block
-            // gets updated as event updates are processed.
-            Status::BlockEvents { latest } => latest.checked_sub(1),
-            Status::WarpEvents { range } => range.start.checked_sub(1),
-        }
+    /// Returns the bounds of the snapshots currently persisted by the state
+    /// machine.
+    ///
+    /// The latest snapshot is the indexer's resume point, while the safe
+    /// snapshot is the earliest rollback anchor retained in storage.
+    pub async fn block_status(&self) -> Result<Option<BlockStatus>, Error> {
+        Ok(self.snapshots.status().await?)
     }
 
     /// Handle an indexer update.
@@ -549,7 +539,10 @@ mod tests {
         // Its newer safe boundary must not prune the rollback state needed by
         // the watcher when it resumes from the last committed block (6).
         machine.handle_update(new_block(7)).await.unwrap();
-        assert_eq!(machine.last_block().await, Some(6));
+        assert_eq!(
+            machine.block_status().await.unwrap(),
+            Some(BlockStatus { latest: 6, safe: 5 })
+        );
         drop(machine);
 
         let mut machine = new_machine(&pool).await;
@@ -623,6 +616,17 @@ mod tests {
             ))
         );
         assert_eq!(snapshot_count(&pool).await, 1);
+        assert_eq!(
+            machine.block_status().await.unwrap(),
+            Some(BlockStatus { latest: 3, safe: 3 })
+        );
+
+        // Restarting in the middle of the warp resumes after the only retained
+        // snapshot. In particular, it does not require a synthetic uncle whose
+        // parent snapshot was pruned with the previous page.
+        drop(machine);
+        let mut machine = new_machine(&pool).await;
+        assert_eq!(machine.handle_update(warp(4, 6)).await.unwrap(), vec![]);
 
         // Continue with the next chunk of events from the warp.
         assert_eq!(
@@ -641,5 +645,9 @@ mod tests {
             ))
         );
         assert_eq!(snapshot_count(&pool).await, 1);
+        assert_eq!(
+            machine.block_status().await.unwrap(),
+            Some(BlockStatus { latest: 6, safe: 6 })
+        );
     }
 }

--- a/crates/core/src/state/storage.rs
+++ b/crates/core/src/state/storage.rs
@@ -9,6 +9,7 @@
 //! A rollback restores the snapshot at the reorg's common ancestor and discards
 //! everything above it. Snapshots below a `safe` block are pruned.
 
+use crate::index::BlockStatus;
 use serde::{Serialize, de::DeserializeOwned};
 use sqlx::sqlite::SqlitePool;
 use std::{marker::PhantomData, num::TryFromIntError};
@@ -64,8 +65,7 @@ where
     /// Returns the tip snapshot (the one with the highest block number) and its
     /// block number, or `None` when the store is empty.
     ///
-    /// On startup this is the resume point: the block number is the indexer's
-    /// last indexed block.
+    /// On startup this is the state machine's resume point.
     pub async fn current(&self) -> Result<Option<(u64, S)>, Error> {
         sqlx::query_as::<_, (i64, String)>(
             "SELECT block_number, state FROM snapshots ORDER BY block_number DESC LIMIT 1",
@@ -76,6 +76,28 @@ where
             Ok((u64::try_from(block_number)?, serde_json::from_str(&state)?))
         })
         .transpose()
+    }
+
+    /// Returns the bounds of the currently retained snapshots, or `None` when
+    /// the store is empty.
+    ///
+    /// `latest` is the resume point and `safe` is the earliest snapshot that
+    /// can be used as a rollback anchor.
+    pub async fn status(&self) -> Result<Option<BlockStatus>, Error> {
+        let (safe, latest) = sqlx::query_as::<_, (Option<i64>, Option<i64>)>(
+            "SELECT MIN(block_number), MAX(block_number) FROM snapshots",
+        )
+        .fetch_one(&self.pool)
+        .await?;
+
+        safe.zip(latest)
+            .map(|(safe, latest)| {
+                Ok(BlockStatus {
+                    latest: u64::try_from(latest)?,
+                    safe: u64::try_from(safe)?,
+                })
+            })
+            .transpose()
     }
 
     /// Records `state` as the snapshot for `block_number`, replacing any existing
@@ -168,6 +190,7 @@ mod tests {
     async fn current_is_none_when_empty() {
         let store = store().await;
         assert_eq!(store.current().await.unwrap(), None);
+        assert_eq!(store.status().await.unwrap(), None);
     }
 
     #[tokio::test]
@@ -177,6 +200,10 @@ mod tests {
         store.commit(2, &state(20)).await.unwrap();
 
         assert_eq!(store.current().await.unwrap(), Some((2, state(20))));
+        assert_eq!(
+            store.status().await.unwrap(),
+            Some(BlockStatus { latest: 2, safe: 1 })
+        );
     }
 
     #[tokio::test]
@@ -229,6 +256,11 @@ mod tests {
 
         store.prune(2).await.unwrap();
 
+        assert_eq!(
+            store.status().await.unwrap(),
+            Some(BlockStatus { latest: 3, safe: 2 })
+        );
+
         // Block 1 is gone; the safe block and above remain.
         assert_eq!(store.reorg(3).await.unwrap(), (2, state(20)));
         assert!(matches!(
@@ -248,6 +280,10 @@ mod tests {
         store.prune(5).await.unwrap();
 
         assert_eq!(store.current().await.unwrap(), Some((2, state(20))));
+        assert_eq!(
+            store.status().await.unwrap(),
+            Some(BlockStatus { latest: 2, safe: 2 })
+        );
 
         // Block 1 is gone, so trying to reorg block 2 would result in an error.
         assert!(matches!(


### PR DESCRIPTION
Fixes #667 

Resume block indexing from the state snapshots retained in storage. This prevents startup from requesting a pruned rollback snapshot after restarting during or shortly after a historical warp.

### Context and Motivation

Driver startup previously derived its synthetic reorg boundary from `latest - max_reorg_depth`, assuming every snapshot in that range still existed. This is not always the case:

- The service is restarted mid-warp sync, where only the latest snapshot is kept (since all blocks in a warp are reorg safe)
- The service is restarted mid-reorg, where a snapshot was removed from storage, but the new canonical block was not yet committed to storage (for example, only the block update but not the logs were processed).

### Testing

Added some new tests for the modified behaviour.

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://docs.safefoundation.org/cla).
