### PR TITLE
[Effects 1a]: Introduce Core Effect Module

### DIFF
--- a/crates/core/src/driver.rs
+++ b/crates/core/src/driver.rs
@@ -8,8 +8,9 @@
 //! for submission.
 
 use crate::{
+    effects::EffectHandler,
     index::{self, Watcher, events::Events},
-    state::{self, EffectHandler, StateMachine, StateTransition},
+    state::{self, StateMachine, StateTransition},
     tx::{self, Signer, Transaction, TransactionQueue},
 };
 use alloy::{primitives::Address, providers::Provider};

--- a/crates/core/src/effects.rs
+++ b/crates/core/src/effects.rs
@@ -1,0 +1,28 @@
+//! Effect handling for state transitions.
+
+use std::{convert::Infallible, future::Future};
+
+/// An effect handler that can be used for handling effects for a state
+/// transition.
+pub trait EffectHandler<Effect, Resume>: Send + Sync + 'static {
+    /// Performs an effect and returns its result to resume a state machine.
+    ///
+    /// Note that this method explicitly does not fail, and is expected to return
+    /// some result that indicates an error so the state machine can handle the
+    /// effect error internally.
+    ///
+    /// The same effect may be performed more than once for the same chain
+    /// message. For consumptive resources such as pre-committed nonces, handlers
+    /// should encode outcomes like "already used" in `Resume`; state transitions
+    /// remain pure because they consume only the resume value.
+    fn perform_effect(&self, effect: Effect) -> impl Future<Output = Resume> + Send;
+}
+
+/// An effect handler for pure state machines without any side-effects.
+pub struct Pure;
+
+impl<Resume> EffectHandler<Infallible, Resume> for Pure {
+    async fn perform_effect(&self, effect: Infallible) -> Resume {
+        match effect {}
+    }
+}

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -11,6 +11,7 @@
 //! - Reliable transaction submission with all its complexities.
 
 pub mod driver;
+pub mod effects;
 pub mod index;
 pub mod kdf;
 pub mod observability;

--- a/crates/core/src/state/mod.rs
+++ b/crates/core/src/state/mod.rs
@@ -7,10 +7,13 @@
 pub mod storage;
 
 use self::storage::SnapshotStore;
-use crate::index::{BlockStatus, BlockUpdate, EventLog, EventUpdate, Update};
+use crate::{
+    effects::EffectHandler,
+    index::{BlockStatus, BlockUpdate, EventLog, EventUpdate, Update},
+};
 use serde::{Serialize, de::DeserializeOwned};
 use sqlx::SqlitePool;
-use std::{collections::VecDeque, convert::Infallible, mem, range::RangeInclusive};
+use std::{collections::VecDeque, mem, range::RangeInclusive};
 use tokio::sync::Mutex;
 
 /// Error produced by the [`StateMachine`].
@@ -91,22 +94,6 @@ where
         state: S,
         message: Message<Self::Event, Self::Resume>,
     ) -> (S, Commands<S, Self>);
-}
-
-/// An effect handler that can be used for handling effects for a state
-/// transition.
-pub trait EffectHandler<Effect, Resume> {
-    /// Performs an effect and returns its result to resume a state machine.
-    ///
-    /// Note that this method explicitly does not fail, and is expected to return
-    /// some result that indicates an error so the state machine can handle the
-    /// effect error internally.
-    ///
-    /// The same effect may be performed more than once for the same chain
-    /// message. For consumptive resources such as pre-committed nonces, handlers
-    /// should encode outcomes like "already used" in `Resume`; state transitions
-    /// remain pure because they consume only the resume value.
-    fn perform_effect(&mut self, effect: Effect) -> impl Future<Output = Resume>;
 }
 
 /// A utility type for a vector of commands for some state and its transition.
@@ -339,19 +326,13 @@ fn is_next_in_range(range: impl Into<RangeInclusive<u64>>, sub: RangeInclusive<u
     range.start == sub.start && range.contains(&sub.last)
 }
 
-/// An effect handler for pure state machines without any side-effects.
-pub struct Pure;
-
-impl<Resume> EffectHandler<Infallible, Resume> for Pure {
-    async fn perform_effect(&mut self, effect: Infallible) -> Resume {
-        match effect {}
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::index::{BlockUpdate, EventUpdate, Update};
+    use crate::{
+        effects::Pure,
+        index::{BlockUpdate, EventUpdate, Update},
+    };
     use alloy::primitives::Address;
     use serde::Deserialize;
     use std::convert::Infallible;

--- a/crates/sentinel/src/effect.rs
+++ b/crates/sentinel/src/effect.rs
@@ -8,7 +8,7 @@
 use crate::checker::{CheckOutcome, Checker};
 use alloy::primitives::{Address, B256};
 use safe_tx::types::SafeTransaction;
-use safenet_core::state::EffectHandler;
+use safenet_core::effects::EffectHandler;
 
 /// An impure operation the sentinel's state transition asks the [`Handler`]
 /// to perform.
@@ -60,7 +60,7 @@ impl Handler {
 }
 
 impl EffectHandler<Effect, Resume> for Handler {
-    async fn perform_effect(&mut self, effect: Effect) -> Resume {
+    async fn perform_effect(&self, effect: Effect) -> Resume {
         match effect {
             Effect::DynamicCheck {
                 request_id,
@@ -114,7 +114,7 @@ mod tests {
         // `SafeTransaction::default()` has no ERC-20 calldata for the
         // earlier checkers to even look at — this only exercises the
         // `Effect` -> `Resume` wiring itself.
-        let mut handler = handler(address_poisoning(), RemoteChecker::new(None));
+        let handler = handler(address_poisoning(), RemoteChecker::new(None));
 
         let resume = handler
             .perform_effect(Effect::DynamicCheck {

--- a/crates/validator/src/service/effect.rs
+++ b/crates/validator/src/service/effect.rs
@@ -10,7 +10,7 @@ use crate::{
     secrets::SecretStore,
 };
 use alloy::primitives::{Address, B256};
-use safenet_core::state::EffectHandler;
+use safenet_core::effects::EffectHandler;
 use std::{
     error::Error,
     fmt::{self, Display, Formatter},
@@ -108,15 +108,17 @@ pub struct Handler {
 }
 
 impl Handler {
-    async fn try_perform_effect(&mut self, effect: Effect) -> Result<Resume, InternalError> {
+    async fn try_perform_effect(&self, effect: Effect) -> Result<Resume, InternalError> {
         match effect {
             Effect::KeyGenSetup {
                 group_id,
                 count,
                 threshold,
             } => {
-                let mut rng = rand::thread_rng();
-                let secrets = frost::keygen::setup(&mut rng, self.account, count, threshold)?;
+                let secrets = {
+                    let mut rng = rand::thread_rng();
+                    frost::keygen::setup(&mut rng, self.account, count, threshold)?
+                };
                 let stored = self
                     .secrets
                     .store_keygen_secrets(group_id, self.account, secrets)
@@ -214,8 +216,10 @@ impl Handler {
         key_share: &KeyShare,
     ) -> Result<Resume, InternalError> {
         let started = Instant::now();
-        let mut rng = rand::thread_rng();
-        let nonce_chunk = frost::preprocess::NonceChunk::generate(key_share, &mut rng)?;
+        let nonce_chunk = {
+            let mut rng = rand::thread_rng();
+            frost::preprocess::NonceChunk::generate(key_share, &mut rng)?
+        };
         let result = self
             .secrets
             .register_nonces_chunk(group_id, self.account, nonce_chunk)
@@ -237,7 +241,7 @@ impl Handler {
 }
 
 impl EffectHandler<Effect, Resume> for Handler {
-    async fn perform_effect(&mut self, effect: Effect) -> Resume {
+    async fn perform_effect(&self, effect: Effect) -> Resume {
         match self.try_perform_effect(effect.clone()).await {
             Ok(resume) => resume,
             Err(err) => {


### PR DESCRIPTION
### Context and Motivation

This PR just introduces an `effects` module to the core and moves the existing effects-related types to that module.

It was done in order to make PR reviews easier and less noisy.

### Decisions and Tradeoffs

We additionally change the method from `&self` to `&mut self`: this is because if we want concurrent processing of effects, the handler itself cannot be mutable in order for it to be shared across `perform_effect` tasks. If parts of the handler _must_ be mutable, then it should use internal mutability (with a `Mutex` or `RWLock`) and must be up to the effect handler to implement correctly (otherwise, all effects would be handled in sequence and not support concurrency).

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://docs.safefoundation.org/cla).
