### PR TITLE
[Effects 3]: Run State Machine Effects Asynchronously

### DIFF
--- a/crates/core/src/driver.rs
+++ b/crates/core/src/driver.rs
@@ -3,20 +3,20 @@
 //! Ties the core building blocks together into a running service: it follows
 //! the chain with an [`indexer`](crate::index), feeds block updates to the
 //! [`transaction queue`](crate::tx) for its per-block housekeeping, and feeds
-//! every update to the [`state machine`](crate::state). The actions produced by
-//! the state machine are encoded into transactions by the [`Service`] and queued
-//! for submission.
+//! every update and completed effect to the [`state machine`](crate::state).
+//! Effects produced by the state machine run concurrently, while actions are
+//! encoded into transactions by the [`Service`] and queued for submission.
 
 use crate::{
-    effects::EffectHandler,
-    index::{self, Watcher, events::Events},
+    effects::{EffectHandler, EffectManager},
+    index::{self, Update, Watcher, events::Events},
     state::{self, StateMachine, StateTransition},
     tx::{self, Signer, Transaction, TransactionQueue},
 };
 use alloy::{primitives::Address, providers::Provider};
 use serde::{Deserialize, Serialize, de::DeserializeOwned};
 use sqlx::sqlite::SqlitePool;
-use std::{fmt::Debug, pin::Pin, time::Duration};
+use std::{fmt::Debug, time::Duration};
 
 /// How long to wait after a failed step before retrying, to avoid spinning on a
 /// persistent failure (such as an unreachable RPC node).
@@ -33,12 +33,15 @@ pub struct Config {
     pub transactions: tx::Config,
 }
 
-/// Whether the [`Driver::run`] loop should keep processing updates or stop.
-enum Loop {
-    /// Continue with the next iteration.
-    Continue,
-    /// Stop the run loop, for example after a shutdown signal.
-    Break,
+/// A state machine input.
+// The watcher update is the common variant and inputs are consumed immediately,
+// so boxing it would add an allocation without reducing retained driver state.
+#[allow(clippy::large_enum_variant)]
+enum Input<Event, Resume> {
+    /// An indexer update.
+    Update(Update<Event>),
+    /// Resume an effect.
+    Resume(Resume),
 }
 
 /// Error produced by the [`Driver`].
@@ -66,14 +69,21 @@ pub trait ActionEncoder<Action> {
 /// A Safenet service definition.
 pub trait Service {
     type State: Default + DeserializeOwned + Serialize;
-    type Event: Debug + Events;
 
-    type Transition: StateTransition<Self::State, Event = Self::Event>;
-    type Effects: EffectHandler<
-            <Self::Transition as StateTransition<Self::State>>::Effect,
-            <Self::Transition as StateTransition<Self::State>>::Resume,
+    type Event: Debug + Events;
+    type Action;
+    type Effect: Send + 'static;
+    type Resume: Send + 'static;
+
+    type Transition: StateTransition<
+            Self::State,
+            Event = Self::Event,
+            Action = Self::Action,
+            Effect = Self::Effect,
+            Resume = Self::Resume,
         >;
-    type Actions: ActionEncoder<<Self::Transition as StateTransition<Self::State>>::Action>;
+    type Effects: EffectHandler<Self::Effect, Self::Resume>;
+    type Actions: ActionEncoder<Self::Action>;
 
     /// Constructs the service components used by the driver.
     fn components(self) -> (Self::Transition, Self::Effects, Self::Actions);
@@ -86,7 +96,8 @@ where
     S: Service,
 {
     watcher: Watcher<P, S::Event>,
-    state: StateMachine<S::State, S::Transition, S::Effects>,
+    state: StateMachine<S::State, S::Transition>,
+    effects: EffectManager<S::Effects, S::Effect, S::Resume>,
     actions: S::Actions,
     transactions: TransactionQueue<P>,
 }
@@ -113,7 +124,8 @@ where
         config: Config,
     ) -> Result<Self, Error> {
         let (transition, effects, actions) = service.components();
-        let state = StateMachine::new(transition, effects, pool.clone()).await?;
+        let state = StateMachine::new(transition, pool.clone()).await?;
+        let effects = EffectManager::new(effects);
         let watcher = Watcher::new(
             provider.clone(),
             config.index,
@@ -127,6 +139,7 @@ where
         Ok(Self {
             watcher,
             state,
+            effects,
             actions,
             transactions,
         })
@@ -137,17 +150,15 @@ where
     ///
     /// This is meant for queuing up initial startup actions that live outside
     /// the state machine's semantics.
-    pub async fn queue_action(
-        &mut self,
-        action: <S::Transition as StateTransition<S::State>>::Action,
-    ) -> Result<(), Error> {
+    pub async fn queue_action(&mut self, action: S::Action) -> Result<(), Error> {
         let transaction = self.actions.encode_action(action);
         self.transactions.queue([transaction]).await?;
         Ok(())
     }
 
-    /// Runs the service, processing indexer updates until a shutdown signal
-    /// (such as Ctrl-C) is received or an unrecoverable error occurs.
+    /// Runs the service, processing watcher updates and completed effects until
+    /// a shutdown signal (such as Ctrl-C) is received or an unrecoverable error
+    /// occurs.
     ///
     /// Failures while waiting for the next indexer update are retried after a
     /// short delay. Errors encountered after an update has been received are
@@ -161,81 +172,89 @@ where
         tokio::pin!(shutdown);
 
         loop {
-            match self.step(shutdown.as_mut()).await {
-                Ok(Loop::Continue) => continue,
-                Ok(Loop::Break) => {
+            let input = tokio::select! {
+                biased;
+                _ = shutdown.as_mut() => {
                     tracing::info!("received shutdown signal; stopping service");
                     break;
-                }
-                Err(err) => {
-                    tracing::error!(?err, "unrecoverable driver error; exiting");
-                    break;
-                }
+                },
+                input = self.next_input() => input,
+            };
+
+            // Once selected, an input is processed to completion before the run
+            // loop can stop; this prevents partial state applies.
+            if let Err(err) = self.update(input).await {
+                tracing::error!(?err, "unrecoverable driver error; exiting");
+                break;
             }
         }
     }
 
-    /// Processes a single indexer update: feeding block updates to the
-    /// transaction queue, advancing the state machine, and queuing the
-    /// transactions its actions encode to.
+    /// Reads the next state machine input to process.
     ///
-    /// Only the wait for the next update races `shutdown`; once an update
-    /// arrives it is processed to completion so its state transition and queued
-    /// transactions are committed before the loop can stop.
-    async fn step(
-        &mut self,
-        mut shutdown: Pin<&mut impl Future<Output = ()>>,
-    ) -> Result<Loop, Error> {
-        let update = tokio::select! {
-            biased;
-            _ = shutdown.as_mut() => return Ok(Loop::Break),
-            update = self.watcher.next() => update,
-        };
-
-        // Make sure that getting the next watcher update was successful. If not
-        // log and continue the loop after a short delay.
-        let update = match update {
-            Ok(update) => {
-                tracing::trace!(?update, "received watcher update");
-                update
-            }
-            Err(err) => {
-                tracing::warn!(
-                    ?err,
-                    "failed to get next blockchain update; retrying after delay"
-                );
-                return tokio::select! {
-                    biased;
-                    _ = shutdown.as_mut() => Ok(Loop::Break),
-                    _ = tokio::time::sleep(STEP_RETRY_DELAY) => Ok(Loop::Continue),
-                };
+    /// Watcher failures are retried after a short delay while completed effects
+    /// remain eligible for selection.
+    async fn next_input(&mut self) -> Input<S::Event, S::Resume> {
+        let update = async {
+            loop {
+                match self.watcher.next().await {
+                    Ok(update) => return update,
+                    Err(err) => {
+                        tracing::warn!(
+                            ?err,
+                            "failed to get next blockchain update; retrying after delay"
+                        );
+                        tokio::time::sleep(STEP_RETRY_DELAY).await;
+                    }
+                }
             }
         };
-        let block_status = self.watcher.block_status();
 
-        // Reconcile the transaction queue against the block watcher's current
-        // chain view before advancing the state machine, so freshly queued
-        // transactions are submitted against the latest known block. If we
-        // encounter an intermittent error - log and continue; things will
-        // naturally get a chance to recover.
-        let result = self.transactions.update_block_status(block_status).await;
-        if let Err(err) = tx::lift_intermittent_error(result)? {
-            tracing::warn!(
-                ?err,
-                "transaction queue failed to handle new block; will continue"
-            );
+        let input = tokio::select! {
+            update = update => Input::Update(update),
+            resume = self.effects.next() => Input::Resume(resume)
+        };
+        input
+    }
+
+    /// Processes a single watcher update or completed effect, advancing the
+    /// state machine and dispatching the commands it returns.
+    async fn update(&mut self, input: Input<S::Event, S::Resume>) -> Result<(), Error> {
+        let commands = match input {
+            Input::Update(update) => {
+                let block_status = self.watcher.block_status();
+
+                // Reconcile the transaction queue against the block watcher's
+                // current chain view before advancing the state machine, so
+                // freshly queued transactions are submitted against the latest
+                // known block. If we encounter an intermittent error, log and
+                // continue; things will naturally get a chance to recover.
+                let result = self.transactions.update_block_status(block_status).await;
+                if let Err(err) = tx::lift_intermittent_error(result)? {
+                    tracing::warn!(
+                        ?err,
+                        "transaction queue failed to handle new block; will continue"
+                    );
+                }
+
+                let commands = self.state.handle_update(update).await?;
+                self.state.prune(block_status.safe).await?;
+                commands
+            }
+            Input::Resume(resume) => self.state.handle_resume(resume).await?,
+        };
+
+        let mut transactions = Vec::with_capacity(commands.len());
+        for command in commands {
+            match command {
+                state::Command::Action(action) => {
+                    transactions.push(self.actions.encode_action(action));
+                }
+                state::Command::Effect(effect) => self.effects.spawn(effect),
+            }
         }
 
-        // Perform a state transition for the next update.
-        let actions = self.state.handle_update(update).await?;
-        self.state.prune(block_status.safe).await?;
-
-        // Submit transactions for execution onchain.
-        if !actions.is_empty() {
-            let transactions = actions
-                .into_iter()
-                .map(|action| self.actions.encode_action(action));
-            // Same for queued transactions.
+        if !transactions.is_empty() {
             let result = self.transactions.queue(transactions).await;
             if let Err(err) = tx::lift_intermittent_error(result)? {
                 tracing::warn!(
@@ -245,6 +264,6 @@ where
             }
         }
 
-        Ok(Loop::Continue)
+        Ok(())
     }
 }

--- a/crates/core/src/state/mod.rs
+++ b/crates/core/src/state/mod.rs
@@ -7,13 +7,10 @@
 pub mod storage;
 
 use self::storage::SnapshotStore;
-use crate::{
-    effects::EffectHandler,
-    index::{BlockStatus, BlockUpdate, EventLog, EventUpdate, Update},
-};
+use crate::index::{BlockStatus, BlockUpdate, EventLog, EventUpdate, Update};
 use serde::{Serialize, de::DeserializeOwned};
 use sqlx::SqlitePool;
-use std::{collections::VecDeque, mem, range::RangeInclusive};
+use std::{mem, range::RangeInclusive};
 use tokio::sync::Mutex;
 
 /// Error produced by the [`StateMachine`].
@@ -101,11 +98,10 @@ pub type Commands<S, T> =
     Vec<Command<<T as StateTransition<S>>::Action, <T as StateTransition<S>>::Effect>>;
 
 /// A service state machine.
-pub struct StateMachine<S, T, E> {
+pub struct StateMachine<S, T> {
     inner: Mutex<Option<(S, Status)>>,
     snapshots: SnapshotStore<S>,
     transition: T,
-    effects: E,
 }
 
 enum Status {
@@ -115,25 +111,23 @@ enum Status {
     WarpEvents { range: RangeInclusive<u64> },
 }
 
-impl<S, T, E> StateMachine<S, T, E>
+impl<S, T> StateMachine<S, T>
 where
     S: Serialize + DeserializeOwned,
     T: StateTransition<S>,
-    E: EffectHandler<T::Effect, T::Resume>,
 {
     /// Creates a new state machine with the given state transition.
-    pub async fn new(transition: T, effects: E, pool: SqlitePool) -> Result<Self, Error>
+    pub async fn new(transition: T, pool: SqlitePool) -> Result<Self, Error>
     where
         S: Default,
     {
-        Self::with_init(transition, effects, pool, S::default).await
+        Self::with_init(transition, pool, S::default).await
     }
 
     /// Creates a new state machine with the given state transition and an
     /// initial value constructor.
     pub async fn with_init(
         transition: T,
-        effects: E,
         pool: SqlitePool,
         init: impl FnOnce() -> S,
     ) -> Result<Self, Error> {
@@ -153,7 +147,6 @@ where
             inner,
             snapshots,
             transition,
-            effects,
         })
     }
 
@@ -173,10 +166,10 @@ where
     pub async fn handle_update(
         &mut self,
         update: Update<T::Event>,
-    ) -> Result<Vec<T::Action>, Error> {
+    ) -> Result<Commands<S, T>, Error> {
         let mut lock = self.inner.lock().await;
         let (state, status) = mem::take(&mut *lock).ok_or(Error::Poisoned)?;
-        let (state, status, actions) = match update {
+        let (state, status, commands) = match update {
             Update::Block(BlockUpdate::Warp { from, to })
                 if matches!(status, Status::Initialized)
                     || matches!(status, Status::BlockPending { pending } if pending == from) =>
@@ -198,13 +191,11 @@ where
                 if matches!(status, Status::Initialized)
                     || matches!(status, Status::BlockPending { pending } if pending == number) =>
             {
-                let (state, actions) =
-                    TransitionBatch::new(&self.transition, &mut self.effects, state)
-                        .apply(Message::NewBlock(number))
-                        .await
-                        .finish();
+                let (state, commands) = self
+                    .transition
+                    .apply_transition(state, Message::NewBlock(number));
                 let status = Status::BlockEvents { latest: number };
-                (state, status, actions)
+                (state, status, commands)
             }
             Update::Logs(EventUpdate { blocks, logs })
                 if matches!(status, Status::BlockEvents { latest } if is_next_in_range(latest..=latest, blocks))
@@ -219,11 +210,17 @@ where
                     return Err(Error::BadUpdate);
                 }
 
-                let mut batch = TransitionBatch::new(&self.transition, &mut self.effects, state);
-                for log in logs {
-                    batch = batch.apply(Message::Event(log)).await;
-                }
-                let (state, actions) = batch.finish();
+                let (state, commands) = {
+                    let mut state = state;
+                    let mut commands = Vec::new();
+                    for log in logs {
+                        let (new_state, new_commands) =
+                            self.transition.apply_transition(state, Message::Event(log));
+                        state = new_state;
+                        commands.extend(new_commands);
+                    }
+                    (state, commands)
+                };
 
                 let status = match status {
                     Status::WarpEvents { range } if blocks.last < range.last => {
@@ -238,75 +235,32 @@ where
 
                 self.snapshots.commit(blocks.last, &state).await?;
 
-                (state, status, actions)
+                (state, status, commands)
             }
             _ => return Err(Error::BadUpdate),
         };
         *lock = Some((state, status));
-        Ok(actions)
+        Ok(commands)
+    }
+
+    /// Handles an effect resume without committing a state snapshot.
+    ///
+    /// Resume transitions update the live state immediately. Their state is
+    /// persisted with the next successfully processed log range.
+    pub async fn handle_resume(&mut self, resume: T::Resume) -> Result<Commands<S, T>, Error> {
+        let mut lock = self.inner.lock().await;
+        let (state, status) = mem::take(&mut *lock).ok_or(Error::Poisoned)?;
+        let (state, commands) = self
+            .transition
+            .apply_transition(state, Message::Resume(resume));
+        *lock = Some((state, status));
+        Ok(commands)
     }
 
     /// Prunes state snapshots older than `safe`, retaining the latest snapshot.
     pub async fn prune(&self, safe: u64) -> Result<(), Error> {
         self.snapshots.prune(safe).await?;
         Ok(())
-    }
-}
-
-struct TransitionBatch<'a, S, T, E>
-where
-    T: StateTransition<S>,
-{
-    transition: &'a T,
-    effects: &'a mut E,
-    state: S,
-    actions: Vec<T::Action>,
-}
-
-impl<'a, S, T, E> TransitionBatch<'a, S, T, E>
-where
-    T: StateTransition<S>,
-    E: EffectHandler<T::Effect, T::Resume>,
-{
-    fn new(transition: &'a T, effects: &'a mut E, state: S) -> Self {
-        Self {
-            transition,
-            effects,
-            state,
-            actions: vec![],
-        }
-    }
-
-    async fn apply(mut self, message: Message<T::Event, T::Resume>) -> Self {
-        let (state, commands) = self.transition.apply_transition(self.state, message);
-        self.state = state;
-
-        // We assume that most commands are actions, and that effect transitions
-        // will generally produce a single command. This allows us to pre-
-        // allocate some space for the final actions. If we are off, then we
-        // either just reserved some additional extra space or need to grow the
-        // vector an additional time while handling new actions.
-        self.actions.reserve(commands.len());
-
-        let mut commands = VecDeque::from(commands);
-        while let Some(command) = commands.pop_front() {
-            match command {
-                Command::Action(action) => self.actions.push(action),
-                Command::Effect(effect) => {
-                    let result = self.effects.perform_effect(effect).await;
-                    let (new_state, new_commands) = self
-                        .transition
-                        .apply_transition(self.state, Message::Resume(result));
-                    self.state = new_state;
-                    commands.extend(new_commands);
-                }
-            }
-        }
-        self
-    }
-
-    fn finish(self) -> (S, Vec<T::Action>) {
-        (self.state, self.actions)
     }
 }
 
@@ -329,13 +283,9 @@ fn is_next_in_range(range: impl Into<RangeInclusive<u64>>, sub: RangeInclusive<u
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{
-        effects::Pure,
-        index::{BlockUpdate, EventUpdate, Update},
-    };
+    use crate::index::{BlockUpdate, EventUpdate, Update};
     use alloy::primitives::Address;
     use serde::Deserialize;
-    use std::convert::Infallible;
 
     /// State that records every block and event it was transitioned with, so
     /// transitions, rollbacks and resumes are all observable.
@@ -343,6 +293,7 @@ mod tests {
     struct TestState {
         blocks: Vec<u64>,
         events: Vec<u64>,
+        resumes: Vec<u64>,
     }
 
     /// An action echoed back by the transition, to assert on the values returned
@@ -351,15 +302,16 @@ mod tests {
     enum Action {
         Block(u64),
         Event(u64),
+        Resume(u64),
     }
 
     struct TestTransition;
 
     impl StateTransition<TestState> for TestTransition {
         type Event = u64;
-        type Resume = Infallible;
+        type Resume = u64;
         type Action = Action;
-        type Effect = Infallible;
+        type Effect = u64;
 
         fn apply_transition(
             &self,
@@ -373,9 +325,18 @@ mod tests {
                 }
                 Message::Event(event) => {
                     state.events.push(event.data);
-                    (state, vec![Command::Action(Action::Event(event.data))])
+                    (
+                        state,
+                        vec![
+                            Command::Action(Action::Event(event.data)),
+                            Command::Effect(event.data),
+                        ],
+                    )
                 }
-                Message::Resume(result) => match result {},
+                Message::Resume(result) => {
+                    state.resumes.push(result);
+                    (state, vec![Command::Action(Action::Resume(result))])
+                }
             }
         }
     }
@@ -384,8 +345,8 @@ mod tests {
         SqlitePool::connect("sqlite::memory:").await.unwrap()
     }
 
-    async fn new_machine(pool: &SqlitePool) -> StateMachine<TestState, TestTransition, Pure> {
-        StateMachine::new(TestTransition, Pure, pool.clone())
+    async fn new_machine(pool: &SqlitePool) -> StateMachine<TestState, TestTransition> {
+        StateMachine::new(TestTransition, pool.clone())
             .await
             .unwrap()
     }
@@ -454,11 +415,16 @@ mod tests {
         // resulting state is committed at the last block of the range.
         assert_eq!(
             machine.handle_update(new_block(1)).await.unwrap(),
-            vec![Action::Block(1)]
+            vec![Command::Action(Action::Block(1))]
         );
         assert_eq!(
             machine.handle_update(logs(1..=1, [10, 20])).await.unwrap(),
-            vec![Action::Event(10), Action::Event(20)]
+            vec![
+                Command::Action(Action::Event(10)),
+                Command::Effect(10),
+                Command::Action(Action::Event(20)),
+                Command::Effect(20),
+            ]
         );
 
         assert_eq!(
@@ -468,6 +434,45 @@ mod tests {
                 TestState {
                     blocks: vec![1],
                     events: vec![10, 20],
+                    resumes: vec![],
+                },
+            ))
+        );
+    }
+
+    #[tokio::test]
+    async fn resume_updates_live_state_without_committing_a_snapshot() {
+        let pool = pool().await;
+        let mut machine = new_machine(&pool).await;
+        machine.handle_update(new_block(1)).await.unwrap();
+        machine.handle_update(logs(1..=1, [42])).await.unwrap();
+
+        assert_eq!(
+            machine.handle_resume(777).await.unwrap(),
+            vec![Command::Action(Action::Resume(777)),]
+        );
+        assert_eq!(
+            committed(&pool).await,
+            Some((
+                1,
+                TestState {
+                    blocks: vec![1],
+                    events: vec![42],
+                    resumes: vec![],
+                },
+            ))
+        );
+
+        machine.handle_update(new_block(2)).await.unwrap();
+        machine.handle_update(logs(2..=2, [1337])).await.unwrap();
+        assert_eq!(
+            committed(&pool).await,
+            Some((
+                2,
+                TestState {
+                    blocks: vec![1, 2],
+                    events: vec![42, 1337],
+                    resumes: vec![777],
                 },
             ))
         );
@@ -495,6 +500,7 @@ mod tests {
                 TestState {
                     blocks: vec![1, 2],
                     events: vec![10, 20],
+                    resumes: vec![],
                 },
             ))
         );
@@ -535,6 +541,7 @@ mod tests {
                 TestState {
                     blocks: (1..=5).collect(),
                     events: vec![],
+                    resumes: vec![],
                 }
             ))
         );
@@ -567,6 +574,7 @@ mod tests {
                 TestState {
                     blocks: vec![1, 2],
                     events: vec![10, 21],
+                    resumes: vec![],
                 },
             ))
         );
@@ -583,7 +591,7 @@ mod tests {
         // (which is the block at the end of the warp).
         assert_eq!(
             machine.handle_update(logs(1..=3, [10])).await.unwrap(),
-            vec![Action::Event(10)]
+            vec![Command::Action(Action::Event(10)), Command::Effect(10)]
         );
         machine.prune(6).await.unwrap();
         assert_eq!(
@@ -593,6 +601,7 @@ mod tests {
                 TestState {
                     blocks: vec![],
                     events: vec![10],
+                    resumes: vec![],
                 },
             ))
         );
@@ -612,7 +621,7 @@ mod tests {
         // Continue with the next chunk of events from the warp.
         assert_eq!(
             machine.handle_update(logs(4..=6, [40])).await.unwrap(),
-            vec![Action::Event(40)]
+            vec![Command::Action(Action::Event(40)), Command::Effect(40)]
         );
         machine.prune(6).await.unwrap();
         assert_eq!(
@@ -622,6 +631,7 @@ mod tests {
                 TestState {
                     blocks: vec![],
                     events: vec![10, 40],
+                    resumes: vec![],
                 },
             ))
         );

--- a/crates/sentinel/src/service.rs
+++ b/crates/sentinel/src/service.rs
@@ -656,6 +656,9 @@ impl ActionEncoder<SentinelAction> for SentinelEncoder {
 impl Service for SentinelService {
     type State = State;
     type Event = SentinelEvents;
+    type Action = SentinelAction;
+    type Effect = effect::Effect;
+    type Resume = effect::Resume;
 
     type Transition = SentinelTransition;
     type Effects = effect::Handler;

--- a/crates/validator/src/service/mod.rs
+++ b/crates/validator/src/service/mod.rs
@@ -82,6 +82,9 @@ watcher_events! {
 impl Service for ValidatorService {
     type State = State;
     type Event = Event;
+    type Action = Action;
+    type Effect = Effect;
+    type Resume = Resume;
 
     type Transition = state::Transition;
     type Effects = effect::Handler;

--- a/crates/validator/src/state/preprocess.rs
+++ b/crates/validator/src/state/preprocess.rs
@@ -15,6 +15,15 @@ impl Transition {
         group_id: B256,
         nonces_commitment: B256,
     ) -> (State, Commands<State, Self>) {
+        if !state
+            .epochs
+            .values()
+            .any(|epoch| epoch.group.id() == group_id)
+        {
+            tracing::debug!(%group_id, "ignoring nonce tree resume for an untracked group");
+            return (state, Vec::new());
+        }
+
         (
             state,
             vec![Command::Action(Action::Preprocess {


### PR DESCRIPTION
Move effect execution from the state machine into the driver so chain updates continue while effects run concurrently. Completed effects resume the serialized state machine.

### Context and Motivation

Inline effect execution blocks indexing until each effect completes, preventing Sentinel from handling onchain events while a long-running dynamic check is outstanding.

### Decisions and Tradeoffs

- All state machine types are now associate types on the `Service`. This makes specifying type parameters and constraints easier (at the cost of a little bit more boilerplate when declaring a `Service` type).
- We refactored the `watcher` update retrying, allowing for completed effects to continue in parallel while waiting for indexer retries.
- Refactored the run-loop to separate more clearly "getting an input for updating the state machine" and "actually updating the state machine". This allowed us to get rid of the `Loop` type.
- Now that nonce tree generation effects can happen out of order, we check to make sure that the generated nonce tree is still relevant before pushing the action to set the nonces tree commitment onchain.
- Since effects are handled outside of the state machine, the old `TransitionBatch` type is no longer needed (it was used to batch transitions with ones applied from effects).

### Testing

Added some tests on state machine application of effects.

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://docs.safefoundation.org/cla).
