### PR TITLE
feat(guard): verify oracle transaction-proposal attestations

### DIFF
--- a/contracts/src/guard/SafenetGuard.sol
+++ b/contracts/src/guard/SafenetGuard.sol
@@ -28,8 +28,8 @@ import {ISafe} from "@safe/interfaces/ISafe.sol";
  *      - **Epochs:** a forest of trusted `(group key, epoch)` pairs kept forever (Consensus lives only on
  *        Gnosis Chain; the guard holds a local copy). Any recorded pair may attest; a compromised
  *        historical key can attest future transactions (but not replay past ones — the Safe nonce binds).
- *      - **Attestation:** an inline trailer on `signatures` carrying `(epoch, groupKey, signature)`,
- *        verified against the full nonce-bound Safe tx hash.
+ *      - **Attestation:** an inline trailer on `signatures` carrying `(epoch, oracle, groupKey, signature)`,
+ *        verified against the oracle-transaction-proposal message over the full nonce-bound Safe tx hash.
  *      - **Escape hatch:** `announceTransaction` queues a transaction by its parameters (nonce excluded);
  *        after `getAllowTxDelay` it executes without attestation within `getAllowTxWindow`, at any nonce.
  *        Single-use; consumed in the pre-execution hook (so it reflects the authorisation path taken, not
@@ -198,7 +198,7 @@ contract SafenetGuard is ISafenetGuard, BaseTransactionGuard {
         if (_isAutoAllowed(to, value, data, operation)) return;
 
         if (AttestationTrailer.hasTrailer(signatures)) {
-            (uint64 epoch, Secp256k1.Point memory groupKey, FROST.Signature memory signature) =
+            (uint64 epoch, address oracle, Secp256k1.Point memory groupKey, FROST.Signature memory signature) =
                 AttestationTrailer.decode(signatures);
             // Cheap forest-membership check first (also implies a non-zero key, enforced on record), so an
             // untrusted key short-circuits before the more expensive Safe tx hash is computed.
@@ -220,7 +220,11 @@ contract SafenetGuard is ISafenetGuard, BaseTransactionGuard {
                     nonce: nonce
                 })
             );
-            bytes32 message = ConsensusMessages.transactionProposal(_CONSENSUS_DOMAIN_SEPARATOR, epoch, safeTxHash);
+            // The attestation binds the oracle it was gated by; the guard trusts the group key and rebuilds
+            // the exact message the network signed. Which oracle is acceptable is a Validator-side policy
+            // (they only attest on results from an oracle they honour), not enforced here.
+            bytes32 message =
+                ConsensusMessages.oracleTransactionProposal(_CONSENSUS_DOMAIN_SEPARATOR, epoch, oracle, safeTxHash);
             FROST.verify(groupKey, signature, message);
             return;
         }

--- a/contracts/src/libraries/AttestationTrailer.sol
+++ b/contracts/src/libraries/AttestationTrailer.sol
@@ -9,11 +9,13 @@ import {SignatureExtension} from "@/libraries/SignatureExtension.sol";
  * @title AttestationTrailer
  * @notice Recognises and decodes a Safenet attestation carried as a {SignatureExtension} on Safe's
  *         `signatures` bytes.
- * @dev The attestation is a typed signature extension: its payload is the fixed 192-byte
- *      `abi.encode(uint64 epoch, Secp256k1.Point groupKey, FROST.Signature signature)`, tagged by the
- *      terminal `TYPE_HASH`. The envelope framing (length word + type hash, tail-anchored so Safe's
- *      front-to-back signature parser is untouched) is owned by {SignatureExtension}; this library owns
- *      only the guard-specific type hash and payload schema.
+ * @dev The attestation is a typed signature extension: its payload is the fixed 224-byte
+ *      `abi.encode(uint64 epoch, address oracle, Secp256k1.Point groupKey, FROST.Signature signature)`,
+ *      tagged by the terminal `TYPE_HASH`. The `oracle` is the oracle contract the attestation was gated
+ *      by; the guard reconstructs the consensus `OracleTransactionProposal` message from it. The envelope
+ *      framing (length word + type hash, tail-anchored so Safe's front-to-back signature parser is
+ *      untouched) is owned by {SignatureExtension}; this library owns only the guard-specific type hash
+ *      and payload schema.
  */
 library AttestationTrailer {
     // ============================================================
@@ -26,16 +28,16 @@ library AttestationTrailer {
     bytes32 internal constant TYPE_HASH = keccak256("SafenetGuard.AttestationTrailer.v1");
 
     /**
-     * @dev Payload is `abi.encode(uint64, Secp256k1.Point, FROST.Signature)` = 6 words = 192 bytes.
+     * @dev Payload is `abi.encode(uint64, address, Secp256k1.Point, FROST.Signature)` = 7 words = 224 bytes.
      */
-    uint256 private constant _PAYLOAD_LENGTH = 192;
+    uint256 private constant _PAYLOAD_LENGTH = 224;
 
     // ============================================================
     // ERRORS
     // ============================================================
 
     /**
-     * @notice Thrown when a recognised trailer's payload is not the expected 192-byte attestation.
+     * @notice Thrown when a recognised trailer's payload is not the expected 224-byte attestation.
      */
     error MalformedAttestationTrailer();
 
@@ -57,19 +59,21 @@ library AttestationTrailer {
      * @notice Decodes the attestation from a trailer-bearing `signatures` blob.
      * @dev Self-verifying via {SignatureExtension.payload}: reverts `MalformedSignatureExtension` if the
      *      envelope itself is malformed, and `MalformedAttestationTrailer` if the payload is not the fixed
-     *      192-byte attestation — a recognised trailer never yields partial or wrongly-sized data.
+     *      224-byte attestation — a recognised trailer never yields partial or wrongly-sized data.
      * @param signatures The Safe `signatures` blob ending in an attestation trailer.
      * @return epoch The attested epoch.
+     * @return oracle The oracle contract the attestation was gated by.
      * @return groupKey The attesting FROST group key.
      * @return signature The FROST signature.
      */
     function decode(bytes calldata signatures)
         internal
         pure
-        returns (uint64 epoch, Secp256k1.Point memory groupKey, FROST.Signature memory signature)
+        returns (uint64 epoch, address oracle, Secp256k1.Point memory groupKey, FROST.Signature memory signature)
     {
         bytes calldata payloadData = SignatureExtension.payload(signatures, TYPE_HASH);
         require(payloadData.length == _PAYLOAD_LENGTH, MalformedAttestationTrailer());
-        (epoch, groupKey, signature) = abi.decode(payloadData, (uint64, Secp256k1.Point, FROST.Signature));
+        (epoch, oracle, groupKey, signature) =
+            abi.decode(payloadData, (uint64, address, Secp256k1.Point, FROST.Signature));
     }
 }

--- a/contracts/test/SafenetGuard.t.sol
+++ b/contracts/test/SafenetGuard.t.sol
@@ -75,6 +75,9 @@ contract SafenetGuardTest is Test {
     bytes public constant TX_DATA = hex"deadbeef";
     Enum.Operation public constant TX_OP = Enum.Operation.Call;
 
+    // Oracle the attestation is gated by (carried in the trailer, per the oracle-based attestation model).
+    address public constant ORACLE_ADDR = address(0x0AC1E);
+
     // ============================================================
     // SAFE DEPLOYMENT
     // ============================================================
@@ -166,16 +169,19 @@ contract SafenetGuardTest is Test {
     }
 
     /// @dev Builds an inline FROST attestation as a signature extension:
-    ///      `[192-byte abi.encode(epoch, groupKey, signature)][uint256 payloadLength = 192][32-byte TYPE_HASH]`.
-    ///      The group key is derived from `sk` so it matches the signing key.
+    ///      `[224-byte abi.encode(epoch, oracle, groupKey, signature)][uint256 payloadLength = 224][32-byte TYPE_HASH]`.
+    ///      The FROST signature is over the oracle-transaction-proposal message; the group key is derived
+    ///      from `sk` so it matches the signing key. Uses `ORACLE_ADDR` as the gating oracle.
     function _buildInlineAttestation(bytes32 txHash, uint64 epoch, uint256 sk, uint256 nk)
         internal
         returns (bytes memory)
     {
         Secp256k1.Point memory groupKey = ForgeSecp256k1.g(sk).toPoint();
-        bytes32 message = ConsensusMessages.transactionProposal(guard.getConsensusDomainSeparator(), epoch, txHash);
+        bytes32 message = ConsensusMessages.oracleTransactionProposal(
+            guard.getConsensusDomainSeparator(), epoch, ORACLE_ADDR, txHash
+        );
         FROST.Signature memory sig = _frostSign(sk, nk, message);
-        bytes memory payload = abi.encode(epoch, groupKey, sig); // 192 bytes
+        bytes memory payload = abi.encode(epoch, ORACLE_ADDR, groupKey, sig); // 224 bytes
         return bytes.concat(payload, abi.encode(payload.length), AttestationTrailer.TYPE_HASH);
     }
 
@@ -419,11 +425,12 @@ contract SafenetGuardTest is Test {
     function test_integration_inlineAttestation_revertsWithTamperedSignature() public {
         uint256 nonce = safe.nonce();
         bytes32 txHash = _safeTxHash(TX_TO, TX_VALUE, TX_DATA, TX_OP, nonce);
-        bytes32 message =
-            ConsensusMessages.transactionProposal(guard.getConsensusDomainSeparator(), GENESIS_EPOCH, txHash);
+        bytes32 message = ConsensusMessages.oracleTransactionProposal(
+            guard.getConsensusDomainSeparator(), GENESIS_EPOCH, ORACLE_ADDR, txHash
+        );
         FROST.Signature memory sig = _frostSign(GENESIS_SK, GENESIS_NK, message);
         sig.z = addmod(sig.z, 1, Secp256k1.N); // tamper
-        bytes memory payload = abi.encode(GENESIS_EPOCH, ForgeSecp256k1.g(GENESIS_SK).toPoint(), sig);
+        bytes memory payload = abi.encode(GENESIS_EPOCH, ORACLE_ADDR, ForgeSecp256k1.g(GENESIS_SK).toPoint(), sig);
         bytes memory combined =
             bytes.concat(_signSafeTx(txHash), payload, abi.encode(payload.length), AttestationTrailer.TYPE_HASH);
         vm.expectRevert(Secp256k1.InvalidMulMulAddWitness.selector);
@@ -804,12 +811,12 @@ contract SafenetGuardTest is Test {
         safe.execTransaction(TX_TO, TX_VALUE, TX_DATA, TX_OP, 0, 0, 0, address(0), payable(address(0)), combined);
     }
 
-    /// @notice A valid signature blob whose final word merely equals 192 (the old length framing) is
-    ///         not mistaken for a trailer under magic framing.
-    function test_trailer_signatureEndingIn192TreatedAsAbsent() public {
+    /// @notice A valid signature blob whose final word merely equals the payload-length framing (224) is
+    ///         not mistaken for a trailer — recognition keys on the terminal `TYPE_HASH`, not the length.
+    function test_trailer_signatureEndingInPayloadLengthTreatedAsAbsent() public {
         uint256 nonce = safe.nonce();
         bytes32 txHash = _safeTxHash(TX_TO, TX_VALUE, TX_DATA, TX_OP, nonce);
-        bytes memory combined = bytes.concat(_signSafeTx(txHash), bytes32(uint256(192)));
+        bytes memory combined = bytes.concat(_signSafeTx(txHash), bytes32(uint256(224)));
         vm.expectRevert(ISafenetGuard.AttestationNotFound.selector);
         safe.execTransaction(TX_TO, TX_VALUE, TX_DATA, TX_OP, 0, 0, 0, address(0), payable(address(0)), combined);
     }
@@ -822,6 +829,20 @@ contract SafenetGuardTest is Test {
         // Owner sig + bare type hash: ends in TYPE_HASH but has no valid [payloadLength][typeHash] envelope.
         bytes memory combined = bytes.concat(_signSafeTx(txHash), AttestationTrailer.TYPE_HASH);
         vm.expectRevert(SignatureExtension.MalformedSignatureExtension.selector);
+        safe.execTransaction(TX_TO, TX_VALUE, TX_DATA, TX_OP, 0, 0, 0, address(0), payable(address(0)), combined);
+    }
+
+    /// @notice A well-formed signature-extension envelope whose payload is not the 224-byte attestation
+    ///         fails closed at the guard level with `MalformedAttestationTrailer` — the `payloadLength != 224`
+    ///         shape, exercised end-to-end through `execTransaction`.
+    function test_trailer_wrongPayloadSizeReverts() public {
+        uint256 nonce = safe.nonce();
+        bytes32 txHash = _safeTxHash(TX_TO, TX_VALUE, TX_DATA, TX_OP, nonce);
+        // Valid envelope: [ownerSig][payload][uint256 payload.length][TYPE_HASH], but payload is 32 bytes.
+        bytes memory payload = new bytes(32);
+        bytes memory combined =
+            bytes.concat(_signSafeTx(txHash), payload, abi.encode(payload.length), AttestationTrailer.TYPE_HASH);
+        vm.expectRevert(AttestationTrailer.MalformedAttestationTrailer.selector);
         safe.execTransaction(TX_TO, TX_VALUE, TX_DATA, TX_OP, 0, 0, 0, address(0), payable(address(0)), combined);
     }
 

--- a/contracts/test/libraries/AttestationTrailer.t.sol
+++ b/contracts/test/libraries/AttestationTrailer.t.sol
@@ -10,13 +10,14 @@ import {Secp256k1} from "@/libraries/Secp256k1.sol";
 /**
  * @title AttestationTrailerTest
  * @notice Unit tests for the typed attestation codec layered on `SignatureExtension`: recognition,
- *         round-trip decode of the fixed 192-byte payload, and the two reverts — a well-formed envelope
+ *         round-trip decode of the fixed 224-byte payload, and the two reverts — a well-formed envelope
  *         whose payload is the wrong size (`MalformedAttestationTrailer`) and a malformed envelope
  *         (`MalformedSignatureExtension`, surfaced from the transport layer). Both functions take
  *         `calldata`, so they run through external `this.call*` wrappers.
  */
 contract AttestationTrailerTest is Test {
     uint64 internal constant EPOCH = 7;
+    address internal constant ORACLE = address(0x0AC1E);
 
     function callHasTrailer(bytes calldata signatures) external pure returns (bool) {
         return AttestationTrailer.hasTrailer(signatures);
@@ -25,15 +26,18 @@ contract AttestationTrailerTest is Test {
     function callDecode(bytes calldata signatures)
         external
         pure
-        returns (uint64 epoch, Secp256k1.Point memory groupKey, FROST.Signature memory signature)
+        returns (uint64 epoch, address oracle, Secp256k1.Point memory groupKey, FROST.Signature memory signature)
     {
         return AttestationTrailer.decode(signatures);
     }
 
     function _attestationPayload() internal pure returns (bytes memory) {
-        // abi.encode(uint64, Secp256k1.Point, FROST.Signature) = 192 bytes.
+        // abi.encode(uint64, address, Secp256k1.Point, FROST.Signature) = 224 bytes.
         return abi.encode(
-            EPOCH, Secp256k1.Point({x: 111, y: 222}), FROST.Signature({r: Secp256k1.Point({x: 333, y: 444}), z: 555})
+            EPOCH,
+            ORACLE,
+            Secp256k1.Point({x: 111, y: 222}),
+            FROST.Signature({r: Secp256k1.Point({x: 333, y: 444}), z: 555})
         );
     }
 
@@ -47,13 +51,14 @@ contract AttestationTrailerTest is Test {
     }
 
     function test_hasTrailer_falseWhenAbsent() public view {
-        assertFalse(this.callHasTrailer(bytes.concat(hex"aabbcc", bytes32(uint256(192)))));
+        assertFalse(this.callHasTrailer(bytes.concat(hex"aabbcc", bytes32(uint256(224)))));
     }
 
     function test_decode_roundTrips() public view {
-        (uint64 epoch, Secp256k1.Point memory k, FROST.Signature memory s) =
+        (uint64 epoch, address oracle, Secp256k1.Point memory k, FROST.Signature memory s) =
             this.callDecode(_trailer(hex"aabbcc", _attestationPayload()));
         assertEq(epoch, EPOCH);
+        assertEq(oracle, ORACLE);
         assertEq(k.x, 111);
         assertEq(k.y, 222);
         assertEq(s.r.x, 333);
@@ -62,7 +67,7 @@ contract AttestationTrailerTest is Test {
     }
 
     function test_decode_revertsOnWrongPayloadSize() public {
-        // A well-formed envelope whose payload is not the fixed 192-byte attestation.
+        // A well-formed envelope whose payload is not the fixed 224-byte attestation.
         vm.expectRevert(AttestationTrailer.MalformedAttestationTrailer.selector);
         this.callDecode(_trailer(hex"aabb", hex"1122334455667788"));
     }


### PR DESCRIPTION
Migrates `SafenetGuard`'s attestation path from the basic `TransactionProposal` message to the oracle `OracleTransactionProposal` message.

### Context and Motivation

- Safenet now gates transaction proposals through an oracle and threshold-signs `OracleTransactionProposal(epoch, oracle, safeTxHash)`. The guard reconstructed the basic `TransactionProposal(epoch, safeTxHash)`, so it would reject every oracle-based attestation. This makes the guard verify the message the network actually produces.

### Decisions and Tradeoffs

- The `AttestationTrailer` payload is re-laid out to carry the gating `oracle` (192 → 224 bytes). `TYPE_HASH` (`SafenetGuard.AttestationTrailer.v1`) is kept - a re-layout, not a version bump, since the format is unreleased.
- The oracle is trailer-supplied; the guard does not pin or allow-list it, it trusts the group key and rebuilds the exact signed message, leaving the "which oracle" policy to the validators (off-chain). The basic path is removed (full migration, no back-compat).

### Testing

- Updated the trailer codec and guard tests to the 224-byte oracle payload and the `OracleTransactionProposal` message; added guard-level fail-closed coverage for the `payloadLength != 224` shape.
- `forge test` - 246 passed, 0 failed.
