### PR TITLE
docs(guard): describe oracle-based attestation

### DIFF
--- a/contracts/src/guard/DESIGN.md
+++ b/contracts/src/guard/DESIGN.md
@@ -15,9 +15,10 @@ Deliberate choices with their rationale, recorded so reviewers and auditors can 
 
 ## Attestation (owner transactions)
 
-- **Inline signature-extension trailer carrying `epoch + groupKey + signature` explicitly** (the forest has no epoch→key reverse lookup). The non-standard encoding (wallets must be Safenet-aware) and the larger trailer are accepted trade-offs.
-- **Carried as a `SignatureExtension`** — the reusable length-prefixed envelope `[payload][uint256 payloadLength][bytes32 TYPE_HASH]`. The terminal type hash (`keccak256("SafenetGuard.AttestationTrailer.v1")`) means a valid Safe-signature suffix cannot be mis-parsed, and a recognised trailer never falls through to the announcement path. `AttestationTrailer` is the typed codec over that transport (it asserts the fixed 192-byte attestation payload).
-- **Replay/ordering come from the Safe nonce** bound into the FROST-verified attestation message (over the nonce-bound Safe tx hash); there is no spent-signature registry. The escape-hatch path is instead single-use and time-boxed.
+- **Inline signature-extension trailer carrying `epoch + oracle + groupKey + signature` explicitly** (the forest has no epoch→key reverse lookup, and the guard needs the oracle to rebuild the consensus message). The non-standard encoding (wallets must be Safenet-aware) and the larger trailer are accepted trade-offs.
+- **Carried as a `SignatureExtension`** — the reusable length-prefixed envelope `[payload][uint256 payloadLength][bytes32 TYPE_HASH]`. The terminal type hash (`keccak256("SafenetGuard.AttestationTrailer.v1")`) means a valid Safe-signature suffix cannot be mis-parsed, and a recognised trailer never falls through to the announcement path. `AttestationTrailer` is the typed codec over that transport (it asserts the fixed 224-byte attestation payload).
+- **The attested message is the `OracleTransactionProposal`** (`epoch + oracle + nonce-bound Safe tx hash`). The `oracle` is trailer-supplied and the guard does not pin or allow-list it — trusting the group key and rebuilding the exact message the network signed. Which oracle is acceptable is enforced off-chain by the validators (they only attest results from an oracle they honour), consistent with the existing validator trust assumption.
+- **Replay/ordering come from the Safe nonce** bound into that FROST-verified message; there is no spent-signature registry. The escape-hatch path is instead single-use and time-boxed.
 
 ## Escape hatch (announcements)
 

--- a/contracts/src/guard/README.md
+++ b/contracts/src/guard/README.md
@@ -18,15 +18,15 @@ The structural self-call gate for the escape-hatch functions (target is the guar
 
 **Epoch forest.** Epoch state is delegated to `EpochRollover`, which tracks a *forest* of trusted `(group key, epoch)` pairs: any trusted pair may sign a rollover to any strictly-greater epoch, an epoch may hold more than one key (reorg branches), and every pair is kept forever. There is no single "active" epoch — `updateEpoch` names the exact `(parentKey, parentEpoch)` to roll over from, and membership is queried with `isKnownEpoch(groupKey, epoch)`.
 
-**Attestation via signature extension.** Because the forest is keyed by key coordinates (there is no reverse "key for epoch N" lookup) and an epoch may hold several keys, the inline attestation carries the key explicitly. It is appended to Safe's `signatures` bytes as a *signature extension* ([`SignatureExtension`](../libraries/SignatureExtension.sol)) — a 192-byte payload, a `uint256` payload-length word, and a terminal 32-byte type hash:
+**Attestation via signature extension.** Because the forest is keyed by key coordinates (there is no reverse "key for epoch N" lookup) and an epoch may hold several keys, the inline attestation carries the key explicitly. It also carries the **oracle** the attestation was gated by, so the guard can reconstruct the consensus *oracle-transaction-proposal* message it verifies against — which oracle is acceptable is enforced off-chain by the validators (who only attest results from an oracle they honour), not by the guard. It is appended to Safe's `signatures` bytes as a *signature extension* ([`SignatureExtension`](../libraries/SignatureExtension.sol)) — a 224-byte payload, a `uint256` payload-length word, and a terminal 32-byte type hash:
 
 ```
-[safe owner signatures] [192-byte abi.encode(epoch, Secp256k1.Point groupKey, FROST.Signature)] [uint256 payloadLength] [32-byte TYPE_HASH]
+[safe owner signatures] [224-byte abi.encode(epoch, address oracle, Secp256k1.Point groupKey, FROST.Signature)] [uint256 payloadLength] [32-byte TYPE_HASH]
 ```
 
-Anchoring the extension at the end leaves Safe's front-to-back signature parser untouched, and the terminal *signature type hash* — so called to distinguish it from the EIP-712 message type hashes used elsewhere in Safenet — makes detection independent of signature suffixes: only a blob whose last word equals `TYPE_HASH` is treated as an attestation, so a valid Safe signature ending in an unrelated value (even the number 192) is never mis-parsed. The signature type hash doubles as an extensible format tag: it embeds the version, so a future format uses a different one (which this guard reads as "no trailer"). This is the first canonical guard the Safe project publishes to use signature extension, and the type-hash separator is intended as a reusable convention for future extensions.
+Anchoring the extension at the end leaves Safe's front-to-back signature parser untouched, and the terminal *signature type hash* — so called to distinguish it from the EIP-712 message type hashes used elsewhere in Safenet — makes detection independent of signature suffixes: only a blob whose last word equals `TYPE_HASH` is treated as an attestation, so a valid Safe signature ending in an unrelated value (even the number 224) is never mis-parsed. The signature type hash doubles as an extensible format tag: it embeds the version, so a future format uses a different one (which this guard reads as "no trailer"). This is the first canonical guard the Safe project publishes to use signature extension, and the type-hash separator is intended as a reusable convention for future extensions.
 
-`checkTransaction` outcomes: no signature type hash → falls through to the announcement path; a signature type hash on a malformed envelope, or a payload that isn't the 192-byte attestation, reverts (fail-closed — `MalformedSignatureExtension` or `MalformedAttestationTrailer` respectively); a recognised trailer → the `(groupKey, epoch)` pair must be trusted (else `UntrustedAttestationKey`) and the FROST signature is verified. A recognised trailer never silently falls through. Forest membership already implies a non-zero key, so no separate non-zero check is needed.
+`checkTransaction` outcomes: no signature type hash → falls through to the announcement path; a signature type hash on a malformed envelope, or a payload that isn't the 224-byte attestation, reverts (fail-closed — `MalformedSignatureExtension` or `MalformedAttestationTrailer` respectively); a recognised trailer → the `(groupKey, epoch)` pair must be trusted (else `UntrustedAttestationKey`) and the FROST signature is verified against the `OracleTransactionProposal` message over the decoded oracle and the full nonce-bound Safe tx hash. A recognised trailer never silently falls through. Forest membership already implies a non-zero key, so no separate non-zero check is needed.
 
 **Nonce-free escape hatch.** Announcements are keyed by a **nonce-free** hash covering every `execTransaction` parameter *except* the Safe nonce (`getAnnouncementHash`). Owners call `announceTransaction(AnnouncedTransaction)` with the **full transaction parameters** (not a bare hash), so signers see exactly what they authorise and the guard derives the announcement hash on-chain — guaranteeing it matches what `checkTransaction` reconstructs and removing a class of silent off-chain hash-mismatch bugs. Because the hash excludes the nonce, a queued announcement survives unrelated nonce advances: owners can keep transacting via attestation while an announcement matures, and after the fixed delay any matching transaction executes without an attestation at whatever nonce is current. Announcements are single-use (consumed on execution) and can be revoked immediately, with no delay, via `cancelAnnouncement(hash)`. Both `announceTransaction` and `cancelAnnouncement` are auto-allowed self-calls, so the escape hatch never requires Safenet. A normally-attested transaction whose parameters happen to match a pending announcement takes the attestation path and does not consume the announcement.
 
@@ -44,15 +44,15 @@ The attestation is a [`SignatureExtension`](../libraries/SignatureExtension.sol)
 
 ```
 [safe owner signatures]
-[192-byte payload]     = abi.encode(uint64 epoch, Secp256k1.Point groupKey, FROST.Signature signature)   // 6 × 32-byte words
-[uint256 payloadLength] = 192
+[224-byte payload]     = abi.encode(uint64 epoch, address oracle, Secp256k1.Point groupKey, FROST.Signature signature)   // 7 × 32-byte words
+[uint256 payloadLength] = 224
 [32-byte TYPE_HASH]    = keccak256("SafenetGuard.AttestationTrailer.v1")
 ```
 
 - **TYPE_HASH** = `keccak256("SafenetGuard.AttestationTrailer.v1")`
   = `0x7574ada57823dfda76df60551fc6a8662abe3441dc7b19194fb2cc08b312e436`
 
-Total trailer overhead is exactly **256 bytes** (192 payload + 32 length + 32 type hash) appended after the Safe owner signatures. Decoding (`AttestationTrailer.decode`): a blob whose last 32 bytes are not `TYPE_HASH` is *no trailer* (falls through to the announcement path); a recognised type hash over a malformed envelope reverts `MalformedSignatureExtension`, and a payload that isn't 192 bytes reverts `MalformedAttestationTrailer`.
+Total trailer overhead is exactly **288 bytes** (224 payload + 32 length + 32 type hash) appended after the Safe owner signatures. Decoding (`AttestationTrailer.decode`): a blob whose last 32 bytes are not `TYPE_HASH` is *no trailer* (falls through to the announcement path); a recognised type hash over a malformed envelope reverts `MalformedSignatureExtension`, and a payload that isn't 224 bytes reverts `MalformedAttestationTrailer`.
 
 ## Design decisions
 


### PR DESCRIPTION
Updates the guard documentation to the oracle-based attestation model introduced in the previous PR.

### Context and Motivation

- `README.md` and `DESIGN.md` still described the basic 192-byte `(epoch, groupKey, signature)` trailer. This updates them to the 224-byte `(epoch, oracle, groupKey, signature)` trailer, the `OracleTransactionProposal` message the guard verifies against, the 288-byte trailer overhead, and the oracle trust model (oracle carried in the trailer, gated off-chain by validators).