### PR TITLE
test(guard): exercise allow-tx delay/window getters

### DIFF
--- a/contracts/test/SafenetGuard.t.sol
+++ b/contracts/test/SafenetGuard.t.sol
@@ -687,7 +687,7 @@ contract SafenetGuardTest is Test {
     function test_cancelAnnouncement_worksAfterExpiry() public {
         bytes32 h = _defaultAnnouncementHash();
         _announce(_defaultAnnouncement());
-        vm.warp(block.timestamp + ALLOW_TX_DELAY_SECONDS + ALLOW_TX_WINDOW_SECONDS + 1); // expired but present
+        vm.warp(block.timestamp + guard.getAllowTxDelay() + guard.getAllowTxWindow() + 1); // expired but present
         assertGt(_announcedActiveFrom(h), 0);
 
         _cancelAnnouncement(h);


### PR DESCRIPTION
## What it solves

`SafenetGuard.sol` reported ~84% line / ~79% function coverage. The only genuinely uncalled functions were the `getAllowTxDelay` and `getAllowTxWindow` getters. This does not need to be merged: it merely raises reported coverage above 90%, and all behaviour is already tested. Everything else `forge coverage` flags on the guard is a `via_ir` instrumentation artifact (the tool mis-maps multi-line `if`/tuple-destructuring, constructor-tail library calls, and an empty-bodied hook that is in fact invoked on every execution), not missing tests.

## How this PR fixes it

Drive the expiry warp in `test_cancelAnnouncement_worksAfterExpiry` from `guard.getAllowTxDelay()` and `guard.getAllowTxWindow()` instead of the raw constants. This exercises both getters as a natural side effect of an existing lifecycle test, with no dedicated getter test and no assertion on the getters' own return values (their authenticity is not this test's concern).

Result: line coverage 84.2% to 91.2%, function coverage 78.6% to 92.9%.

## How to test it

`cd contracts && forge test` (251 tests pass), `forge coverage --report summary`.
