### PR TITLE
explorer: aim proposal lookup at the transaction timestamp

### DIFF
--- a/explorer/src/components/transaction/SafeTxProposals.tsx
+++ b/explorer/src/components/transaction/SafeTxProposals.tsx
@@ -18,8 +18,16 @@ import { SafeTxAttestationStatus } from "./SafeTxAttestationStatus";
 import { SentinelVoteList } from "./SentinelVoteList";
 import { VotingStatusBadge } from "./VotingStatusBadge";
 
-export function SafeTxProposals({ safeTxHash, transaction }: { safeTxHash: Hex; transaction: SafeTransaction }) {
-	const proposals = useProposalsForTransaction(safeTxHash);
+export function SafeTxProposals({
+	safeTxHash,
+	transaction,
+	submittedAtSeconds,
+}: {
+	safeTxHash: Hex;
+	transaction: SafeTransaction;
+	submittedAtSeconds?: number | null;
+}) {
+	const proposals = useProposalsForTransaction(safeTxHash, submittedAtSeconds ?? undefined);
 
 	return (
 		<div className={"space-y-4"}>

--- a/explorer/src/hooks/useProposalsForTransaction.tsx
+++ b/explorer/src/hooks/useProposalsForTransaction.tsx
@@ -7,7 +7,7 @@ import {
 	type TransactionProposalWithStatus,
 } from "@/lib/consensus";
 
-export function useProposalsForTransaction(proposalTxHash: Hex) {
+export function useProposalsForTransaction(proposalTxHash: Hex, timestampSeconds?: number) {
 	const [settings] = useSettings();
 
 	return useQuery<LoadTransactionProposalsResult, Error, TransactionProposalWithStatus[]>({
@@ -18,6 +18,7 @@ export function useProposalsForTransaction(proposalTxHash: Hex) {
 			settings.maxBlockRange,
 			settings.signingTimeout,
 			settings.oracles,
+			timestampSeconds,
 		],
 		queryFn: () =>
 			getConsensusWorker().loadTransactionProposals({
@@ -27,6 +28,7 @@ export function useProposalsForTransaction(proposalTxHash: Hex) {
 				maxBlockRange: BigInt(settings.maxBlockRange),
 				signingTimeout: settings.signingTimeout,
 				oracles: settings.oracles,
+				timestampSeconds,
 			}),
 		select: (data) => data.proposals,
 		initialData: { proposals: [], fromBlock: 0n, toBlock: 0n },

--- a/explorer/src/hooks/useSafeTransactionDetails.tsx
+++ b/explorer/src/hooks/useSafeTransactionDetails.tsx
@@ -4,19 +4,19 @@ import { useSettings } from "@/hooks/useSettings";
 import { getConsensusWorker, type SafeTransaction } from "@/lib/consensus";
 import { loadSafeTransactionDetails } from "@/lib/safe/service";
 
-type SafeTransactionSource = { data: SafeTransaction; fromSafeApi: boolean };
+type SafeTransactionSource = { data: SafeTransaction; fromSafeApi: boolean; submittedAtSeconds: number | null };
 
 export function useSafeTransactionDetails(
 	chainId: bigint,
 	safeTxHash: Hex,
-): { data: SafeTransaction | null; fromSafeApi: boolean; isFetching: boolean } {
+): { data: SafeTransaction | null; fromSafeApi: boolean; submittedAtSeconds: number | null; isFetching: boolean } {
 	const [settings] = useSettings();
 	const query = useQuery<SafeTransactionSource | null, Error>({
 		queryKey: ["safeTxDetails", chainId.toString(), safeTxHash, settings.consensus, settings.maxBlockRange],
 		queryFn: async () => {
 			const apiData = await loadSafeTransactionDetails(chainId, safeTxHash);
 			if (apiData !== null) {
-				return { data: apiData, fromSafeApi: true };
+				return { data: apiData.transaction, fromSafeApi: true, submittedAtSeconds: apiData.submittedAtSeconds };
 			}
 			const onChainData = await getConsensusWorker().loadProposedSafeTransaction({
 				rpc: settings.rpc,
@@ -24,13 +24,14 @@ export function useSafeTransactionDetails(
 				safeTxHash,
 				maxBlockRange: BigInt(settings.maxBlockRange),
 			});
-			return onChainData !== null ? { data: onChainData, fromSafeApi: false } : null;
+			return onChainData !== null ? { data: onChainData, fromSafeApi: false, submittedAtSeconds: null } : null;
 		},
 		initialData: null,
 	});
 	return {
 		data: query.data?.data ?? null,
 		fromSafeApi: query.data?.fromSafeApi ?? false,
+		submittedAtSeconds: query.data?.submittedAtSeconds ?? null,
 		isFetching: query.isFetching,
 	};
 }

--- a/explorer/src/lib/consensus/consensus.test.ts
+++ b/explorer/src/lib/consensus/consensus.test.ts
@@ -346,6 +346,79 @@ describe("loadTransactionProposals oracle recognition", () => {
 	});
 });
 
+describe("loadTransactionProposals timestamp targeting", () => {
+	const ORACLE = "0x5555555555555555555555555555555555555555" as Address;
+	const GENESIS_TS = 1_600_000_000;
+	const tsAt = (block: number) => GENESIS_TS + block * 5;
+
+	const makeTargetingProvider = (
+		logsByFromBlock: Record<string, ReturnType<typeof makeRawConsensusLog>[]> = {},
+	): PublicClient =>
+		({
+			getBlockNumber: vi.fn().mockResolvedValue(CURRENT_BLOCK),
+			getBlock: vi.fn(({ blockNumber }: { blockNumber: bigint }) =>
+				Promise.resolve({ number: blockNumber, timestamp: BigInt(tsAt(Number(blockNumber))) }),
+			),
+			request: vi.fn(({ params }: { params: [{ fromBlock: string }] }) =>
+				Promise.resolve(logsByFromBlock[params[0].fromBlock] ?? []),
+			),
+		}) as unknown as PublicClient;
+
+	it("reads a second window aimed at an old timestamp alongside the head window", async () => {
+		const provider = makeTargetingProvider();
+		await loadTransactionProposals({
+			provider,
+			consensus: CONSENSUS,
+			safeTxHash: SAFE_TX_HASH,
+			maxBlockRange: MAX_BLOCK_RANGE,
+			signingTimeout: SIGNING_TIMEOUT,
+			timestampSeconds: tsAt(2000),
+		});
+		const calls = (provider.request as ReturnType<typeof vi.fn>).mock.calls;
+		expect(calls).toHaveLength(2);
+		expect(calls[0][0].params[0]).toMatchObject({ fromBlock: numberToHex(1000n), toBlock: numberToHex(2000n) });
+		expect(calls[1][0].params[0]).toMatchObject({ fromBlock: numberToHex(9000n), toBlock: numberToHex(10000n) });
+	});
+
+	it("surfaces an old attested proposal found only in the targeted window", async () => {
+		const provider = makeTargetingProvider({
+			[numberToHex(1000n)]: [
+				makeOracleProposedLog({ safeTxHash: SAFE_TX_HASH, epoch: 1n, oracle: ORACLE, blockNumber: 1500n }),
+				makeOracleAttestedLog({ safeTxHash: SAFE_TX_HASH, epoch: 1n, oracle: ORACLE, blockNumber: 1600n }),
+			],
+		});
+		const result = await loadTransactionProposals({
+			provider,
+			consensus: CONSENSUS,
+			safeTxHash: SAFE_TX_HASH,
+			maxBlockRange: MAX_BLOCK_RANGE,
+			signingTimeout: SIGNING_TIMEOUT,
+			timestampSeconds: tsAt(2000),
+		});
+		expect(result.proposals).toHaveLength(1);
+		expect(result.proposals[0].status).toBe("ATTESTED");
+		expect(result.proposals[0].proposedAt.block).toBe(1500n);
+		expect(result.fromBlock).toBe(1000n);
+		expect(result.toBlock).toBe(CURRENT_BLOCK);
+	});
+
+	it("falls back to the single head window when block probes fail", async () => {
+		const provider = makeTargetingProvider();
+		(provider.getBlock as ReturnType<typeof vi.fn>).mockRejectedValue(new Error("pruned"));
+		await loadTransactionProposals({
+			provider,
+			consensus: CONSENSUS,
+			safeTxHash: SAFE_TX_HASH,
+			maxBlockRange: MAX_BLOCK_RANGE,
+			signingTimeout: SIGNING_TIMEOUT,
+			timestampSeconds: tsAt(2000),
+		});
+		const calls = (provider.request as ReturnType<typeof vi.fn>).mock.calls;
+		expect(calls).toHaveLength(1);
+		expect(calls[0][0].params[0]).toMatchObject({ fromBlock: numberToHex(9000n), toBlock: numberToHex(10000n) });
+	});
+});
+
 const makeStagedLog = ({
 	activeEpoch,
 	proposedEpoch,

--- a/explorer/src/lib/consensus/transactions.ts
+++ b/explorer/src/lib/consensus/transactions.ts
@@ -10,7 +10,7 @@ import {
 } from "viem";
 import z from "zod";
 import { bigIntSchema, checkedAddressSchema, hexDataSchema } from "@/lib/schemas";
-import { getBlockRange, jsonReplacer, mostRecentFirst } from "@/lib/utils";
+import { getBlockRange, getTargetedBlockRange, jsonReplacer, mostRecentFirst } from "@/lib/utils";
 import { consensusAbi, proposedEventSelectors, transactionEventSelectors } from "./abi";
 
 export const safeTransactionSchema = z.object({
@@ -99,6 +99,7 @@ export const loadTransactionProposals = async ({
 	maxBlockRange,
 	signingTimeout,
 	oracles = [],
+	timestampSeconds,
 }: {
 	provider: PublicClient;
 	consensus: Address;
@@ -108,23 +109,40 @@ export const loadTransactionProposals = async ({
 	maxBlockRange: bigint;
 	signingTimeout: number;
 	oracles?: Address[];
+	timestampSeconds?: number;
 }): Promise<LoadTransactionProposalsResult> => {
-	const { fromBlock, toBlock } = await getBlockRange(provider, maxBlockRange, referenceBlock);
-	const blockRange = { fromBlock: numberToHex(fromBlock), toBlock: numberToHex(toBlock) };
+	const headRange = await getBlockRange(provider, maxBlockRange, referenceBlock);
+	// Proposals older than the head-relative window would otherwise read as "not found".
+	// When the caller knows roughly when the transaction was submitted, a second disjoint
+	// window is aimed there via a block-at-timestamp estimate.
+	const targeted =
+		timestampSeconds !== undefined
+			? await getTargetedBlockRange(provider, maxBlockRange, timestampSeconds, headRange)
+			: null;
+	const ranges = targeted !== null ? [targeted, headRange] : [headRange];
+	const { toBlock } = headRange;
+	const fromBlock = targeted?.fromBlock ?? headRange.fromBlock;
 
 	// We use an `eth_getLogs` here directly, in order to filter on the `safeTxHash` topic.
 	// When `safe` is set, topic[3] silently drops `TransactionAttested` (only 1 indexed topic);
 	// those proposals will have attestedAt: null until contract events are updated.
-	const rawLogs = await provider.request({
-		method: "eth_getLogs",
-		params: [
-			{
-				address: consensus,
-				...blockRange,
-				topics: [transactionEventSelectors, safeTxHash ?? null, null, safe ? pad(safe) : null],
-			},
-		],
-	});
+	const rawLogs = (
+		await Promise.all(
+			ranges.map((range) =>
+				provider.request({
+					method: "eth_getLogs",
+					params: [
+						{
+							address: consensus,
+							fromBlock: numberToHex(range.fromBlock),
+							toBlock: numberToHex(range.toBlock),
+							topics: [transactionEventSelectors, safeTxHash ?? null, null, safe ? pad(safe) : null],
+						},
+					],
+				}),
+			),
+		)
+	).flat();
 	const allEventLogs = mostRecentFirst(
 		parseEventLogs({
 			// <https://github.com/wevm/viem/issues/4340>

--- a/explorer/src/lib/consensus/worker.ts
+++ b/explorer/src/lib/consensus/worker.ts
@@ -17,6 +17,7 @@ const workerApi = {
 		maxBlockRange: bigint;
 		signingTimeout: number;
 		oracles?: Address[];
+		timestampSeconds?: number;
 	}) => loadTransactionProposals({ ...params, provider: createRpcClient(rpc) }),
 
 	loadConsensusState: ({ rpc, consensus }: { rpc: string; consensus: Address }) =>

--- a/explorer/src/lib/safe/service.ts
+++ b/explorer/src/lib/safe/service.ts
@@ -19,12 +19,23 @@ const safeTransactionSchema = z.object({
 	gasToken: checkedAddressSchema,
 	refundReceiver: checkedAddressSchema,
 	nonce: bigIntSchema,
+	// ISO timestamp from the tx-service; used to aim on-chain log windows at old proposals.
+	submissionDate: z.string().optional(),
 });
 
 const buildSafeTxDetailsEndpoint = (base: string, shortName: string, safeTxHash: Hex) =>
 	`${base}/tx-service/${shortName}/api/v2/multisig-transactions/${safeTxHash}/`;
 
-export const loadSafeTransactionDetails = async (chainId: bigint, safeTxHash: Hex): Promise<SafeTransaction | null> => {
+export type SafeTransactionDetails = {
+	transaction: SafeTransaction;
+	/** Unix seconds the transaction was submitted, when the tx-service reports it. */
+	submittedAtSeconds: number | null;
+};
+
+export const loadSafeTransactionDetails = async (
+	chainId: bigint,
+	safeTxHash: Hex,
+): Promise<SafeTransactionDetails | null> => {
 	const { url } = loadSafeApiSettings();
 	const chainInfo = SAFE_SERVICE_CHAINS[chainId.toString()];
 	if (chainInfo === undefined) return null;
@@ -32,9 +43,12 @@ export const loadSafeTransactionDetails = async (chainId: bigint, safeTxHash: He
 	if (!response.ok) return null;
 	const parsed = safeTransactionSchema.safeParse(await response.json());
 	if (!parsed.success) return null;
+	const { submissionDate, ...fields } = parsed.data;
 	const transaction = {
 		chainId,
-		...parsed.data,
+		...fields,
 	};
-	return calculateSafeTxHash(transaction) === safeTxHash ? transaction : null;
+	if (calculateSafeTxHash(transaction) !== safeTxHash) return null;
+	const submittedAtMs = submissionDate !== undefined ? Date.parse(submissionDate) : Number.NaN;
+	return { transaction, submittedAtSeconds: Number.isFinite(submittedAtMs) ? Math.floor(submittedAtMs / 1000) : null };
 };

--- a/explorer/src/lib/utils.test.ts
+++ b/explorer/src/lib/utils.test.ts
@@ -1,6 +1,6 @@
 import type { PublicClient } from "viem";
 import { describe, expect, it, vi } from "vitest";
-import { getBlockRange, loadChainId, mostRecentFirst } from "./utils";
+import { estimateBlockAt, getBlockRange, getTargetedBlockRange, loadChainId, mostRecentFirst } from "./utils";
 
 const CURRENT_BLOCK = 10000n;
 const MAX_BLOCK_RANGE = 1000n;
@@ -117,5 +117,109 @@ describe("loadChainId", () => {
 		await expect(loadChainId(provider)).rejects.toThrow("network error");
 		await expect(loadChainId(provider)).resolves.toBe(7);
 		expect(provider.getChainId).toHaveBeenCalledTimes(2);
+	});
+});
+
+const GENESIS_TS = 1_600_000_000;
+
+/** Chain whose block timestamps follow `tsAt`; getBlock resolves any probed number. */
+const makeTimestampProvider = (tsAt: (block: number) => number): PublicClient =>
+	({
+		getBlock: vi.fn(({ blockNumber }: { blockNumber: bigint }) =>
+			Promise.resolve({ number: blockNumber, timestamp: BigInt(tsAt(Number(blockNumber))) }),
+		),
+	}) as unknown as PublicClient;
+
+describe("estimateBlockAt", () => {
+	const HEAD = 1_000_000n;
+
+	it("converges on a uniform chain matching the nominal seed", async () => {
+		const tsAt = (block: number) => GENESIS_TS + block * 5;
+		const provider = makeTimestampProvider(tsAt);
+		const { block, driftSeconds } = await estimateBlockAt(provider, tsAt(400_000), {
+			number: HEAD,
+			timestamp: tsAt(1_000_000),
+		});
+		expect(block).toBe(400_000n);
+		expect(Math.abs(driftSeconds)).toBeLessThanOrEqual(600);
+	});
+
+	it("converges when the real cadence is far from the seed", async () => {
+		const tsAt = (block: number) => GENESIS_TS + block * 12;
+		const provider = makeTimestampProvider(tsAt);
+		const { block, driftSeconds } = await estimateBlockAt(provider, tsAt(400_000), {
+			number: HEAD,
+			timestamp: tsAt(1_000_000),
+		});
+		expect(Math.abs(driftSeconds)).toBeLessThanOrEqual(600);
+		expect(Math.abs(Number(block) - 400_000)).toBeLessThanOrEqual(600 / 12);
+	});
+
+	it("converges across a cadence shift for a target in the old regime", async () => {
+		// 12s blocks before 500k, 5s after — the target sits in the slow regime.
+		const tsAt = (block: number) =>
+			block < 500_000 ? GENESIS_TS + block * 12 : GENESIS_TS + 500_000 * 12 + (block - 500_000) * 5;
+		const provider = makeTimestampProvider(tsAt);
+		const { driftSeconds } = await estimateBlockAt(provider, tsAt(100_000), {
+			number: HEAD,
+			timestamp: tsAt(1_000_000),
+		});
+		expect(Math.abs(driftSeconds)).toBeLessThanOrEqual(600);
+	});
+
+	it("returns Infinity drift when every probe fails", async () => {
+		const provider = { getBlock: vi.fn().mockRejectedValue(new Error("pruned")) } as unknown as PublicClient;
+		const { driftSeconds } = await estimateBlockAt(provider, GENESIS_TS, {
+			number: HEAD,
+			timestamp: GENESIS_TS + 5_000_000,
+		});
+		expect(driftSeconds).toBe(Number.POSITIVE_INFINITY);
+	});
+
+	it("pins a future timestamp to the head", async () => {
+		const tsAt = (block: number) => GENESIS_TS + block * 5;
+		const provider = makeTimestampProvider(tsAt);
+		const { block } = await estimateBlockAt(provider, tsAt(1_000_000) + 100_000, {
+			number: HEAD,
+			timestamp: tsAt(1_000_000),
+		});
+		expect(block).toBe(HEAD);
+	});
+});
+
+describe("getTargetedBlockRange", () => {
+	const HEAD_RANGE = { fromBlock: 990_000n, toBlock: 1_000_000n };
+	const RANGE = 10_000n;
+	const tsAt = (block: number) => GENESIS_TS + block * 5;
+
+	it("aims a window at an old timestamp, disjoint from the head window", async () => {
+		const provider = makeTimestampProvider(tsAt);
+		const range = await getTargetedBlockRange(provider, RANGE, tsAt(400_000), HEAD_RANGE);
+		expect(range).toEqual({ fromBlock: 399_000n, toBlock: 409_000n });
+	});
+
+	it("clamps the window just below the head window", async () => {
+		const provider = makeTimestampProvider(tsAt);
+		const range = await getTargetedBlockRange(provider, RANGE, tsAt(985_000), HEAD_RANGE);
+		expect(range).toEqual({ fromBlock: 984_000n, toBlock: 989_999n });
+	});
+
+	it("returns null for a recent timestamp already inside the head window", async () => {
+		const provider = makeTimestampProvider(tsAt);
+		const range = await getTargetedBlockRange(provider, RANGE, tsAt(995_000), HEAD_RANGE);
+		expect(range).toBeNull();
+	});
+
+	it("returns null when the head window already reaches genesis", async () => {
+		const provider = makeTimestampProvider(tsAt);
+		const range = await getTargetedBlockRange(provider, RANGE, tsAt(1_000), { fromBlock: 0n, toBlock: 5_000n });
+		expect(range).toBeNull();
+		expect(provider.getBlock).not.toHaveBeenCalled();
+	});
+
+	it("returns null when block probes fail, keeping the caller on the head window", async () => {
+		const provider = { getBlock: vi.fn().mockRejectedValue(new Error("pruned")) } as unknown as PublicClient;
+		const range = await getTargetedBlockRange(provider, RANGE, tsAt(400_000), HEAD_RANGE);
+		expect(range).toBeNull();
 	});
 });

--- a/explorer/src/lib/utils.ts
+++ b/explorer/src/lib/utils.ts
@@ -38,6 +38,83 @@ export const getBlockRange = async (
 	return { fromBlock, toBlock };
 };
 
+/** Nominal seed for the block-at-timestamp estimate; refinement corrects for the real cadence. */
+const BLOCK_TIME_SEED_SECONDS = 5;
+/** Stop refining once a probe lands within this many seconds of the target. */
+const BLOCK_ESTIMATE_TOLERANCE_SECONDS = 600;
+/** Max refinement round-trips after the first probe (one cheap `eth_getBlockByNumber` each). */
+const BLOCK_ESTIMATE_MAX_REFINEMENTS = 8;
+/** How far behind the estimated block a targeted window starts, absorbing estimate error. */
+const TARGETED_WINDOW_BACK_BLOCKS = 1000n;
+
+/**
+ * Estimate the block nearest a unix timestamp via secant refinement: the first step
+ * uses the block time observed between the probe and the head, later steps the local
+ * cadence between the last two probes, so the estimate converges even when the real
+ * cadence drifts from the nominal seed or shifted over the chain's history.
+ * `driftSeconds` is measured at the returned block and is `Infinity` when no probe
+ * succeeded.
+ */
+export const estimateBlockAt = async (
+	provider: PublicClient,
+	targetSeconds: number,
+	head: { number: bigint; timestamp: number },
+): Promise<{ block: bigint; driftSeconds: number }> => {
+	const headNumber = Number(head.number);
+	const clamp = (block: number) => Math.min(headNumber, Math.max(0, Math.round(block)));
+	let guess = clamp(headNumber - (head.timestamp - targetSeconds) / BLOCK_TIME_SEED_SECONDS);
+	let best = { block: guess, driftSeconds: Number.POSITIVE_INFINITY };
+	let prev: { block: number; timestamp: number } | null = null;
+
+	for (let probe = 0; probe <= BLOCK_ESTIMATE_MAX_REFINEMENTS; probe++) {
+		// A failed probe (e.g. a pruned header on public RPC) degrades to the caller's
+		// head-relative scan rather than failing the whole read.
+		const block = await provider.getBlock({ blockNumber: BigInt(guess) }).catch(() => null);
+		if (!block) break;
+		const timestamp = Number(block.timestamp);
+		const driftSeconds = timestamp - targetSeconds;
+		if (Math.abs(driftSeconds) < Math.abs(best.driftSeconds)) best = { block: guess, driftSeconds };
+		if (Math.abs(driftSeconds) <= BLOCK_ESTIMATE_TOLERANCE_SECONDS) break;
+		// Consecutive probes bracket the target's cadence regime, so their secant slope
+		// beats the whole-chain average; the first probe only has the head to lean on.
+		const span = prev === null ? headNumber - guess : guess - prev.block;
+		const rise = prev === null ? head.timestamp - timestamp : timestamp - prev.timestamp;
+		// Floored so a run of equal timestamps cannot divide by zero below.
+		const observedBlockTime = span !== 0 ? Math.max(rise / span, 0.1) : BLOCK_TIME_SEED_SECONDS;
+		prev = { block: guess, timestamp };
+		const next = clamp(guess - driftSeconds / observedBlockTime);
+		if (next === guess) break;
+		guess = next;
+	}
+	return { block: BigInt(best.block), driftSeconds: best.driftSeconds };
+};
+
+/**
+ * A second log window aimed at `timestampSeconds`, for events that fell out of the
+ * head-relative window. Returns `null` when the head window already reaches genesis,
+ * the estimate did not converge, or the target is recent enough that the aimed window
+ * would overlap the head-relative one — callers then keep their current behaviour.
+ */
+export const getTargetedBlockRange = async (
+	provider: PublicClient,
+	maxBlockRange: bigint,
+	timestampSeconds: number,
+	headRange: BlockRange,
+): Promise<BlockRange | null> => {
+	if (headRange.fromBlock === 0n) return null;
+	const head = await provider.getBlock({ blockNumber: headRange.toBlock }).catch(() => null);
+	if (head === null) return null;
+	const { block, driftSeconds } = await estimateBlockAt(provider, timestampSeconds, {
+		number: headRange.toBlock,
+		timestamp: Number(head.timestamp),
+	});
+	if (Math.abs(driftSeconds) > BLOCK_ESTIMATE_TOLERANCE_SECONDS) return null;
+	const fromBlock = block > TARGETED_WINDOW_BACK_BLOCKS ? block - TARGETED_WINDOW_BACK_BLOCKS : 0n;
+	const toBlock =
+		headRange.fromBlock - 1n < fromBlock + maxBlockRange ? headRange.fromBlock - 1n : fromBlock + maxBlockRange;
+	return toBlock >= fromBlock ? { fromBlock, toBlock } : null;
+};
+
 export const mostRecentFirst = <T extends Pick<Log<bigint, number, false>, "blockNumber" | "logIndex">>(
 	logs: T[],
 ): T[] =>

--- a/explorer/src/routes/safeTx.tsx
+++ b/explorer/src/routes/safeTx.tsx
@@ -37,7 +37,11 @@ export function SafeTransaction() {
 						<SafeTxSummary transaction={details.data} />
 					</Box>
 					<Box>
-						<SafeTxProposals safeTxHash={safeTxHash} transaction={details.data} />
+						<SafeTxProposals
+							safeTxHash={safeTxHash}
+							transaction={details.data}
+							submittedAtSeconds={details.submittedAtSeconds}
+						/>
 					</Box>
 				</>
 			)}


### PR DESCRIPTION
Proposals older than the head-relative `maxBlockRange` window (default 10k blocks, ~14h on Gnosis) show as "No proposals found" on the transaction page.

Fix: when the Safe tx-service reports a `submissionDate`, estimate the consensus-chain block at that timestamp and read a second log window aimed there, in addition to the head window. The head window is still read, so a proposal submitted now for an old transaction keeps showing up.

The estimate is secant refinement on observed block time: the first step uses the probe-to-head average, later steps use the cadence between the last two probes, so it converges across historical cadence shifts. Cost is 2-4 `eth_getBlockByNumber` plus one extra `eth_getLogs`, and only when the target is older than the head window. With no timestamp, a non-converging estimate, or a recent target, behaviour is unchanged.

Verified against `rpc.gnosischain.com` with an attestation ~210k blocks back (epoch 32947, proposed at block 47444993): main finds nothing, this branch shows it ATTESTED.
