### PR TITLE
[Sentinel Engine 2a]: Introduce Sentinel Engine Crate

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,6 +14,7 @@ The repository is a hybrid monorepo with:
 - Rust crates:
   - `crates/core/` — Shared code used by all Safenet offchain services
   - `crates/sentinel/` — Rust port of the sentinel service that watches the `SentinelOracle` and `Consensus` contracts, decides whether to approve or deny proposed oracle transactions, and puts up bonds onchain
+  - `crates/sentinel-engine/` — Transaction verification service the sentinel defers its checks to.
   - `crates/validator/` — Rust port of the validator service that participates in FROST DKG and signing rounds and submits epoch rollovers, transaction attestations, and oracle transaction attestations onchain
 
 Additionally, formal verification specs live in `certora/`. Integration and devnet scripts are in `scripts/`.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4231,6 +4231,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "sentinel-engine"
+version = "0.1.0"
+dependencies = [
+ "argh",
+ "safenet-core",
+ "serde",
+ "thiserror",
+ "tokio",
+ "toml",
+ "tracing",
+]
+
+[[package]]
 name = "serde"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ This is a work-in-progress. Don't use it yet!
 - [Validator](./validator) Validator service (Typescript & npm)
 - [Services core crate](./crates/core) Shared logic between the offchain Safenet services (Rust)
 - [Sentinel](./crates/sentinel) Sentinel service that watches and puts up bonds in support of transaction correctness (Rust)
+- [Sentinel engine](./crates/sentinel-engine) Transaction verification service that the sentinel defers its checks to
 - [Validator (Rust port)](./crates/validator) Rust port of the validator service that participates in FROST signing rounds and epoch rollovers
 
 ## Developing

--- a/crates/sentinel-engine/Cargo.toml
+++ b/crates/sentinel-engine/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "sentinel-engine"
+version = "0.1.0"
+edition = "2024"
+publish = false
+
+[dependencies]
+argh.workspace = true
+safenet-core.workspace = true
+serde.workspace = true
+thiserror.workspace = true
+tokio.workspace = true
+toml.workspace = true
+tracing.workspace = true

--- a/crates/sentinel-engine/src/config.rs
+++ b/crates/sentinel-engine/src/config.rs
@@ -1,0 +1,89 @@
+use safenet_core::observability;
+use serde::Deserialize;
+use std::path::Path;
+use tokio::{fs, io};
+
+/// Error produced when loading the configuration.
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+    /// An IO error when interacting with the filesystem.
+    #[error(transparent)]
+    Io(#[from] io::Error),
+    /// Error when parsing the configuration.
+    #[error(transparent)]
+    Parse(#[from] toml::de::Error),
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct Config {
+    /// Observability (logging and metrics) configuration.
+    #[serde(default)]
+    pub observability: observability::Config,
+}
+
+impl Config {
+    /// Loads a configuration from a file.
+    pub async fn load(file: &Path) -> Result<Self, Error> {
+        let contents = fs::read_to_string(file).await?;
+        let config = toml::from_str(&contents)?;
+        Ok(config)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::net::{Ipv4Addr, SocketAddr};
+
+    #[test]
+    fn deserializes_required_fields_and_defaults_the_rest() {
+        let config = toml::from_str::<Config>(
+            r#"
+            "#,
+        )
+        .unwrap();
+
+        assert_eq!(
+            config.observability.log_filter.to_string(),
+            observability::Config::default().log_filter.to_string()
+        );
+        assert_eq!(
+            config.observability.metrics_address,
+            observability::Config::default().metrics_address
+        );
+    }
+
+    #[test]
+    fn deserializes_observability_overrides() {
+        let config = toml::from_str::<Config>(
+            r#"
+                [observability]
+                log_filter = "sentinel_engine=debug,info"
+                metrics_address = "127.0.0.1:9090"
+            "#,
+        )
+        .unwrap();
+
+        assert_eq!(
+            config.observability.log_filter.to_string(),
+            "sentinel_engine=debug,info"
+        );
+        assert_eq!(
+            config.observability.metrics_address,
+            SocketAddr::from((Ipv4Addr::LOCALHOST, 9090))
+        );
+    }
+
+    #[test]
+    fn rejects_unknown_field() {
+        assert!(
+            toml::from_str::<Config>(
+                r#"
+                    invalid_field = "foo"
+                "#,
+            )
+            .is_err()
+        );
+    }
+}

--- a/crates/sentinel-engine/src/main.rs
+++ b/crates/sentinel-engine/src/main.rs
@@ -1,0 +1,36 @@
+mod config;
+
+use self::config::Config;
+use argh::FromArgs;
+use safenet_core::observability;
+use std::{error::Error, path::PathBuf};
+
+#[derive(Debug, FromArgs)]
+/// Safenet sentinel engine.
+struct Options {
+    /// path to the sentinel engine TOML configuration file.
+    #[argh(option, default = "PathBuf::from(\"sentinel-engine.toml\")")]
+    config_file: PathBuf,
+
+    /// print version information.
+    #[argh(switch)]
+    version: bool,
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn Error>> {
+    let options: Options = argh::from_env();
+    if options.version {
+        println!("{}", env!("CARGO_PKG_VERSION"));
+        return Ok(());
+    }
+
+    let config = Config::load(&options.config_file).await?;
+    observability::init(config.observability)?;
+    tracing::debug!(
+        config_file = %options.config_file.display(),
+        "sentinel engine configuration loaded"
+    );
+
+    todo!("sentinel engine is not implemented yet");
+}


### PR DESCRIPTION
This PR just introduces the sentinel engine crate that we will build on. Note that this is phase 2 in the epic, but I decided to start with it (as phase 1 requires a bit more thought in how I organize the types without making a 1000 line PR that touches the whole codebase).

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://docs.safefoundation.org/cla).
