### PR TITLE
[Sentinel Engine 1a]: Prefer Local Binding Types

### DIFF
--- a/crates/sentinel/src/address_poisoning.rs
+++ b/crates/sentinel/src/address_poisoning.rs
@@ -21,7 +21,10 @@
 //! so that case defers to whatever check runs next. See the `TODO` on
 //! [`AddressPoisoningChecker`]'s [`Checker`] impl.
 
-use crate::checker::{CheckOutcome, Checker};
+use crate::{
+    bindings::consensus::SafeTransaction,
+    checker::{CheckOutcome, Checker},
+};
 use alloy::{
     primitives::Address,
     providers::{DynProvider, Provider},
@@ -31,10 +34,7 @@ use alloy::{
 };
 use safe_tx::{
     rule::RuleId,
-    types::{
-        SafeTransaction,
-        erc20::{approveCall, transferCall, transferFromCall},
-    },
+    types::erc20::{approveCall, transferCall, transferFromCall},
 };
 
 sol! {

--- a/crates/sentinel/src/bindings.rs
+++ b/crates/sentinel/src/bindings.rs
@@ -59,13 +59,14 @@ pub mod oracle {
 
 pub mod consensus {
     use alloy::sol;
+    use serde::Serialize;
 
     sol! {
-        #[derive(Debug, Default)]
+        #[derive(Debug, Default, PartialEq, Eq, Serialize)]
         enum Operation { #[default] CALL, DELEGATECALL }
 
         // Full transaction struct carried by OracleTransactionProposed; mirrors SafeTransaction.T.
-        #[derive(Debug, Default)]
+        #[derive(Debug, Default, PartialEq, Eq, Serialize)]
         struct SafeTransaction {
             uint256 chainId;
             address safe;
@@ -115,8 +116,8 @@ pub mod consensus {
     // near-verbatim in `crates/validator/src/bindings.rs`. Consider moving
     // the ABI/event definitions into a shared crate so both consumers
     // declare the `sol!` types (and this conversion) exactly once.
-    impl From<&SafeTransaction> for safe_tx::types::SafeTransaction {
-        fn from(tx: &SafeTransaction) -> Self {
+    impl From<SafeTransaction> for safe_tx::types::SafeTransaction {
+        fn from(tx: SafeTransaction) -> Self {
             let operation = match tx.operation {
                 Operation::CALL => safe_tx::types::Operation::CALL,
                 Operation::DELEGATECALL => safe_tx::types::Operation::DELEGATECALL,
@@ -127,7 +128,31 @@ pub mod consensus {
                 safe: tx.safe,
                 to: tx.to,
                 value: tx.value,
-                data: tx.data.clone(),
+                data: tx.data,
+                operation,
+                safeTxGas: tx.safeTxGas,
+                baseGas: tx.baseGas,
+                gasPrice: tx.gasPrice,
+                gasToken: tx.gasToken,
+                refundReceiver: tx.refundReceiver,
+                nonce: tx.nonce,
+            }
+        }
+    }
+
+    impl From<safe_tx::types::SafeTransaction> for SafeTransaction {
+        fn from(tx: safe_tx::types::SafeTransaction) -> SafeTransaction {
+            let operation = match tx.operation {
+                safe_tx::types::Operation::CALL => Operation::CALL,
+                safe_tx::types::Operation::DELEGATECALL => Operation::DELEGATECALL,
+                safe_tx::types::Operation::__Invalid => Operation::__Invalid,
+            };
+            SafeTransaction {
+                chainId: tx.chainId,
+                safe: tx.safe,
+                to: tx.to,
+                value: tx.value,
+                data: tx.data,
                 operation,
                 safeTxGas: tx.safeTxGas,
                 baseGas: tx.baseGas,

--- a/crates/sentinel/src/checker.rs
+++ b/crates/sentinel/src/checker.rs
@@ -15,7 +15,8 @@
 //! one's outcome beyond stop-on-first-answer) and is expected to be
 //! iterated on.
 
-use safe_tx::{rule::RuleId, types::SafeTransaction};
+use crate::bindings::consensus::SafeTransaction;
+use safe_tx::rule::RuleId;
 
 /// The result of running one checker in [`crate::effect::Handler`]'s chain.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/crates/sentinel/src/cow.rs
+++ b/crates/sentinel/src/cow.rs
@@ -56,17 +56,16 @@
 //! under-approval and an over-approval are denied here. An unreachable or
 //! malformed API response is `Unknown`, not guessed at either way.
 
-use crate::checker::{CheckOutcome, Checker};
+use crate::{
+    bindings::consensus::{Operation, SafeTransaction},
+    checker::{CheckOutcome, Checker},
+};
 use alloy::{
     primitives::{Address, B256, Bytes, U256, address},
     sol,
     sol_types::{Eip712Domain, SolCall, SolStruct, SolValue, eip712_domain},
 };
-use safe_tx::{
-    multi_send::decode_multi_send_call,
-    rule::RuleId,
-    types::{Operation, SafeTransaction, erc20::approveCall},
-};
+use safe_tx::{multi_send::decode_multi_send_call, rule::RuleId, types::erc20::approveCall};
 use serde::Deserialize;
 
 sol! {
@@ -466,9 +465,10 @@ impl Checker for CowChecker {
 
 /// `tx` itself, or, if it's a MultiSend batch, each of its sub-calls.
 fn sub_transactions(tx: &SafeTransaction) -> Vec<SafeTransaction> {
-    decode_multi_send_call(tx)
-        .map(|(sub_txs, _)| sub_txs)
-        .unwrap_or_else(|| vec![tx.clone()])
+    let tx = tx.clone().into();
+    decode_multi_send_call(&tx)
+        .map(|(sub_txs, _)| sub_txs.into_iter().map(|sub_tx| sub_tx.into()).collect())
+        .unwrap_or_else(|| vec![tx.into()])
 }
 
 /// Only a plain, valueless `CALL` is recognized — a `DELEGATECALL` executes

--- a/crates/sentinel/src/dynamic_checker.rs
+++ b/crates/sentinel/src/dynamic_checker.rs
@@ -8,9 +8,12 @@
 //! "trigger this endpoint, parse the response" along if that ever needs to
 //! move out on its own.
 
-use crate::checker::{CheckOutcome, Checker};
+use crate::{
+    bindings::consensus::SafeTransaction,
+    checker::{CheckOutcome, Checker},
+};
 use alloy::primitives::Address;
-use safe_tx::{rule::RuleId, types::SafeTransaction};
+use safe_tx::rule::RuleId;
 use serde::{Deserialize, Serialize};
 use url::Url;
 

--- a/crates/sentinel/src/effect.rs
+++ b/crates/sentinel/src/effect.rs
@@ -5,9 +5,11 @@
 //! `SentinelTransition::handle_oracle_transaction_proposed` and consumed by
 //! `SentinelTransition::apply_transition`'s `Message::Resume` arm.
 
-use crate::checker::{CheckOutcome, Checker};
+use crate::{
+    bindings::consensus::SafeTransaction,
+    checker::{CheckOutcome, Checker},
+};
 use alloy::primitives::B256;
-use safe_tx::types::SafeTransaction;
 use safenet_core::effects::EffectHandler;
 
 /// An impure operation the sentinel's state transition asks the [`Handler`]

--- a/crates/sentinel/src/service.rs
+++ b/crates/sentinel/src/service.rs
@@ -154,7 +154,7 @@ impl SentinelTransition {
             state,
             vec![Command::Effect(effect::Effect::DynamicCheck {
                 request_id,
-                transaction: (&event.transaction).into(),
+                transaction: event.transaction,
             })],
         )
     }
@@ -796,7 +796,7 @@ mod tests {
     fn dynamic_check_effect(id: B256, to: Address) -> Command<SentinelAction, effect::Effect> {
         Command::Effect(effect::Effect::DynamicCheck {
             request_id: id,
-            transaction: (&safe_tx(to)).into(),
+            transaction: safe_tx(to),
         })
     }
 

--- a/crates/sentinel/src/static_checker.rs
+++ b/crates/sentinel/src/static_checker.rs
@@ -36,11 +36,11 @@ impl Decision {
     }
 }
 
-/// A single policy check, evaluated against the shared `safe-tx` transaction
-/// type. `StaticChecker::check` runs its checks in a fixed order and stops at
-/// the first denial.
+/// A single policy check, evaluated against a proposed transaction.
+/// `StaticChecker::check` runs its checks in a fixed order and stops at the
+/// first denial.
 trait Check {
-    fn evaluate(&self, tx: &safe_tx::types::SafeTransaction) -> Result<(), RuleId>;
+    fn evaluate(&self, tx: &SafeTransaction) -> Result<(), RuleId>;
 }
 
 /// Article IV Part A base guarantees, shared with the validator's
@@ -48,8 +48,9 @@ trait Check {
 struct BaseGuarantees;
 
 impl Check for BaseGuarantees {
-    fn evaluate(&self, tx: &safe_tx::types::SafeTransaction) -> Result<(), RuleId> {
-        safe_tx::checks::check_transaction(tx)
+    fn evaluate(&self, tx: &SafeTransaction) -> Result<(), RuleId> {
+        let tx = tx.clone().into();
+        safe_tx::checks::check_transaction(&tx)
     }
 }
 
@@ -59,7 +60,7 @@ impl Check for BaseGuarantees {
 struct Blocklist(HashSet<Address>);
 
 impl Check for Blocklist {
-    fn evaluate(&self, tx: &safe_tx::types::SafeTransaction) -> Result<(), RuleId> {
+    fn evaluate(&self, tx: &SafeTransaction) -> Result<(), RuleId> {
         if self.0.contains(&tx.to) {
             Err(RuleId::R4_6KnownMaliciousTarget)
         } else {
@@ -76,8 +77,9 @@ impl Check for Blocklist {
 struct ExcessiveApproval;
 
 impl Check for ExcessiveApproval {
-    fn evaluate(&self, tx: &safe_tx::types::SafeTransaction) -> Result<(), RuleId> {
-        for effect in decode_target_effects(tx) {
+    fn evaluate(&self, tx: &SafeTransaction) -> Result<(), RuleId> {
+        let tx = tx.clone().into();
+        for effect in decode_target_effects(&tx) {
             let unlimited = match effect.kind {
                 EffectKind::Erc20Approval { amount } => amount == U256::MAX,
                 EffectKind::OperatorApproval { approved } => approved,
@@ -112,10 +114,8 @@ impl StaticChecker {
     }
 
     pub fn check(&self, tx: &SafeTransaction) -> Decision {
-        let shared_tx: safe_tx::types::SafeTransaction = tx.into();
-
         for check in &self.checks {
-            if let Err(rule) = check.evaluate(&shared_tx) {
+            if let Err(rule) = check.evaluate(tx) {
                 return Decision::denied(rule);
             }
         }

--- a/crates/validator/src/bindings.rs
+++ b/crates/validator/src/bindings.rs
@@ -27,13 +27,6 @@ sol! {
     }
 
     /// Safe transaction operation type; mirrors `Enum.Operation` onchain.
-    ///
-    /// `sol!` requires custom types used as event/struct fields to be
-    /// declared in the same macro invocation, so this ABI-decoding copy
-    /// can't be replaced with a `use` of [`safe_tx::types::Operation`] --
-    /// [`From`] converts one into the other at the point an event is
-    /// consumed, so the rest of the validator only ever sees the shared
-    /// `safe-tx` type.
     #[derive(Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
     enum Operation {
         #[default]
@@ -42,8 +35,7 @@ sol! {
     }
 
     /// A full Safe transaction as carried by the `(Oracle)TransactionProposed`
-    /// events (the 12-field `SafeTransaction.T` tuple). See [`Operation`] for
-    /// why this can't just be [`safe_tx::types::SafeTransaction`].
+    /// events (the 12-field `SafeTransaction.T` tuple).
     #[derive(Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
     struct SafeTransaction {
         uint256 chainId;
@@ -272,8 +264,8 @@ sol! {
     }
 }
 
-impl From<&SafeTransaction> for safe_tx::types::SafeTransaction {
-    fn from(tx: &SafeTransaction) -> Self {
+impl From<SafeTransaction> for safe_tx::types::SafeTransaction {
+    fn from(tx: SafeTransaction) -> Self {
         let operation = match tx.operation {
             Operation::CALL => safe_tx::types::Operation::CALL,
             Operation::DELEGATECALL => safe_tx::types::Operation::DELEGATECALL,
@@ -284,7 +276,7 @@ impl From<&SafeTransaction> for safe_tx::types::SafeTransaction {
             safe: tx.safe,
             to: tx.to,
             value: tx.value,
-            data: tx.data.clone(),
+            data: tx.data,
             operation,
             safeTxGas: tx.safeTxGas,
             baseGas: tx.baseGas,

--- a/crates/validator/src/consensus/hashing.rs
+++ b/crates/validator/src/consensus/hashing.rs
@@ -7,13 +7,15 @@
 //! contract lives on, and the contract's own address). The latter hash is
 //! the message a validator group's FROST signature actually attests to.
 
-use crate::{bindings::Point, consensus::epoch::EpochId};
+use crate::{
+    bindings::{Point, SafeTransaction},
+    consensus::epoch::EpochId,
+};
 use alloy::{
     primitives::{Address, B256, U256},
     sol,
     sol_types::{Eip712Domain, SolStruct},
 };
-use safe_tx::types::SafeTransaction;
 use std::num::NonZeroU64;
 
 sol! {
@@ -172,8 +174,8 @@ impl ConsensusDomain {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::bindings::Operation;
     use alloy::primitives::{Bytes, address, b256};
-    use safe_tx::types::Operation;
 
     const TEST_ADDRESS: Address = address!("d8dA6BF26964aF9D7eEd9e03E53415D37aA96045");
     const TEST_DOMAIN: ConsensusDomain = ConsensusDomain::new(1, TEST_ADDRESS);

--- a/crates/validator/src/state/mod.rs
+++ b/crates/validator/src/state/mod.rs
@@ -6,7 +6,7 @@ mod sign;
 mod transactions;
 
 use crate::{
-    bindings::{Consensus, Coordinator, Oracle, Point},
+    bindings::{Consensus, Coordinator, Oracle, Point, SafeTransaction},
     config::ValidatorConfig,
     consensus::{
         epoch::EpochId,
@@ -24,7 +24,6 @@ use crate::{
     service::{Action, Effect, Event, Resume},
 };
 use alloy::primitives::{Address, B256};
-use safe_tx::types::SafeTransaction;
 use safenet_core::state::{Commands, Message, StateTransition};
 use serde::{Deserialize, Serialize};
 use std::{

--- a/crates/validator/src/state/transactions.rs
+++ b/crates/validator/src/state/transactions.rs
@@ -1,7 +1,10 @@
 use std::collections::btree_map;
 
 use super::{Packet, SigningState, State, Transition};
-use crate::{bindings::Consensus, consensus::epoch::EpochId};
+use crate::{
+    bindings::{Consensus, SafeTransaction},
+    consensus::epoch::EpochId,
+};
 use safenet_core::state::Commands;
 
 impl Transition {
@@ -26,15 +29,19 @@ impl Transition {
             return (state, Vec::new());
         };
 
-        let transaction: safe_tx::types::SafeTransaction = (&event.transaction).into();
-        let message = self.consensus.transaction_packet_hash(epoch, &transaction);
+        let message = self
+            .consensus
+            .transaction_packet_hash(epoch, &event.transaction);
 
         // Prevent duplicate ongoing transaction proposals. This is to prevent
         // malicious parties from blocking transaction attestations from ever
         // being produced by resetting the signing state of honest validators.
         if let btree_map::Entry::Vacant(signing) = state.signing.entry(message) {
-            let passed_checks = safe_tx::checks::check_transaction(&transaction).is_ok();
-            let packet = Packet::Transaction { epoch, transaction };
+            let passed_checks = check_transaction(&event.transaction);
+            let packet = Packet::Transaction {
+                epoch,
+                transaction: event.transaction.clone(),
+            };
 
             let signers = participating_epoch.group.participants().clone();
             let deadline = block.saturating_add(self.config.signing_timeout.get());
@@ -129,10 +136,9 @@ impl Transition {
             return (state, Vec::new());
         }
 
-        let transaction: safe_tx::types::SafeTransaction = (&event.transaction).into();
         let message =
             self.consensus
-                .oracle_transaction_packet_hash(epoch, event.oracle, &transaction);
+                .oracle_transaction_packet_hash(epoch, event.oracle, &event.transaction);
 
         // Prevent duplicate ongoing transaction proposals. This is to prevent
         // malicious parties from blocking transaction attestations from ever
@@ -141,7 +147,7 @@ impl Transition {
             let packet = Packet::OracleTransaction {
                 epoch,
                 oracle: event.oracle,
-                transaction,
+                transaction: event.transaction.clone(),
             };
             let signers = participating_epoch.group.participants().clone();
             let deadline = block.saturating_add(self.config.signing_timeout.get());
@@ -182,4 +188,13 @@ impl Transition {
         );
         self.handle_sign_attested(state, event.signatureId, message)
     }
+}
+
+fn check_transaction(transaction: &SafeTransaction) -> bool {
+    // `sol!` requires custom types used as event/struct fields to be declared
+    // in the same macro invocation, so this ABI-decoding copy can't be replaced
+    // with a `use` of [`safe_tx::types::*`] in our bindings. Do the conversion
+    // to the `safe_tx` transaction type when it is needed.
+    let transaction = transaction.clone().into();
+    safe_tx::checks::check_transaction(&transaction).is_ok()
 }


### PR DESCRIPTION
This PR refactors the `sentinel` and `validator` crates to use their internal `binding::SafeTransaction` types until using the common ones are necessary.

### Context and Motivation

With the Sentinel Engine epic, we will be defining strict `SafeTransaction` wire types for the sentinel engine API. In particular, these types **are not compatible** with the `sol!` generated types (since they add an `__Invalid` variant to the enum). On the way to implementing the sentinel engine, we want to make the `SafeTransaction` types more sound.

Unfortunately, just refactoring the Safe transaction type _everywhere_ would end up in a 1000+ line PR which is too much to review at once. Instead, we first modify both the `sentinel` and `validator` crates to use their internal `binding::SafeTransaction` representations everywhere, and only convert to the `safe_tx` variants where it is necessary. This also paves the way for removing the `safe_tx` dependency completely from the `validator` once the #696 lands in full, and move its contents completely to the `sentinel-engine` crate in this epic (also enabling the removal of the dependency in the `sentinel` crate by the end of this epic).

Additionally, we have a bit of type-level coupling between the `sentinel` and `safe_tx` (some check and types are implemented in `safe_tx`, others in `sentinel` with the separation appearing seemingly arbitrary). I will move everything over time to the `sentinel-engine` crate.

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://docs.safefoundation.org/cla).
