### PR TITLE
[Sentinel Engine 1d]: JSON Serialization for Sentinel Engine API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4023,6 +4023,8 @@ version = "0.1.0"
 dependencies = [
  "alloy",
  "serde",
+ "serde_json",
+ "thiserror",
 ]
 
 [[package]]

--- a/crates/safe-tx/Cargo.toml
+++ b/crates/safe-tx/Cargo.toml
@@ -7,3 +7,7 @@ publish = false
 [dependencies]
 alloy.workspace = true
 serde.workspace = true
+thiserror.workspace = true
+
+[dev-dependencies]
+serde_json.workspace = true

--- a/crates/safe-tx/src/lib.rs
+++ b/crates/safe-tx/src/lib.rs
@@ -8,6 +8,7 @@ pub mod rule;
 pub mod target_effects;
 
 use alloy::primitives::{Address, Bytes, U256};
+use serde::{Deserialize, Deserializer, Serialize, Serializer, de};
 
 /// The Safe call type; mirrors `Enum.Operation` onchain.
 #[allow(nonstandard_style)]
@@ -19,16 +20,56 @@ pub enum Operation {
     DELEGATECALL = 1,
 }
 
+/// An operation byte that is not a Safe [`Operation`].
+#[derive(Debug, thiserror::Error)]
+#[error("{0} is not a valid Safe operation")]
+pub struct InvalidOperation(pub u8);
+
+impl TryFrom<u8> for Operation {
+    type Error = InvalidOperation;
+
+    fn try_from(byte: u8) -> Result<Self, Self::Error> {
+        match byte {
+            0 => Ok(Self::CALL),
+            1 => Ok(Self::DELEGATECALL),
+            byte => Err(InvalidOperation(byte)),
+        }
+    }
+}
+
+impl Serialize for Operation {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_u8(*self as _)
+    }
+}
+
+impl<'de> Deserialize<'de> for Operation {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        u8::deserialize(deserializer)?
+            .try_into()
+            .map_err(de::Error::custom)
+    }
+}
+
 /// A full Safe transaction as carried by the `(Oracle)TransactionProposed`
 /// events (the 12-field `SafeTransaction.T` tuple), and the input every
 /// check in this crate is written against.
 #[allow(nonstandard_style)]
-#[derive(Clone, Debug, Default, Eq, PartialEq)]
+#[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(deny_unknown_fields, rename_all = "camelCase")]
 pub struct SafeTransaction {
     /// The chain the transaction is to execute on.
     pub chainId: U256,
     /// The Safe executing the transaction.
+    #[serde(serialize_with = "checksummed_address::serialize")]
     pub safe: Address,
+    #[serde(serialize_with = "checksummed_address::serialize")]
     pub to: Address,
     pub value: U256,
     pub data: Bytes,
@@ -36,7 +77,103 @@ pub struct SafeTransaction {
     pub safeTxGas: U256,
     pub baseGas: U256,
     pub gasPrice: U256,
+    #[serde(serialize_with = "checksummed_address::serialize")]
     pub gasToken: Address,
+    #[serde(serialize_with = "checksummed_address::serialize")]
     pub refundReceiver: Address,
     pub nonce: U256,
+}
+
+/// Serde for an [`Address`], emitting the EIP-55 mixed-case checksum and
+/// accepting any case in order to be more lenient.
+mod checksummed_address {
+    use alloy::primitives::Address;
+    use serde::Serializer;
+
+    #[doc(hidden)]
+    pub fn serialize<S>(address: &Address, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        // `Address`'s `Display` is the EIP-55 checksummed form.
+        serializer.collect_str(address)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloy::primitives::{address, bytes};
+
+    #[test]
+    fn json_roundtrip() {
+        let transaction = SafeTransaction {
+            chainId: U256::from(1u64),
+            safe: address!("0x5aFE3855358E112B5647B952709E6165e1c1eEEe"),
+            to: address!("0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2"),
+            value: U256::from(0x1234u64),
+            data: bytes!("0xd0e30db0"),
+            operation: Operation::DELEGATECALL,
+            safeTxGas: U256::from(100_000u64),
+            baseGas: U256::from(21_000u64),
+            gasPrice: U256::from(1u64),
+            gasToken: address!("0x6B175474E89094C44Da98b954EedeAC495271d0F"),
+            refundReceiver: address!("0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045"),
+            nonce: U256::ZERO,
+        };
+        let json = serde_json::json!({
+            "chainId": "0x1",
+            "safe": "0x5aFE3855358E112B5647B952709E6165e1c1eEEe",
+            "to": "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2",
+            "value": "0x1234",
+            "data": "0xd0e30db0",
+            "operation": 1,
+            "safeTxGas": "0x186a0",
+            "baseGas": "0x5208",
+            "gasPrice": "0x1",
+            "gasToken": "0x6B175474E89094C44Da98b954EedeAC495271d0F",
+            "refundReceiver": "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045",
+            "nonce": "0x0",
+        });
+
+        assert_eq!(serde_json::to_value(&transaction).unwrap(), json);
+        assert_eq!(
+            serde_json::from_value::<SafeTransaction>(json).unwrap(),
+            transaction
+        );
+    }
+
+    fn default_json_with(field: &str, value: impl Into<serde_json::Value>) -> serde_json::Value {
+        let mut json = serde_json::to_value(SafeTransaction::default()).unwrap();
+        json[field] = value.into();
+        json
+    }
+
+    #[test]
+    fn accepts_an_address_in_any_case_and_re_emits_it_checksummed() {
+        for spelling in [
+            "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+            "0xC02AAA39B223FE8D0A0E5C4F27EAD9083C756CC2",
+            "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2",
+        ] {
+            let json = default_json_with("to", spelling);
+            let decoded = serde_json::from_value::<SafeTransaction>(json).unwrap();
+            assert_eq!(
+                decoded.to,
+                address!("0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2")
+            );
+        }
+    }
+
+    #[test]
+    fn rejects_an_unknown_member() {
+        let json = default_json_with("unknown", 42);
+        assert!(serde_json::from_value::<SafeTransaction>(json).is_err());
+    }
+
+    #[test]
+    fn rejects_an_operation_outside_the_two_safe_call_types() {
+        let json = default_json_with("operation", 42);
+        assert!(serde_json::from_value::<SafeTransaction>(json).is_err());
+    }
 }

--- a/crates/safe-tx/src/rule.rs
+++ b/crates/safe-tx/src/rule.rs
@@ -7,6 +7,9 @@
 //! implements the check giving it meaning, not declared upfront as an
 //! unused placeholder.
 
+use serde::{Deserialize, Deserializer, Serialize, Serializer, de};
+use std::borrow::Cow;
+
 /// A specific Safenet Arbitration Charter rule that a check denial maps to.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum RuleId {
@@ -73,6 +76,26 @@ pub enum RuleId {
     R4_4AuthorizationTarget,
 }
 
+impl Serialize for RuleId {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_str(self.code())
+    }
+}
+
+impl<'de> Deserialize<'de> for RuleId {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let code = Cow::<'de, str>::deserialize(deserializer)?;
+        Self::from_code(&code)
+            .ok_or_else(|| de::Error::custom(format_args!("unrecognized rule code `{code}`")))
+    }
+}
+
 impl RuleId {
     /// The rule's canonical Charter citation, e.g. `"R-4.1"`.
     pub const fn code(self) -> &'static str {
@@ -118,11 +141,20 @@ mod tests {
             RuleId::R4_4AuthorizationTarget,
         ] {
             assert_eq!(RuleId::from_code(rule.code()), Some(rule));
+            let json = serde_json::to_string(&rule).unwrap();
+            assert_eq!(json, format!("\"{}\"", rule.code()));
+            assert_eq!(serde_json::from_str::<RuleId>(&json).unwrap(), rule);
         }
     }
 
     #[test]
     fn from_code_rejects_unknown_codes() {
         assert_eq!(RuleId::from_code("R-4.99"), None);
+        let error = serde_json::from_str::<RuleId>(r#""R-4.99""#).unwrap_err();
+        assert!(
+            error
+                .to_string()
+                .contains("unrecognized rule code `R-4.99`")
+        );
     }
 }

--- a/crates/sentinel/src/bindings.rs
+++ b/crates/sentinel/src/bindings.rs
@@ -118,21 +118,16 @@ pub mod consensus {
     // the ABI/event definitions into a shared crate so both consumers
     // declare the `sol!` types (and this conversion) exactly once.
     impl TryFrom<SafeTransaction> for safe_tx::SafeTransaction {
-        type Error = Operation;
+        type Error = safe_tx::InvalidOperation;
 
         fn try_from(tx: SafeTransaction) -> Result<Self, Self::Error> {
-            let operation = match tx.operation {
-                Operation::CALL => safe_tx::Operation::CALL,
-                Operation::DELEGATECALL => safe_tx::Operation::DELEGATECALL,
-                Operation::__Invalid => return Err(Operation::__Invalid),
-            };
             Ok(safe_tx::SafeTransaction {
                 chainId: tx.chainId,
                 safe: tx.safe,
                 to: tx.to,
                 value: tx.value,
                 data: tx.data,
-                operation,
+                operation: (tx.operation as u8).try_into()?,
                 safeTxGas: tx.safeTxGas,
                 baseGas: tx.baseGas,
                 gasPrice: tx.gasPrice,

--- a/crates/validator/src/bindings.rs
+++ b/crates/validator/src/bindings.rs
@@ -265,21 +265,16 @@ sol! {
 }
 
 impl TryFrom<SafeTransaction> for safe_tx::SafeTransaction {
-    type Error = Operation;
+    type Error = safe_tx::InvalidOperation;
 
     fn try_from(tx: SafeTransaction) -> Result<Self, Self::Error> {
-        let operation = match tx.operation {
-            Operation::CALL => safe_tx::Operation::CALL,
-            Operation::DELEGATECALL => safe_tx::Operation::DELEGATECALL,
-            Operation::__Invalid => return Err(Operation::__Invalid),
-        };
         Ok(safe_tx::SafeTransaction {
             chainId: tx.chainId,
             safe: tx.safe,
             to: tx.to,
             value: tx.value,
             data: tx.data,
-            operation,
+            operation: (tx.operation as u8).try_into()?,
             safeTxGas: tx.safeTxGas,
             baseGas: tx.baseGas,
             gasPrice: tx.gasPrice,


### PR DESCRIPTION
Add the JSON serialization implementation for the Safe transaction type. This represents the Safe transaction type that the Sentinel Engine is expecting over the wire.

### Decisions and Tradeoffs

- For now, we strictly parse rules (i.e. we error when we receive an unknown rule). This is expected to change in the future where:
  - The `sentinel` will accept arbitrary rules for the purpose of putting them onchain
  - The `sentinel-engine` will only construct well-defined rules as they exist now as is done by the `enum`
- Operation is serialized as a number, this is to exactly match the JSON format for the Solidity ABI decoded type (where the `operation` enum is a `uint8`).

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://docs.safefoundation.org/cla).
