### PR TITLE
[Sentinel Engine 1e]: Rust Naming Convention

### DIFF
--- a/crates/safe-tx/src/checks.rs
+++ b/crates/safe-tx/src/checks.rs
@@ -59,7 +59,7 @@ pub fn check_transaction(tx: &SafeTransaction) -> Result<(), RuleId> {
 /// Article IV Part A settings-change guarantee. `None` if `tx` isn't a
 /// self-call at all — not this rule's concern.
 fn check_settings_change(tx: &SafeTransaction) -> Option<Result<(), RuleId>> {
-    if tx.operation != Operation::CALL {
+    if tx.operation != Operation::Call {
         return None;
     }
     Some(if check_calls(tx) {
@@ -73,7 +73,7 @@ fn check_settings_change(tx: &SafeTransaction) -> Option<Result<(), RuleId>> {
 /// a delegatecall at all — not this rule's concern. Allowed via either a
 /// known delegatecall target or a known MultiSend contract.
 fn check_delegatecall_integrity(tx: &SafeTransaction) -> Option<Result<(), RuleId>> {
-    if tx.operation != Operation::DELEGATECALL {
+    if tx.operation != Operation::DelegateCall {
         return None;
     }
     Some(if check_delegate_calls(tx) || check_multi_send(tx) {
@@ -86,7 +86,7 @@ fn check_delegatecall_integrity(tx: &SafeTransaction) -> Option<Result<(), RuleI
 /// Calls to other contracts are freely allowed; self-calls are restricted to a
 /// whitelist of Safe management functions.
 fn check_calls(tx: &SafeTransaction) -> bool {
-    if tx.operation != Operation::CALL {
+    if tx.operation != Operation::Call {
         return false;
     }
     if tx.safe != tx.to {
@@ -156,7 +156,7 @@ fn check_self_calls(tx: &SafeTransaction) -> bool {
 /// Delegate calls are restricted to known Safe migration and signing-library
 /// contracts, each with a fixed set of allowed function selectors.
 fn check_delegate_calls(tx: &SafeTransaction) -> bool {
-    if tx.operation != Operation::DELEGATECALL {
+    if tx.operation != Operation::DelegateCall {
         return false;
     }
 
@@ -243,17 +243,17 @@ mod tests {
         operation: Operation,
     ) -> SafeTransaction {
         SafeTransaction {
-            chainId: U256::ZERO,
+            chain_id: U256::ZERO,
             safe,
             to,
             value,
             data: data.into(),
             operation,
-            safeTxGas: U256::ZERO,
-            baseGas: U256::ZERO,
-            gasPrice: U256::ZERO,
-            gasToken: Address::ZERO,
-            refundReceiver: Address::ZERO,
+            safe_tx_gas: U256::ZERO,
+            base_gas: U256::ZERO,
+            gas_price: U256::ZERO,
+            gas_token: Address::ZERO,
+            refund_receiver: Address::ZERO,
             nonce: U256::ZERO,
         }
     }
@@ -296,7 +296,7 @@ mod tests {
                    0000000000000000000000002dc63c83040669f0adba5f832f713152ba862c97\
                    000000000000000000000000e7f8c378df23ebb06d5fc5a33bd471ef510f8cc9\
                    000000000000000000000000baf055b4ae60b897649f654df8def87bb4f86299"),
-                Operation::CALL,
+                Operation::Call,
             ))
             .is_ok()
         );
@@ -313,7 +313,7 @@ mod tests {
                   0000000000000000000000002dc63c83040669f0adba5f832f713152ba862c97\
                   000000000000000000000000e7f8c378df23ebb06d5fc5a33bd471ef510f8cc9\
                   000000000000000000000000baf055b4ae60b897649f654df8def87bb4f86299"),
-                Operation::CALL,
+                Operation::Call,
             ))
             .is_ok()
         );
@@ -365,7 +365,7 @@ mod tests {
                    4d31f5b1c71352252dcc93000000000000000000000000f01888f0677547ec07\
                    cd16c8680e699c96588e6b00000000000000000000000000000000ffffffffff\
                    ffffffffffffffffffffff000000000000000000000000000000000000000000"),
-                Operation::DELEGATECALL,
+                Operation::DelegateCall,
             ))
             .is_ok()
         );
@@ -379,7 +379,7 @@ mod tests {
                 address!("F01888f0677547Ec07cd16c8680e699c96588E6B"),
                 U256::ZERO,
                 Bytes::new(),
-                Operation::CALL,
+                Operation::Call,
             ))
             .is_ok()
         );
@@ -413,7 +413,7 @@ mod tests {
                    7467372f9a41665820a14f000000000000000000000000c0ffeee8baafa7ba6a\
                    6af2329892b88796cf44cf000000000000000000000000000000000000000000\
                    0000000000000000000002000000000000000000000000000000000000000000"),
-                Operation::DELEGATECALL,
+                Operation::DelegateCall,
             ))
             .is_ok()
         );
@@ -427,7 +427,7 @@ mod tests {
                 address!("526643F69b81B008F46d95CD5ced5eC0edFFDaC6"),
                 U256::ZERO,
                 hex("0xed007fc6"),
-                Operation::DELEGATECALL,
+                Operation::DelegateCall,
             ))
             .is_ok()
         );
@@ -441,7 +441,7 @@ mod tests {
                 address!("526643F69b81B008F46d95CD5ced5eC0edFFDaC6"),
                 U256::from(1u64),
                 hex("0xed007fc6"),
-                Operation::DELEGATECALL,
+                Operation::DelegateCall,
             ))
             .is_ok()
         );
@@ -455,7 +455,7 @@ mod tests {
                 address!("1db92e2EeBC8E0c075a02BeA49a2935BcD2dFCF4"),
                 U256::ZERO,
                 Bytes::new(),
-                Operation::DELEGATECALL,
+                Operation::DelegateCall,
             ))
             .is_err()
         );
@@ -471,7 +471,7 @@ mod tests {
                 hex("0xa9059cbb\
                    000000000000000000000000bdd077f651ebe7f7b3ce16fe5f2b025be2969516\
                    0000000000000000000000000000000000000000000000000000000000000000"),
-                Operation::DELEGATECALL,
+                Operation::DelegateCall,
             ))
             .is_err()
         );
@@ -491,7 +491,7 @@ mod tests {
                    0000000000000000000000000000000000000000000000000000000000000000\
                    00000000000000000000000000000000000000024610b5925000000000000000\
                    0000000005afe8f36504462aa6a7467372f9a41665820a14f00000000000000"),
-                Operation::DELEGATECALL,
+                Operation::DelegateCall,
             ))
             .is_err()
         );
@@ -514,13 +514,13 @@ mod tests {
 
         let data = multisend(&[
             pack(
-                Operation::DELEGATECALL,
+                Operation::DelegateCall,
                 address!("4FfeF8222648872B3dE295Ba1e49110E61f5b5aa"),
                 U256::ZERO,
                 &sign_msg_data,
             ),
             pack(
-                Operation::CALL,
+                Operation::Call,
                 address!("9C58BAcC331c9aa871AFD802DB6379a98e80CEdb"),
                 U256::ZERO,
                 &approve_data,
@@ -533,7 +533,7 @@ mod tests {
                 address!("218543288004CD07832472D464648173c77D7eB7"),
                 U256::ZERO,
                 data,
-                Operation::DELEGATECALL,
+                Operation::DelegateCall,
             ))
             .is_ok()
         );
@@ -556,13 +556,13 @@ mod tests {
 
         let data = multisend(&[
             pack(
-                Operation::DELEGATECALL,
+                Operation::DelegateCall,
                 address!("4FfeF8222648872B3dE295Ba1e49110E61f5b5aa"),
                 U256::ZERO,
                 &sign_msg_data,
             ),
             pack(
-                Operation::CALL,
+                Operation::Call,
                 address!("9C58BAcC331c9aa871AFD802DB6379a98e80CEdb"),
                 U256::ZERO,
                 &approve_data,
@@ -576,7 +576,7 @@ mod tests {
                 address!("A83c336B20401Af773B6219BA5027174338D1836"),
                 U256::ZERO,
                 data,
-                Operation::DELEGATECALL,
+                Operation::DelegateCall,
             ))
             .is_err()
         );
@@ -587,14 +587,14 @@ mod tests {
         let safe = address!("3850cd76006dc6CaCBCBB514995C47Ca8Ad0bb96");
         let recipient = address!("C92E8bdf79f0507f65a392b0ab4667716BFE0110");
 
-        let data = multisend(&[pack(Operation::CALL, recipient, U256::from(1u64), &[])]);
+        let data = multisend(&[pack(Operation::Call, recipient, U256::from(1u64), &[])]);
         assert!(
             check_transaction(&tx(
                 safe,
                 address!("40A2aCCbd92BCA938b02010E17A5b8929b49130D"),
                 U256::ZERO,
                 data,
-                Operation::DELEGATECALL,
+                Operation::DelegateCall,
             ))
             .is_ok()
         );
@@ -609,7 +609,7 @@ mod tests {
                 address!("40A2aCCbd92BCA938b02010E17A5b8929b49130D"),
                 U256::ZERO,
                 multisend(&[]),
-                Operation::DELEGATECALL,
+                Operation::DelegateCall,
             ))
             .is_ok()
         );
@@ -620,14 +620,14 @@ mod tests {
         let safe = address!("3850cd76006dc6CaCBCBB514995C47Ca8Ad0bb96");
         let recipient = address!("C92E8bdf79f0507f65a392b0ab4667716BFE0110");
 
-        let data = multisend(&[pack(Operation::CALL, recipient, U256::from(1u64), &[])]);
+        let data = multisend(&[pack(Operation::Call, recipient, U256::from(1u64), &[])]);
         assert!(
             check_transaction(&tx(
                 safe,
                 address!("40A2aCCbd92BCA938b02010E17A5b8929b49130D"),
                 U256::from(1u64),
                 data,
-                Operation::DELEGATECALL,
+                Operation::DelegateCall,
             ))
             .is_ok()
         );
@@ -660,7 +660,7 @@ mod tests {
                     multisend_addr,
                     U256::ZERO,
                     data.clone(),
-                    Operation::DELEGATECALL
+                    Operation::DelegateCall
                 ))
                 .is_err(),
                 "multisend at {multisend_addr} should deny delegatecall to disallowed target",
@@ -691,7 +691,7 @@ mod tests {
                     create_call_addr,
                     U256::ZERO,
                     data,
-                    Operation::DELEGATECALL
+                    Operation::DelegateCall
                 ))
                 .is_ok(),
                 "should allow performCreate delegatecall to {create_call_addr}",
@@ -711,7 +711,7 @@ mod tests {
                     create_call_addr,
                     U256::ZERO,
                     data,
-                    Operation::DELEGATECALL
+                    Operation::DelegateCall
                 ))
                 .is_ok(),
                 "should allow performCreate2 delegatecall to {create_call_addr}",

--- a/crates/safe-tx/src/lib.rs
+++ b/crates/safe-tx/src/lib.rs
@@ -11,13 +11,12 @@ use alloy::primitives::{Address, Bytes, U256};
 use serde::{Deserialize, Deserializer, Serialize, Serializer, de};
 
 /// The Safe call type; mirrors `Enum.Operation` onchain.
-#[allow(nonstandard_style)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 #[repr(u8)]
 pub enum Operation {
     #[default]
-    CALL = 0,
-    DELEGATECALL = 1,
+    Call = 0,
+    DelegateCall = 1,
 }
 
 /// An operation byte that is not a Safe [`Operation`].
@@ -30,8 +29,8 @@ impl TryFrom<u8> for Operation {
 
     fn try_from(byte: u8) -> Result<Self, Self::Error> {
         match byte {
-            0 => Ok(Self::CALL),
-            1 => Ok(Self::DELEGATECALL),
+            0 => Ok(Self::Call),
+            1 => Ok(Self::DelegateCall),
             byte => Err(InvalidOperation(byte)),
         }
     }
@@ -60,12 +59,11 @@ impl<'de> Deserialize<'de> for Operation {
 /// A full Safe transaction as carried by the `(Oracle)TransactionProposed`
 /// events (the 12-field `SafeTransaction.T` tuple), and the input every
 /// check in this crate is written against.
-#[allow(nonstandard_style)]
 #[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
 #[serde(deny_unknown_fields, rename_all = "camelCase")]
 pub struct SafeTransaction {
     /// The chain the transaction is to execute on.
-    pub chainId: U256,
+    pub chain_id: U256,
     /// The Safe executing the transaction.
     #[serde(serialize_with = "checksummed_address::serialize")]
     pub safe: Address,
@@ -74,13 +72,13 @@ pub struct SafeTransaction {
     pub value: U256,
     pub data: Bytes,
     pub operation: Operation,
-    pub safeTxGas: U256,
-    pub baseGas: U256,
-    pub gasPrice: U256,
+    pub safe_tx_gas: U256,
+    pub base_gas: U256,
+    pub gas_price: U256,
     #[serde(serialize_with = "checksummed_address::serialize")]
-    pub gasToken: Address,
+    pub gas_token: Address,
     #[serde(serialize_with = "checksummed_address::serialize")]
-    pub refundReceiver: Address,
+    pub refund_receiver: Address,
     pub nonce: U256,
 }
 
@@ -108,17 +106,17 @@ mod tests {
     #[test]
     fn json_roundtrip() {
         let transaction = SafeTransaction {
-            chainId: U256::from(1u64),
+            chain_id: U256::from(1u64),
             safe: address!("0x5aFE3855358E112B5647B952709E6165e1c1eEEe"),
             to: address!("0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2"),
             value: U256::from(0x1234u64),
             data: bytes!("0xd0e30db0"),
-            operation: Operation::DELEGATECALL,
-            safeTxGas: U256::from(100_000u64),
-            baseGas: U256::from(21_000u64),
-            gasPrice: U256::from(1u64),
-            gasToken: address!("0x6B175474E89094C44Da98b954EedeAC495271d0F"),
-            refundReceiver: address!("0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045"),
+            operation: Operation::DelegateCall,
+            safe_tx_gas: U256::from(100_000u64),
+            base_gas: U256::from(21_000u64),
+            gas_price: U256::from(1u64),
+            gas_token: address!("0x6B175474E89094C44Da98b954EedeAC495271d0F"),
+            refund_receiver: address!("0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045"),
             nonce: U256::ZERO,
         };
         let json = serde_json::json!({

--- a/crates/safe-tx/src/multi_send.rs
+++ b/crates/safe-tx/src/multi_send.rs
@@ -95,8 +95,8 @@ pub fn decode_multi_send(
     let mut cursor = Cursor(data);
     while let Some(operation) = cursor.next() {
         let operation = match operation {
-            0 => Operation::CALL,
-            1 => Operation::DELEGATECALL,
+            0 => Operation::Call,
+            1 => Operation::DelegateCall,
             _ => return None,
         };
 
@@ -111,17 +111,17 @@ pub fn decode_multi_send(
         };
 
         result.push(SafeTransaction {
-            chainId: U256::ZERO,
+            chain_id: U256::ZERO,
             safe,
             to,
             value,
             data,
             operation,
-            safeTxGas: U256::ZERO,
-            baseGas: U256::ZERO,
-            gasPrice: U256::ZERO,
-            gasToken: Address::ZERO,
-            refundReceiver: Address::ZERO,
+            safe_tx_gas: U256::ZERO,
+            base_gas: U256::ZERO,
+            gas_price: U256::ZERO,
+            gas_token: Address::ZERO,
+            refund_receiver: Address::ZERO,
             nonce: U256::ZERO,
         });
     }
@@ -137,7 +137,7 @@ pub fn decode_multi_send(
 /// `known_deployment`, decoding the outer `multiSend(bytes)` call, and
 /// `decode_multi_send`, the three steps every caller needs together.
 pub fn decode_multi_send_call(tx: &SafeTransaction) -> Option<(Vec<SafeTransaction>, bool)> {
-    if tx.operation != Operation::DELEGATECALL {
+    if tx.operation != Operation::DelegateCall {
         return None;
     }
     let (version, allows_delegate_calls) = known_deployment(tx.to)?;

--- a/crates/safe-tx/src/target_effects.rs
+++ b/crates/safe-tx/src/target_effects.rs
@@ -183,7 +183,7 @@ mod tests {
             RECIPIENT,
             U256::from(5u64),
             Bytes::new(),
-            Operation::CALL,
+            Operation::Call,
         ));
         assert_eq!(
             effects,
@@ -199,7 +199,7 @@ mod tests {
     #[test]
     fn no_effect_for_zero_value_empty_call() {
         assert_eq!(
-            decode_target_effects(&tx(RECIPIENT, U256::ZERO, Bytes::new(), Operation::CALL)),
+            decode_target_effects(&tx(RECIPIENT, U256::ZERO, Bytes::new(), Operation::Call)),
             vec![]
         );
     }
@@ -208,7 +208,7 @@ mod tests {
     fn no_effect_for_unrecognized_calldata() {
         let data = Bytes::from(vec![0xde, 0xad, 0xbe, 0xef, 0x01]);
         assert_eq!(
-            decode_target_effects(&tx(TOKEN, U256::ZERO, data, Operation::CALL)),
+            decode_target_effects(&tx(TOKEN, U256::ZERO, data, Operation::Call)),
             vec![]
         );
     }
@@ -216,7 +216,7 @@ mod tests {
     #[test]
     fn decodes_native_value_alongside_unrecognized_calldata() {
         let data = Bytes::from(vec![0xde, 0xad, 0xbe, 0xef, 0x01]);
-        let effects = decode_target_effects(&tx(TOKEN, U256::from(9u64), data, Operation::CALL));
+        let effects = decode_target_effects(&tx(TOKEN, U256::from(9u64), data, Operation::Call));
         assert_eq!(
             effects,
             vec![TargetEffect {
@@ -235,7 +235,7 @@ mod tests {
             amount: U256::from(3u64),
         }
         .abi_encode();
-        let effects = decode_target_effects(&tx(TOKEN, U256::from(9u64), data, Operation::CALL));
+        let effects = decode_target_effects(&tx(TOKEN, U256::from(9u64), data, Operation::Call));
         assert_eq!(
             effects,
             vec![
@@ -262,7 +262,7 @@ mod tests {
             amount: U256::from(1_000u64),
         }
         .abi_encode();
-        let effects = decode_target_effects(&tx(TOKEN, U256::ZERO, data, Operation::CALL));
+        let effects = decode_target_effects(&tx(TOKEN, U256::ZERO, data, Operation::Call));
         assert_eq!(
             effects,
             vec![TargetEffect {
@@ -282,7 +282,7 @@ mod tests {
             amount: U256::from(7u64),
         }
         .abi_encode();
-        let effects = decode_target_effects(&tx(TOKEN, U256::ZERO, data, Operation::CALL));
+        let effects = decode_target_effects(&tx(TOKEN, U256::ZERO, data, Operation::Call));
         assert_eq!(
             effects,
             vec![TargetEffect {
@@ -301,7 +301,7 @@ mod tests {
             amount: U256::MAX,
         }
         .abi_encode();
-        let effects = decode_target_effects(&tx(TOKEN, U256::ZERO, data, Operation::CALL));
+        let effects = decode_target_effects(&tx(TOKEN, U256::ZERO, data, Operation::Call));
         assert_eq!(
             effects,
             vec![TargetEffect {
@@ -318,7 +318,7 @@ mod tests {
             approved: true,
         }
         .abi_encode();
-        let effects = decode_target_effects(&tx(TOKEN, U256::ZERO, data, Operation::CALL));
+        let effects = decode_target_effects(&tx(TOKEN, U256::ZERO, data, Operation::Call));
         assert_eq!(
             effects,
             vec![TargetEffect {
@@ -337,7 +337,7 @@ mod tests {
             tokenId: U256::from(42u64),
         }
         .abi_encode();
-        let effects = decode_target_effects(&tx(TOKEN, U256::ZERO, data, Operation::CALL));
+        let effects = decode_target_effects(&tx(TOKEN, U256::ZERO, data, Operation::Call));
         assert_eq!(
             effects,
             vec![TargetEffect {
@@ -359,7 +359,7 @@ mod tests {
             data: Bytes::from(vec![0x01]),
         }
         .abi_encode();
-        let effects = decode_target_effects(&tx(TOKEN, U256::ZERO, data, Operation::CALL));
+        let effects = decode_target_effects(&tx(TOKEN, U256::ZERO, data, Operation::Call));
         assert_eq!(
             effects,
             vec![TargetEffect {
@@ -382,7 +382,7 @@ mod tests {
             data: Bytes::new(),
         }
         .abi_encode();
-        let effects = decode_target_effects(&tx(TOKEN, U256::ZERO, data, Operation::CALL));
+        let effects = decode_target_effects(&tx(TOKEN, U256::ZERO, data, Operation::Call));
         assert_eq!(
             effects,
             vec![TargetEffect {
@@ -408,7 +408,7 @@ mod tests {
             data: Bytes::new(),
         }
         .abi_encode();
-        let effects = decode_target_effects(&tx(TOKEN, U256::ZERO, data, Operation::CALL));
+        let effects = decode_target_effects(&tx(TOKEN, U256::ZERO, data, Operation::Call));
         assert_eq!(
             effects,
             vec![TargetEffect {
@@ -426,15 +426,15 @@ mod tests {
         }
         .abi_encode();
         let data = multisend(&[
-            pack(Operation::CALL, RECIPIENT, U256::from(2u64), &[]),
-            pack(Operation::CALL, TOKEN, U256::ZERO, &approve_data),
+            pack(Operation::Call, RECIPIENT, U256::from(2u64), &[]),
+            pack(Operation::Call, TOKEN, U256::ZERO, &approve_data),
         ]);
 
         let effects = decode_target_effects(&tx(
             address!("218543288004CD07832472D464648173c77D7eB7"),
             U256::ZERO,
             data,
-            Operation::DELEGATECALL,
+            Operation::DelegateCall,
         ));
 
         assert_eq!(

--- a/crates/sentinel/src/bindings.rs
+++ b/crates/sentinel/src/bindings.rs
@@ -122,17 +122,17 @@ pub mod consensus {
 
         fn try_from(tx: SafeTransaction) -> Result<Self, Self::Error> {
             Ok(safe_tx::SafeTransaction {
-                chainId: tx.chainId,
+                chain_id: tx.chainId,
                 safe: tx.safe,
                 to: tx.to,
                 value: tx.value,
                 data: tx.data,
                 operation: (tx.operation as u8).try_into()?,
-                safeTxGas: tx.safeTxGas,
-                baseGas: tx.baseGas,
-                gasPrice: tx.gasPrice,
-                gasToken: tx.gasToken,
-                refundReceiver: tx.refundReceiver,
+                safe_tx_gas: tx.safeTxGas,
+                base_gas: tx.baseGas,
+                gas_price: tx.gasPrice,
+                gas_token: tx.gasToken,
+                refund_receiver: tx.refundReceiver,
                 nonce: tx.nonce,
             })
         }
@@ -141,21 +141,21 @@ pub mod consensus {
     impl From<safe_tx::SafeTransaction> for SafeTransaction {
         fn from(tx: safe_tx::SafeTransaction) -> Self {
             let operation = match tx.operation {
-                safe_tx::Operation::CALL => Operation::CALL,
-                safe_tx::Operation::DELEGATECALL => Operation::DELEGATECALL,
+                safe_tx::Operation::Call => Operation::CALL,
+                safe_tx::Operation::DelegateCall => Operation::DELEGATECALL,
             };
             Self {
-                chainId: tx.chainId,
+                chainId: tx.chain_id,
                 safe: tx.safe,
                 to: tx.to,
                 value: tx.value,
                 data: tx.data,
                 operation,
-                safeTxGas: tx.safeTxGas,
-                baseGas: tx.baseGas,
-                gasPrice: tx.gasPrice,
-                gasToken: tx.gasToken,
-                refundReceiver: tx.refundReceiver,
+                safeTxGas: tx.safe_tx_gas,
+                baseGas: tx.base_gas,
+                gasPrice: tx.gas_price,
+                gasToken: tx.gas_token,
+                refundReceiver: tx.refund_receiver,
                 nonce: tx.nonce,
             }
         }

--- a/crates/validator/src/bindings.rs
+++ b/crates/validator/src/bindings.rs
@@ -269,17 +269,17 @@ impl TryFrom<SafeTransaction> for safe_tx::SafeTransaction {
 
     fn try_from(tx: SafeTransaction) -> Result<Self, Self::Error> {
         Ok(safe_tx::SafeTransaction {
-            chainId: tx.chainId,
+            chain_id: tx.chainId,
             safe: tx.safe,
             to: tx.to,
             value: tx.value,
             data: tx.data,
             operation: (tx.operation as u8).try_into()?,
-            safeTxGas: tx.safeTxGas,
-            baseGas: tx.baseGas,
-            gasPrice: tx.gasPrice,
-            gasToken: tx.gasToken,
-            refundReceiver: tx.refundReceiver,
+            safe_tx_gas: tx.safeTxGas,
+            base_gas: tx.baseGas,
+            gas_price: tx.gasPrice,
+            gas_token: tx.gasToken,
+            refund_receiver: tx.refundReceiver,
             nonce: tx.nonce,
         })
     }


### PR DESCRIPTION
Changes our new `SafeTransaction` and `Operation` types to use Rust-y naming conventions. This was kept as a separate PR to reduce review noise.

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://docs.safefoundation.org/cla).
