### PR TITLE
Generate Nonces in Background Thread Pool

### DIFF
--- a/crates/validator/src/service/effect.rs
+++ b/crates/validator/src/service/effect.rs
@@ -131,7 +131,7 @@ impl Handler {
             Effect::NonceTree {
                 group_id,
                 key_share,
-            } => self.sample_nonces(group_id, &key_share).await,
+            } => self.sample_nonces(group_id, key_share).await,
             Effect::LinkNonceTree {
                 group_id,
                 chunk,
@@ -197,7 +197,7 @@ impl Handler {
                 if available >= NONCE_TOPUP_THRESHOLD {
                     return Ok(Resume::Noop);
                 }
-                return self.sample_nonces(group_id, &key_share).await;
+                return self.sample_nonces(group_id, key_share).await;
             }
             Effect::PruneKeyGenSecrets { group_id } => {
                 self.secrets.prune_keygen_secrets(group_id).await?;
@@ -213,13 +213,14 @@ impl Handler {
     async fn sample_nonces(
         &self,
         group_id: B256,
-        key_share: &KeyShare,
+        key_share: Arc<KeyShare>,
     ) -> Result<Resume, InternalError> {
         let started = Instant::now();
-        let nonce_chunk = {
+        let nonce_chunk = tokio::task::spawn_blocking(move || {
             let mut rng = rand::thread_rng();
-            frost::preprocess::NonceChunk::generate(key_share, &mut rng)?
-        };
+            frost::preprocess::NonceChunk::generate(&key_share, &mut rng)
+        })
+        .await??;
         let result = self
             .secrets
             .register_nonces_chunk(group_id, self.account, nonce_chunk)


### PR DESCRIPTION
This PR makes a small change to the validator effect handler, and pushes the nonce chunk generation to a background thread to not prevent the Tokio executor from getting blocked.

See [`spawn_blocking` documentation](https://docs.rs/tokio/latest/tokio/task/fn.spawn_blocking.html) for more information.

### Testing

This **does not** fix the integration test issues, but it was a small mistake a I noticed when reviewing the code.

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://docs.safefoundation.org/cla).
