### PR TITLE
[Phase 5] Remove non oracle proposal related Rust code

### DIFF
--- a/crates/validator/src/bindings.rs
+++ b/crates/validator/src/bindings.rs
@@ -122,21 +122,6 @@ sol! {
             bytes32 signatureId,
             Signature attestation
         );
-        event TransactionProposed(
-            bytes32 indexed safeTxHash,
-            uint256 indexed chainId,
-            address indexed safe,
-            uint64 epoch,
-            SafeTransaction transaction
-        );
-        event TransactionAttested(
-            bytes32 indexed safeTxHash,
-            uint256 indexed chainId,
-            address indexed safe,
-            uint64 epoch,
-            bytes32 signatureId,
-            Signature attestation
-        );
         event OracleTransactionProposed(
             bytes32 indexed safeTxHash,
             uint256 indexed chainId,
@@ -161,13 +146,6 @@ sol! {
             uint64 proposedEpoch,
             uint64 rolloverBlock,
             bytes32 groupId,
-            bytes32 signatureId
-        ) external;
-        function attestTransaction(
-            uint64 epoch,
-            uint256 chainId,
-            address safe,
-            bytes32 safeTxStructHash,
             bytes32 signatureId
         ) external;
         function attestOracleTransaction(

--- a/crates/validator/src/consensus/hashing.rs
+++ b/crates/validator/src/consensus/hashing.rs
@@ -33,13 +33,6 @@ sol! {
         uint256 nonce;
     }
 
-    /// The consensus-domain packet proposing a Safe transaction for
-    /// attestation.
-    struct TransactionProposal {
-        uint64 epoch;
-        bytes32 safeTxHash;
-    }
-
     /// The consensus-domain packet proposing an oracle-backed Safe
     /// transaction for attestation.
     struct OracleTransactionProposal {
@@ -106,22 +99,6 @@ impl ConsensusDomain {
             Some(consensus),
             None,
         ))
-    }
-
-    /// The consensus-domain hash of a Safe transaction proposal, embedding the
-    /// already-computed [`safe_tx_hash`] as its `safeTxHash` field.
-    pub fn transaction_proposal_hash(&self, epoch: EpochId, safe_tx_hash: B256) -> B256 {
-        TransactionProposal {
-            epoch: epoch.raw_value(),
-            safeTxHash: safe_tx_hash,
-        }
-        .eip712_signing_hash(&self.0)
-    }
-
-    /// The consensus-domain hash of a Safe transaction packet: shorthand for
-    /// [`transaction_proposal_hash`] with [`safe_tx_hash`] computed from `tx`.
-    pub fn transaction_packet_hash(&self, epoch: EpochId, tx: &SafeTransaction) -> B256 {
-        self.transaction_proposal_hash(epoch, safe_tx_hash(tx))
     }
 
     /// The consensus-domain hash of an oracle-backed Safe transaction proposal,
@@ -203,14 +180,6 @@ mod tests {
         assert_eq!(
             safe_tx_hash(&safe_tx()),
             b256!("fe8b85e8d090b16fe8f142d3c9292dc1fc77daf9eb4af8f7cf4a7707d95f4028")
-        );
-    }
-
-    #[test]
-    fn reference_transaction_packet_hash() {
-        assert_eq!(
-            TEST_DOMAIN.transaction_packet_hash(EPOCH_ONE, &safe_tx()),
-            b256!("3ff98ecae85843603560e9509346df2f35c0ad1dd1ceda5dcbb145745dfc4e00")
         );
     }
 

--- a/crates/validator/src/service/action.rs
+++ b/crates/validator/src/service/action.rs
@@ -85,17 +85,6 @@ pub enum Action {
         message: B256,
         expires_at: u64,
     },
-    /// A fallback action to submit a completed transaction attestation
-    /// directly, when the automatic `signShareWithCallback` submission did
-    /// not land in time.
-    AttestTransaction {
-        epoch: EpochId,
-        chain_id: U256,
-        safe: Address,
-        safe_tx_struct_hash: B256,
-        signature_id: B256,
-        expires_at: u64,
-    },
     /// A fallback action to submit a completed oracle-backed transaction
     /// attestation directly, when the automatic `signShareWithCallback`
     /// submission did not land in time.
@@ -339,30 +328,6 @@ impl ActionEncoder<Action> for Encoder {
                     .abi_encode()
                     .into(),
                     gas: 150_000,
-                },
-                Some(expires_at),
-            ),
-            Action::AttestTransaction {
-                epoch,
-                chain_id,
-                safe,
-                safe_tx_struct_hash,
-                signature_id,
-                expires_at,
-            } => (
-                Transaction {
-                    to: self.consensus,
-                    value: U256::ZERO,
-                    data: Consensus::attestTransactionCall {
-                        epoch: epoch.raw_value(),
-                        chainId: chain_id,
-                        safe,
-                        safeTxStructHash: safe_tx_struct_hash,
-                        signatureId: signature_id,
-                    }
-                    .abi_encode()
-                    .into(),
-                    gas: 250_000,
                 },
                 Some(expires_at),
             ),

--- a/crates/validator/src/state/mod.rs
+++ b/crates/validator/src/state/mod.rs
@@ -230,13 +230,6 @@ enum Packet {
         /// The newly generated group's public key.
         group_key: Point,
     },
-    /// A proposed Safe transaction.
-    Transaction {
-        /// The epoch whose group signs the attestation.
-        epoch: EpochId,
-        /// The proposed transaction.
-        transaction: SafeTransaction,
-    },
     /// A proposed oracle-backed Safe transaction.
     OracleTransaction {
         /// The epoch whose group signs the attestation.
@@ -244,7 +237,7 @@ enum Packet {
         /// The oracle vouching for the transaction.
         oracle: Address,
         /// The proposed transaction.
-        transaction: SafeTransaction,
+        transaction: Box<SafeTransaction>,
     },
 }
 
@@ -430,12 +423,6 @@ impl StateTransition<State> for Transition {
                 }
                 Event::Consensus(Consensus::ConsensusEvents::EpochStaged(event)) => {
                     self.handle_epoch_staged(state, &event)
-                }
-                Event::Consensus(Consensus::ConsensusEvents::TransactionProposed(event)) => {
-                    self.handle_transaction_proposed(state, log.block, &event)
-                }
-                Event::Consensus(Consensus::ConsensusEvents::TransactionAttested(event)) => {
-                    self.handle_transaction_attested(state, &event)
                 }
                 Event::Consensus(Consensus::ConsensusEvents::OracleTransactionProposed(event)) => {
                     self.handle_oracle_transaction_proposed(state, log.block, &event)

--- a/crates/validator/src/state/sign.rs
+++ b/crates/validator/src/state/sign.rs
@@ -91,7 +91,7 @@ impl Transition {
                         .signature_id_to_message
                         .insert(event.sid, event.message);
                 }
-                Packet::Transaction { .. } | Packet::EpochRollover { .. } => {
+                Packet::EpochRollover { .. } => {
                     let deadline = block.saturating_add(self.config.signing_timeout.get());
                     tracing::info!(
                         message = %event.message,
@@ -366,9 +366,9 @@ impl Transition {
 
     /// Publishes this validator's signature share once the
     /// [`Effect::UseNonce`] effect has produced it, attaching the packet's
-    /// completion callback (`stageEpoch`/`attestTransaction`/
-    /// `attestOracleTransaction`) so the group's completed signature carries
-    /// out its onchain effect automatically.
+    /// completion callback (`stageEpoch`/`attestOracleTransaction`) so the
+    /// group's completed signature carries out its onchain effect
+    /// automatically.
     pub(super) fn handle_nonces(
         &self,
         state: State,
@@ -489,7 +489,7 @@ impl Transition {
 
     /// Handles a signature attestation, which can mean different things for
     /// different packets. Called by the individual attestations handlers
-    /// (`EpochStaged`, `TransactionAttested`, `OracleTransactionAttested`).
+    /// (`EpochStaged`, `OracleTransactionAttested`).
     pub(super) fn handle_sign_attested(
         &self,
         mut state: State,
@@ -798,23 +798,22 @@ impl Packet {
     pub(super) fn epoch(&self) -> EpochId {
         match self {
             Packet::EpochRollover { active_epoch, .. } => *active_epoch,
-            Packet::Transaction { epoch, .. } | Packet::OracleTransaction { epoch, .. } => *epoch,
+            Packet::OracleTransaction { epoch, .. } => *epoch,
         }
     }
 
     /// Builds the callback invoked once this packet's group signature
-    /// completes: `attestTransaction`/`attestOracleTransaction` calldata
-    /// targeting the `Consensus` contract. The signature id argument is left
-    /// as a zero placeholder - the `Consensus` contract fills it in itself
-    /// when it invokes the callback from a completed `signShareWithCallback`.
+    /// completes: `stageEpoch`/`attestOracleTransaction` calldata targeting
+    /// the `Consensus` contract. The signature id argument is left as a zero
+    /// placeholder - the `Consensus` contract fills it in itself when it
+    /// invokes the callback from a completed `signShareWithCallback`.
     fn attestation_callback(&self, consensus: Address) -> bindings::Callback {
         let (epoch, oracle, transaction) = match self {
-            Packet::Transaction { epoch, transaction } => (*epoch, None, transaction),
             Packet::OracleTransaction {
                 epoch,
                 oracle,
                 transaction,
-            } => (*epoch, Some(*oracle), transaction),
+            } => (*epoch, *oracle, transaction),
             Packet::EpochRollover {
                 proposed_epoch,
                 rollover_block,
@@ -836,25 +835,15 @@ impl Packet {
         };
 
         let safe_tx_struct_hash = hashing::safe_tx_struct_hash(transaction);
-        let context = match oracle {
-            None => Consensus::attestTransactionCall {
-                epoch: epoch.raw_value(),
-                chainId: transaction.chainId,
-                safe: transaction.safe,
-                safeTxStructHash: safe_tx_struct_hash,
-                signatureId: B256::ZERO,
-            }
-            .abi_encode(),
-            Some(oracle) => Consensus::attestOracleTransactionCall {
-                epoch: epoch.raw_value(),
-                oracle,
-                chainId: transaction.chainId,
-                safe: transaction.safe,
-                safeTxStructHash: safe_tx_struct_hash,
-                signatureId: B256::ZERO,
-            }
-            .abi_encode(),
-        };
+        let context = Consensus::attestOracleTransactionCall {
+            epoch: epoch.raw_value(),
+            oracle,
+            chainId: transaction.chainId,
+            safe: transaction.safe,
+            safeTxStructHash: safe_tx_struct_hash,
+            signatureId: B256::ZERO,
+        }
+        .abi_encode();
         bindings::Callback {
             target: consensus,
             context: context.into(),
@@ -875,14 +864,6 @@ impl Packet {
                 proposed_epoch: *proposed_epoch,
                 rollover_block: *rollover_block,
                 group_id: *group_id,
-                signature_id,
-                expires_at,
-            },
-            Packet::Transaction { epoch, transaction } => Action::AttestTransaction {
-                epoch: *epoch,
-                chain_id: transaction.chainId,
-                safe: transaction.safe,
-                safe_tx_struct_hash: hashing::safe_tx_struct_hash(transaction),
                 signature_id,
                 expires_at,
             },

--- a/crates/validator/src/state/transactions.rs
+++ b/crates/validator/src/state/transactions.rs
@@ -1,115 +1,18 @@
 use std::collections::btree_map;
 
 use super::{Packet, SigningState, State, Transition};
-use crate::{
-    bindings::{Consensus, SafeTransaction},
-    consensus::epoch::EpochId,
-};
+use crate::{bindings::Consensus, consensus::epoch::EpochId};
 use safenet_core::state::Commands;
 
 impl Transition {
-    /// Verifies a proposed Safe transaction against the epoch's resolved
-    /// group, opening a signing session for it: [`SigningState::WaitingForRequest`]
-    /// if it passes Safenet policy, [`SigningState::WaitingToDecline`]
-    /// otherwise. A transaction proposed for an unknown or unresolved epoch,
-    /// or one whose group this validator is not part of, is ignored.
-    pub(super) fn handle_transaction_proposed(
-        &self,
-        mut state: State,
-        block: u64,
-        event: &Consensus::TransactionProposed,
-    ) -> (State, Commands<State, Self>) {
-        let epoch = EpochId::from_raw(event.epoch);
-        let Some(participating_epoch) = state.epochs.get(&epoch) else {
-            tracing::debug!(
-                ?epoch,
-                safe_tx_hash = %event.safeTxHash,
-                "ignoring transaction proposal for non-participating epoch"
-            );
-            return (state, Vec::new());
-        };
-
-        let message = self
-            .consensus
-            .transaction_packet_hash(epoch, &event.transaction);
-
-        // Prevent duplicate ongoing transaction proposals. This is to prevent
-        // malicious parties from blocking transaction attestations from ever
-        // being produced by resetting the signing state of honest validators.
-        if let btree_map::Entry::Vacant(signing) = state.signing.entry(message) {
-            let passed_checks = check_transaction(&event.transaction);
-            let packet = Packet::Transaction {
-                epoch,
-                transaction: event.transaction.clone(),
-            };
-
-            let signers = participating_epoch.group.participants().clone();
-            let deadline = block.saturating_add(self.config.signing_timeout.get());
-
-            let group_id = participating_epoch.group.id();
-            let signing_state = if passed_checks {
-                SigningState::WaitingForRequest {
-                    key_share: participating_epoch.key_share.clone(),
-                    group_id,
-                    responsible: None,
-                    packet,
-                    signers,
-                    deadline,
-                }
-            } else {
-                tracing::info!(
-                    ?epoch,
-                    %message,
-                    safe_tx_hash = %event.safeTxHash,
-                    "transaction proposal failed local checks; will decline signing request"
-                );
-                SigningState::WaitingToDecline { packet, deadline }
-            };
-
-            signing.insert(signing_state);
-        } else {
-            tracing::warn!(
-                %message,
-                "ignoring duplicate transaction proposal"
-            )
-        }
-
-        (state, Vec::new())
-    }
-
-    /// Clears a completed signing session once its attestation lands
-    /// onchain, keyed by the same proposal hash used to open it:
-    /// [`SigningState::WaitingForRequest`] verifies the full transaction,
-    /// while the attestation only carries its
-    /// [`safe_tx_hash`](crate::consensus::hashing::safe_tx_hash), so the
-    /// proposal is re-hashed directly from the event rather than the packet.
-    pub(super) fn handle_transaction_attested(
-        &self,
-        state: State,
-        event: &Consensus::TransactionAttested,
-    ) -> (State, Commands<State, Self>) {
-        let epoch = EpochId::from_raw(event.epoch);
-        let message = self
-            .consensus
-            .transaction_proposal_hash(epoch, event.safeTxHash);
-        tracing::info!(
-            ?epoch,
-            safe_tx_hash = %event.safeTxHash,
-            signature_id = %event.signatureId,
-            "transaction attested"
-        );
-        self.handle_sign_attested(state, event.signatureId, message)
-    }
-
     /// Verifies a proposed oracle-backed Safe transaction against the
     /// epoch's resolved group, opening a [`SigningState::WaitingForRequest`]
-    /// signing session for it. Unlike a plain [`Consensus::TransactionProposed`],
-    /// the transaction itself is not checked against Safenet policy here -
-    /// the oracle vouches for it, and its result is checked once attested -
-    /// only the oracle's own identity is verified against the configured
-    /// allow-list. A transaction proposed for an unknown or unresolved epoch,
-    /// one whose group this validator is not part of, or from a disallowed
-    /// oracle, is ignored.
+    /// signing session for it. The transaction itself is not checked against
+    /// Safenet policy here - the oracle vouches for it, and its result is
+    /// checked once attested - only the oracle's own identity is verified
+    /// against the configured allow-list. A transaction proposed for an
+    /// unknown or unresolved epoch, one whose group this validator is not
+    /// part of, or from a disallowed oracle, is ignored.
     pub(super) fn handle_oracle_transaction_proposed(
         &self,
         mut state: State,
@@ -147,7 +50,7 @@ impl Transition {
             let packet = Packet::OracleTransaction {
                 epoch,
                 oracle: event.oracle,
-                transaction: event.transaction.clone(),
+                transaction: Box::new(event.transaction.clone()),
             };
             let signers = participating_epoch.group.participants().clone();
             let deadline = block.saturating_add(self.config.signing_timeout.get());
@@ -188,18 +91,4 @@ impl Transition {
         );
         self.handle_sign_attested(state, event.signatureId, message)
     }
-}
-
-fn check_transaction(transaction: &SafeTransaction) -> bool {
-    // `sol!` requires custom types used as event/struct fields to be declared
-    // in the same macro invocation, so this ABI-decoding copy can't be replaced
-    // with the plain [`safe_tx::SafeTransaction`] in our bindings. Convert at
-    // the policy boundary, rejecting the generated enum's `__Invalid` escape
-    // hatch just like any other transaction that fails local checks.
-    let Ok(transaction) = transaction.clone().try_into() else {
-        tracing::error!(?transaction, "invalid Safe transaction value");
-        return false;
-    };
-
-    safe_tx::checks::check_transaction(&transaction).is_ok()
 }


### PR DESCRIPTION
To reduce the amount of unused Rust code the code paths not related to oracle proposals are removed.

This PR will not adjust the naming of the oracle related functions to keep the diff clean.

### Testing

- Integration test should pass

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://docs.safefoundation.org/cla).
