### PR TITLE
[Phase 7a] Remove Oracle prefix from contract code naming

### DIFF
--- a/contracts/package.json
+++ b/contracts/package.json
@@ -10,7 +10,7 @@
 		"cmd:deploy:testing-erc20": "forge script DeployERC20Script",
 		"cmd:deploy:sentinel-oracle": "forge script DeploySentinelOracleScript",
 		"cmd:deploy:test-consensus": "forge script DeployTestConsensusScript",
-		"cmd:propose:oracle": "forge script ProposeOracleTransactionScript",
+		"cmd:propose": "forge script ProposeTransactionScript",
 		"cmd:deploy:staking": "forge script DeployStakingScript",
 		"cmd:proposeValidators": "forge script ProposeValidatorsScript",
 		"cmd:acceptValidators": "forge script AcceptValidatorsScript",

--- a/contracts/script/DeployTestConsensus.s.sol
+++ b/contracts/script/DeployTestConsensus.s.sol
@@ -11,7 +11,7 @@ contract DeployTestConsensusScript is Script {
         vm.startBroadcast();
 
         // The real `Consensus`, backed by a coordinator that no-ops `sign()`.
-        // Sentinels only need `OracleTransactionProposed` and the resulting
+        // Sentinels only need `TransactionProposed` and the resulting
         // `postRequest` call; they never verify a FROST signature, so the
         // genesis group id is an arbitrary placeholder — `MockCoordinator`
         // never checks it against real group state.

--- a/contracts/script/ProposeTransaction.s.sol
+++ b/contracts/script/ProposeTransaction.s.sol
@@ -5,7 +5,7 @@ import {Script, console} from "@forge-std/Script.sol";
 import {Consensus} from "@/Consensus.sol";
 import {SafeTransaction} from "@/libraries/SafeTransaction.sol";
 
-contract ProposeOracleTransactionScript is Script {
+contract ProposeTransactionScript is Script {
     function run() public returns (bytes32 safeTxHash) {
         SafeTransaction.T memory transaction;
 
@@ -30,7 +30,7 @@ contract ProposeOracleTransactionScript is Script {
 
         vm.startBroadcast();
 
-        safeTxHash = Consensus(consensusAddress).proposeOracleTransaction(oracle, oracleData, transaction);
+        safeTxHash = Consensus(consensusAddress).proposeTransaction(oracle, oracleData, transaction);
 
         vm.stopBroadcast();
 

--- a/contracts/src/Consensus.sol
+++ b/contracts/src/Consensus.sol
@@ -249,17 +249,15 @@ contract Consensus is IConsensus, IERC165, IFROSTCoordinatorCallback {
     /**
      * @inheritdoc IConsensus
      */
-    function proposeOracleTransaction(address oracle, bytes calldata oracleData, SafeTransaction.T memory transaction)
+    function proposeTransaction(address oracle, bytes calldata oracleData, SafeTransaction.T memory transaction)
         public
         returns (bytes32 safeTxHash)
     {
         Epochs memory epochs = _processRollover();
         safeTxHash = transaction.hash();
-        bytes32 message = domainSeparator().oracleTransactionProposal(epochs.active, oracle, safeTxHash);
+        bytes32 message = domainSeparator().transactionProposal(epochs.active, oracle, safeTxHash);
         require($attestations[message].isZero(), AlreadyAttested());
-        emit OracleTransactionProposed(
-            safeTxHash, transaction.chainId, transaction.safe, epochs.active, oracle, transaction
-        );
+        emit TransactionProposed(safeTxHash, transaction.chainId, transaction.safe, epochs.active, oracle, transaction);
         _COORDINATOR.sign($groups[epochs.active], message);
         IOracle(oracle).postRequest(message, msg.sender, oracleData);
     }
@@ -267,7 +265,7 @@ contract Consensus is IConsensus, IERC165, IFROSTCoordinatorCallback {
     /**
      * @inheritdoc IConsensus
      */
-    function attestOracleTransaction(
+    function attestTransaction(
         uint64 epoch,
         address oracle,
         uint256 chainId,
@@ -276,22 +274,22 @@ contract Consensus is IConsensus, IERC165, IFROSTCoordinatorCallback {
         FROSTSignatureId.T signatureId
     ) public {
         bytes32 safeTxHash = SafeTransaction.partialHash(chainId, safe, safeTxStructHash);
-        bytes32 message = domainSeparator().oracleTransactionProposal(epoch, oracle, safeTxHash);
+        bytes32 message = domainSeparator().transactionProposal(epoch, oracle, safeTxHash);
         require($attestations[message].isZero(), AlreadyAttested());
         FROST.Signature memory attestation = _COORDINATOR.signatureVerify(signatureId, $groups[epoch], message);
         $attestations[message] = signatureId;
-        emit OracleTransactionAttested(safeTxHash, chainId, safe, epoch, oracle, signatureId, attestation);
+        emit TransactionAttested(safeTxHash, chainId, safe, epoch, oracle, signatureId, attestation);
     }
 
     /**
      * @inheritdoc IConsensus
      */
-    function getOracleTransactionAttestationByHash(uint64 epoch, address oracle, bytes32 safeTxHash)
+    function getTransactionAttestationByHash(uint64 epoch, address oracle, bytes32 safeTxHash)
         public
         view
         returns (FROST.Signature memory signature)
     {
-        bytes32 message = domainSeparator().oracleTransactionProposal(epoch, oracle, safeTxHash);
+        bytes32 message = domainSeparator().transactionProposal(epoch, oracle, safeTxHash);
         return _COORDINATOR.signatureValue($attestations[message]);
     }
 
@@ -329,10 +327,10 @@ contract Consensus is IConsensus, IERC165, IFROSTCoordinatorCallback {
             (uint64 proposedEpoch, uint64 rolloverBlock, FROSTGroupId.T groupId) =
                 abi.decode(context[4:], (uint64, uint64, FROSTGroupId.T));
             stageEpoch(proposedEpoch, rolloverBlock, groupId, signatureId);
-        } else if (selector == this.attestOracleTransaction.selector) {
+        } else if (selector == this.attestTransaction.selector) {
             (uint64 epoch, address oracle, uint256 chainId, address safe, bytes32 safeTxStructHash) =
                 abi.decode(context[4:], (uint64, address, uint256, address, bytes32));
-            attestOracleTransaction(epoch, oracle, chainId, safe, safeTxStructHash, signatureId);
+            attestTransaction(epoch, oracle, chainId, safe, safeTxStructHash, signatureId);
         } else {
             revert UnknownSignatureSelector();
         }

--- a/contracts/src/guard/SafenetGuard.sol
+++ b/contracts/src/guard/SafenetGuard.sol
@@ -225,7 +225,7 @@ contract SafenetGuard is ISafenetGuard, BaseTransactionGuard {
             // oracle is acceptable is a Validator-side policy (they only attest on results from an oracle
             // they honour), not enforced here.
             bytes32 message =
-                ConsensusMessages.oracleTransactionProposal(_CONSENSUS_DOMAIN_SEPARATOR, epoch, oracle, safeTxHash);
+                ConsensusMessages.transactionProposal(_CONSENSUS_DOMAIN_SEPARATOR, epoch, oracle, safeTxHash);
             FROST.verify(groupKey, signature, message);
             return;
         }

--- a/contracts/src/interfaces/IConsensus.sol
+++ b/contracts/src/interfaces/IConsensus.sol
@@ -73,7 +73,7 @@ interface IConsensus {
      * @param oracle The address of the oracle contract used for evaluation.
      * @param transaction The proposed Safe transaction.
      */
-    event OracleTransactionProposed(
+    event TransactionProposed(
         bytes32 indexed safeTxHash,
         uint256 indexed chainId,
         address indexed safe,
@@ -92,7 +92,7 @@ interface IConsensus {
      * @param signatureId The FROST signature identifier corresponding to the attestation.
      * @param attestation The attestation to the oracle-checked Safe transaction.
      */
-    event OracleTransactionAttested(
+    event TransactionAttested(
         bytes32 indexed safeTxHash,
         uint256 indexed chainId,
         address indexed safe,
@@ -180,7 +180,7 @@ interface IConsensus {
      * @param transaction The Safe transaction to propose.
      * @return safeTxHash The Safe transaction hash.
      */
-    function proposeOracleTransaction(address oracle, bytes calldata oracleData, SafeTransaction.T memory transaction)
+    function proposeTransaction(address oracle, bytes calldata oracleData, SafeTransaction.T memory transaction)
         external
         returns (bytes32 safeTxHash);
 
@@ -194,7 +194,7 @@ interface IConsensus {
      * @param signatureId The FROST signature identifier attesting to the transaction.
      * @dev Called internally via the onSignCompleted callback. No explicit time limit is imposed.
      */
-    function attestOracleTransaction(
+    function attestTransaction(
         uint64 epoch,
         address oracle,
         uint256 chainId,
@@ -204,13 +204,13 @@ interface IConsensus {
     ) external;
 
     /**
-     * @notice Gets an oracle transaction attestation by transaction hash.
+     * @notice Gets a transaction attestation by transaction hash.
      * @param epoch The epoch in which the transaction was proposed.
      * @param oracle The address of the oracle contract used for evaluation.
      * @param safeTxHash The Safe transaction hash to query the attestation for.
      * @return signature The FROST signature attesting to the oracle-checked transaction.
      */
-    function getOracleTransactionAttestationByHash(uint64 epoch, address oracle, bytes32 safeTxHash)
+    function getTransactionAttestationByHash(uint64 epoch, address oracle, bytes32 safeTxHash)
         external
         view
         returns (FROST.Signature memory signature);

--- a/contracts/src/interfaces/IOracle.sol
+++ b/contracts/src/interfaces/IOracle.sol
@@ -30,7 +30,7 @@ interface IOracle {
      * @param oracleData Arbitrary oracle-specific data passed by the proposer; not part of the
      *                   signed message hash. The oracle may decode this however it sees fit.
      * @dev Transaction data is not passed here; the oracle is expected to fetch it independently
-     *      from the OracleTransactionProposed event. The oracle pulls the fee directly from
+     *      from the TransactionProposed event. The oracle pulls the fee directly from
      *      proposer and refunds to proposer on resolution when applicable.
      */
     function postRequest(bytes32 requestId, address proposer, bytes calldata oracleData) external;

--- a/contracts/src/libraries/ConsensusMessages.sol
+++ b/contracts/src/libraries/ConsensusMessages.sol
@@ -24,10 +24,10 @@ library ConsensusMessages {
         hex"13de01993286119c9a7628720a5b7d7c32841dbf2d23752b59de86a7e03fe1bf";
 
     /**
-     * @custom:precomputed keccak256("OracleTransactionProposal(uint64 epoch,address oracle,bytes32 safeTxHash)")
+     * @custom:precomputed keccak256("TransactionProposal(uint64 epoch,address oracle,bytes32 safeTxHash)")
      */
-    bytes32 internal constant ORACLE_TRANSACTION_PROPOSAL_TYPEHASH =
-        hex"30673a82bcf1a0fa66d1c97cbe53999fc6c0b3e987742353c9aaecb3890205e9";
+    bytes32 internal constant TRANSACTION_PROPOSAL_TYPEHASH =
+        hex"d169b83f5cc55f1f8ad78e16e0feae4c314849f017eabb46c45c1ee5750be8c6";
 
     // ============================================================
     // INTERNAL FUNCTIONS
@@ -80,21 +80,21 @@ library ConsensusMessages {
     }
 
     /**
-     * @notice Computes the oracle transaction proposal message that must be attested to by validators.
+     * @notice Computes the transaction proposal message that must be attested to by validators.
      * @param domainSeparator The EIP-712 domain separator.
-     * @param epoch The epoch for the oracle transaction proposal.
+     * @param epoch The epoch for the transaction proposal.
      * @param oracle The address of the oracle contract used for evaluation.
      * @param safeTxHash The hash of the Safe transaction.
-     * @return result The oracle transaction proposal message hash, used as the oracle requestId.
+     * @return result The transaction proposal message hash, used as the oracle requestId.
      */
-    function oracleTransactionProposal(bytes32 domainSeparator, uint64 epoch, address oracle, bytes32 safeTxHash)
+    function transactionProposal(bytes32 domainSeparator, uint64 epoch, address oracle, bytes32 safeTxHash)
         internal
         pure
         returns (bytes32 result)
     {
         assembly ("memory-safe") {
             let ptr := mload(0x40)
-            mstore(ptr, ORACLE_TRANSACTION_PROPOSAL_TYPEHASH)
+            mstore(ptr, TRANSACTION_PROPOSAL_TYPEHASH)
             mstore(add(ptr, 0x20), epoch)
             mstore(add(ptr, 0x40), oracle)
             mstore(add(ptr, 0x60), safeTxHash)

--- a/contracts/test/Consensus.t.sol
+++ b/contracts/test/Consensus.t.sol
@@ -108,7 +108,7 @@ contract ConsensusTest is Test {
     }
 
     // ============================================================
-    // ORACLE TRANSACTION TESTS
+    // TRANSACTION TESTS
     // ============================================================
 
     // keccak256("SafeTx(address to,uint256 value,bytes data,uint8 operation,uint256 safeTxGas,uint256 baseGas,uint256 gasPrice,address gasToken,address refundReceiver,uint256 nonce)")
@@ -142,32 +142,32 @@ contract ConsensusTest is Test {
         }
     }
 
-    function test_ProposeOracleTransaction_EmitsEvent() public {
+    function test_ProposeTransaction_EmitsEvent() public {
         MockOracle oracle = new MockOracle();
         SafeTransaction.T memory transaction = _makeTransaction();
         bytes32 safeTxHash = transaction.hash();
 
         vm.expectEmit(true, true, true, true);
-        emit IConsensus.OracleTransactionProposed(safeTxHash, block.chainid, SAFE, 0, address(oracle), transaction);
+        emit IConsensus.TransactionProposed(safeTxHash, block.chainid, SAFE, 0, address(oracle), transaction);
 
-        consensus.proposeOracleTransaction(address(oracle), "", transaction);
+        consensus.proposeTransaction(address(oracle), "", transaction);
     }
 
-    function test_ProposeOracleTransaction_AlreadyAttested_Reverts() public {
+    function test_ProposeTransaction_AlreadyAttested_Reverts() public {
         MockOracle oracle = new MockOracle();
         SafeTransaction.T memory transaction = _makeTransaction();
         bytes32 safeTxStructHash = _transactionStructHash(transaction);
         FROSTSignatureId.T signatureId = FROSTSignatureId.T.wrap(keccak256("testSig"));
 
         // Attest the transaction so the message slot is occupied.
-        consensus.attestOracleTransaction(0, address(oracle), block.chainid, SAFE, safeTxStructHash, signatureId);
+        consensus.attestTransaction(0, address(oracle), block.chainid, SAFE, safeTxStructHash, signatureId);
 
         // Proposing the same (oracle, transaction) should now revert since it is already attested.
         vm.expectRevert(Consensus.AlreadyAttested.selector);
-        consensus.proposeOracleTransaction(address(oracle), "", transaction);
+        consensus.proposeTransaction(address(oracle), "", transaction);
     }
 
-    function test_AttestOracleTransaction_StoresAndEmits() public {
+    function test_AttestTransaction_StoresAndEmits() public {
         MockOracle oracle = new MockOracle();
         bytes32 safeTxStructHash = bytes32(uint256(0xdeadbeef));
         bytes32 safeTxHash = SafeTransaction.partialHash(block.chainid, SAFE, safeTxStructHash);
@@ -176,33 +176,31 @@ contract ConsensusTest is Test {
         FROST.Signature memory emptySig = coordinator.signatureValue(signatureId);
 
         vm.expectEmit(true, true, true, true);
-        emit IConsensus.OracleTransactionAttested(
-            safeTxHash, block.chainid, SAFE, 0, address(oracle), signatureId, emptySig
-        );
+        emit IConsensus.TransactionAttested(safeTxHash, block.chainid, SAFE, 0, address(oracle), signatureId, emptySig);
 
-        consensus.attestOracleTransaction(0, address(oracle), block.chainid, SAFE, safeTxStructHash, signatureId);
+        consensus.attestTransaction(0, address(oracle), block.chainid, SAFE, safeTxStructHash, signatureId);
     }
 
-    function test_AttestOracleTransaction_DoubleAttest_Reverts() public {
+    function test_AttestTransaction_DoubleAttest_Reverts() public {
         MockOracle oracle = new MockOracle();
         bytes32 safeTxStructHash = bytes32(uint256(0xdeadbeef));
         FROSTSignatureId.T signatureId = FROSTSignatureId.T.wrap(keccak256("testSig"));
 
-        consensus.attestOracleTransaction(0, address(oracle), block.chainid, SAFE, safeTxStructHash, signatureId);
+        consensus.attestTransaction(0, address(oracle), block.chainid, SAFE, safeTxStructHash, signatureId);
 
         vm.expectRevert(Consensus.AlreadyAttested.selector);
-        consensus.attestOracleTransaction(0, address(oracle), block.chainid, SAFE, safeTxStructHash, signatureId);
+        consensus.attestTransaction(0, address(oracle), block.chainid, SAFE, safeTxStructHash, signatureId);
     }
 
-    function test_GetOracleTransactionAttestationByHash() public {
+    function test_GetTransactionAttestationByHash() public {
         MockOracle oracle = new MockOracle();
         bytes32 safeTxStructHash = bytes32(uint256(0xdeadbeef));
         bytes32 safeTxHash = SafeTransaction.partialHash(block.chainid, SAFE, safeTxStructHash);
         FROSTSignatureId.T signatureId = FROSTSignatureId.T.wrap(keccak256("testSig"));
 
-        consensus.attestOracleTransaction(0, address(oracle), block.chainid, SAFE, safeTxStructHash, signatureId);
+        consensus.attestTransaction(0, address(oracle), block.chainid, SAFE, safeTxStructHash, signatureId);
 
-        FROST.Signature memory sig = consensus.getOracleTransactionAttestationByHash(0, address(oracle), safeTxHash);
+        FROST.Signature memory sig = consensus.getTransactionAttestationByHash(0, address(oracle), safeTxHash);
         // MockCoordinator returns an empty signature — we verify the call succeeds.
         assertEq(sig.r.x, 0);
     }

--- a/contracts/test/SafenetGuard.t.sol
+++ b/contracts/test/SafenetGuard.t.sol
@@ -177,9 +177,8 @@ contract SafenetGuardTest is Test {
         returns (bytes memory)
     {
         Secp256k1.Point memory groupKey = ForgeSecp256k1.g(sk).toPoint();
-        bytes32 message = ConsensusMessages.oracleTransactionProposal(
-            guard.getConsensusDomainSeparator(), epoch, ORACLE_ADDR, txHash
-        );
+        bytes32 message =
+            ConsensusMessages.transactionProposal(guard.getConsensusDomainSeparator(), epoch, ORACLE_ADDR, txHash);
         FROST.Signature memory sig = _frostSign(sk, nk, message);
         bytes memory payload = abi.encode(epoch, ORACLE_ADDR, groupKey, sig); // 224 bytes
         return bytes.concat(payload, abi.encode(payload.length), AttestationTrailer.TYPE_HASH);
@@ -436,7 +435,7 @@ contract SafenetGuardTest is Test {
     function test_integration_inlineAttestation_revertsWithTamperedSignature() public {
         uint256 nonce = safe.nonce();
         bytes32 txHash = _safeTxHash(TX_TO, TX_VALUE, TX_DATA, TX_OP, nonce);
-        bytes32 message = ConsensusMessages.oracleTransactionProposal(
+        bytes32 message = ConsensusMessages.transactionProposal(
             guard.getConsensusDomainSeparator(), GENESIS_EPOCH, ORACLE_ADDR, txHash
         );
         FROST.Signature memory sig = _frostSign(GENESIS_SK, GENESIS_NK, message);

--- a/contracts/test/libraries/ConsensusMessages.t.sol
+++ b/contracts/test/libraries/ConsensusMessages.t.sol
@@ -3,10 +3,12 @@ pragma solidity ^0.8.30;
 
 import {Test} from "@forge-std/Test.sol";
 import {ConsensusMessages} from "@/libraries/ConsensusMessages.sol";
+import {SafeTransaction} from "@/libraries/SafeTransaction.sol";
 import {Secp256k1} from "@/libraries/Secp256k1.sol";
 
 contract ConsensusMessagesTest is Test {
     using ConsensusMessages for bytes32;
+    using SafeTransaction for SafeTransaction.T;
 
     function test_EpochRollover() public pure {
         bytes32 message = ConsensusMessages.domain(23, 0x4838B106FCe9647Bdf1E7877BF73cE8B0BAD5f97)
@@ -23,17 +25,44 @@ contract ConsensusMessagesTest is Test {
         assertEq(message, hex"c1e4d484d6c376741c904290cc043f4afb4618f9d567dcdd0edcbf22abae57f7");
     }
 
-    function test_OracleTransactionProposalTypehash() public pure {
+    function test_TransactionProposalTypehash() public pure {
         assertEq(
-            ConsensusMessages.ORACLE_TRANSACTION_PROPOSAL_TYPEHASH,
-            keccak256("OracleTransactionProposal(uint64 epoch,address oracle,bytes32 safeTxHash)")
+            ConsensusMessages.TRANSACTION_PROPOSAL_TYPEHASH,
+            keccak256("TransactionProposal(uint64 epoch,address oracle,bytes32 safeTxHash)")
         );
     }
 
-    function test_OracleTransactionProposal() public pure {
+    function test_TransactionProposal() public pure {
         bytes32 message = ConsensusMessages.domain(23, 0x4838B106FCe9647Bdf1E7877BF73cE8B0BAD5f97)
-            .oracleTransactionProposal(1, 0x1234567890123456789012345678901234567890, bytes32(uint256(42)));
+            .transactionProposal(1, 0x1234567890123456789012345678901234567890, bytes32(uint256(42)));
 
-        assertEq(message, hex"8c14cc0ff2766f091808488a64caf93c17362432d9384fd7ee3d9c6975dea85f");
+        assertEq(message, hex"19f3fa0234f374f2e8ec0c2f2a45777a0696ba1ac8a214acf921c3ccfa080717");
+    }
+
+    /// Cross-language parity vector for `oracle_tx_proposal_hash_parity` in `crates/sentinel/src/hashing.rs`:
+    /// domain.chain=23, consensus=0x22Cb221c..., epoch=11, oracle=safe=0x4838B106..., to=consensus, chainId=1,
+    /// all other fields zero. Keep both in sync if either implementation or expected hash changes.
+    function test_TransactionProposal_SentinelParityVector() public pure {
+        address consensus = 0x22Cb221caE98D6097082C80158B1472C45FEd729;
+        address oracle = 0x4838B106FCe9647Bdf1E7877BF73cE8B0BAD5f97;
+
+        SafeTransaction.T memory transaction = SafeTransaction.T({
+            chainId: 1,
+            safe: oracle,
+            to: consensus,
+            value: 0,
+            data: "",
+            operation: SafeTransaction.Operation.CALL,
+            safeTxGas: 0,
+            baseGas: 0,
+            gasPrice: 0,
+            gasToken: address(0),
+            refundReceiver: address(0),
+            nonce: 0
+        });
+
+        bytes32 message = ConsensusMessages.domain(23, consensus).transactionProposal(11, oracle, transaction.hash());
+
+        assertEq(message, hex"13889a221bc89a7b93781ab5457f5b7b9a6d9f2e9fe8d97dcf6be83a8658c58c");
     }
 }

--- a/crates/sentinel/src/bindings.rs
+++ b/crates/sentinel/src/bindings.rs
@@ -65,7 +65,7 @@ pub mod consensus {
         #[derive(Debug, Default, PartialEq, Eq, Serialize)]
         enum Operation { #[default] CALL, DELEGATECALL }
 
-        // Full transaction struct carried by OracleTransactionProposed; mirrors SafeTransaction.T.
+        // Full transaction struct carried by TransactionProposed; mirrors SafeTransaction.T.
         #[derive(Debug, Default, PartialEq, Eq, Serialize)]
         struct SafeTransaction {
             uint256 chainId;
@@ -84,10 +84,10 @@ pub mod consensus {
 
         // EIP-712 struct for the oracle requestId.
         // Field order and types must exactly match the onchain typehash in ConsensusMessages.sol:
-        // keccak256("OracleTransactionProposal(uint64 epoch,address oracle,bytes32 safeTxHash)")
+        // keccak256("TransactionProposal(uint64 epoch,address oracle,bytes32 safeTxHash)")
         // Domain: { chainId, verifyingContract: consensus }
         #[derive(Debug)]
-        struct OracleTransactionProposal {
+        struct TransactionProposal {
             uint64 epoch;
             address oracle;
             bytes32 safeTxHash;
@@ -95,7 +95,7 @@ pub mod consensus {
 
         #[derive(Debug)]
         contract Consensus {
-            event OracleTransactionProposed(
+            event TransactionProposed(
                 bytes32 indexed safeTxHash,
                 uint256 indexed chainId,
                 address indexed safe,

--- a/crates/sentinel/src/hashing.rs
+++ b/crates/sentinel/src/hashing.rs
@@ -1,5 +1,5 @@
 use crate::bindings::{
-    consensus::{OracleTransactionProposal, SafeTransaction},
+    consensus::{SafeTransaction, TransactionProposal},
     safe::{Operation as SafeOperation, SafeTx},
 };
 use alloy::{
@@ -91,7 +91,7 @@ pub fn oracle_tx_proposal_hash(
         verifying_contract: Some(consensus),
         ..Default::default()
     };
-    OracleTransactionProposal {
+    TransactionProposal {
         epoch,
         oracle,
         safeTxHash: stx_hash,
@@ -138,10 +138,11 @@ mod tests {
         );
     }
 
-    /// Parity vector: `oracleTxPacketHash(VALID_PACKET)` from
-    /// `validator/src/consensus/verify/oracleTx/handler.test.ts`.
-    /// VALID_PACKET: domain.chain=23, consensus=0x22Cb221c..., epoch=11,
-    /// oracle=safe=0x4838B106..., to=0x22Cb221c..., chainId=1, all other fields zero.
+    /// Parity vector: `test_TransactionProposal_SentinelParityVector` in
+    /// `contracts/test/libraries/ConsensusMessages.t.sol` — keep both in sync if either
+    /// implementation or expected hash changes.
+    /// domain.chain=23, consensus=0x22Cb221c..., epoch=11, oracle=safe=0x4838B106...,
+    /// to=0x22Cb221c..., chainId=1, all other fields zero.
     #[test]
     fn oracle_tx_proposal_hash_parity() {
         let consensus = address!("22Cb221caE98D6097082C80158B1472C45FEd729");
@@ -151,7 +152,7 @@ mod tests {
         let id = oracle_tx_proposal_hash(U256::from(23u64), consensus, 11, oracle, stx_hash);
         assert_eq!(
             id,
-            b256!("2a29f463bfd18f87230f795b09f22d8d126f0fcedab6149ce430777c827115b0"),
+            b256!("13889a221bc89a7b93781ab5457f5b7b9a6d9f2e9fe8d97dcf6be83a8658c58c"),
         );
     }
 

--- a/crates/sentinel/src/service.rs
+++ b/crates/sentinel/src/service.rs
@@ -50,7 +50,7 @@ pub struct SentinelService {
 /// events.
 pub struct SentinelTransition {
     oracle: Address,
-    /// The `Consensus` contract whose `OracleTransactionProposed` events are
+    /// The `Consensus` contract whose `TransactionProposed` events are
     /// hashed into request ids.
     consensus: Address,
     /// Our own account, used to compute commitment hashes and identify votes
@@ -112,7 +112,7 @@ impl SentinelTransition {
         &self,
         mut state: State,
         block: u64,
-        event: Consensus::OracleTransactionProposed,
+        event: Consensus::TransactionProposed,
     ) -> (State, Commands<State, Self>) {
         if event.oracle != self.oracle {
             return (state, Vec::new());
@@ -676,9 +676,9 @@ impl StateTransition<State> for SentinelTransition {
             Message::Event(event) => {
                 let block = event.block;
                 match event.data {
-                    SentinelEvents::Consensus(
-                        Consensus::ConsensusEvents::OracleTransactionProposed(event),
-                    ) => self.handle_oracle_transaction_proposed(state, block, event),
+                    SentinelEvents::Consensus(Consensus::ConsensusEvents::TransactionProposed(
+                        event,
+                    )) => self.handle_oracle_transaction_proposed(state, block, event),
                     SentinelEvents::Oracle(SentinelOracle::SentinelOracleEvents::NewRequest(
                         event,
                     )) => self.handle_new_request(state, event),
@@ -832,8 +832,8 @@ mod tests {
     }
 
     fn proposed_event(oracle: Address, safe_tx_hash: B256, to: Address) -> SentinelEvents {
-        SentinelEvents::Consensus(Consensus::ConsensusEvents::OracleTransactionProposed(
-            Consensus::OracleTransactionProposed {
+        SentinelEvents::Consensus(Consensus::ConsensusEvents::TransactionProposed(
+            Consensus::TransactionProposed {
                 safeTxHash: safe_tx_hash,
                 chainId: U256::from(CHAIN_ID),
                 safe: SAFE,

--- a/crates/validator/src/bindings.rs
+++ b/crates/validator/src/bindings.rs
@@ -122,7 +122,7 @@ sol! {
             bytes32 signatureId,
             Signature attestation
         );
-        event OracleTransactionProposed(
+        event TransactionProposed(
             bytes32 indexed safeTxHash,
             uint256 indexed chainId,
             address indexed safe,
@@ -130,7 +130,7 @@ sol! {
             address oracle,
             SafeTransaction transaction
         );
-        event OracleTransactionAttested(
+        event TransactionAttested(
             bytes32 indexed safeTxHash,
             uint256 indexed chainId,
             address indexed safe,
@@ -148,7 +148,7 @@ sol! {
             bytes32 groupId,
             bytes32 signatureId
         ) external;
-        function attestOracleTransaction(
+        function attestTransaction(
             uint64 epoch,
             address oracle,
             uint256 chainId,

--- a/crates/validator/src/consensus/hashing.rs
+++ b/crates/validator/src/consensus/hashing.rs
@@ -35,7 +35,7 @@ sol! {
 
     /// The consensus-domain packet proposing an oracle-backed Safe
     /// transaction for attestation.
-    struct OracleTransactionProposal {
+    struct TransactionProposal {
         uint64 epoch;
         address oracle;
         bytes32 safeTxHash;
@@ -109,7 +109,7 @@ impl ConsensusDomain {
         oracle: Address,
         safe_tx_hash: B256,
     ) -> B256 {
-        OracleTransactionProposal {
+        TransactionProposal {
             epoch: epoch.raw_value(),
             oracle,
             safeTxHash: safe_tx_hash,
@@ -187,7 +187,7 @@ mod tests {
     fn sample_oracle_transaction_packet_hash() {
         assert_eq!(
             TEST_DOMAIN.oracle_transaction_packet_hash(EPOCH_ONE, TEST_ADDRESS, &safe_tx()),
-            b256!("b89cd5ddc8b9a71c6469b79711f8ce0000edd6fc3f47ad057a772302fcfa82af")
+            b256!("44151ab85018beace71ef3255d90480c7b41a3c42b2cf892c155a304875abc9e")
         );
     }
 

--- a/crates/validator/src/service/action.rs
+++ b/crates/validator/src/service/action.rs
@@ -343,7 +343,7 @@ impl ActionEncoder<Action> for Encoder {
                 Transaction {
                     to: self.consensus,
                     value: U256::ZERO,
-                    data: Consensus::attestOracleTransactionCall {
+                    data: Consensus::attestTransactionCall {
                         epoch: epoch.raw_value(),
                         oracle,
                         chainId: chain_id,

--- a/crates/validator/src/state/mod.rs
+++ b/crates/validator/src/state/mod.rs
@@ -424,10 +424,10 @@ impl StateTransition<State> for Transition {
                 Event::Consensus(Consensus::ConsensusEvents::EpochStaged(event)) => {
                     self.handle_epoch_staged(state, &event)
                 }
-                Event::Consensus(Consensus::ConsensusEvents::OracleTransactionProposed(event)) => {
+                Event::Consensus(Consensus::ConsensusEvents::TransactionProposed(event)) => {
                     self.handle_oracle_transaction_proposed(state, log.block, &event)
                 }
-                Event::Consensus(Consensus::ConsensusEvents::OracleTransactionAttested(event)) => {
+                Event::Consensus(Consensus::ConsensusEvents::TransactionAttested(event)) => {
                     self.handle_oracle_transaction_attested(state, &event)
                 }
                 Event::Oracle(Oracle::OracleEvents::OracleResult(event)) => {

--- a/crates/validator/src/state/sign.rs
+++ b/crates/validator/src/state/sign.rs
@@ -366,7 +366,7 @@ impl Transition {
 
     /// Publishes this validator's signature share once the
     /// [`Effect::UseNonce`] effect has produced it, attaching the packet's
-    /// completion callback (`stageEpoch`/`attestOracleTransaction`) so the
+    /// completion callback (`stageEpoch`/`attestTransaction`) so the
     /// group's completed signature carries out its onchain effect
     /// automatically.
     pub(super) fn handle_nonces(
@@ -489,7 +489,7 @@ impl Transition {
 
     /// Handles a signature attestation, which can mean different things for
     /// different packets. Called by the individual attestations handlers
-    /// (`EpochStaged`, `OracleTransactionAttested`).
+    /// (`EpochStaged`, `TransactionAttested`).
     pub(super) fn handle_sign_attested(
         &self,
         mut state: State,
@@ -803,7 +803,7 @@ impl Packet {
     }
 
     /// Builds the callback invoked once this packet's group signature
-    /// completes: `stageEpoch`/`attestOracleTransaction` calldata targeting
+    /// completes: `stageEpoch`/`attestTransaction` calldata targeting
     /// the `Consensus` contract. The signature id argument is left as a zero
     /// placeholder - the `Consensus` contract fills it in itself when it
     /// invokes the callback from a completed `signShareWithCallback`.
@@ -835,7 +835,7 @@ impl Packet {
         };
 
         let safe_tx_struct_hash = hashing::safe_tx_struct_hash(transaction);
-        let context = Consensus::attestOracleTransactionCall {
+        let context = Consensus::attestTransactionCall {
             epoch: epoch.raw_value(),
             oracle,
             chainId: transaction.chainId,

--- a/crates/validator/src/state/transactions.rs
+++ b/crates/validator/src/state/transactions.rs
@@ -17,7 +17,7 @@ impl Transition {
         &self,
         mut state: State,
         block: u64,
-        event: &Consensus::OracleTransactionProposed,
+        event: &Consensus::TransactionProposed,
     ) -> (State, Commands<State, Self>) {
         let epoch = EpochId::from_raw(event.epoch);
         let Some(participating_epoch) = state.epochs.get(&epoch) else {
@@ -76,7 +76,7 @@ impl Transition {
     pub(super) fn handle_oracle_transaction_attested(
         &self,
         state: State,
-        event: &Consensus::OracleTransactionAttested,
+        event: &Consensus::TransactionAttested,
     ) -> (State, Commands<State, Self>) {
         let epoch = EpochId::from_raw(event.epoch);
         let message =

--- a/docs/devnet.md
+++ b/docs/devnet.md
@@ -138,7 +138,7 @@ pointed at the devnet's RPC and one of the accounts above. Proposing a transacti
 oracle approval (`CONSENSUS_ADDRESS` is already exported from [above](#setting-up-environment-variables),
 so it doesn't need to be restated here). `SentinelOracle.postRequest`
 pulls the request fee from the proposing account (`--sender`, i.e. `msg.sender` on
-`proposeOracleTransaction`) via `transferFrom`, so that account must first `approve` the oracle to
+`proposeTransaction`) via `transferFrom`, so that account must first `approve` the oracle to
 spend the fee token:
 
 ```sh
@@ -159,7 +159,7 @@ TX_TO=<TO_ADDRESS> \
 TX_NONCE=0 \
 TX_DATA=<CALLDATA> \
 TX_OPERATION=0 \
-npm run cmd:propose:oracle -w @safenet/contracts -- \
+npm run cmd:propose -w @safenet/contracts -- \
     --rpc-url http://127.0.0.1:8545 --unlocked --sender 0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266 --broadcast
 ```
 
@@ -183,7 +183,7 @@ three fields `0`) means the FROST group hasn't produced an attestation for that 
 Check it using the epoch from `getActiveEpoch()` (from [above](#reading-contract-state-with-cast)):
 
 ```sh
-cast call $CONSENSUS_ADDRESS "getOracleTransactionAttestationByHash(uint64,address,bytes32)(((uint256,uint256),uint256))" \
+cast call $CONSENSUS_ADDRESS "getTransactionAttestationByHash(uint64,address,bytes32)(((uint256,uint256),uint256))" \
     <EPOCH> $ORACLE_ADDRESS <SAFE_TX_HASH> --rpc-url http://localhost:8545
 ```
 

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -182,7 +182,7 @@ stateDiagram-v2
 	share --> attest : SignCompleted()
 	share --> failure : timeout
 
-	attest --> success : EpochStaged()<br>OracleTransactionAttested()
+	attest --> success : EpochStaged()<br>TransactionAttested()
 	attest --> failure : timeout
 
 	failure --> request : len(remaining_selection) >= threshold

--- a/examples/README.md
+++ b/examples/README.md
@@ -8,7 +8,7 @@ Scripts for interacting with the Safenet protocol on public testnets.
 and assembles the `signatures` blob that satisfies `SafenetGuard` — the owner signatures
 followed by the inline attestation *trailer* — ready to submit via `execTransaction`.
 
-Use this after a Safe transaction has been proposed to Safenet (via `proposeOracleTransaction`
+Use this after a Safe transaction has been proposed to Safenet (via `proposeTransaction`
 on the Consensus contract) and the FROST signing round has completed.
 
 ### Prerequisites
@@ -49,7 +49,7 @@ npm run attest-safe-tx -w @safenet/examples -- <safeTxHash> <guardAddress>
 
 ### What it does
 
-1. Calls `getActiveEpoch()` and then `getOracleTransactionAttestationByHash(epoch, oracleAddress, safeTxHash)`
+1. Calls `getActiveEpoch()` and then `getTransactionAttestationByHash(epoch, oracleAddress, safeTxHash)`
    on the Consensus contract on Gnosis Chain to fetch the FROST signature.
 2. Resolves the attesting group key by scanning the guard's `EpochInitialized` /
    `EpochRolledOver` events for that epoch (Consensus exposes no group-key getter).

--- a/examples/attest-safe-tx.ts
+++ b/examples/attest-safe-tx.ts
@@ -124,7 +124,7 @@ const gnosisClient = createPublicClient({ chain: gnosis, transport: http(rpc) })
 const GET_ACTIVE_EPOCH = parseAbiItem("function getActiveEpoch() view returns (uint64 epoch, bytes32 groupId)");
 
 const GET_ATTESTATION = parseAbiItem(
-	"function getOracleTransactionAttestationByHash(uint64, address, bytes32) view returns (((uint256 x, uint256 y) r, uint256 z) signature)",
+	"function getTransactionAttestationByHash(uint64, address, bytes32) view returns (((uint256 x, uint256 y) r, uint256 z) signature)",
 );
 
 // The getter reverts NotSigned() until the FROST round completes; declaring the error lets viem decode
@@ -185,7 +185,7 @@ async function pollAttestation(): Promise<{ epoch: bigint; sig: { r: Point; z: b
 			const sig = await gnosisClient.readContract({
 				address: consensusAddress,
 				abi: [GET_ATTESTATION, NOT_SIGNED],
-				functionName: "getOracleTransactionAttestationByHash",
+				functionName: "getTransactionAttestationByHash",
 				args: [epoch, oracleAddress, safeTxHash],
 			});
 			if (sig.r.x !== 0n || sig.r.y !== 0n || sig.z !== 0n) {

--- a/scripts/run_sentinel_integration_test.sh
+++ b/scripts/run_sentinel_integration_test.sh
@@ -4,7 +4,7 @@
 # against the same dispute on Anvil, and asserts they agree (no arbitration)
 # and settle fees/bonds correctly. Unlike scripts/run_validator_integration_test.sh,
 # this does not require a full validator/FROST genesis: a `TestConsensus` contract
-# stands in for `Consensus`, only emitting the `OracleTransactionProposed`
+# stands in for `Consensus`, only emitting the `TransactionProposed`
 # event the sentinels need.
 set -eo pipefail
 # Job control, so each `&`-backgrounded command below gets its own process
@@ -172,7 +172,7 @@ env \
 	TX_SAFE=0x1111111111111111111111111111111111111111 \
 	TX_TO=0x2222222222222222222222222222222222222222 \
 	TX_NONCE=0 \
-	npm run -w contracts cmd:propose:oracle -- --rpc-url "$RPC_URL" --private-key "$PROPOSER_PK" --broadcast
+	npm run -w contracts cmd:propose -- --rpc-url "$RPC_URL" --private-key "$PROPOSER_PK" --broadcast
 
 REQUEST_ID=$(cast logs --rpc-url "$RPC_URL" --json --from-block 0 --address "$ORACLE" \
 	'NewRequest(bytes32,address,uint256,uint256,uint256,uint256)' | jq -r '.[0].topics[1]')

--- a/scripts/run_validator_integration_test.sh
+++ b/scripts/run_validator_integration_test.sh
@@ -201,7 +201,7 @@ while [ "$SECONDS" -lt "$DEADLINE" ]; do
             TX_SAFE="$SENDER" \
             TX_TO="$SENDER" \
             TX_NONCE=1 \
-            npm run --prefix "$REPO_ROOT" --workspace contracts cmd:propose:oracle -- \
+            npm run --prefix "$REPO_ROOT" --workspace contracts cmd:propose -- \
             --rpc-url "$ANVIL_RPC_URL" \
             --unlocked \
             --sender "$SENDER" \
@@ -212,7 +212,7 @@ while [ "$SECONDS" -lt "$DEADLINE" ]; do
             --from-block 0 \
             --to-block latest \
             --address "$CONSENSUS_ADDR" \
-            'OracleTransactionProposed(bytes32,uint256,address,uint64,address,(uint256,address,address,uint256,bytes,uint8,uint256,uint256,uint256,address,address,uint256))')
+            'TransactionProposed(bytes32,uint256,address,uint64,address,(uint256,address,address,uint256,bytes,uint8,uint256,uint256,uint256,address,address,uint256))')
         TRANSACTION_HASH=$(jq -er --arg epoch "$EPOCH_ONE_WORD" \
             '[.[] | select(.data | startswith($epoch))][-1].topics[1]' <<< "$PROPOSALS")
         TRANSACTION_PROPOSED=1
@@ -232,7 +232,7 @@ while [ "$SECONDS" -lt "$DEADLINE" ]; do
             --from-block 0 \
             --to-block latest \
             --address "$CONSENSUS_ADDR" \
-            'OracleTransactionAttested(bytes32,uint256,address,uint64,address,bytes32,((uint256,uint256),uint256))')
+            'TransactionAttested(bytes32,uint256,address,uint64,address,bytes32,((uint256,uint256),uint256))')
         TRANSACTION_ATTESTED=$(jq --arg hash "$TRANSACTION_HASH" --arg epoch "$EPOCH_ONE_WORD" \
             '[.[] | select((.topics[1] == $hash) and (.data | startswith($epoch)))] | length' <<< "$ATTESTATIONS")
     fi


### PR DESCRIPTION
As there is only one transaction type it is not necessary to use the oracle prefix to distuingish. This PR adjusts this across the whole code base. Only renaming should be done, no logic change.

### Testing

- Integration tests should pass

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://docs.safefoundation.org/cla).
