### PR TITLE
[Phase 7b] Remove Oracle prefix from rust and explorer code

### DIFF
--- a/crates/validator/src/consensus/hashing.rs
+++ b/crates/validator/src/consensus/hashing.rs
@@ -103,7 +103,7 @@ impl ConsensusDomain {
 
     /// The consensus-domain hash of an oracle-backed Safe transaction proposal,
     /// embedding the already-computed [`safe_tx_hash`] as its `safeTxHash` field.
-    pub fn oracle_transaction_proposal_hash(
+    pub fn transaction_proposal_hash(
         &self,
         epoch: EpochId,
         oracle: Address,
@@ -118,15 +118,15 @@ impl ConsensusDomain {
     }
 
     /// The consensus-domain hash of an oracle-backed Safe transaction packet:
-    /// shorthand for [`oracle_transaction_proposal_hash`] with [`safe_tx_hash`]
+    /// shorthand for [`transaction_proposal_hash`] with [`safe_tx_hash`]
     /// computed from `tx`.
-    pub fn oracle_transaction_packet_hash(
+    pub fn transaction_packet_hash(
         &self,
         epoch: EpochId,
         oracle: Address,
         tx: &SafeTransaction,
     ) -> B256 {
-        self.oracle_transaction_proposal_hash(epoch, oracle, safe_tx_hash(tx))
+        self.transaction_proposal_hash(epoch, oracle, safe_tx_hash(tx))
     }
 
     /// The consensus-domain hash of an epoch rollover proposal.
@@ -184,9 +184,9 @@ mod tests {
     }
 
     #[test]
-    fn sample_oracle_transaction_packet_hash() {
+    fn sample_transaction_packet_hash() {
         assert_eq!(
-            TEST_DOMAIN.oracle_transaction_packet_hash(EPOCH_ONE, TEST_ADDRESS, &safe_tx()),
+            TEST_DOMAIN.transaction_packet_hash(EPOCH_ONE, TEST_ADDRESS, &safe_tx()),
             b256!("44151ab85018beace71ef3255d90480c7b41a3c42b2cf892c155a304875abc9e")
         );
     }

--- a/crates/validator/src/service/action.rs
+++ b/crates/validator/src/service/action.rs
@@ -88,7 +88,7 @@ pub enum Action {
     /// A fallback action to submit a completed oracle-backed transaction
     /// attestation directly, when the automatic `signShareWithCallback`
     /// submission did not land in time.
-    AttestOracleTransaction {
+    AttestTransaction {
         epoch: EpochId,
         oracle: Address,
         chain_id: U256,
@@ -331,7 +331,7 @@ impl ActionEncoder<Action> for Encoder {
                 },
                 Some(expires_at),
             ),
-            Action::AttestOracleTransaction {
+            Action::AttestTransaction {
                 epoch,
                 oracle,
                 chain_id,

--- a/crates/validator/src/state/mod.rs
+++ b/crates/validator/src/state/mod.rs
@@ -231,7 +231,7 @@ enum Packet {
         group_key: Point,
     },
     /// A proposed oracle-backed Safe transaction.
-    OracleTransaction {
+    Transaction {
         /// The epoch whose group signs the attestation.
         epoch: EpochId,
         /// The oracle vouching for the transaction.
@@ -425,10 +425,10 @@ impl StateTransition<State> for Transition {
                     self.handle_epoch_staged(state, &event)
                 }
                 Event::Consensus(Consensus::ConsensusEvents::TransactionProposed(event)) => {
-                    self.handle_oracle_transaction_proposed(state, log.block, &event)
+                    self.handle_transaction_proposed(state, log.block, &event)
                 }
                 Event::Consensus(Consensus::ConsensusEvents::TransactionAttested(event)) => {
-                    self.handle_oracle_transaction_attested(state, &event)
+                    self.handle_transaction_attested(state, &event)
                 }
                 Event::Oracle(Oracle::OracleEvents::OracleResult(event)) => {
                     self.handle_oracle_result(state, log.block, log.address, &event)

--- a/crates/validator/src/state/sign.rs
+++ b/crates/validator/src/state/sign.rs
@@ -65,7 +65,7 @@ impl Transition {
                 signers,
                 ..
             }) if group_id == event.gid => match packet {
-                Packet::OracleTransaction { oracle, .. } => {
+                Packet::Transaction { oracle, .. } => {
                     let deadline = block.saturating_add(self.config.oracle_timeout.get());
                     tracing::info!(
                         message = %event.message,
@@ -798,7 +798,7 @@ impl Packet {
     pub(super) fn epoch(&self) -> EpochId {
         match self {
             Packet::EpochRollover { active_epoch, .. } => *active_epoch,
-            Packet::OracleTransaction { epoch, .. } => *epoch,
+            Packet::Transaction { epoch, .. } => *epoch,
         }
     }
 
@@ -809,7 +809,7 @@ impl Packet {
     /// invokes the callback from a completed `signShareWithCallback`.
     fn attestation_callback(&self, consensus: Address) -> bindings::Callback {
         let (epoch, oracle, transaction) = match self {
-            Packet::OracleTransaction {
+            Packet::Transaction {
                 epoch,
                 oracle,
                 transaction,
@@ -867,11 +867,11 @@ impl Packet {
                 signature_id,
                 expires_at,
             },
-            Packet::OracleTransaction {
+            Packet::Transaction {
                 epoch,
                 oracle,
                 transaction,
-            } => Action::AttestOracleTransaction {
+            } => Action::AttestTransaction {
                 epoch: *epoch,
                 oracle: *oracle,
                 chain_id: transaction.chainId,

--- a/crates/validator/src/state/transactions.rs
+++ b/crates/validator/src/state/transactions.rs
@@ -13,7 +13,7 @@ impl Transition {
     /// against the configured allow-list. A transaction proposed for an
     /// unknown or unresolved epoch, one whose group this validator is not
     /// part of, or from a disallowed oracle, is ignored.
-    pub(super) fn handle_oracle_transaction_proposed(
+    pub(super) fn handle_transaction_proposed(
         &self,
         mut state: State,
         block: u64,
@@ -41,13 +41,13 @@ impl Transition {
 
         let message =
             self.consensus
-                .oracle_transaction_packet_hash(epoch, event.oracle, &event.transaction);
+                .transaction_packet_hash(epoch, event.oracle, &event.transaction);
 
         // Prevent duplicate ongoing transaction proposals. This is to prevent
         // malicious parties from blocking transaction attestations from ever
         // being produced by resetting the signing state of honest validators.
         if let btree_map::Entry::Vacant(signing) = state.signing.entry(message) {
-            let packet = Packet::OracleTransaction {
+            let packet = Packet::Transaction {
                 epoch,
                 oracle: event.oracle,
                 transaction: Box::new(event.transaction.clone()),
@@ -73,7 +73,7 @@ impl Transition {
 
     /// Clears a completed oracle-backed signing session once its attestation
     /// lands onchain.
-    pub(super) fn handle_oracle_transaction_attested(
+    pub(super) fn handle_transaction_attested(
         &self,
         state: State,
         event: &Consensus::TransactionAttested,
@@ -81,7 +81,7 @@ impl Transition {
         let epoch = EpochId::from_raw(event.epoch);
         let message =
             self.consensus
-                .oracle_transaction_proposal_hash(epoch, event.oracle, event.safeTxHash);
+                .transaction_proposal_hash(epoch, event.oracle, event.safeTxHash);
         tracing::info!(
             ?epoch,
             safe_tx_hash = %event.safeTxHash,

--- a/explorer/src/lib/consensus/abi.ts
+++ b/explorer/src/lib/consensus/abi.ts
@@ -5,17 +5,16 @@ export const consensusAbi = parseAbi([
 	"function getActiveEpoch() external view returns (uint64 epoch, bytes32 groupId)",
 	"function getEpochsState() external view returns (uint64 previous, uint64 active, uint64 staged, uint64 rolloverBlock)",
 	"function getEpochGroupId(uint64 epoch) external view returns (bytes32 groupId)",
-	"event OracleTransactionProposed(bytes32 indexed safeTxHash, uint256 indexed chainId, address indexed safe, uint64 epoch, address oracle, (uint256 chainId, address safe, address to, uint256 value, bytes data, uint8 operation, uint256 safeTxGas, uint256 baseGas, uint256 gasPrice, address gasToken, address refundReceiver, uint256 nonce) transaction)",
-	"event OracleTransactionAttested(bytes32 indexed safeTxHash, uint256 indexed chainId, address indexed safe, uint64 epoch, address oracle, bytes32 signatureId, ((uint256 x, uint256 y) r, uint256 z) attestation)",
+	"event TransactionProposed(bytes32 indexed safeTxHash, uint256 indexed chainId, address indexed safe, uint64 epoch, address oracle, (uint256 chainId, address safe, address to, uint256 value, bytes data, uint8 operation, uint256 safeTxGas, uint256 baseGas, uint256 gasPrice, address gasToken, address refundReceiver, uint256 nonce) transaction)",
+	"event TransactionAttested(bytes32 indexed safeTxHash, uint256 indexed chainId, address indexed safe, uint64 epoch, address oracle, bytes32 signatureId, ((uint256 x, uint256 y) r, uint256 z) attestation)",
 	"event EpochProposed(uint64 indexed activeEpoch, uint64 indexed proposedEpoch, uint64 rolloverBlock, bytes32 groupId, (uint256 x, uint256 y) groupKey)",
 	"event EpochStaged(uint64 indexed activeEpoch, uint64 indexed proposedEpoch, uint64 rolloverBlock, bytes32 groupId, (uint256 x, uint256 y) groupKey, bytes32 signatureId, ((uint256 x, uint256 y) r, uint256 z) attestation)",
 ]);
 
-export const transactionEventSelectors = [
-	"OracleTransactionProposed" as const,
-	"OracleTransactionAttested" as const,
-].map((eventName) => toEventSelector(getAbiItem({ abi: consensusAbi, name: eventName })));
+export const transactionEventSelectors = ["TransactionProposed" as const, "TransactionAttested" as const].map(
+	(eventName) => toEventSelector(getAbiItem({ abi: consensusAbi, name: eventName })),
+);
 
-export const proposedEventSelectors = ["OracleTransactionProposed" as const].map((eventName) =>
+export const proposedEventSelectors = ["TransactionProposed" as const].map((eventName) =>
 	toEventSelector(getAbiItem({ abi: consensusAbi, name: eventName })),
 );

--- a/explorer/src/lib/consensus/consensus.test.ts
+++ b/explorer/src/lib/consensus/consensus.test.ts
@@ -163,7 +163,7 @@ const makeRawConsensusLog = ({
 	blockNumber,
 	logIndex = 0,
 }: {
-	eventName: "OracleTransactionProposed" | "OracleTransactionAttested";
+	eventName: "TransactionProposed" | "TransactionAttested";
 	indexedArgs: Record<string, unknown>;
 	nonIndexedValues: unknown[];
 	blockNumber: bigint;
@@ -197,7 +197,7 @@ const makeOracleProposedLog = ({
 	blockNumber: bigint;
 }) =>
 	makeRawConsensusLog({
-		eventName: "OracleTransactionProposed",
+		eventName: "TransactionProposed",
 		indexedArgs: { safeTxHash, chainId: 1n, safe: SAFE_ADDRESS },
 		nonIndexedValues: [epoch, oracle, ORACLE_TX],
 		blockNumber,
@@ -217,7 +217,7 @@ const makeOracleAttestedLog = ({
 	logIndex?: number;
 }) =>
 	makeRawConsensusLog({
-		eventName: "OracleTransactionAttested",
+		eventName: "TransactionAttested",
 		indexedArgs: { safeTxHash, chainId: 1n, safe: SAFE_ADDRESS },
 		nonIndexedValues: [epoch, oracle, `0x${"00".repeat(32)}`, { r: { x: 0n, y: 0n }, z: 0n }],
 		blockNumber,
@@ -244,7 +244,7 @@ describe("loadProposedSafeTransaction", () => {
 		expect(firstCall(provider).topics[1]).toBe(SAFE_TX_HASH);
 	});
 
-	it("returns the transaction from an OracleTransactionProposed log", async () => {
+	it("returns the transaction from a TransactionProposed log", async () => {
 		const oracle = "0x3333333333333333333333333333333333333333" as Address;
 		const provider = makeProviderWithLogs([
 			makeOracleProposedLog({ safeTxHash: SAFE_TX_HASH, epoch: 1n, oracle, blockNumber: 100n }),
@@ -290,7 +290,7 @@ describe("loadTransactionProposals oracle recognition", () => {
 		expect(result.proposals[0].oracle).toBe(ORACLE);
 	});
 
-	it("derives trust from an OracleTransactionAttested log when no allow-list is configured", async () => {
+	it("derives trust from a TransactionAttested log when no allow-list is configured", async () => {
 		const provider = makeProviderWithLogs([
 			makeOracleProposedLog({ safeTxHash: SAFE_TX_HASH, epoch: 1n, oracle: OTHER_ORACLE, blockNumber: CURRENT_BLOCK }),
 			makeOracleProposedLog({ safeTxHash: SAFE_TX_HASH, epoch: 1n, oracle: ORACLE, blockNumber: CURRENT_BLOCK }),

--- a/explorer/src/lib/consensus/transactions.ts
+++ b/explorer/src/lib/consensus/transactions.ts
@@ -81,7 +81,7 @@ export const loadProposedSafeTransaction = async ({
 	const logs = parseEventLogs({
 		logs: rawLogs.map((log) => formatLog(log)),
 		abi: consensusAbi,
-		eventName: "OracleTransactionProposed",
+		eventName: "TransactionProposed",
 		strict: true,
 	});
 	return safeTransactionSchema.safeParse(logs.at(0)?.args?.transaction).data ?? null;
@@ -110,7 +110,7 @@ export const loadTransactionProposals = async ({
 	const blockRange = { fromBlock: numberToHex(fromBlock), toBlock: numberToHex(toBlock) };
 
 	// We use an `eth_getLogs` here directly, in order to filter on the `safeTxHash` topic.
-	// When `safe` is set, topic[3] silently drops `OracleTransactionAttested` (only 1 indexed topic);
+	// When `safe` is set, topic[3] silently drops `TransactionAttested` (only 1 indexed topic);
 	// those proposals will have attestedAt: null until contract events are updated.
 	const rawLogs = await provider.request({
 		method: "eth_getLogs",
@@ -127,20 +127,20 @@ export const loadTransactionProposals = async ({
 			// <https://github.com/wevm/viem/issues/4340>
 			logs: rawLogs.map((log) => formatLog(log)),
 			abi: consensusAbi,
-			eventName: ["OracleTransactionProposed", "OracleTransactionAttested"],
+			eventName: ["TransactionProposed", "TransactionAttested"],
 			strict: true,
 		}),
 	);
 
 	// `oracle` isn't an indexed topic on either oracle event, so it can't be filtered via
 	// eth_getLogs topics; trust is resolved here, after decoding. With no explicit allow-list,
-	// an oracle is trusted once it has an `OracleTransactionAttested` log in this same batch.
+	// an oracle is trusted once it has a `TransactionAttested` log in this same batch.
 	// Addresses are compared via their checksummed form: `oracles` comes from user settings and
 	// may not be checksummed, while addresses decoded from logs by viem always are.
 	const trustedOracles = new Set(
 		(oracles.length > 0
 			? oracles
-			: allEventLogs.filter((log) => log.eventName === "OracleTransactionAttested").map((log) => log.args.oracle)
+			: allEventLogs.filter((log) => log.eventName === "TransactionAttested").map((log) => log.args.oracle)
 		).map((oracle) => getAddress(oracle)),
 	);
 	const eventLogs = allEventLogs.filter((log) => trustedOracles.has(getAddress(log.args.oracle)));
@@ -149,12 +149,12 @@ export const loadTransactionProposals = async ({
 		`${log.args.safeTxHash}:${log.args.epoch}:${getAddress(log.args.oracle)}`;
 	const attestations = new Map(
 		eventLogs
-			.filter((log) => log.eventName === "OracleTransactionAttested")
+			.filter((log) => log.eventName === "TransactionAttested")
 			.map((log) => [attestationKey(log), { block: log.blockNumber, tx: log.transactionHash }] as const),
 	);
 	const proposals = eventLogs
 		.map((log) => {
-			if (log.eventName !== "OracleTransactionProposed") {
+			if (log.eventName !== "TransactionProposed") {
 				return undefined;
 			}
 

--- a/explorer/src/lib/coordinator/signing.ts
+++ b/explorer/src/lib/coordinator/signing.ts
@@ -112,7 +112,7 @@ export const loadLatestAttestationStatus = async ({
 	const fromBlock = proposedAt ?? defaultFromBlock;
 	const chainId = await provider.getChainId();
 	const coordinator = await loadCoordinator(provider, consensus);
-	// An oracle-checked proposal is attested via `OracleTransactionAttested`, whose message is
+	// An oracle-checked proposal is attested via `TransactionAttested`, whose message is
 	// the oracle's requestId hash.
 	const message = oracleRequestId({ chainId, consensus, epoch, oracle, safeTxHash });
 	// Get signing events related to this message

--- a/explorer/src/lib/oracle/hashing.test.ts
+++ b/explorer/src/lib/oracle/hashing.test.ts
@@ -3,9 +3,9 @@ import { describe, expect, it } from "vitest";
 import { oracleRequestId } from "./hashing";
 
 describe("oracleRequestId", () => {
-	it("matches the Rust validator's oracle_transaction_proposal_hash reference vector", () => {
+	it("matches the Rust validator's transaction_proposal_hash reference vector", () => {
 		// Vector derived from crates/validator/src/consensus/hashing.rs's
-		// `sample_oracle_transaction_packet_hash` test.
+		// `sample_transaction_packet_hash` test.
 		const hash = oracleRequestId({
 			chainId: 1n,
 			consensus: "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045" as Address,
@@ -14,6 +14,6 @@ describe("oracleRequestId", () => {
 			safeTxHash: "0xfe8b85e8d090b16fe8f142d3c9292dc1fc77daf9eb4af8f7cf4a7707d95f4028" as Hex,
 		});
 
-		expect(hash).toBe("0xb89cd5ddc8b9a71c6469b79711f8ce0000edd6fc3f47ad057a772302fcfa82af");
+		expect(hash).toBe("0x44151ab85018beace71ef3255d90480c7b41a3c42b2cf892c155a304875abc9e");
 	});
 });

--- a/explorer/src/lib/oracle/hashing.ts
+++ b/explorer/src/lib/oracle/hashing.ts
@@ -8,8 +8,8 @@ export type OracleRequestIdParams = {
 	safeTxHash: Hex;
 };
 
-// Mirrors `ConsensusMessages.oracleTransactionProposal` (validator's `oracleTxProposalHash`).
-// The result isn't just an attestation message hash — `Consensus.proposeOracleTransaction`
+// Mirrors `ConsensusMessages.transactionProposal` (validator's `transaction_proposal_hash`).
+// The result isn't just an attestation message hash — `Consensus.proposeTransaction`
 // posts this same value to the oracle as its `requestId`, so it doubles as the lookup key for
 // `getRequest`/`Committed`/`Revealed`/`OracleResult`.
 export const oracleRequestId = ({ chainId, consensus, epoch, oracle, safeTxHash }: OracleRequestIdParams): Hex =>
@@ -19,12 +19,12 @@ export const oracleRequestId = ({ chainId, consensus, epoch, oracle, safeTxHash 
 			verifyingContract: consensus,
 		},
 		types: {
-			OracleTransactionProposal: [
+			TransactionProposal: [
 				{ type: "uint64", name: "epoch" },
 				{ type: "address", name: "oracle" },
 				{ type: "bytes32", name: "safeTxHash" },
 			],
 		},
-		primaryType: "OracleTransactionProposal",
+		primaryType: "TransactionProposal",
 		message: { epoch, oracle, safeTxHash },
 	});


### PR DESCRIPTION
As there is only one transaction type it is not necessary to use the oracle prefix to distuingish. This PR adjusts this across the remaining code
base. Only renaming should be done, no logic change.

### Testing

- Integration tests should still pass
- Explorer should **not** work with testnet anymore 

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://docs.safefoundation.org/cla).
