### PR TITLE
feat(consensus): bind oracleData into the oracle transaction proposal

### DIFF
--- a/contracts/src/Consensus.sol
+++ b/contracts/src/Consensus.sol
@@ -256,10 +256,12 @@ contract Consensus is IConsensus, IERC165, IFROSTCoordinatorCallback {
     {
         Epochs memory epochs = _processRollover();
         safeTxHash = transaction.hash();
-        bytes32 message = domainSeparator().transactionProposal(epochs.active, oracle, safeTxHash);
+        // forge-lint: disable-next-line(asm-keccak256)
+        bytes32 message =
+            domainSeparator().transactionProposal(epochs.active, oracle, keccak256(oracleData), safeTxHash);
         require($attestations[message].isZero(), AlreadyAttested());
         SafeId.T safeId = SafeId.create(transaction.chainId, transaction.safe);
-        emit TransactionProposed(safeTxHash, safeId, oracle, epochs.active, transaction);
+        emit TransactionProposed(safeTxHash, safeId, oracle, epochs.active, oracleData, transaction);
         _COORDINATOR.sign($groups[epochs.active], message);
         IOracle(oracle).postRequest(message, msg.sender, oracleData);
     }
@@ -270,29 +272,30 @@ contract Consensus is IConsensus, IERC165, IFROSTCoordinatorCallback {
     function attestTransaction(
         uint64 epoch,
         address oracle,
+        bytes32 oracleDataHash,
         uint256 chainId,
         address safe,
         bytes32 safeTxStructHash,
         FROSTSignatureId.T signatureId
     ) public {
         bytes32 safeTxHash = SafeTransaction.partialHash(chainId, safe, safeTxStructHash);
-        bytes32 message = domainSeparator().transactionProposal(epoch, oracle, safeTxHash);
+        bytes32 message = domainSeparator().transactionProposal(epoch, oracle, oracleDataHash, safeTxHash);
         require($attestations[message].isZero(), AlreadyAttested());
         FROST.Signature memory attestation = _COORDINATOR.signatureVerify(signatureId, $groups[epoch], message);
         $attestations[message] = signatureId;
         SafeId.T safeId = SafeId.create(chainId, safe);
-        emit TransactionAttested(safeTxHash, safeId, oracle, epoch, signatureId, attestation);
+        emit TransactionAttested(safeTxHash, safeId, oracle, epoch, oracleDataHash, signatureId, attestation);
     }
 
     /**
      * @inheritdoc IConsensus
      */
-    function getTransactionAttestationByHash(uint64 epoch, address oracle, bytes32 safeTxHash)
+    function getTransactionAttestationByHash(uint64 epoch, address oracle, bytes32 oracleDataHash, bytes32 safeTxHash)
         public
         view
         returns (FROST.Signature memory signature)
     {
-        bytes32 message = domainSeparator().transactionProposal(epoch, oracle, safeTxHash);
+        bytes32 message = domainSeparator().transactionProposal(epoch, oracle, oracleDataHash, safeTxHash);
         return _COORDINATOR.signatureValue($attestations[message]);
     }
 
@@ -331,9 +334,15 @@ contract Consensus is IConsensus, IERC165, IFROSTCoordinatorCallback {
                 abi.decode(context[4:], (uint64, uint64, FROSTGroupId.T));
             stageEpoch(proposedEpoch, rolloverBlock, groupId, signatureId);
         } else if (selector == this.attestTransaction.selector) {
-            (uint64 epoch, address oracle, uint256 chainId, address safe, bytes32 safeTxStructHash) =
-                abi.decode(context[4:], (uint64, address, uint256, address, bytes32));
-            attestTransaction(epoch, oracle, chainId, safe, safeTxStructHash, signatureId);
+            (
+                uint64 epoch,
+                address oracle,
+                bytes32 oracleDataHash,
+                uint256 chainId,
+                address safe,
+                bytes32 safeTxStructHash
+            ) = abi.decode(context[4:], (uint64, address, bytes32, uint256, address, bytes32));
+            attestTransaction(epoch, oracle, oracleDataHash, chainId, safe, safeTxStructHash, signatureId);
         } else {
             revert UnknownSignatureSelector();
         }

--- a/contracts/src/guard/SafenetGuard.sol
+++ b/contracts/src/guard/SafenetGuard.sol
@@ -223,9 +223,13 @@ contract SafenetGuard is ISafenetGuard, BaseTransactionGuard {
             // The attestation binds the oracle it was gated by. Having verified the (groupKey, epoch) is a
             // known forest member (above), the guard rebuilds the exact message the network signed. Which
             // oracle is acceptable is a Validator-side policy (they only attest on results from an oracle
-            // they honour), not enforced here.
-            bytes32 message =
-                ConsensusMessages.transactionProposal(_CONSENSUS_DOMAIN_SEPARATOR, epoch, oracle, safeTxHash);
+            // they honour), not enforced here. The trailer does not yet carry `oracleData` (empty in every
+            // current proposal), so the message binds `keccak256("")`; the trailer is extended to carry and
+            // verify a real oracleData hash in a follow-up.
+            // forge-lint: disable-next-line(asm-keccak256)
+            bytes32 message = ConsensusMessages.transactionProposal(
+                _CONSENSUS_DOMAIN_SEPARATOR, epoch, oracle, keccak256(""), safeTxHash
+            );
             FROST.verify(groupKey, signature, message);
             return;
         }

--- a/contracts/src/interfaces/IConsensus.sol
+++ b/contracts/src/interfaces/IConsensus.sol
@@ -71,6 +71,7 @@ interface IConsensus {
      * @param safeId The identifier of the Safe account, combining its chain ID and address.
      * @param oracle The address of the oracle contract used for evaluation.
      * @param epoch The epoch in which the transaction is proposed.
+     * @param oracleData Arbitrary oracle-specific data, bound into the signed message hash.
      * @param transaction The proposed Safe transaction.
      */
     event TransactionProposed(
@@ -78,6 +79,7 @@ interface IConsensus {
         SafeId.T indexed safeId,
         address indexed oracle,
         uint64 epoch,
+        bytes oracleData,
         SafeTransaction.T transaction
     );
 
@@ -87,6 +89,9 @@ interface IConsensus {
      * @param safeId The identifier of the Safe account, combining its chain ID and address.
      * @param oracle The address of the oracle contract used for evaluation.
      * @param epoch The epoch in which the attested transaction was proposed.
+     * @param oracleDataHash The `keccak256` of the oracle-specific data bound into the signed message hash. Only the
+     *        hash is echoed here (the full data is emitted by `TransactionProposed`), keeping the attestation a fixed
+     *        size so the validator callback has a constant calldata cost.
      * @param signatureId The FROST signature identifier corresponding to the attestation.
      * @param attestation The attestation to the oracle-checked Safe transaction.
      */
@@ -95,6 +100,7 @@ interface IConsensus {
         SafeId.T indexed safeId,
         address indexed oracle,
         uint64 epoch,
+        bytes32 oracleDataHash,
         FROSTSignatureId.T signatureId,
         FROST.Signature attestation
     );
@@ -173,7 +179,8 @@ interface IConsensus {
     /**
      * @notice Proposes a transaction for oracle-checked validator approval.
      * @param oracle Address of the oracle contract to use for evaluation.
-     * @param oracleData Arbitrary oracle-specific data passed to the oracle; not part of the signed message hash.
+     * @param oracleData Arbitrary oracle-specific data passed to the oracle; bound into the signed message hash
+     *        (as the `bytes oracleData` EIP-712 member).
      * @param transaction The Safe transaction to propose.
      * @return safeTxHash The Safe transaction hash.
      */
@@ -185,6 +192,7 @@ interface IConsensus {
      * @notice Attests to an oracle-checked transaction.
      * @param epoch The epoch in which the transaction was proposed.
      * @param oracle The address of the oracle contract used for evaluation.
+     * @param oracleDataHash The `keccak256` of the oracle-specific data bound into the signed message hash.
      * @param chainId The chain ID of the Safe account.
      * @param safe The address of the Safe account.
      * @param safeTxStructHash The EIP-712 struct hash of the Safe transaction data.
@@ -194,6 +202,7 @@ interface IConsensus {
     function attestTransaction(
         uint64 epoch,
         address oracle,
+        bytes32 oracleDataHash,
         uint256 chainId,
         address safe,
         bytes32 safeTxStructHash,
@@ -204,10 +213,11 @@ interface IConsensus {
      * @notice Gets a transaction attestation by transaction hash.
      * @param epoch The epoch in which the transaction was proposed.
      * @param oracle The address of the oracle contract used for evaluation.
+     * @param oracleDataHash The `keccak256` of the oracle-specific data bound into the signed message hash.
      * @param safeTxHash The Safe transaction hash to query the attestation for.
      * @return signature The FROST signature attesting to the oracle-checked transaction.
      */
-    function getTransactionAttestationByHash(uint64 epoch, address oracle, bytes32 safeTxHash)
+    function getTransactionAttestationByHash(uint64 epoch, address oracle, bytes32 oracleDataHash, bytes32 safeTxHash)
         external
         view
         returns (FROST.Signature memory signature);

--- a/contracts/src/interfaces/IOracle.sol
+++ b/contracts/src/interfaces/IOracle.sol
@@ -27,7 +27,7 @@ interface IOracle {
      * @notice Post a signing request to the oracle for evaluation.
      * @param requestId A unique id that allows fetching additional information related to the request.
      * @param proposer The address that offered the reward and to whom any refund is owed.
-     * @param oracleData Arbitrary oracle-specific data passed by the proposer; not part of the
+     * @param oracleData Arbitrary oracle-specific data passed by the proposer; bound into the
      *                   signed message hash. The oracle may decode this however it sees fit.
      * @dev Transaction data is not passed here; the oracle is expected to fetch it independently
      *      from the TransactionProposed event. The oracle pulls the fee directly from

--- a/contracts/src/libraries/ConsensusMessages.sol
+++ b/contracts/src/libraries/ConsensusMessages.sol
@@ -24,10 +24,10 @@ library ConsensusMessages {
         hex"13de01993286119c9a7628720a5b7d7c32841dbf2d23752b59de86a7e03fe1bf";
 
     /**
-     * @custom:precomputed keccak256("TransactionProposal(uint64 epoch,address oracle,bytes32 safeTxHash)")
+     * @custom:precomputed keccak256("TransactionProposal(uint64 epoch,address oracle,bytes oracleData,bytes32 safeTxHash)")
      */
     bytes32 internal constant TRANSACTION_PROPOSAL_TYPEHASH =
-        hex"d169b83f5cc55f1f8ad78e16e0feae4c314849f017eabb46c45c1ee5750be8c6";
+        hex"9c6706f5afdb1de99f5ad39011e7770ce471f51d78380634f6cedb21a648b8d0";
 
     // ============================================================
     // INTERNAL FUNCTIONS
@@ -81,24 +81,32 @@ library ConsensusMessages {
 
     /**
      * @notice Computes the transaction proposal message that must be attested to by validators.
+     * @dev The message's `bytes oracleData` member is EIP-712 encoded as its `keccak256`, so callers pass the
+     *      pre-computed `oracleDataHash` directly. A caller holding the full data (e.g. `proposeTransaction`) hashes
+     *      it at the callsite; a caller holding only the hash (the guard, from its attestation trailer) uses it as-is.
+     *      Either way the raw data stays with the oracle contract and is never needed to rebuild the signed message.
      * @param domainSeparator The EIP-712 domain separator.
      * @param epoch The epoch for the transaction proposal.
      * @param oracle The address of the oracle contract used for evaluation.
+     * @param oracleDataHash The `keccak256` of the arbitrary oracle-specific data.
      * @param safeTxHash The hash of the Safe transaction.
      * @return result The transaction proposal message hash, used as the oracle requestId.
      */
-    function transactionProposal(bytes32 domainSeparator, uint64 epoch, address oracle, bytes32 safeTxHash)
-        internal
-        pure
-        returns (bytes32 result)
-    {
+    function transactionProposal(
+        bytes32 domainSeparator,
+        uint64 epoch,
+        address oracle,
+        bytes32 oracleDataHash,
+        bytes32 safeTxHash
+    ) internal pure returns (bytes32 result) {
         assembly ("memory-safe") {
             let ptr := mload(0x40)
             mstore(ptr, TRANSACTION_PROPOSAL_TYPEHASH)
             mstore(add(ptr, 0x20), epoch)
             mstore(add(ptr, 0x40), oracle)
-            mstore(add(ptr, 0x60), safeTxHash)
-            mstore(add(ptr, 0x22), keccak256(ptr, 0x80))
+            mstore(add(ptr, 0x60), oracleDataHash)
+            mstore(add(ptr, 0x80), safeTxHash)
+            mstore(add(ptr, 0x22), keccak256(ptr, 0xa0))
             mstore(ptr, hex"1901")
             mstore(add(ptr, 0x02), domainSeparator)
             result := keccak256(ptr, 0x42)

--- a/contracts/test/Consensus.t.sol
+++ b/contracts/test/Consensus.t.sol
@@ -150,7 +150,7 @@ contract ConsensusTest is Test {
 
         vm.expectEmit(true, true, true, true);
         emit IConsensus.TransactionProposed(
-            safeTxHash, SafeId.create(block.chainid, SAFE), address(oracle), 0, transaction
+            safeTxHash, SafeId.create(block.chainid, SAFE), address(oracle), 0, "", transaction
         );
 
         consensus.proposeTransaction(address(oracle), "", transaction);
@@ -163,7 +163,9 @@ contract ConsensusTest is Test {
         FROSTSignatureId.T signatureId = FROSTSignatureId.T.wrap(keccak256("testSig"));
 
         // Attest the transaction so the message slot is occupied.
-        consensus.attestTransaction(0, address(oracle), block.chainid, SAFE, safeTxStructHash, signatureId);
+        consensus.attestTransaction(
+            0, address(oracle), keccak256(""), block.chainid, SAFE, safeTxStructHash, signatureId
+        );
 
         // Proposing the same (oracle, transaction) should now revert since it is already attested.
         vm.expectRevert(Consensus.AlreadyAttested.selector);
@@ -180,10 +182,12 @@ contract ConsensusTest is Test {
 
         vm.expectEmit(true, true, true, true);
         emit IConsensus.TransactionAttested(
-            safeTxHash, SafeId.create(block.chainid, SAFE), address(oracle), 0, signatureId, emptySig
+            safeTxHash, SafeId.create(block.chainid, SAFE), address(oracle), 0, keccak256(""), signatureId, emptySig
         );
 
-        consensus.attestTransaction(0, address(oracle), block.chainid, SAFE, safeTxStructHash, signatureId);
+        consensus.attestTransaction(
+            0, address(oracle), keccak256(""), block.chainid, SAFE, safeTxStructHash, signatureId
+        );
     }
 
     function test_AttestTransaction_DoubleAttest_Reverts() public {
@@ -191,10 +195,14 @@ contract ConsensusTest is Test {
         bytes32 safeTxStructHash = bytes32(uint256(0xdeadbeef));
         FROSTSignatureId.T signatureId = FROSTSignatureId.T.wrap(keccak256("testSig"));
 
-        consensus.attestTransaction(0, address(oracle), block.chainid, SAFE, safeTxStructHash, signatureId);
+        consensus.attestTransaction(
+            0, address(oracle), keccak256(""), block.chainid, SAFE, safeTxStructHash, signatureId
+        );
 
         vm.expectRevert(Consensus.AlreadyAttested.selector);
-        consensus.attestTransaction(0, address(oracle), block.chainid, SAFE, safeTxStructHash, signatureId);
+        consensus.attestTransaction(
+            0, address(oracle), keccak256(""), block.chainid, SAFE, safeTxStructHash, signatureId
+        );
     }
 
     function test_GetTransactionAttestationByHash() public {
@@ -203,9 +211,12 @@ contract ConsensusTest is Test {
         bytes32 safeTxHash = SafeTransaction.partialHash(block.chainid, SAFE, safeTxStructHash);
         FROSTSignatureId.T signatureId = FROSTSignatureId.T.wrap(keccak256("testSig"));
 
-        consensus.attestTransaction(0, address(oracle), block.chainid, SAFE, safeTxStructHash, signatureId);
+        consensus.attestTransaction(
+            0, address(oracle), keccak256(""), block.chainid, SAFE, safeTxStructHash, signatureId
+        );
 
-        FROST.Signature memory sig = consensus.getTransactionAttestationByHash(0, address(oracle), safeTxHash);
+        FROST.Signature memory sig =
+            consensus.getTransactionAttestationByHash(0, address(oracle), keccak256(""), safeTxHash);
         // MockCoordinator returns an empty signature — we verify the call succeeds.
         assertEq(sig.r.x, 0);
     }

--- a/contracts/test/SafenetGuard.t.sol
+++ b/contracts/test/SafenetGuard.t.sol
@@ -177,8 +177,9 @@ contract SafenetGuardTest is Test {
         returns (bytes memory)
     {
         Secp256k1.Point memory groupKey = ForgeSecp256k1.g(sk).toPoint();
-        bytes32 message =
-            ConsensusMessages.transactionProposal(guard.getConsensusDomainSeparator(), epoch, ORACLE_ADDR, txHash);
+        bytes32 message = ConsensusMessages.transactionProposal(
+            guard.getConsensusDomainSeparator(), epoch, ORACLE_ADDR, keccak256(hex""), txHash
+        );
         FROST.Signature memory sig = _frostSign(sk, nk, message);
         bytes memory payload = abi.encode(epoch, ORACLE_ADDR, groupKey, sig); // 224 bytes
         return bytes.concat(payload, abi.encode(payload.length), AttestationTrailer.TYPE_HASH);
@@ -436,7 +437,7 @@ contract SafenetGuardTest is Test {
         uint256 nonce = safe.nonce();
         bytes32 txHash = _safeTxHash(TX_TO, TX_VALUE, TX_DATA, TX_OP, nonce);
         bytes32 message = ConsensusMessages.transactionProposal(
-            guard.getConsensusDomainSeparator(), GENESIS_EPOCH, ORACLE_ADDR, txHash
+            guard.getConsensusDomainSeparator(), GENESIS_EPOCH, ORACLE_ADDR, keccak256(hex""), txHash
         );
         FROST.Signature memory sig = _frostSign(GENESIS_SK, GENESIS_NK, message);
         sig.z = addmod(sig.z, 1, Secp256k1.N); // tamper

--- a/contracts/test/libraries/ConsensusMessages.t.sol
+++ b/contracts/test/libraries/ConsensusMessages.t.sol
@@ -28,15 +28,17 @@ contract ConsensusMessagesTest is Test {
     function test_TransactionProposalTypehash() public pure {
         assertEq(
             ConsensusMessages.TRANSACTION_PROPOSAL_TYPEHASH,
-            keccak256("TransactionProposal(uint64 epoch,address oracle,bytes32 safeTxHash)")
+            keccak256("TransactionProposal(uint64 epoch,address oracle,bytes oracleData,bytes32 safeTxHash)")
         );
     }
 
     function test_TransactionProposal() public pure {
         bytes32 message = ConsensusMessages.domain(23, 0x4838B106FCe9647Bdf1E7877BF73cE8B0BAD5f97)
-            .transactionProposal(1, 0x1234567890123456789012345678901234567890, bytes32(uint256(42)));
+            .transactionProposal(
+                1, 0x1234567890123456789012345678901234567890, keccak256(hex"cafe"), bytes32(uint256(42))
+            );
 
-        assertEq(message, hex"19f3fa0234f374f2e8ec0c2f2a45777a0696ba1ac8a214acf921c3ccfa080717");
+        assertEq(message, hex"973d5f5f4f873250bac60f83283dcff0f1bfbfa8ef19c2120830189a4ffa7084");
     }
 
     /// Cross-language parity vector for `oracle_tx_proposal_hash_parity` in `crates/sentinel/src/hashing.rs`:
@@ -61,8 +63,9 @@ contract ConsensusMessagesTest is Test {
             nonce: 0
         });
 
-        bytes32 message = ConsensusMessages.domain(23, consensus).transactionProposal(11, oracle, transaction.hash());
+        bytes32 message = ConsensusMessages.domain(23, consensus)
+            .transactionProposal(11, oracle, keccak256(hex""), transaction.hash());
 
-        assertEq(message, hex"13889a221bc89a7b93781ab5457f5b7b9a6d9f2e9fe8d97dcf6be83a8658c58c");
+        assertEq(message, hex"8080890fb312c10d10238e8eb3d58a5682e4e691862afee94e94726ad1a16dd5");
     }
 }

--- a/crates/sentinel/src/bindings.rs
+++ b/crates/sentinel/src/bindings.rs
@@ -84,12 +84,13 @@ pub mod consensus {
 
         // EIP-712 struct for the oracle requestId.
         // Field order and types must exactly match the onchain typehash in ConsensusMessages.sol:
-        // keccak256("TransactionProposal(uint64 epoch,address oracle,bytes32 safeTxHash)")
+        // keccak256("TransactionProposal(uint64 epoch,address oracle,bytes oracleData,bytes32 safeTxHash)")
         // Domain: { chainId, verifyingContract: consensus }
         #[derive(Debug)]
         struct TransactionProposal {
             uint64 epoch;
             address oracle;
+            bytes oracleData;
             bytes32 safeTxHash;
         }
 
@@ -100,6 +101,7 @@ pub mod consensus {
                 bytes32 indexed safeId,
                 address indexed oracle,
                 uint64 epoch,
+                bytes oracleData,
                 SafeTransaction transaction
             );
         }

--- a/crates/sentinel/src/hashing.rs
+++ b/crates/sentinel/src/hashing.rs
@@ -3,7 +3,7 @@ use crate::bindings::{
     safe::{Operation as SafeOperation, SafeTx},
 };
 use alloy::{
-    primitives::{Address, B256, Keccak256, U256},
+    primitives::{Address, B256, Bytes, Keccak256, U256},
     sol_types::{Eip712Domain, SolStruct},
 };
 use safenet_core::tx::Signer;
@@ -84,6 +84,7 @@ pub fn oracle_tx_proposal_hash(
     consensus: Address,
     epoch: u64,
     oracle: Address,
+    oracle_data: Bytes,
     stx_hash: B256,
 ) -> B256 {
     let domain = Eip712Domain {
@@ -94,6 +95,7 @@ pub fn oracle_tx_proposal_hash(
     TransactionProposal {
         epoch,
         oracle,
+        oracleData: oracle_data,
         safeTxHash: stx_hash,
     }
     .eip712_signing_hash(&domain)
@@ -149,10 +151,17 @@ mod tests {
         let oracle = address!("4838B106FCe9647Bdf1E7877BF73cE8B0BAD5f97");
 
         let stx_hash = safe_tx_hash(&zero_tx(1, oracle, consensus));
-        let id = oracle_tx_proposal_hash(U256::from(23u64), consensus, 11, oracle, stx_hash);
+        let id = oracle_tx_proposal_hash(
+            U256::from(23u64),
+            consensus,
+            11,
+            oracle,
+            Bytes::new(),
+            stx_hash,
+        );
         assert_eq!(
             id,
-            b256!("13889a221bc89a7b93781ab5457f5b7b9a6d9f2e9fe8d97dcf6be83a8658c58c"),
+            b256!("8080890fb312c10d10238e8eb3d58a5682e4e691862afee94e94726ad1a16dd5"),
         );
     }
 

--- a/crates/sentinel/src/service.rs
+++ b/crates/sentinel/src/service.rs
@@ -122,6 +122,7 @@ impl SentinelTransition {
             self.consensus,
             event.epoch,
             event.oracle,
+            event.oracleData.clone(),
             event.safeTxHash,
         );
         // A duplicate or re-delivered proposal for the same request must not
@@ -759,7 +760,7 @@ mod tests {
     use super::*;
     use crate::bindings::consensus::{Operation, SafeTransaction};
     use alloy::{
-        primitives::{address, keccak256},
+        primitives::{Bytes, address, keccak256},
         providers::Provider as _,
         signers::k256::ecdsa::SigningKey,
     };
@@ -828,7 +829,14 @@ mod tests {
     }
 
     fn request_id(safe_tx_hash: B256, epoch: u64, oracle: Address) -> B256 {
-        oracle_tx_proposal_hash(U256::from(CHAIN_ID), CONSENSUS, epoch, oracle, safe_tx_hash)
+        oracle_tx_proposal_hash(
+            U256::from(CHAIN_ID),
+            CONSENSUS,
+            epoch,
+            oracle,
+            Bytes::new(),
+            safe_tx_hash,
+        )
     }
 
     /// Mirrors `SafeId.create` in `contracts/src/libraries/SafeId.sol`: the chain ID occupies the
@@ -845,6 +853,7 @@ mod tests {
                 safeId: safe_id(CHAIN_ID, SAFE),
                 oracle,
                 epoch: 7,
+                oracleData: Bytes::new(),
                 transaction: safe_tx(to),
             },
         ))

--- a/crates/validator/src/bindings.rs
+++ b/crates/validator/src/bindings.rs
@@ -5,6 +5,13 @@
 //! values are transcribed only where a return is actually decoded onchain
 //! (`getValidatorStaker`); the mutating calls omit them.
 
+// `sol!` expands to constructors whose arity matches the onchain event/function field count, and the
+// oracle attestation carries enough fields to trip `too_many_arguments`. The offending constructor is
+// macro-generated, so it cannot be annotated per-function (an `#[allow]` on the `sol!` invocation is
+// reported as unused); the allow therefore sits at module scope, where the only hand-written item is a
+// single-argument `TryFrom` that can never trip the lint.
+#![allow(clippy::too_many_arguments)]
+
 use alloy::sol;
 use serde::{Deserialize, Serialize};
 
@@ -127,6 +134,7 @@ sol! {
             bytes32 indexed safeId,
             address indexed oracle,
             uint64 epoch,
+            bytes oracleData,
             SafeTransaction transaction
         );
         event TransactionAttested(
@@ -134,6 +142,7 @@ sol! {
             bytes32 indexed safeId,
             address indexed oracle,
             uint64 epoch,
+            bytes32 oracleDataHash,
             bytes32 signatureId,
             Signature attestation
         );
@@ -149,6 +158,7 @@ sol! {
         function attestTransaction(
             uint64 epoch,
             address oracle,
+            bytes32 oracleDataHash,
             uint256 chainId,
             address safe,
             bytes32 safeTxStructHash,

--- a/crates/validator/src/consensus/hashing.rs
+++ b/crates/validator/src/consensus/hashing.rs
@@ -12,11 +12,19 @@ use crate::{
     consensus::epoch::EpochId,
 };
 use alloy::{
-    primitives::{Address, B256, U256},
+    primitives::{Address, B256, Bytes, U256, b256, keccak256},
     sol,
     sol_types::{Eip712Domain, SolStruct},
 };
 use std::num::NonZeroU64;
+
+/// `keccak256("TransactionProposal(uint64 epoch,address oracle,bytes oracleData,bytes32 safeTxHash)")`.
+///
+/// Kept in sync with `ConsensusMessages.TRANSACTION_PROPOSAL_TYPEHASH` onchain; used only by
+/// [`ConsensusDomain::transaction_proposal_hash_from_data_hash`], which rebuilds the digest from a
+/// pre-hashed `oracleData`.
+const TRANSACTION_PROPOSAL_TYPE_HASH: B256 =
+    b256!("9c6706f5afdb1de99f5ad39011e7770ce471f51d78380634f6cedb21a648b8d0");
 
 sol! {
     /// The classic Safe `SafeTx` EIP-712 struct.
@@ -38,6 +46,7 @@ sol! {
     struct TransactionProposal {
         uint64 epoch;
         address oracle;
+        bytes oracleData;
         bytes32 safeTxHash;
     }
 
@@ -103,18 +112,53 @@ impl ConsensusDomain {
 
     /// The consensus-domain hash of an oracle-backed Safe transaction proposal,
     /// embedding the already-computed [`safe_tx_hash`] as its `safeTxHash` field.
+    ///
+    /// This is the proposal/signing path, which always holds the full `oracleData`, so it uses the
+    /// canonical `SolStruct` EIP-712 hashing (alloy hashes the `bytes` member itself).
     pub fn transaction_proposal_hash(
         &self,
         epoch: EpochId,
         oracle: Address,
+        oracle_data: Bytes,
         safe_tx_hash: B256,
     ) -> B256 {
         TransactionProposal {
             epoch: epoch.raw_value(),
             oracle,
+            oracleData: oracle_data,
             safeTxHash: safe_tx_hash,
         }
         .eip712_signing_hash(&self.0)
+    }
+
+    /// The same proposal digest, rebuilt from a pre-hashed `oracleData`.
+    ///
+    /// Used only on the attest path: the onchain `TransactionAttested` event carries just
+    /// `keccak256(oracleData)` (so the validator callback stays a constant size) and the full bytes
+    /// are not available there. EIP-712 encodes the `bytes oracleData` member as its `keccak256`, so
+    /// this produces a digest identical to [`transaction_proposal_hash`] for the same data (asserted
+    /// in the tests). It is spelled out by hand because alloy's `SolStruct` signing hash requires a
+    /// value holding the full bytes, which this path does not have.
+    pub fn transaction_proposal_hash_from_data_hash(
+        &self,
+        epoch: EpochId,
+        oracle: Address,
+        oracle_data_hash: B256,
+        safe_tx_hash: B256,
+    ) -> B256 {
+        let mut data = [0u8; 160];
+        data[0..32].copy_from_slice(TRANSACTION_PROPOSAL_TYPE_HASH.as_slice());
+        data[32..64].copy_from_slice(&U256::from(epoch.raw_value()).to_be_bytes::<32>());
+        data[64..96].copy_from_slice(oracle.into_word().as_slice());
+        data[96..128].copy_from_slice(oracle_data_hash.as_slice());
+        data[128..160].copy_from_slice(safe_tx_hash.as_slice());
+        let struct_hash = keccak256(data);
+
+        let mut message = [0u8; 66];
+        message[0..2].copy_from_slice(&[0x19, 0x01]);
+        message[2..34].copy_from_slice(self.0.separator().as_slice());
+        message[34..66].copy_from_slice(struct_hash.as_slice());
+        keccak256(message)
     }
 
     /// The consensus-domain hash of an oracle-backed Safe transaction packet:
@@ -124,9 +168,10 @@ impl ConsensusDomain {
         &self,
         epoch: EpochId,
         oracle: Address,
+        oracle_data: Bytes,
         tx: &SafeTransaction,
     ) -> B256 {
-        self.transaction_proposal_hash(epoch, oracle, safe_tx_hash(tx))
+        self.transaction_proposal_hash(epoch, oracle, oracle_data, safe_tx_hash(tx))
     }
 
     /// The consensus-domain hash of an epoch rollover proposal.
@@ -186,9 +231,31 @@ mod tests {
     #[test]
     fn sample_transaction_packet_hash() {
         assert_eq!(
-            TEST_DOMAIN.transaction_packet_hash(EPOCH_ONE, TEST_ADDRESS, &safe_tx()),
-            b256!("44151ab85018beace71ef3255d90480c7b41a3c42b2cf892c155a304875abc9e")
+            TEST_DOMAIN.transaction_packet_hash(EPOCH_ONE, TEST_ADDRESS, Bytes::new(), &safe_tx()),
+            b256!("5ac4a916cb21b51c5b61c6d4479f7c7477856abecb96e439fb53d5462fb5b3ed")
         );
+    }
+
+    /// The hand-rolled attest-path reconstruction must match the canonical `SolStruct`-based proposal
+    /// hash for the same data (EIP-712 encodes the `bytes oracleData` member as its keccak256).
+    #[test]
+    fn proposal_hash_from_data_hash_matches_full_data() {
+        for oracle_data in [Bytes::new(), Bytes::from_static(&[0xca, 0xfe])] {
+            let safe_tx = safe_tx();
+            let full = TEST_DOMAIN.transaction_packet_hash(
+                EPOCH_ONE,
+                TEST_ADDRESS,
+                oracle_data.clone(),
+                &safe_tx,
+            );
+            let from_hash = TEST_DOMAIN.transaction_proposal_hash_from_data_hash(
+                EPOCH_ONE,
+                TEST_ADDRESS,
+                keccak256(&oracle_data),
+                safe_tx_hash(&safe_tx),
+            );
+            assert_eq!(full, from_hash);
+        }
     }
 
     #[test]

--- a/crates/validator/src/service/action.rs
+++ b/crates/validator/src/service/action.rs
@@ -91,6 +91,7 @@ pub enum Action {
     AttestTransaction {
         epoch: EpochId,
         oracle: Address,
+        oracle_data_hash: B256,
         chain_id: U256,
         safe: Address,
         safe_tx_struct_hash: B256,
@@ -334,6 +335,7 @@ impl ActionEncoder<Action> for Encoder {
             Action::AttestTransaction {
                 epoch,
                 oracle,
+                oracle_data_hash,
                 chain_id,
                 safe,
                 safe_tx_struct_hash,
@@ -346,6 +348,7 @@ impl ActionEncoder<Action> for Encoder {
                     data: Consensus::attestTransactionCall {
                         epoch: epoch.raw_value(),
                         oracle,
+                        oracleDataHash: oracle_data_hash,
                         chainId: chain_id,
                         safe,
                         safeTxStructHash: safe_tx_struct_hash,

--- a/crates/validator/src/state/mod.rs
+++ b/crates/validator/src/state/mod.rs
@@ -23,7 +23,7 @@ use crate::{
     merkle::MerkleRoot,
     service::{Action, Effect, Event, Resume},
 };
-use alloy::primitives::{Address, B256};
+use alloy::primitives::{Address, B256, Bytes};
 use safenet_core::state::{Commands, Message, StateTransition};
 use serde::{Deserialize, Serialize};
 use std::{
@@ -236,6 +236,9 @@ enum Packet {
         epoch: EpochId,
         /// The oracle vouching for the transaction.
         oracle: Address,
+        /// Arbitrary oracle-specific data, bound into the signed message. Retained as bytes and hashed
+        /// only when building the (constant-size) attestation call.
+        oracle_data: Bytes,
         /// The proposed transaction.
         transaction: Box<SafeTransaction>,
     },

--- a/crates/validator/src/state/sign.rs
+++ b/crates/validator/src/state/sign.rs
@@ -7,7 +7,7 @@ use crate::{
     service::{Action, Effect},
 };
 use alloy::{
-    primitives::{Address, B256},
+    primitives::{Address, B256, keccak256},
     sol_types::SolCall as _,
 };
 use safenet_core::state::{Command, Commands};
@@ -808,12 +808,13 @@ impl Packet {
     /// placeholder - the `Consensus` contract fills it in itself when it
     /// invokes the callback from a completed `signShareWithCallback`.
     fn attestation_callback(&self, consensus: Address) -> bindings::Callback {
-        let (epoch, oracle, transaction) = match self {
+        let (epoch, oracle, oracle_data, transaction) = match self {
             Packet::Transaction {
                 epoch,
                 oracle,
+                oracle_data,
                 transaction,
-            } => (*epoch, *oracle, transaction),
+            } => (*epoch, *oracle, oracle_data, transaction),
             Packet::EpochRollover {
                 proposed_epoch,
                 rollover_block,
@@ -838,6 +839,7 @@ impl Packet {
         let context = Consensus::attestTransactionCall {
             epoch: epoch.raw_value(),
             oracle,
+            oracleDataHash: keccak256(oracle_data),
             chainId: transaction.chainId,
             safe: transaction.safe,
             safeTxStructHash: safe_tx_struct_hash,
@@ -870,10 +872,12 @@ impl Packet {
             Packet::Transaction {
                 epoch,
                 oracle,
+                oracle_data,
                 transaction,
             } => Action::AttestTransaction {
                 epoch: *epoch,
                 oracle: *oracle,
+                oracle_data_hash: keccak256(oracle_data),
                 chain_id: transaction.chainId,
                 safe: transaction.safe,
                 safe_tx_struct_hash: hashing::safe_tx_struct_hash(transaction),

--- a/crates/validator/src/state/transactions.rs
+++ b/crates/validator/src/state/transactions.rs
@@ -39,9 +39,12 @@ impl Transition {
             return (state, Vec::new());
         }
 
-        let message =
-            self.consensus
-                .transaction_packet_hash(epoch, event.oracle, &event.transaction);
+        let message = self.consensus.transaction_packet_hash(
+            epoch,
+            event.oracle,
+            event.oracleData.clone(),
+            &event.transaction,
+        );
 
         // Prevent duplicate ongoing transaction proposals. This is to prevent
         // malicious parties from blocking transaction attestations from ever
@@ -50,6 +53,7 @@ impl Transition {
             let packet = Packet::Transaction {
                 epoch,
                 oracle: event.oracle,
+                oracle_data: event.oracleData.clone(),
                 transaction: Box::new(event.transaction.clone()),
             };
             let signers = participating_epoch.group.participants().clone();
@@ -79,9 +83,12 @@ impl Transition {
         event: &Consensus::TransactionAttested,
     ) -> (State, Commands<State, Self>) {
         let epoch = EpochId::from_raw(event.epoch);
-        let message =
-            self.consensus
-                .transaction_proposal_hash(epoch, event.oracle, event.safeTxHash);
+        let message = self.consensus.transaction_proposal_hash_from_data_hash(
+            epoch,
+            event.oracle,
+            event.oracleDataHash,
+            event.safeTxHash,
+        );
         tracing::info!(
             ?epoch,
             safe_tx_hash = %event.safeTxHash,

--- a/scripts/run_validator_integration_test.sh
+++ b/scripts/run_validator_integration_test.sh
@@ -212,7 +212,7 @@ while [ "$SECONDS" -lt "$DEADLINE" ]; do
             --from-block 0 \
             --to-block latest \
             --address "$CONSENSUS_ADDR" \
-            'TransactionProposed(bytes32,bytes32,address,uint64,(uint256,address,address,uint256,bytes,uint8,uint256,uint256,uint256,address,address,uint256))')
+            'TransactionProposed(bytes32,bytes32,address,uint64,bytes,(uint256,address,address,uint256,bytes,uint8,uint256,uint256,uint256,address,address,uint256))')
         TRANSACTION_HASH=$(jq -er --arg epoch "$EPOCH_ONE_WORD" \
             '[.[] | select(.data | startswith($epoch))][-1].topics[1]' <<< "$PROPOSALS")
         TRANSACTION_PROPOSED=1
@@ -232,7 +232,7 @@ while [ "$SECONDS" -lt "$DEADLINE" ]; do
             --from-block 0 \
             --to-block latest \
             --address "$CONSENSUS_ADDR" \
-            'TransactionAttested(bytes32,bytes32,address,uint64,bytes32,((uint256,uint256),uint256))')
+            'TransactionAttested(bytes32,bytes32,address,uint64,bytes32,bytes32,((uint256,uint256),uint256))')
         TRANSACTION_ATTESTED=$(jq --arg hash "$TRANSACTION_HASH" --arg epoch "$EPOCH_ONE_WORD" \
             '[.[] | select((.topics[1] == $hash) and (.data | startswith($epoch)))] | length' <<< "$ATTESTATIONS")
     fi


### PR DESCRIPTION
Bind `oracleData` into the FROST-signed transaction-proposal message across consensus, the validator, and the sentinel.

### Context and Motivation

- The guard attestation needs to authenticate the `oracleData` a proposal was gated with. This adds `oracleData` as a `bytes` member of the `TransactionProposal` EIP-712 message, so the signed message (and the oracle `requestId`) commits to it.

### Decisions and Tradeoffs

- `ConsensusMessages.transactionProposal` takes the `oracleData` as its `keccak256` directly (EIP-712 encodes a `bytes` member as its hash), placed next to `oracle`. Callers holding the full data hash at the callsite; the guard supplies the hash. This keeps a single builder (no separate hash variant).
- The proposed event emits the full `oracleData` (and it is passed to the oracle); the attested event, `attestTransaction`, the getter, and the `onSignCompleted` context carry only the `bytes32` hash, so the attestation and validator callback stay a constant size.
- Validator: the proposed/signing path uses alloy's `SolStruct` hashing over the full bytes; the attest path (which only has the hash on-chain) rebuilds the same digest by hand, pinned against the `SolStruct` and the cross-language vectors in tests.

### Testing

- `forge test` (253), `forge fmt --check`, `forge lint`.
- `cargo fmt --check`, `cargo clippy --workspace --all-targets`, `cargo test --workspace`.
- `scripts/run_validator_integration_test.sh` and `scripts/run_sentinel_integration_test.sh`: both SUCCESS end-to-end.
