### PR TITLE
feat(guard): carry and verify oracleData in the attestation trailer

### DIFF
--- a/contracts/src/guard/SafenetGuard.sol
+++ b/contracts/src/guard/SafenetGuard.sol
@@ -198,8 +198,13 @@ contract SafenetGuard is ISafenetGuard, BaseTransactionGuard {
         if (_isAutoAllowed(to, value, data, operation)) return;
 
         if (AttestationTrailer.hasTrailer(signatures)) {
-            (uint64 epoch, address oracle, Secp256k1.Point memory groupKey, FROST.Signature memory signature) =
-                AttestationTrailer.decode(signatures);
+            (
+                uint64 epoch,
+                address oracle,
+                bytes32 oracleDataHash,
+                Secp256k1.Point memory groupKey,
+                FROST.Signature memory signature
+            ) = AttestationTrailer.decode(signatures);
             // Cheap forest-membership check first (also implies a non-zero key, enforced on record), so an
             // untrusted key short-circuits before the more expensive Safe tx hash is computed.
             require($epochs.isKnown(groupKey, epoch), UntrustedAttestationKey());
@@ -220,15 +225,13 @@ contract SafenetGuard is ISafenetGuard, BaseTransactionGuard {
                     nonce: nonce
                 })
             );
-            // The attestation binds the oracle it was gated by. Having verified the (groupKey, epoch) is a
-            // known forest member (above), the guard rebuilds the exact message the network signed. Which
-            // oracle is acceptable is a Validator-side policy (they only attest on results from an oracle
-            // they honour), not enforced here. The trailer does not yet carry `oracleData` (empty in every
-            // current proposal), so the message binds `keccak256("")`; the trailer is extended to carry and
-            // verify a real oracleData hash in a follow-up.
-            // forge-lint: disable-next-line(asm-keccak256)
+            // The attestation binds the oracle it was gated by and the oracleData (by its hash) it was gated
+            // with. Having verified the (groupKey, epoch) is a known forest member (above), the guard rebuilds
+            // the exact message the network signed. The guard neither pins the oracle nor validates the
+            // oracleData; which oracle is acceptable is a Validator-side policy (they only attest on results
+            // from an oracle they honour), not enforced here.
             bytes32 message = ConsensusMessages.transactionProposal(
-                _CONSENSUS_DOMAIN_SEPARATOR, epoch, oracle, keccak256(""), safeTxHash
+                _CONSENSUS_DOMAIN_SEPARATOR, epoch, oracle, oracleDataHash, safeTxHash
             );
             FROST.verify(groupKey, signature, message);
             return;

--- a/contracts/src/libraries/AttestationTrailer.sol
+++ b/contracts/src/libraries/AttestationTrailer.sol
@@ -9,10 +9,12 @@ import {SignatureExtension} from "@/libraries/SignatureExtension.sol";
  * @title AttestationTrailer
  * @notice Recognises and decodes a Safenet attestation carried as a {SignatureExtension} on Safe's
  *         `signatures` bytes.
- * @dev The attestation is a typed signature extension: its payload is the fixed 224-byte
- *      `abi.encode(uint64 epoch, address oracle, Secp256k1.Point groupKey, FROST.Signature signature)`,
+ * @dev The attestation is a typed signature extension: its payload is the fixed 256-byte
+ *      `abi.encode(uint64 epoch, address oracle, bytes32 oracleDataHash, Secp256k1.Point groupKey, FROST.Signature signature)`,
  *      tagged by the terminal `TYPE_HASH`. The `oracle` is the oracle contract the attestation was gated
- *      by; the guard reconstructs the consensus `OracleTransactionProposal` message from it. The envelope
+ *      by, and `oracleDataHash` is the keccak256 of the data it was gated with; the guard reconstructs the
+ *      consensus `TransactionProposal` message from them (the raw oracleData is not needed on-chain and
+ *      stays with the oracle contract). The envelope
  *      framing (length word + type hash, tail-anchored so Safe's front-to-back signature parser is
  *      untouched) is owned by {SignatureExtension}; this library owns only the guard-specific type hash
  *      and payload schema.
@@ -28,16 +30,16 @@ library AttestationTrailer {
     bytes32 internal constant TYPE_HASH = keccak256("SafenetGuard.AttestationTrailer.v1");
 
     /**
-     * @dev Payload is `abi.encode(uint64, address, Secp256k1.Point, FROST.Signature)` = 7 words = 224 bytes.
+     * @dev Payload is `abi.encode(uint64, address, bytes32, Secp256k1.Point, FROST.Signature)` = 8 words = 256 bytes.
      */
-    uint256 private constant _PAYLOAD_LENGTH = 224;
+    uint256 private constant _PAYLOAD_LENGTH = 256;
 
     // ============================================================
     // ERRORS
     // ============================================================
 
     /**
-     * @notice Thrown when a recognised trailer's payload is not the expected 224-byte attestation.
+     * @notice Thrown when a recognised trailer's payload is not the expected 256-byte attestation.
      */
     error MalformedAttestationTrailer();
 
@@ -59,21 +61,28 @@ library AttestationTrailer {
      * @notice Decodes the attestation from a trailer-bearing `signatures` blob.
      * @dev Self-verifying via {SignatureExtension.payload}: reverts `MalformedSignatureExtension` if the
      *      envelope itself is malformed, and `MalformedAttestationTrailer` if the payload is not the fixed
-     *      224-byte attestation — a recognised trailer never yields partial or wrongly-sized data.
+     *      256-byte attestation — a recognised trailer never yields partial or wrongly-sized data.
      * @param signatures The Safe `signatures` blob ending in an attestation trailer.
      * @return epoch The attested epoch.
      * @return oracle The oracle contract the attestation was gated by.
+     * @return oracleDataHash The keccak256 of the oracle data bound into the attested message.
      * @return groupKey The attesting FROST group key.
      * @return signature The FROST signature.
      */
     function decode(bytes calldata signatures)
         internal
         pure
-        returns (uint64 epoch, address oracle, Secp256k1.Point memory groupKey, FROST.Signature memory signature)
+        returns (
+            uint64 epoch,
+            address oracle,
+            bytes32 oracleDataHash,
+            Secp256k1.Point memory groupKey,
+            FROST.Signature memory signature
+        )
     {
         bytes calldata payloadData = SignatureExtension.payload(signatures, TYPE_HASH);
         require(payloadData.length == _PAYLOAD_LENGTH, MalformedAttestationTrailer());
-        (epoch, oracle, groupKey, signature) =
-            abi.decode(payloadData, (uint64, address, Secp256k1.Point, FROST.Signature));
+        (epoch, oracle, oracleDataHash, groupKey, signature) =
+            abi.decode(payloadData, (uint64, address, bytes32, Secp256k1.Point, FROST.Signature));
     }
 }

--- a/contracts/test/SafenetGuard.t.sol
+++ b/contracts/test/SafenetGuard.t.sol
@@ -169,19 +169,28 @@ contract SafenetGuardTest is Test {
     }
 
     /// @dev Builds an inline FROST attestation as a signature extension:
-    ///      `[224-byte abi.encode(epoch, oracle, groupKey, signature)][uint256 payloadLength = 224][32-byte TYPE_HASH]`.
+    ///      `[256-byte abi.encode(epoch, oracle, oracleDataHash, groupKey, signature)][uint256 payloadLength = 256][32-byte TYPE_HASH]`.
     ///      The FROST signature is over the oracle-transaction-proposal message; the group key is derived
     ///      from `sk` so it matches the signing key. Uses `ORACLE_ADDR` as the gating oracle.
     function _buildInlineAttestation(bytes32 txHash, uint64 epoch, uint256 sk, uint256 nk)
         internal
         returns (bytes memory)
     {
+        return _buildInlineAttestation(txHash, epoch, sk, nk, hex"");
+    }
+
+    /// @dev Like the four-argument overload, but binds an explicit `oracleData` into the attested message;
+    ///      the trailer carries only its keccak256 hash (the fifth payload field, next to the oracle).
+    function _buildInlineAttestation(bytes32 txHash, uint64 epoch, uint256 sk, uint256 nk, bytes memory oracleData)
+        internal
+        returns (bytes memory)
+    {
         Secp256k1.Point memory groupKey = ForgeSecp256k1.g(sk).toPoint();
         bytes32 message = ConsensusMessages.transactionProposal(
-            guard.getConsensusDomainSeparator(), epoch, ORACLE_ADDR, keccak256(hex""), txHash
+            guard.getConsensusDomainSeparator(), epoch, ORACLE_ADDR, keccak256(oracleData), txHash
         );
         FROST.Signature memory sig = _frostSign(sk, nk, message);
-        bytes memory payload = abi.encode(epoch, ORACLE_ADDR, groupKey, sig); // 224 bytes
+        bytes memory payload = abi.encode(epoch, ORACLE_ADDR, keccak256(oracleData), groupKey, sig); // 256 bytes
         return bytes.concat(payload, abi.encode(payload.length), AttestationTrailer.TYPE_HASH);
     }
 
@@ -375,6 +384,42 @@ contract SafenetGuardTest is Test {
         _execSafeTx(TX_TO, TX_VALUE, TX_DATA, TX_OP, ExecMode.Attested); // must not revert
     }
 
+    function test_checkTransaction_passesWithOracleData() public {
+        // A non-empty oracleData, bound into the signed message and carried (as its hash) in the trailer.
+        uint256 nonce = safe.nonce();
+        bytes32 txHash = _safeTxHash(TX_TO, TX_VALUE, TX_DATA, TX_OP, nonce);
+        bytes memory trailer = _buildInlineAttestation(txHash, GENESIS_EPOCH, GENESIS_SK, GENESIS_NK, hex"c0ffee");
+        safe.execTransaction(
+            TX_TO,
+            TX_VALUE,
+            TX_DATA,
+            TX_OP,
+            0,
+            0,
+            0,
+            address(0),
+            payable(address(0)),
+            bytes.concat(_signSafeTx(txHash), trailer)
+        ); // must not revert
+    }
+
+    function test_checkTransaction_revertsWhenOracleDataTampered() public {
+        // Signature is over one oracleData, but a different oracleDataHash is carried in the trailer, so the
+        // guard rebuilds a message the group never signed and FROST verification fails.
+        uint256 nonce = safe.nonce();
+        bytes32 txHash = _safeTxHash(TX_TO, TX_VALUE, TX_DATA, TX_OP, nonce);
+        bytes32 message = ConsensusMessages.transactionProposal(
+            guard.getConsensusDomainSeparator(), GENESIS_EPOCH, ORACLE_ADDR, keccak256(hex"c0ffee"), txHash
+        );
+        FROST.Signature memory sig = _frostSign(GENESIS_SK, GENESIS_NK, message);
+        bytes memory payload =
+            abi.encode(GENESIS_EPOCH, ORACLE_ADDR, keccak256(hex"beef"), ForgeSecp256k1.g(GENESIS_SK).toPoint(), sig);
+        bytes memory combined =
+            bytes.concat(_signSafeTx(txHash), payload, abi.encode(payload.length), AttestationTrailer.TYPE_HASH);
+        vm.expectRevert(Secp256k1.InvalidMulMulAddWitness.selector);
+        safe.execTransaction(TX_TO, TX_VALUE, TX_DATA, TX_OP, 0, 0, 0, address(0), payable(address(0)), combined);
+    }
+
     function test_checkTransaction_revertsWithUntrustedKey() public {
         // A well-formed attestation whose group key was never recorded in the forest.
         uint256 nonce = safe.nonce();
@@ -441,7 +486,8 @@ contract SafenetGuardTest is Test {
         );
         FROST.Signature memory sig = _frostSign(GENESIS_SK, GENESIS_NK, message);
         sig.z = addmod(sig.z, 1, Secp256k1.N); // tamper
-        bytes memory payload = abi.encode(GENESIS_EPOCH, ORACLE_ADDR, ForgeSecp256k1.g(GENESIS_SK).toPoint(), sig);
+        bytes memory payload =
+            abi.encode(GENESIS_EPOCH, ORACLE_ADDR, keccak256(hex""), ForgeSecp256k1.g(GENESIS_SK).toPoint(), sig);
         bytes memory combined =
             bytes.concat(_signSafeTx(txHash), payload, abi.encode(payload.length), AttestationTrailer.TYPE_HASH);
         vm.expectRevert(Secp256k1.InvalidMulMulAddWitness.selector);
@@ -867,8 +913,8 @@ contract SafenetGuardTest is Test {
         safe.execTransaction(TX_TO, TX_VALUE, TX_DATA, TX_OP, 0, 0, 0, address(0), payable(address(0)), combined);
     }
 
-    /// @notice A well-formed signature-extension envelope whose payload is not the 224-byte attestation
-    ///         fails closed at the guard level with `MalformedAttestationTrailer` — the `payloadLength != 224`
+    /// @notice A well-formed signature-extension envelope whose payload is not the 256-byte attestation
+    ///         fails closed at the guard level with `MalformedAttestationTrailer` - the `payloadLength != 256`
     ///         shape, exercised end-to-end through `execTransaction`.
     function test_trailer_wrongPayloadSizeReverts() public {
         uint256 nonce = safe.nonce();

--- a/contracts/test/libraries/AttestationTrailer.t.sol
+++ b/contracts/test/libraries/AttestationTrailer.t.sol
@@ -10,14 +10,15 @@ import {Secp256k1} from "@/libraries/Secp256k1.sol";
 /**
  * @title AttestationTrailerTest
  * @notice Unit tests for the typed attestation codec layered on `SignatureExtension`: recognition,
- *         round-trip decode of the fixed 224-byte payload, and the two reverts — a well-formed envelope
- *         whose payload is the wrong size (`MalformedAttestationTrailer`) and a malformed envelope
- *         (`MalformedSignatureExtension`, surfaced from the transport layer). Both functions take
- *         `calldata`, so they run through external `this.call*` wrappers.
+ *         round-trip decode of the fixed 256-byte payload (including the `oracleDataHash`), and the two
+ *         reverts — a well-formed envelope whose payload is the wrong size (`MalformedAttestationTrailer`)
+ *         and a malformed envelope (`MalformedSignatureExtension`, surfaced from the transport layer).
+ *         Both functions take `calldata`, so they run through external `this.call*` wrappers.
  */
 contract AttestationTrailerTest is Test {
     uint64 internal constant EPOCH = 7;
     address internal constant ORACLE = address(0x0AC1E);
+    bytes32 internal constant ORACLE_DATA_HASH = keccak256("oracle-data");
 
     function callHasTrailer(bytes calldata signatures) external pure returns (bool) {
         return AttestationTrailer.hasTrailer(signatures);
@@ -26,16 +27,23 @@ contract AttestationTrailerTest is Test {
     function callDecode(bytes calldata signatures)
         external
         pure
-        returns (uint64 epoch, address oracle, Secp256k1.Point memory groupKey, FROST.Signature memory signature)
+        returns (
+            uint64 epoch,
+            address oracle,
+            bytes32 oracleDataHash,
+            Secp256k1.Point memory groupKey,
+            FROST.Signature memory signature
+        )
     {
         return AttestationTrailer.decode(signatures);
     }
 
     function _attestationPayload() internal pure returns (bytes memory) {
-        // abi.encode(uint64, address, Secp256k1.Point, FROST.Signature) = 224 bytes.
+        // abi.encode(uint64, address, bytes32, Secp256k1.Point, FROST.Signature) = 256 bytes.
         return abi.encode(
             EPOCH,
             ORACLE,
+            ORACLE_DATA_HASH,
             Secp256k1.Point({x: 111, y: 222}),
             FROST.Signature({r: Secp256k1.Point({x: 333, y: 444}), z: 555})
         );
@@ -51,14 +59,15 @@ contract AttestationTrailerTest is Test {
     }
 
     function test_hasTrailer_falseWhenAbsent() public view {
-        assertFalse(this.callHasTrailer(bytes.concat(hex"aabbcc", bytes32(uint256(224)))));
+        assertFalse(this.callHasTrailer(bytes.concat(hex"aabbcc", bytes32(uint256(256)))));
     }
 
     function test_decode_roundTrips() public view {
-        (uint64 epoch, address oracle, Secp256k1.Point memory k, FROST.Signature memory s) =
+        (uint64 epoch, address oracle, bytes32 oracleDataHash, Secp256k1.Point memory k, FROST.Signature memory s) =
             this.callDecode(_trailer(hex"aabbcc", _attestationPayload()));
         assertEq(epoch, EPOCH);
         assertEq(oracle, ORACLE);
+        assertEq(oracleDataHash, ORACLE_DATA_HASH);
         assertEq(k.x, 111);
         assertEq(k.y, 222);
         assertEq(s.r.x, 333);
@@ -67,7 +76,7 @@ contract AttestationTrailerTest is Test {
     }
 
     function test_decode_revertsOnWrongPayloadSize() public {
-        // A well-formed envelope whose payload is not the fixed 224-byte attestation.
+        // A well-formed envelope whose payload is not the fixed 256-byte attestation.
         vm.expectRevert(AttestationTrailer.MalformedAttestationTrailer.selector);
         this.callDecode(_trailer(hex"aabb", hex"1122334455667788"));
     }


### PR DESCRIPTION
Carry and verify the `oracleData` hash in the guard's attestation trailer.

### Context and Motivation

- With `oracleData` now bound into the consensus message (#726), the guard must rebuild that message to verify the FROST signature. The trailer gains a `bytes32 oracleDataHash` field so `checkTransaction` can reconstruct the exact signed message.

### Decisions and Tradeoffs

- Only the `keccak256` of `oracleData` is carried (a fixed 256-byte payload), placed next to `oracle`; the guard does not introspect the data and the raw bytes stay with the oracle contract. The message is rebuilt via `ConsensusMessages.transactionProposal`, which takes the hash directly.

### Testing

- `forge test` (253, incl. non-empty `oracleData` success + tampered-hash revert + fixed-size codec round-trip), `forge fmt --check`, `forge lint`.
