### PR TITLE
[Sentinel Engine 2b]: Build Docker Image

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -26,6 +26,8 @@ jobs:
             dockerfile: crates/validator/Dockerfile
           - image: sentinel
             dockerfile: crates/sentinel/Dockerfile
+          - image: sentinel-engine
+            dockerfile: crates/sentinel-engine/Dockerfile
           - image: contracts
             dockerfile: contracts/Dockerfile
 

--- a/crates/sentinel-engine/Dockerfile
+++ b/crates/sentinel-engine/Dockerfile
@@ -1,0 +1,28 @@
+# ---- Builder Stage ----
+# Compiles the release binary against the full workspace: `sentinel-engine`
+# depends on `safenet-core`/`safe-tx` via workspace path dependencies, so the
+# build needs the whole `crates/` tree.
+FROM rust:1-slim AS builder
+WORKDIR /usr/src/app
+
+COPY Cargo.toml Cargo.lock ./
+COPY crates/ crates/
+
+RUN cargo build --release --locked --package sentinel-engine
+
+# ---- Runtime Stage ----
+# Slim image with only the compiled binary and CA roots for the TLS endpoints
+# used by the engine's checks.
+FROM debian:trixie-slim AS runner
+WORKDIR /usr/src/app
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+	ca-certificates \
+	&& rm -rf /var/lib/apt/lists/*
+
+COPY --from=builder /usr/src/app/target/release/sentinel-engine ./sentinel-engine
+
+# `ENTRYPOINT` (not `CMD`) so that a Kubernetes/`podman kube play` pod spec's
+# `args:` (e.g. `--config-file=...`) appends to the binary instead of
+# replacing it.
+ENTRYPOINT ["./sentinel-engine"]

--- a/crates/sentinel-engine/Dockerfile.dockerignore
+++ b/crates/sentinel-engine/Dockerfile.dockerignore
@@ -1,0 +1,4 @@
+/**
+!/Cargo.toml
+!/Cargo.lock
+!/crates/**


### PR DESCRIPTION
Adds a docker file to build the docker image for the sentinel engine.

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://docs.safefoundation.org/cla).
