### PR TITLE
feat(explorer): mirror oracleData in the oracle proposal hash

### DIFF
--- a/explorer/src/components/transaction/SafeTxAttestationStatus.tsx
+++ b/explorer/src/components/transaction/SafeTxAttestationStatus.tsx
@@ -13,6 +13,7 @@ export function SafeTxAttestationStatus({ proposal }: { proposal: TransactionPro
 		proposal.proposedAt.block,
 		proposal.attestedAt?.block ?? null,
 		proposal.oracle,
+		proposal.oracleData,
 	);
 	const allValidatorIds = Array.from(validatorInfo.data?.keys() ?? []);
 	const committedIds = status.data?.committed.map((s) => s.address) ?? [];

--- a/explorer/src/components/transaction/SafeTxProposals.test.tsx
+++ b/explorer/src/components/transaction/SafeTxProposals.test.tsx
@@ -67,6 +67,7 @@ const makeProposal = (overrides?: Partial<TransactionProposalWithStatus>): Trans
 	safeTxHash: SAFE_TX_HASH,
 	epoch: 1n,
 	oracle: "0x0000000000000000000000000000000000000099" as Address,
+	oracleData: "0x" as Hex,
 	transaction: makeTransaction(),
 	proposedAt: { block: 100n, tx: "0xabc" as Hex },
 	attestedAt: null,

--- a/explorer/src/components/transaction/SafeTxProposals.tsx
+++ b/explorer/src/components/transaction/SafeTxProposals.tsx
@@ -43,6 +43,7 @@ function ProposalInfoButton({ proposal }: { proposal: TransactionProposal }) {
 		proposal.proposedAt.block,
 		proposal.attestedAt?.block ?? null,
 		proposal.oracle,
+		proposal.oracleData,
 	);
 	if (status.data === null) return null;
 
@@ -74,9 +75,9 @@ function ProposalInfoButton({ proposal }: { proposal: TransactionProposal }) {
 }
 
 function SafeTxProposalVoting({ oracle, proposal }: { oracle: Address; proposal: TransactionProposal }) {
-	const votingStatus = useVotingStatus(oracle, proposal.epoch, proposal.safeTxHash);
+	const votingStatus = useVotingStatus(oracle, proposal.epoch, proposal.safeTxHash, proposal.oracleData);
 	const isSentinel = votingStatus.data?.kind === "sentinel";
-	const sentinelVotes = useSentinelVotes(oracle, proposal.epoch, proposal.safeTxHash, isSentinel);
+	const sentinelVotes = useSentinelVotes(oracle, proposal.epoch, proposal.safeTxHash, proposal.oracleData, isSentinel);
 	return (
 		<div className="space-y-2">
 			<div className="md:flex md:justify-between">

--- a/explorer/src/components/transaction/TransactionProposalsList.test.tsx
+++ b/explorer/src/components/transaction/TransactionProposalsList.test.tsx
@@ -24,6 +24,7 @@ const makeProposal = (safeTxHash: string, epoch = 1n): TransactionProposalWithSt
 	safeTxHash: safeTxHash as Hex,
 	epoch,
 	oracle: "0x0000000000000000000000000000000000000099" as Address,
+	oracleData: "0x" as Hex,
 	transaction: {
 		chainId: 1n,
 		safe: "0x0000000000000000000000000000000000000001" as Address,

--- a/explorer/src/hooks/useSentinelVotes.tsx
+++ b/explorer/src/hooks/useSentinelVotes.tsx
@@ -6,7 +6,7 @@ import { getOracleWorker, type SentinelVote } from "@/lib/oracle";
 // `enabled` should be false until the caller knows the oracle is `SentinelOracle`-shaped
 // (i.e. `useVotingStatus(...).data?.kind === "sentinel"`) — a generic `IOracle` has no
 // `Committed`/`Revealed` events to read, so querying it is pure wasted RPC traffic.
-export function useSentinelVotes(oracle: Address, epoch: bigint, safeTxHash: Hex, enabled = false) {
+export function useSentinelVotes(oracle: Address, epoch: bigint, safeTxHash: Hex, oracleData: Hex, enabled = false) {
 	const [settings] = useSettings();
 	return useQuery<SentinelVote[], Error>({
 		queryKey: [
@@ -16,6 +16,7 @@ export function useSentinelVotes(oracle: Address, epoch: bigint, safeTxHash: Hex
 			settings.consensus,
 			epoch.toString(),
 			safeTxHash,
+			oracleData,
 			settings.maxBlockRange,
 		],
 		queryFn: () =>
@@ -25,6 +26,7 @@ export function useSentinelVotes(oracle: Address, epoch: bigint, safeTxHash: Hex
 				consensus: settings.consensus,
 				epoch,
 				safeTxHash,
+				oracleData,
 				maxBlockRange: BigInt(settings.maxBlockRange),
 			}),
 		initialData: [],

--- a/explorer/src/hooks/useSigningProgress.tsx
+++ b/explorer/src/hooks/useSigningProgress.tsx
@@ -9,6 +9,7 @@ export function useAttestationStatus(
 	proposedAt: bigint,
 	attestedAt: bigint | null,
 	oracle: Address,
+	oracleData: Hex,
 ) {
 	const [settings] = useSettings();
 	return useQuery<AttestationStatus | null, Error>({
@@ -20,6 +21,7 @@ export function useAttestationStatus(
 			proposedAt.toString(),
 			attestedAt?.toString(),
 			oracle,
+			oracleData,
 			settings.maxBlockRange,
 		],
 		queryFn: () =>
@@ -29,6 +31,7 @@ export function useAttestationStatus(
 				safeTxHash,
 				epoch,
 				oracle,
+				oracleData,
 				proposedAt,
 				attestedAt,
 				maxBlockRange: BigInt(settings.maxBlockRange),

--- a/explorer/src/hooks/useVotingStatus.tsx
+++ b/explorer/src/hooks/useVotingStatus.tsx
@@ -3,7 +3,7 @@ import type { Address, Hex } from "viem";
 import { useSettings } from "@/hooks/useSettings";
 import { getOracleWorker, type VotingStatus } from "@/lib/oracle";
 
-export function useVotingStatus(oracle: Address, epoch: bigint, safeTxHash: Hex) {
+export function useVotingStatus(oracle: Address, epoch: bigint, safeTxHash: Hex, oracleData: Hex) {
 	const [settings] = useSettings();
 	return useQuery<VotingStatus, Error>({
 		queryKey: [
@@ -13,6 +13,7 @@ export function useVotingStatus(oracle: Address, epoch: bigint, safeTxHash: Hex)
 			settings.consensus,
 			epoch.toString(),
 			safeTxHash,
+			oracleData,
 			settings.maxBlockRange,
 		],
 		queryFn: () =>
@@ -22,6 +23,7 @@ export function useVotingStatus(oracle: Address, epoch: bigint, safeTxHash: Hex)
 				consensus: settings.consensus,
 				epoch,
 				safeTxHash,
+				oracleData,
 				maxBlockRange: BigInt(settings.maxBlockRange),
 			}),
 		initialData: null,

--- a/explorer/src/lib/consensus/abi.ts
+++ b/explorer/src/lib/consensus/abi.ts
@@ -5,8 +5,8 @@ export const consensusAbi = parseAbi([
 	"function getActiveEpoch() external view returns (uint64 epoch, bytes32 groupId)",
 	"function getEpochsState() external view returns (uint64 previous, uint64 active, uint64 staged, uint64 rolloverBlock)",
 	"function getEpochGroupId(uint64 epoch) external view returns (bytes32 groupId)",
-	"event TransactionProposed(bytes32 indexed safeTxHash, bytes32 indexed safeId, address indexed oracle, uint64 epoch, (uint256 chainId, address safe, address to, uint256 value, bytes data, uint8 operation, uint256 safeTxGas, uint256 baseGas, uint256 gasPrice, address gasToken, address refundReceiver, uint256 nonce) transaction)",
-	"event TransactionAttested(bytes32 indexed safeTxHash, bytes32 indexed safeId, address indexed oracle, uint64 epoch, bytes32 signatureId, ((uint256 x, uint256 y) r, uint256 z) attestation)",
+	"event TransactionProposed(bytes32 indexed safeTxHash, bytes32 indexed safeId, address indexed oracle, uint64 epoch, bytes oracleData, (uint256 chainId, address safe, address to, uint256 value, bytes data, uint8 operation, uint256 safeTxGas, uint256 baseGas, uint256 gasPrice, address gasToken, address refundReceiver, uint256 nonce) transaction)",
+	"event TransactionAttested(bytes32 indexed safeTxHash, bytes32 indexed safeId, address indexed oracle, uint64 epoch, bytes32 oracleDataHash, bytes32 signatureId, ((uint256 x, uint256 y) r, uint256 z) attestation)",
 	"event EpochProposed(uint64 indexed activeEpoch, uint64 indexed proposedEpoch, uint64 rolloverBlock, bytes32 groupId, (uint256 x, uint256 y) groupKey)",
 	"event EpochStaged(uint64 indexed activeEpoch, uint64 indexed proposedEpoch, uint64 rolloverBlock, bytes32 groupId, (uint256 x, uint256 y) groupKey, bytes32 signatureId, ((uint256 x, uint256 y) r, uint256 z) attestation)",
 ]);

--- a/explorer/src/lib/consensus/consensus.test.ts
+++ b/explorer/src/lib/consensus/consensus.test.ts
@@ -226,7 +226,7 @@ const makeOracleProposedLog = ({
 	makeRawConsensusLog({
 		eventName: "TransactionProposed",
 		indexedArgs: { safeTxHash, safeId: computeSafeId({ chainId: 1n, safe: SAFE_ADDRESS }), oracle },
-		nonIndexedValues: [epoch, ORACLE_TX],
+		nonIndexedValues: [epoch, "0x", ORACLE_TX],
 		blockNumber,
 	});
 
@@ -246,7 +246,7 @@ const makeOracleAttestedLog = ({
 	makeRawConsensusLog({
 		eventName: "TransactionAttested",
 		indexedArgs: { safeTxHash, safeId: computeSafeId({ chainId: 1n, safe: SAFE_ADDRESS }), oracle },
-		nonIndexedValues: [epoch, `0x${"00".repeat(32)}`, { r: { x: 0n, y: 0n }, z: 0n }],
+		nonIndexedValues: [epoch, `0x${"00".repeat(32)}`, `0x${"00".repeat(32)}`, { r: { x: 0n, y: 0n }, z: 0n }],
 		blockNumber,
 		logIndex,
 	});

--- a/explorer/src/lib/consensus/transactions.ts
+++ b/explorer/src/lib/consensus/transactions.ts
@@ -41,6 +41,7 @@ export type TransactionProposal = {
 	safeTxHash: Hex;
 	epoch: bigint;
 	oracle: Address;
+	oracleData: Hex;
 	transaction: SafeTransaction;
 	proposedAt: ExecutionLink;
 	attestedAt: ExecutionLink | null;
@@ -177,6 +178,7 @@ export const loadTransactionProposals = async ({
 			}
 
 			const oracle = log.args.oracle;
+			const oracleData = log.args.oracleData;
 			const attestedAt = attestations.get(attestationKey(log)) ?? null;
 			const proposedAt = { block: log.blockNumber, tx: log.transactionHash };
 			const status: ProposalStatus =
@@ -190,6 +192,7 @@ export const loadTransactionProposals = async ({
 				safeTxHash: log.args.safeTxHash,
 				epoch: log.args.epoch,
 				oracle,
+				oracleData,
 				transaction: transaction.data,
 				proposedAt,
 				attestedAt,

--- a/explorer/src/lib/coordinator/signing.test.ts
+++ b/explorer/src/lib/coordinator/signing.test.ts
@@ -1,4 +1,4 @@
-import type { Address, PublicClient } from "viem";
+import type { Address, Hex, PublicClient } from "viem";
 import { zeroAddress } from "viem";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { oracleRequestId } from "@/lib/oracle/hashing";
@@ -53,6 +53,7 @@ const baseArgs = {
 	proposedAt: 0n,
 	maxBlockRange: 1000n,
 	oracle: ORACLE,
+	oracleData: "0x" as Hex,
 };
 
 describe("loadLatestAttestationStatus — message selection", () => {
@@ -76,6 +77,7 @@ describe("loadLatestAttestationStatus — message selection", () => {
 			epoch: baseArgs.epoch,
 			oracle: ORACLE,
 			safeTxHash: SAFE_TX_HASH,
+			oracleData: "0x",
 		});
 		expect(provider.getLogs).toHaveBeenCalledWith(expect.objectContaining({ args: { message: expectedMessage } }));
 	});

--- a/explorer/src/lib/coordinator/signing.ts
+++ b/explorer/src/lib/coordinator/signing.ts
@@ -91,6 +91,7 @@ export const loadLatestAttestationStatus = async ({
 	safeTxHash,
 	epoch,
 	oracle,
+	oracleData,
 	proposedAt,
 	attestedAt,
 	maxBlockRange,
@@ -100,6 +101,7 @@ export const loadLatestAttestationStatus = async ({
 	safeTxHash: Hex;
 	epoch: bigint;
 	oracle: Address;
+	oracleData: Hex;
 	proposedAt?: bigint;
 	attestedAt?: bigint | null;
 	maxBlockRange: bigint;
@@ -114,7 +116,7 @@ export const loadLatestAttestationStatus = async ({
 	const coordinator = await loadCoordinator(provider, consensus);
 	// An oracle-checked proposal is attested via `TransactionAttested`, whose message is
 	// the oracle's requestId hash.
-	const message = oracleRequestId({ chainId, consensus, epoch, oracle, safeTxHash });
+	const message = oracleRequestId({ chainId, consensus, epoch, oracle, safeTxHash, oracleData });
 	// Get signing events related to this message
 	const signingEvents = await provider.getLogs({
 		address: coordinator,

--- a/explorer/src/lib/coordinator/worker.ts
+++ b/explorer/src/lib/coordinator/worker.ts
@@ -14,6 +14,7 @@ const workerApi = {
 		safeTxHash: Hex;
 		epoch: bigint;
 		oracle: Address;
+		oracleData: Hex;
 		proposedAt?: bigint;
 		attestedAt?: bigint | null;
 		maxBlockRange: bigint;

--- a/explorer/src/lib/oracle/hashing.test.ts
+++ b/explorer/src/lib/oracle/hashing.test.ts
@@ -12,8 +12,9 @@ describe("oracleRequestId", () => {
 			epoch: 1n,
 			oracle: "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045" as Address,
 			safeTxHash: "0xfe8b85e8d090b16fe8f142d3c9292dc1fc77daf9eb4af8f7cf4a7707d95f4028" as Hex,
+			oracleData: "0x",
 		});
 
-		expect(hash).toBe("0x44151ab85018beace71ef3255d90480c7b41a3c42b2cf892c155a304875abc9e");
+		expect(hash).toBe("0x5ac4a916cb21b51c5b61c6d4479f7c7477856abecb96e439fb53d5462fb5b3ed");
 	});
 });

--- a/explorer/src/lib/oracle/hashing.ts
+++ b/explorer/src/lib/oracle/hashing.ts
@@ -5,6 +5,7 @@ export type OracleRequestIdParams = {
 	consensus: Address;
 	epoch: bigint;
 	oracle: Address;
+	oracleData: Hex;
 	safeTxHash: Hex;
 };
 
@@ -12,7 +13,14 @@ export type OracleRequestIdParams = {
 // The result isn't just an attestation message hash — `Consensus.proposeTransaction`
 // posts this same value to the oracle as its `requestId`, so it doubles as the lookup key for
 // `getRequest`/`Committed`/`Revealed`/`OracleResult`.
-export const oracleRequestId = ({ chainId, consensus, epoch, oracle, safeTxHash }: OracleRequestIdParams): Hex =>
+export const oracleRequestId = ({
+	chainId,
+	consensus,
+	epoch,
+	oracle,
+	safeTxHash,
+	oracleData,
+}: OracleRequestIdParams): Hex =>
 	hashTypedData({
 		domain: {
 			chainId,
@@ -22,9 +30,10 @@ export const oracleRequestId = ({ chainId, consensus, epoch, oracle, safeTxHash 
 			TransactionProposal: [
 				{ type: "uint64", name: "epoch" },
 				{ type: "address", name: "oracle" },
+				{ type: "bytes", name: "oracleData" },
 				{ type: "bytes32", name: "safeTxHash" },
 			],
 		},
 		primaryType: "TransactionProposal",
-		message: { epoch, oracle, safeTxHash },
+		message: { epoch, oracle, oracleData, safeTxHash },
 	});

--- a/explorer/src/lib/oracle/votes.test.ts
+++ b/explorer/src/lib/oracle/votes.test.ts
@@ -23,6 +23,7 @@ const REQUEST_ID: Hex = oracleRequestId({
 	epoch: EPOCH,
 	oracle: ORACLE,
 	safeTxHash: SAFE_TX_HASH,
+	oracleData: "0x",
 });
 const SENTINEL_A: Address = "0x1111111111111111111111111111111111111111";
 const SENTINEL_B: Address = "0x2222222222222222222222222222222222222222";
@@ -32,6 +33,7 @@ const commonParams = {
 	consensus: CONSENSUS,
 	epoch: EPOCH,
 	safeTxHash: SAFE_TX_HASH,
+	oracleData: "0x" as Hex,
 	maxBlockRange: 500n,
 };
 

--- a/explorer/src/lib/oracle/votes.ts
+++ b/explorer/src/lib/oracle/votes.ts
@@ -17,6 +17,7 @@ export const loadSentinelVotes = async ({
 	consensus,
 	epoch,
 	safeTxHash,
+	oracleData,
 	maxBlockRange,
 }: {
 	provider: PublicClient;
@@ -24,10 +25,11 @@ export const loadSentinelVotes = async ({
 	consensus: Address;
 	epoch: bigint;
 	safeTxHash: Hex;
+	oracleData: Hex;
 	maxBlockRange: bigint;
 }): Promise<SentinelVote[]> => {
 	const chainId = await loadChainId(provider);
-	const requestId = oracleRequestId({ chainId, consensus, epoch, oracle, safeTxHash });
+	const requestId = oracleRequestId({ chainId, consensus, epoch, oracle, safeTxHash, oracleData });
 	const { fromBlock, toBlock } = await getBlockRange(provider, maxBlockRange);
 
 	// A single `eth_getLogs` here, in order to filter on the `requestId` topic while still

--- a/explorer/src/lib/oracle/votingStatus.test.ts
+++ b/explorer/src/lib/oracle/votingStatus.test.ts
@@ -16,6 +16,7 @@ const commonParams = {
 	consensus: CONSENSUS,
 	epoch: EPOCH,
 	safeTxHash: SAFE_TX_HASH,
+	oracleData: "0x" as Hex,
 	maxBlockRange: 500n,
 };
 

--- a/explorer/src/lib/oracle/votingStatus.ts
+++ b/explorer/src/lib/oracle/votingStatus.ts
@@ -18,6 +18,7 @@ export const loadVotingStatus = async ({
 	consensus,
 	epoch,
 	safeTxHash,
+	oracleData,
 	maxBlockRange,
 }: {
 	provider: PublicClient;
@@ -25,10 +26,11 @@ export const loadVotingStatus = async ({
 	consensus: Address;
 	epoch: bigint;
 	safeTxHash: Hex;
+	oracleData: Hex;
 	maxBlockRange: bigint;
 }): Promise<VotingStatus> => {
 	const chainId = await loadChainId(provider);
-	const requestId = oracleRequestId({ chainId, consensus, epoch, oracle, safeTxHash });
+	const requestId = oracleRequestId({ chainId, consensus, epoch, oracle, safeTxHash, oracleData });
 
 	// `getRequest` is a bare mapping read on `SentinelOracle` — it never reverts, even for an
 	// unknown requestId, instead returning a zero-initialized struct. The catch below only fires

--- a/explorer/src/lib/oracle/worker.ts
+++ b/explorer/src/lib/oracle/worker.ts
@@ -10,6 +10,7 @@ type LoadVotesParams = {
 	consensus: Address;
 	epoch: bigint;
 	safeTxHash: Hex;
+	oracleData: Hex;
 	maxBlockRange: bigint;
 };
 

--- a/explorer/src/routes/safe.test.tsx
+++ b/explorer/src/routes/safe.test.tsx
@@ -85,6 +85,7 @@ const makeProposal = (safeTxHash: string): TransactionProposal => ({
 	safeTxHash: safeTxHash as Hex,
 	epoch: 1n,
 	oracle: "0x0000000000000000000000000000000000000099" as Address,
+	oracleData: "0x" as Hex,
 	transaction: {
 		chainId: 1n,
 		safe: "0x0000000000000000000000000000000000000001" as Address,


### PR DESCRIPTION
Mirror `oracleData` in the explorer's transaction-proposal hashing and event decoding.

### Context and Motivation

- The explorer derives the oracle `requestId` from proposal data; it must match the on-chain value now that `oracleData` is bound into the message (#726).

### Decisions and Tradeoffs

- `oracleData` is added to the `TransactionProposal` typed data (next to `oracle`) and threaded through the proposal type, request-id derivation, and voting/attestation loaders and hooks. The `TransactionAttested` ABI carries only the `bytes32 oracleDataHash` (matching the on-chain constant-size attestation); the explorer keys attestations by the indexed fields and never reads it.

### Testing

- `npm run check` (biome + tsc) and `npm run test` (268) all pass, including the request-id reference vector.
