### PR TITLE
[Sentinel Engine 2d]: Add OpenAPI Specification

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,6 @@ jobs:
       - name: Install just
         run: sudo apt-get update && sudo apt-get install -y just
 
-      - run: npm ci --prefix examples
-      - run: npm ci --prefix explorer
+      - run: just deps
       - run: just check
       - run: just test

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -38,8 +38,7 @@ jobs:
       - uses: ./.github/actions/install-lcov
       - uses: ./.github/actions/install-cargo-llvm-cov
 
-      - run: npm ci --prefix examples
-      - run: npm ci --prefix explorer
+      - run: just deps
       - run: scripts/generate_coverage_report.sh
 
       - name: Post Coverage Step Summary

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4089,7 +4089,7 @@ checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "safe-tx"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "alloy",
  "serde",
@@ -4304,7 +4304,7 @@ dependencies = [
 
 [[package]]
 name = "sentinel-engine"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "argh",
  "axum",

--- a/Justfile
+++ b/Justfile
@@ -4,6 +4,9 @@
 
 set shell := ["bash", "-euo", "pipefail", "-c"]
 
+# Configure the default container runtime to use for Just recipes.
+docker := env("DOCKER", "docker")
+
 # List available recipes.
 default:
     @just --list
@@ -20,6 +23,7 @@ check:
     npm --prefix explorer run check
     cargo fmt --all -- --check
     cargo clippy --workspace --all-targets --locked -- -D warnings
+    @just lint-openapi crates/sentinel-engine/openapi.yaml
 
 # Auto-fix formatting issues.
 fix:
@@ -43,6 +47,17 @@ coverage:
 # Install the pinned Foundry toolchain version.
 foundryup:
     foundryup --install v1.5.1
+
+# Install NPM dependencies.
+deps:
+    npm --prefix examples ci
+    npm --prefix explorer ci
+
+# Lints an OpenAPI specification file.
+lint-openapi spec:
+    {{docker}} run --rm \
+        -v $PWD/{{spec}}:/spec/openapi.yaml:ro,z \
+        ghcr.io/redocly/cli:2.46.0 lint --extends=spec openapi.yaml
 
 # Start the local Podman devnet. Pass through any run_devnet.sh flag, e.g.
 # `just devnet --build`.

--- a/README.md
+++ b/README.md
@@ -47,8 +47,7 @@ git submodule update --init --recursive
 with:
 
 ```sh
-npm ci --prefix examples
-npm ci --prefix explorer
+just deps
 ```
 
 Each of `examples/`/`explorer/` also has its own [Biome](https://biomejs.dev/) devDependency and

--- a/crates/safe-tx/Cargo.toml
+++ b/crates/safe-tx/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "safe-tx"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2024"
 publish = false
 

--- a/crates/sentinel-engine/Cargo.toml
+++ b/crates/sentinel-engine/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sentinel-engine"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2024"
 publish = false
 

--- a/crates/sentinel-engine/openapi.yaml
+++ b/crates/sentinel-engine/openapi.yaml
@@ -1,0 +1,157 @@
+openapi: 3.2.0
+info:
+  title: Safenet Sentinel Engine API
+  version: 0.2.0
+  summary: Safenet transaction verification API that backs sentinel services.
+  description: >-
+    A sentinel watching the Consensus contract POSTs each proposed Safe
+    transaction to a sentinel engine and votes according to the verdict it gets
+    back from this API.
+paths:
+  /v1/security-check:
+    post:
+      operationId: security-check-v1
+      summary: Decide whether a proposed Safe transaction is secure.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/SecurityCheckRequest"
+      responses:
+        "200":
+          description: >-
+            The verdict. Note that `unknown` is a successful response: the
+            engine is reporting that it has no definitive answer, which a caller
+            must not read as either secure or insecure.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SecurityCheckResponse"
+components:
+  schemas:
+    SecurityCheckRequest:
+      type: object
+      additionalProperties: false
+      required: [transaction]
+      properties:
+        transaction:
+          $ref: "#/components/schemas/SafeTransaction"
+      examples:
+        - transaction:
+            chainId: "0x1"
+            safe: "0x5aFE3855358E112B5647B952709E6165e1c1eEEe"
+            to: "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2"
+            value: "0x1234"
+            data: "0xd0e30db0"
+            operation: 1
+            safeTxGas: "0x186a0"
+            baseGas: "0x5208"
+            gasPrice: "0x1"
+            gasToken: "0x6B175474E89094C44Da98b954EedeAC495271d0F"
+            refundReceiver: "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045"
+            nonce: "0x0"
+    SecurityCheckResponse:
+      description: >-
+        The engine's answer about the transaction. A sentinel maps `secure` to
+        an approving vote and `insecure` to a denying one, and `unknown` as
+        abstaining from voting.
+      oneOf:
+        - $ref: "#/components/schemas/Secure"
+        - $ref: "#/components/schemas/Insecure"
+        - $ref: "#/components/schemas/Unknown"
+      discriminator:
+        propertyName: verdict
+        mapping:
+          secure: "#/components/schemas/Secure"
+          insecure: "#/components/schemas/Insecure"
+          unknown: "#/components/schemas/Unknown"
+    SafeTransaction:
+      description: >-
+        The Safenet SafeTransaction type.
+      type: object
+      additionalProperties: false
+      required:
+        [
+          chainId,
+          safe,
+          to,
+          value,
+          data,
+          operation,
+          safeTxGas,
+          baseGas,
+          gasPrice,
+          gasToken,
+          refundReceiver,
+          nonce,
+        ]
+      properties:
+        chainId: { $ref: "#/components/schemas/Quantity" }
+        safe: { $ref: "#/components/schemas/Address" }
+        to: { $ref: "#/components/schemas/Address" }
+        value: { $ref: "#/components/schemas/Quantity" }
+        data: { $ref: "#/components/schemas/Bytes" }
+        operation: { $ref: "#/components/schemas/Operation" }
+        safeTxGas: { $ref: "#/components/schemas/Quantity" }
+        baseGas: { $ref: "#/components/schemas/Quantity" }
+        gasPrice: { $ref: "#/components/schemas/Quantity" }
+        gasToken: { $ref: "#/components/schemas/Address" }
+        refundReceiver: { $ref: "#/components/schemas/Address" }
+        nonce: { $ref: "#/components/schemas/Quantity" }
+    Operation:
+      description: >-
+        The Safe call type: `0` is CALL and `1` is DELEGATECALL.
+      type: integer
+      enum: [0, 1]
+    Secure:
+      description: >-
+        The engine considers the transaction secure.
+      type: object
+      required: [verdict]
+      properties:
+        verdict: { const: secure }
+      examples: [{ verdict: secure }]
+    Insecure:
+      description: >-
+        A check found the transaction to be in violation of the cited Charter
+        rule.
+      type: object
+      required: [verdict, rule]
+      properties:
+        verdict: { const: insecure }
+        rule: { $ref: "#/components/schemas/RuleId" }
+      examples: [{ verdict: insecure, rule: "R-4.1" }]
+    Unknown:
+      description: >-
+        The engine cannot reliably determine whether or not a transaction is
+        secure, and indicates the sentinel should abstain from voting.
+      type: object
+      required: [verdict]
+      properties:
+        verdict: { const: unknown }
+      examples: [{ verdict: unknown }]
+    RuleId:
+      type: string
+      description: >-
+        A Safenet Arbitration Charter rule citation. This is not a closed set
+        as the security Charter is an evolving document, and this list grows
+        with it.
+      pattern: "^R-[0-9]+\\.[0-9]+$"
+      examples: ["R-4.1", "R-42.1337"]
+    Address:
+      type: string
+      description: >-
+        A `0x`-prefixed 20-byte address.
+      pattern: "^0x[0-9a-fA-F]{40}$"
+      examples: ["0x5aFE3855358E112B5647B952709E6165e1c1eEEe"]
+    Quantity:
+      type: string
+      description: >-
+        A 256-bit unsigned integer as minimal (no leading zeros), lower-case,
+        `0x`-prefixed hex string. Zero is "0x0".
+      pattern: "^0x([1-9a-f][0-9a-f]*|0)$"
+    Bytes:
+      type: string
+      description: Lower-case, `0x`-prefixed byte string; empty is "0x".
+      pattern: "^0x([0-9a-f]{2})*$"


### PR DESCRIPTION
This PR adds an OpenAPI specification for the sentinel engine HTTP API.

### Decisions and Tradeoffs

We added another `just` recipe for validating the OpenAPI spec is valid. I decided to:

- Use docker to run the `redocly` CLI to avoid any additional NPM dependencies
- Only check against the specification is valid instead of general linting, since many of the rules do not apply to us (we are using the spec to define what should be implemented by a sentinel engine and not as a general public API specification).

Additionally, I updated the Cargo crate versions to 0.2.0 to match our "this is Safenet Q3" versioning everywhere.

### Testing

OpenAPI specification is now checked in CI.

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://docs.safefoundation.org/cla).
