### PR TITLE
Use SafeId and oracleas indeces on proposal event

### DIFF
--- a/contracts/src/Consensus.sol
+++ b/contracts/src/Consensus.sol
@@ -10,6 +10,7 @@ import {ConsensusMessages} from "@/libraries/ConsensusMessages.sol";
 import {FROST} from "@/libraries/FROST.sol";
 import {FROSTGroupId} from "@/libraries/FROSTGroupId.sol";
 import {FROSTSignatureId} from "@/libraries/FROSTSignatureId.sol";
+import {SafeId} from "@/libraries/SafeId.sol";
 import {SafeTransaction} from "@/libraries/SafeTransaction.sol";
 import {Secp256k1} from "@/libraries/Secp256k1.sol";
 
@@ -257,7 +258,8 @@ contract Consensus is IConsensus, IERC165, IFROSTCoordinatorCallback {
         safeTxHash = transaction.hash();
         bytes32 message = domainSeparator().transactionProposal(epochs.active, oracle, safeTxHash);
         require($attestations[message].isZero(), AlreadyAttested());
-        emit TransactionProposed(safeTxHash, transaction.chainId, transaction.safe, epochs.active, oracle, transaction);
+        SafeId.T safeId = SafeId.create(transaction.chainId, transaction.safe);
+        emit TransactionProposed(safeTxHash, safeId, oracle, epochs.active, transaction);
         _COORDINATOR.sign($groups[epochs.active], message);
         IOracle(oracle).postRequest(message, msg.sender, oracleData);
     }
@@ -278,7 +280,8 @@ contract Consensus is IConsensus, IERC165, IFROSTCoordinatorCallback {
         require($attestations[message].isZero(), AlreadyAttested());
         FROST.Signature memory attestation = _COORDINATOR.signatureVerify(signatureId, $groups[epoch], message);
         $attestations[message] = signatureId;
-        emit TransactionAttested(safeTxHash, chainId, safe, epoch, oracle, signatureId, attestation);
+        SafeId.T safeId = SafeId.create(chainId, safe);
+        emit TransactionAttested(safeTxHash, safeId, oracle, epoch, signatureId, attestation);
     }
 
     /**

--- a/contracts/src/interfaces/IConsensus.sol
+++ b/contracts/src/interfaces/IConsensus.sol
@@ -4,6 +4,7 @@ pragma solidity ^0.8.30;
 import {FROST} from "@/libraries/FROST.sol";
 import {FROSTGroupId} from "@/libraries/FROSTGroupId.sol";
 import {FROSTSignatureId} from "@/libraries/FROSTSignatureId.sol";
+import {SafeId} from "@/libraries/SafeId.sol";
 import {SafeTransaction} from "@/libraries/SafeTransaction.sol";
 import {Secp256k1} from "@/libraries/Secp256k1.sol";
 
@@ -67,37 +68,33 @@ interface IConsensus {
     /**
      * @notice Emitted when a transaction is proposed for oracle-checked validator approval.
      * @param safeTxHash The hash of the proposed Safe transaction.
-     * @param chainId The chain ID of the Safe account.
-     * @param safe The address of the Safe.
-     * @param epoch The epoch in which the transaction is proposed.
+     * @param safeId The identifier of the Safe account, combining its chain ID and address.
      * @param oracle The address of the oracle contract used for evaluation.
+     * @param epoch The epoch in which the transaction is proposed.
      * @param transaction The proposed Safe transaction.
      */
     event TransactionProposed(
         bytes32 indexed safeTxHash,
-        uint256 indexed chainId,
-        address indexed safe,
+        SafeId.T indexed safeId,
+        address indexed oracle,
         uint64 epoch,
-        address oracle,
         SafeTransaction.T transaction
     );
 
     /**
      * @notice Emitted when an oracle-checked transaction is attested by the validator set.
      * @param safeTxHash The hash of the attested Safe transaction.
-     * @param chainId The chain ID of the Safe account.
-     * @param safe The address of the Safe account.
-     * @param epoch The epoch in which the attested transaction was proposed.
+     * @param safeId The identifier of the Safe account, combining its chain ID and address.
      * @param oracle The address of the oracle contract used for evaluation.
+     * @param epoch The epoch in which the attested transaction was proposed.
      * @param signatureId The FROST signature identifier corresponding to the attestation.
      * @param attestation The attestation to the oracle-checked Safe transaction.
      */
     event TransactionAttested(
         bytes32 indexed safeTxHash,
-        uint256 indexed chainId,
-        address indexed safe,
+        SafeId.T indexed safeId,
+        address indexed oracle,
         uint64 epoch,
-        address oracle,
         FROSTSignatureId.T signatureId,
         FROST.Signature attestation
     );

--- a/contracts/src/libraries/SafeId.sol
+++ b/contracts/src/libraries/SafeId.sol
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: GPL-3.0-only
+pragma solidity ^0.8.30;
+
+/**
+ * @title Safe ID
+ * @notice A unique identifier for a Safe smart account on a specific chain.
+ */
+library SafeId {
+    // ============================================================
+    // TYPES
+    // ============================================================
+
+    type T is bytes32;
+
+    // ============================================================
+    // ERRORS
+    // ============================================================
+
+    /**
+     * @notice Thrown when a chain ID does not fit in the 96 bits reserved for it in a Safe ID.
+     */
+    error ChainIdOverflow();
+
+    // ============================================================
+    // INTERNAL FUNCTIONS
+    // ============================================================
+
+    /**
+     * @notice Computes the unique identifier for a Safe smart account on a specific chain.
+     * @param chainId The chain ID of the Safe account.
+     * @param safe The address of the Safe account.
+     * @return result The computed Safe ID.
+     * @dev The chain ID and Safe address are concatenated (rather than hashed) into the 32-byte result: the top 96
+     *      bits hold the chain ID and the bottom 160 bits hold the address. This requires the chain ID to fit in 96
+     *      bits, which holds for all chains in practice.
+     */
+    function create(uint256 chainId, address safe) internal pure returns (T result) {
+        require(chainId <= type(uint96).max, ChainIdOverflow());
+        return T.wrap(bytes32((chainId << 160) | uint256(uint160(safe))));
+    }
+}

--- a/contracts/test/Consensus.t.sol
+++ b/contracts/test/Consensus.t.sol
@@ -7,6 +7,7 @@ import {Consensus, IConsensus} from "@/Consensus.sol";
 import {FROST} from "@/libraries/FROST.sol";
 import {FROSTGroupId} from "@/libraries/FROSTGroupId.sol";
 import {FROSTSignatureId} from "@/libraries/FROSTSignatureId.sol";
+import {SafeId} from "@/libraries/SafeId.sol";
 import {SafeTransaction} from "@/libraries/SafeTransaction.sol";
 
 contract MockOracle {
@@ -148,7 +149,9 @@ contract ConsensusTest is Test {
         bytes32 safeTxHash = transaction.hash();
 
         vm.expectEmit(true, true, true, true);
-        emit IConsensus.TransactionProposed(safeTxHash, block.chainid, SAFE, 0, address(oracle), transaction);
+        emit IConsensus.TransactionProposed(
+            safeTxHash, SafeId.create(block.chainid, SAFE), address(oracle), 0, transaction
+        );
 
         consensus.proposeTransaction(address(oracle), "", transaction);
     }
@@ -176,7 +179,9 @@ contract ConsensusTest is Test {
         FROST.Signature memory emptySig = coordinator.signatureValue(signatureId);
 
         vm.expectEmit(true, true, true, true);
-        emit IConsensus.TransactionAttested(safeTxHash, block.chainid, SAFE, 0, address(oracle), signatureId, emptySig);
+        emit IConsensus.TransactionAttested(
+            safeTxHash, SafeId.create(block.chainid, SAFE), address(oracle), 0, signatureId, emptySig
+        );
 
         consensus.attestTransaction(0, address(oracle), block.chainid, SAFE, safeTxStructHash, signatureId);
     }

--- a/contracts/test/libraries/SafeId.t.sol
+++ b/contracts/test/libraries/SafeId.t.sol
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: GPL-3.0-only
+pragma solidity ^0.8.30;
+
+import {Test} from "@forge-std/Test.sol";
+import {SafeId} from "@/libraries/SafeId.sol";
+
+contract SafeIdTest is Test {
+    /// @dev `SafeId.create` is a pure internal function; call it through an external wrapper so
+    ///      `vm.expectRevert` can observe the revert at a lower call depth.
+    function callCreate(uint256 chainId, address safe) external pure returns (SafeId.T) {
+        return SafeId.create(chainId, safe);
+    }
+
+    function test_Create_ConcatenatesChainIdAndSafe() public pure {
+        uint256 chainId = 0x5afe;
+        address safe = 0x1111111111111111111111111111111111111111;
+
+        SafeId.T id = SafeId.create(chainId, safe);
+
+        assertEq(SafeId.T.unwrap(id), bytes32((chainId << 160) | uint256(uint160(safe))));
+    }
+
+    function test_Create_MaxChainId() public pure {
+        uint256 chainId = type(uint96).max;
+        address safe = 0x2222222222222222222222222222222222222222;
+
+        SafeId.T id = SafeId.create(chainId, safe);
+
+        assertEq(SafeId.T.unwrap(id), bytes32((chainId << 160) | uint256(uint160(safe))));
+    }
+
+    function test_Create_RevertsWhenChainIdOverflows() public {
+        uint256 chainId = uint256(type(uint96).max) + 1;
+        address safe = 0x3333333333333333333333333333333333333333;
+
+        vm.expectRevert(SafeId.ChainIdOverflow.selector);
+        this.callCreate(chainId, safe);
+    }
+}

--- a/crates/sentinel/src/bindings.rs
+++ b/crates/sentinel/src/bindings.rs
@@ -97,10 +97,9 @@ pub mod consensus {
         contract Consensus {
             event TransactionProposed(
                 bytes32 indexed safeTxHash,
-                uint256 indexed chainId,
-                address indexed safe,
+                bytes32 indexed safeId,
+                address indexed oracle,
                 uint64 epoch,
-                address oracle,
                 SafeTransaction transaction
             );
         }

--- a/crates/sentinel/src/service.rs
+++ b/crates/sentinel/src/service.rs
@@ -831,14 +831,20 @@ mod tests {
         oracle_tx_proposal_hash(U256::from(CHAIN_ID), CONSENSUS, epoch, oracle, safe_tx_hash)
     }
 
+    /// Mirrors `SafeId.create` in `contracts/src/libraries/SafeId.sol`: the chain ID occupies the
+    /// upper 96 bits and the address the lower 160 bits of the resulting `bytes32`.
+    fn safe_id(chain_id: u64, safe: Address) -> B256 {
+        let value: U256 = U256::from(chain_id) << 160 | U256::from_be_bytes(safe.into_word().0);
+        B256::from(value.to_be_bytes::<32>())
+    }
+
     fn proposed_event(oracle: Address, safe_tx_hash: B256, to: Address) -> SentinelEvents {
         SentinelEvents::Consensus(Consensus::ConsensusEvents::TransactionProposed(
             Consensus::TransactionProposed {
                 safeTxHash: safe_tx_hash,
-                chainId: U256::from(CHAIN_ID),
-                safe: SAFE,
-                epoch: 7,
+                safeId: safe_id(CHAIN_ID, SAFE),
                 oracle,
+                epoch: 7,
                 transaction: safe_tx(to),
             },
         ))

--- a/crates/validator/src/bindings.rs
+++ b/crates/validator/src/bindings.rs
@@ -124,18 +124,16 @@ sol! {
         );
         event TransactionProposed(
             bytes32 indexed safeTxHash,
-            uint256 indexed chainId,
-            address indexed safe,
+            bytes32 indexed safeId,
+            address indexed oracle,
             uint64 epoch,
-            address oracle,
             SafeTransaction transaction
         );
         event TransactionAttested(
             bytes32 indexed safeTxHash,
-            uint256 indexed chainId,
-            address indexed safe,
+            bytes32 indexed safeId,
+            address indexed oracle,
             uint64 epoch,
-            address oracle,
             bytes32 signatureId,
             Signature attestation
         );

--- a/explorer/src/hooks/useSafeTransactionProposals.test.ts
+++ b/explorer/src/hooks/useSafeTransactionProposals.test.ts
@@ -76,14 +76,16 @@ describe("useSafeTransactionProposals", () => {
 		);
 	});
 
-	it("filters by safe address in params", async () => {
+	it("filters by safeId in params", async () => {
 		const { result } = renderHook(() => useSafeTransactionProposals({ safeAddress: SAFE_ADDRESS, chainId: CHAIN_ID }), {
 			wrapper: createWrapper(),
 		});
 
 		await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
-		expect(mockLoadTransactionProposals).toHaveBeenCalledWith(expect.objectContaining({ safe: SAFE_ADDRESS }));
+		expect(mockLoadTransactionProposals).toHaveBeenCalledWith(
+			expect.objectContaining({ safeId: { chainId: CHAIN_ID, safe: SAFE_ADDRESS } }),
+		);
 	});
 
 	it("exposes a flat list of proposals across all pages", async () => {

--- a/explorer/src/hooks/useSafeTransactionProposals.ts
+++ b/explorer/src/hooks/useSafeTransactionProposals.ts
@@ -42,7 +42,7 @@ export function useSafeTransactionProposals({
 			getConsensusWorker().loadTransactionProposals({
 				rpc: settings.rpc,
 				consensus: settings.consensus,
-				safe: safeAddress,
+				safeId: { chainId, safe: safeAddress },
 				toBlock,
 				maxBlockRange: BigInt(settings.maxBlockRange),
 				signingTimeout: settings.signingTimeout,

--- a/explorer/src/lib/consensus/abi.ts
+++ b/explorer/src/lib/consensus/abi.ts
@@ -5,8 +5,8 @@ export const consensusAbi = parseAbi([
 	"function getActiveEpoch() external view returns (uint64 epoch, bytes32 groupId)",
 	"function getEpochsState() external view returns (uint64 previous, uint64 active, uint64 staged, uint64 rolloverBlock)",
 	"function getEpochGroupId(uint64 epoch) external view returns (bytes32 groupId)",
-	"event TransactionProposed(bytes32 indexed safeTxHash, uint256 indexed chainId, address indexed safe, uint64 epoch, address oracle, (uint256 chainId, address safe, address to, uint256 value, bytes data, uint8 operation, uint256 safeTxGas, uint256 baseGas, uint256 gasPrice, address gasToken, address refundReceiver, uint256 nonce) transaction)",
-	"event TransactionAttested(bytes32 indexed safeTxHash, uint256 indexed chainId, address indexed safe, uint64 epoch, address oracle, bytes32 signatureId, ((uint256 x, uint256 y) r, uint256 z) attestation)",
+	"event TransactionProposed(bytes32 indexed safeTxHash, bytes32 indexed safeId, address indexed oracle, uint64 epoch, (uint256 chainId, address safe, address to, uint256 value, bytes data, uint8 operation, uint256 safeTxGas, uint256 baseGas, uint256 gasPrice, address gasToken, address refundReceiver, uint256 nonce) transaction)",
+	"event TransactionAttested(bytes32 indexed safeTxHash, bytes32 indexed safeId, address indexed oracle, uint64 epoch, bytes32 signatureId, ((uint256 x, uint256 y) r, uint256 z) attestation)",
 	"event EpochProposed(uint64 indexed activeEpoch, uint64 indexed proposedEpoch, uint64 rolloverBlock, bytes32 groupId, (uint256 x, uint256 y) groupKey)",
 	"event EpochStaged(uint64 indexed activeEpoch, uint64 indexed proposedEpoch, uint64 rolloverBlock, bytes32 groupId, (uint256 x, uint256 y) groupKey, bytes32 signatureId, ((uint256 x, uint256 y) r, uint256 z) attestation)",
 ]);

--- a/explorer/src/lib/consensus/consensus.test.ts
+++ b/explorer/src/lib/consensus/consensus.test.ts
@@ -3,7 +3,7 @@ import { encodeAbiParameters, encodeEventTopics, getAbiItem, numberToHex } from 
 import { describe, expect, it, vi } from "vitest";
 import { consensusAbi } from "./abi";
 import { loadEpochRolloverHistory, loadEpochsState } from "./epochs";
-import { loadProposedSafeTransaction, loadTransactionProposals } from "./transactions";
+import { computeSafeId, loadProposedSafeTransaction, loadTransactionProposals } from "./transactions";
 
 const CONSENSUS = "0x0000000000000000000000000000000000000001" as Address;
 const SAFE_TX_HASH = `0x${"ab".repeat(32)}` as Hex;
@@ -71,7 +71,30 @@ describe("loadTransactionProposals", () => {
 			expect(firstCall(provider).topics[1]).toBe(SAFE_TX_HASH);
 		});
 
-		it("uses null for topic[3] when safe is not provided", async () => {
+		it("uses null for topic[2] when safeId is not provided", async () => {
+			const provider = makeProvider();
+			await loadTransactionProposals({
+				provider,
+				consensus: CONSENSUS,
+				maxBlockRange: MAX_BLOCK_RANGE,
+				signingTimeout: SIGNING_TIMEOUT,
+			});
+			expect(firstCall(provider).topics[2]).toBeNull();
+		});
+
+		it("filters by safeId in topic[2] when provided", async () => {
+			const provider = makeProvider();
+			await loadTransactionProposals({
+				provider,
+				consensus: CONSENSUS,
+				safeId: { chainId: 1n, safe: SAFE_ADDRESS },
+				maxBlockRange: MAX_BLOCK_RANGE,
+				signingTimeout: SIGNING_TIMEOUT,
+			});
+			expect(firstCall(provider).topics[2]).toBe("0x000000000000000000000001deadbeefdeadbeefdeadbeefdeadbeefdeadbeef");
+		});
+
+		it("uses null for topic[3] when no oracle allow-list is configured", async () => {
 			const provider = makeProvider();
 			await loadTransactionProposals({
 				provider,
@@ -82,17 +105,21 @@ describe("loadTransactionProposals", () => {
 			expect(firstCall(provider).topics[3]).toBeNull();
 		});
 
-		it("filters by safe address in topic[3] when provided", async () => {
+		it("filters by the oracle allow-list as an OR filter in topic[3]", async () => {
 			const provider = makeProvider();
+			const oracleA = "0x3333333333333333333333333333333333333333" as Address;
+			const oracleB = "0x4444444444444444444444444444444444444444" as Address;
 			await loadTransactionProposals({
 				provider,
 				consensus: CONSENSUS,
-				safe: SAFE_ADDRESS,
 				maxBlockRange: MAX_BLOCK_RANGE,
 				signingTimeout: SIGNING_TIMEOUT,
+				oracles: [oracleA, oracleB],
 			});
-			expect(firstCall(provider).topics[2]).toBeNull(); // chainId wildcard
-			expect(firstCall(provider).topics[3]).toBe("0x000000000000000000000000DeaDbeefdEAdbeefdEadbEEFdeadbeEFdEaDbeeF");
+			expect(firstCall(provider).topics[3]).toEqual([
+				"0x0000000000000000000000003333333333333333333333333333333333333333",
+				"0x0000000000000000000000004444444444444444444444444444444444444444",
+			]);
 		});
 	});
 
@@ -198,8 +225,8 @@ const makeOracleProposedLog = ({
 }) =>
 	makeRawConsensusLog({
 		eventName: "TransactionProposed",
-		indexedArgs: { safeTxHash, chainId: 1n, safe: SAFE_ADDRESS },
-		nonIndexedValues: [epoch, oracle, ORACLE_TX],
+		indexedArgs: { safeTxHash, safeId: computeSafeId({ chainId: 1n, safe: SAFE_ADDRESS }), oracle },
+		nonIndexedValues: [epoch, ORACLE_TX],
 		blockNumber,
 	});
 
@@ -218,8 +245,8 @@ const makeOracleAttestedLog = ({
 }) =>
 	makeRawConsensusLog({
 		eventName: "TransactionAttested",
-		indexedArgs: { safeTxHash, chainId: 1n, safe: SAFE_ADDRESS },
-		nonIndexedValues: [epoch, oracle, `0x${"00".repeat(32)}`, { r: { x: 0n, y: 0n }, z: 0n }],
+		indexedArgs: { safeTxHash, safeId: computeSafeId({ chainId: 1n, safe: SAFE_ADDRESS }), oracle },
+		nonIndexedValues: [epoch, `0x${"00".repeat(32)}`, { r: { x: 0n, y: 0n }, z: 0n }],
 		blockNumber,
 		logIndex,
 	});

--- a/explorer/src/lib/consensus/transactions.ts
+++ b/explorer/src/lib/consensus/transactions.ts
@@ -7,6 +7,7 @@ import {
 	type PublicClient,
 	pad,
 	parseEventLogs,
+	toHex,
 } from "viem";
 import z from "zod";
 import { bigIntSchema, checkedAddressSchema, hexDataSchema } from "@/lib/schemas";
@@ -55,6 +56,13 @@ export type LoadTransactionProposalsResult = {
 	toBlock: bigint;
 };
 
+// A Safe smart account on a specific chain: a Safe address is only unique per chain.
+export type SafeId = { chainId: bigint; safe: Address };
+
+// Mirrors `SafeId.create` in contracts/src/libraries/SafeId.sol: the chain ID occupies the upper
+// 96 bits and the address the lower 160 bits of the resulting bytes32.
+export const computeSafeId = ({ chainId, safe }: SafeId): Hex => toHex((chainId << 160n) | BigInt(safe), { size: 32 });
+
 export const loadProposedSafeTransaction = async ({
 	provider,
 	consensus,
@@ -91,7 +99,7 @@ export const loadTransactionProposals = async ({
 	provider,
 	consensus,
 	safeTxHash,
-	safe,
+	safeId,
 	toBlock: referenceBlock,
 	maxBlockRange,
 	signingTimeout,
@@ -100,7 +108,7 @@ export const loadTransactionProposals = async ({
 	provider: PublicClient;
 	consensus: Address;
 	safeTxHash?: Hex;
-	safe?: Address;
+	safeId?: SafeId;
 	toBlock?: bigint;
 	maxBlockRange: bigint;
 	signingTimeout: number;
@@ -109,16 +117,20 @@ export const loadTransactionProposals = async ({
 	const { fromBlock, toBlock } = await getBlockRange(provider, maxBlockRange, referenceBlock);
 	const blockRange = { fromBlock: numberToHex(fromBlock), toBlock: numberToHex(toBlock) };
 
-	// We use an `eth_getLogs` here directly, in order to filter on the `safeTxHash` topic.
-	// When `safe` is set, topic[3] silently drops `TransactionAttested` (only 1 indexed topic);
-	// those proposals will have attestedAt: null until contract events are updated.
+	// `TransactionProposed` and `TransactionAttested` both index `safeTxHash`, `safeId` and `oracle`,
+	// so an explicit allow-list can be pushed straight into the `oracle` topic as an OR filter.
 	const rawLogs = await provider.request({
 		method: "eth_getLogs",
 		params: [
 			{
 				address: consensus,
 				...blockRange,
-				topics: [transactionEventSelectors, safeTxHash ?? null, null, safe ? pad(safe) : null],
+				topics: [
+					transactionEventSelectors,
+					safeTxHash ?? null,
+					safeId ? computeSafeId(safeId) : null,
+					oracles.length > 0 ? oracles.map((oracle) => pad(oracle)) : null,
+				],
 			},
 		],
 	});
@@ -132,11 +144,12 @@ export const loadTransactionProposals = async ({
 		}),
 	);
 
-	// `oracle` isn't an indexed topic on either oracle event, so it can't be filtered via
-	// eth_getLogs topics; trust is resolved here, after decoding. With no explicit allow-list,
-	// an oracle is trusted once it has a `TransactionAttested` log in this same batch.
-	// Addresses are compared via their checksummed form: `oracles` comes from user settings and
-	// may not be checksummed, while addresses decoded from logs by viem always are.
+	// With an explicit allow-list, `eth_getLogs` already filtered to just those oracles above; this
+	// re-derives the same set from the (now pre-filtered) results as a cheap defensive check.
+	// Without an allow-list, trust is derived after decoding: an oracle is trusted once it has a
+	// `TransactionAttested` log in this same batch. Addresses are compared via their checksummed
+	// form: `oracles` comes from user settings and may not be checksummed, while addresses decoded
+	// from logs by viem always are.
 	const trustedOracles = new Set(
 		(oracles.length > 0
 			? oracles
@@ -173,7 +186,7 @@ export const loadTransactionProposals = async ({
 						? "TIMED_OUT"
 						: "PROPOSED";
 			return {
-				chainId: log.args.chainId,
+				chainId: transaction.data.chainId,
 				safeTxHash: log.args.safeTxHash,
 				epoch: log.args.epoch,
 				oracle,

--- a/explorer/src/lib/consensus/worker.ts
+++ b/explorer/src/lib/consensus/worker.ts
@@ -2,7 +2,7 @@ import { expose } from "comlink";
 import type { Address, Hex } from "viem";
 import { createRpcClient } from "@/lib/rpc";
 import { loadConsensusState, loadEpochRolloverHistory, loadEpochsState } from "./epochs";
-import { loadProposedSafeTransaction, loadTransactionProposals } from "./transactions";
+import { loadProposedSafeTransaction, loadTransactionProposals, type SafeId } from "./transactions";
 
 const workerApi = {
 	loadTransactionProposals: ({
@@ -12,7 +12,7 @@ const workerApi = {
 		rpc: string;
 		consensus: Address;
 		safeTxHash?: Hex;
-		safe?: Address;
+		safeId?: SafeId;
 		toBlock?: bigint;
 		maxBlockRange: bigint;
 		signingTimeout: number;

--- a/scripts/run_validator_integration_test.sh
+++ b/scripts/run_validator_integration_test.sh
@@ -212,7 +212,7 @@ while [ "$SECONDS" -lt "$DEADLINE" ]; do
             --from-block 0 \
             --to-block latest \
             --address "$CONSENSUS_ADDR" \
-            'TransactionProposed(bytes32,uint256,address,uint64,address,(uint256,address,address,uint256,bytes,uint8,uint256,uint256,uint256,address,address,uint256))')
+            'TransactionProposed(bytes32,bytes32,address,uint64,(uint256,address,address,uint256,bytes,uint8,uint256,uint256,uint256,address,address,uint256))')
         TRANSACTION_HASH=$(jq -er --arg epoch "$EPOCH_ONE_WORD" \
             '[.[] | select(.data | startswith($epoch))][-1].topics[1]' <<< "$PROPOSALS")
         TRANSACTION_PROPOSED=1
@@ -232,7 +232,7 @@ while [ "$SECONDS" -lt "$DEADLINE" ]; do
             --from-block 0 \
             --to-block latest \
             --address "$CONSENSUS_ADDR" \
-            'TransactionAttested(bytes32,uint256,address,uint64,address,bytes32,((uint256,uint256),uint256))')
+            'TransactionAttested(bytes32,bytes32,address,uint64,bytes32,((uint256,uint256),uint256))')
         TRANSACTION_ATTESTED=$(jq --arg hash "$TRANSACTION_HASH" --arg epoch "$EPOCH_ONE_WORD" \
             '[.[] | select((.topics[1] == $hash) and (.data | startswith($epoch)))] | length' <<< "$ATTESTATIONS")
     fi


### PR DESCRIPTION
Fixes #669 

To allow indexing for the oracle address on the proposal event the chain id and Safe address are combined into a Safe id. The assumption is made that currently common chainIds do not exceed uint96.

The new indexed oracle is used to limit the events loaded in the explorer.

### Testing

- Integration tests should pass


---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://docs.safefoundation.org/cla).
