### PR TITLE
[Nonces 3]: Integrate the Nonce Generator with Effects

### DIFF
--- a/crates/validator/src/secrets/nonces.rs
+++ b/crates/validator/src/secrets/nonces.rs
@@ -1,10 +1,5 @@
 //! Process-local background generation of FROST nonce chunks.
 
-// The generator is introduced independently from its effect-handler wiring so
-// that the component can be reviewed in isolation. This allowance can be
-// removed when the effect handler starts consuming it.
-#![expect(dead_code)]
-
 use crate::frost::{keygen::KeyShare, preprocess::NonceChunk};
 use alloy::primitives::B256;
 use rand::{CryptoRng, RngCore};
@@ -12,6 +7,7 @@ use std::{
     collections::{BTreeMap, btree_map},
     sync::{Arc, Mutex, PoisonError, mpsc},
     thread,
+    time::Instant,
 };
 use tokio::sync::{Semaphore, oneshot};
 
@@ -45,7 +41,8 @@ impl NonceGenerator {
         };
 
         tracing::debug!(%group_id, "starting nonce stream for group");
-        let stream = NonceStream::new(sampler)?;
+        let span = tracing::debug_span!("nonce_generator", %group_id);
+        let stream = NonceStream::new(sampler, span)?;
         entry.insert(stream);
         Ok(())
     }
@@ -103,20 +100,23 @@ impl Sampler {
 
 /// A stream of nonces for a given key share.
 struct NonceStream {
-    worker: thread::JoinHandle<()>,
+    _worker: thread::JoinHandle<()>,
     pending: Arc<Semaphore>,
     requests: mpsc::Sender<oneshot::Sender<NonceChunk>>,
 }
 
 impl NonceStream {
-    fn new(sampler: Sampler) -> Result<Self, Error> {
+    fn new(sampler: Sampler, span: tracing::Span) -> Result<Self, Error> {
         let (sender, receiver) = mpsc::channel();
         let worker = thread::Builder::new()
-            .spawn(move || Self::stream(sampler, receiver))
+            .spawn(move || {
+                let _guard = span.enter();
+                Self::stream(sampler, receiver);
+            })
             .map_err(Error::Spawn)?;
 
         Ok(Self {
-            worker,
+            _worker: worker,
             pending: Arc::new(Semaphore::new(1)),
             requests: sender,
         })
@@ -125,6 +125,7 @@ impl NonceStream {
     fn stream(sampler: Sampler, requests: mpsc::Receiver<oneshot::Sender<NonceChunk>>) {
         let mut rng = rand::thread_rng();
         'outer: loop {
+            let started = Instant::now();
             let mut nonces = match sampler.nonces_chunk(&mut rng) {
                 Ok(nonces) => nonces,
                 Err(err) => {
@@ -132,6 +133,10 @@ impl NonceStream {
                     break;
                 }
             };
+            tracing::trace!(
+                elapsed_ms = started.elapsed().as_millis(),
+                "completed nonce tree sampling effect"
+            );
 
             loop {
                 let Ok(request) = requests.recv() else {

--- a/crates/validator/src/secrets/store.rs
+++ b/crates/validator/src/secrets/store.rs
@@ -286,13 +286,6 @@ impl SecretStore {
     /// non-consuming read of public data, a state transition may call it
     /// repeatedly - for example to re-emit a nonce reveal after a reorg -
     /// without risking nonce reuse.
-    #[cfg_attr(
-        not(test),
-        expect(
-            dead_code,
-            reason = "introduced ahead of root-based nonce effect integration"
-        )
-    )]
     pub async fn nonces_reveal_by_root(
         &self,
         root: B256,
@@ -356,13 +349,6 @@ impl SecretStore {
     /// gracefully no-ops instead of reusing the nonce. Deletion is permanent
     /// and not undone by a reorg; the returned nonce lives on only in the
     /// snapshot state, which a reorg is free to roll back.
-    #[cfg_attr(
-        not(test),
-        expect(
-            dead_code,
-            reason = "introduced ahead of root-based nonce effect integration"
-        )
-    )]
     pub async fn take_nonce_by_root(
         &self,
         root: B256,

--- a/crates/validator/src/service/effect.rs
+++ b/crates/validator/src/service/effect.rs
@@ -7,7 +7,7 @@ use crate::{
         keygen::{KeyShare, Secrets},
         preprocess::Nonces,
     },
-    secrets::SecretStore,
+    secrets::{SecretStore, nonces::NonceGenerator},
 };
 use alloy::primitives::{Address, B256};
 use safenet_core::effects::EffectHandler;
@@ -15,7 +15,6 @@ use std::{
     error::Error,
     fmt::{self, Display, Formatter},
     sync::Arc,
-    time::Instant,
 };
 
 /// An impure operation the state transition asks the handler to perform.
@@ -28,7 +27,20 @@ pub enum Effect {
         count: u16,
         threshold: u16,
     },
+    /// Start eagerly generating nonce chunks for a group. Idempotent within a
+    /// process.
+    #[expect(
+        dead_code,
+        reason = "introduced ahead of state-machine nonce integration"
+    )]
+    StartNonceGeneration {
+        group_id: B256,
+        key_share: Arc<KeyShare>,
+    },
     /// Sample a fresh nonce tree for `key_share` and persist it.
+    ///
+    /// This compatibility effect starts the group's generator if necessary,
+    /// then takes its next generated chunk.
     NonceTree {
         group_id: B256,
         key_share: Arc<KeyShare>,
@@ -48,12 +60,34 @@ pub enum Effect {
         message: B256,
         sequence: u64,
     },
+    /// Reveal this validator's nonce commitment at `(root, offset)`.
+    #[expect(
+        dead_code,
+        reason = "introduced ahead of state-machine nonce integration"
+    )]
+    RevealNonceCommitmentsByRoot {
+        signature_id: B256,
+        message: B256,
+        root: B256,
+        offset: u64,
+    },
     /// Use this validator's own nonce for the signing round at `sequence`.
     /// Once the nonce is taken, it is burned and can no longer be used.
     UseNonce {
         group_id: B256,
         message: B256,
         sequence: u64,
+    },
+    /// Use this validator's own nonce at `(root, offset)`.
+    /// Once the nonce is taken, it is burned and can no longer be used.
+    #[expect(
+        dead_code,
+        reason = "introduced ahead of state-machine nonce integration"
+    )]
+    UseNonceByRoot {
+        message: B256,
+        root: B256,
+        offset: u64,
     },
     /// Check that at least [`NONCE_TOPUP_THRESHOLD`] nonces remain usable for
     /// `key_share`'s group from `(chunk, offset)` onward, generating and
@@ -102,12 +136,23 @@ pub enum Resume {
 /// Performs the validator's [`Effect`]s, resuming with a [`Resume`].
 pub struct Handler {
     /// The account of the running validator.
-    pub account: Address,
+    account: Address,
     /// The secret store containing randomly generated secrets.
-    pub secrets: SecretStore,
+    secrets: SecretStore,
+    /// Process-local streams that eagerly generate nonce chunks by group.
+    nonce_generator: NonceGenerator,
 }
 
 impl Handler {
+    /// Creates an effect handler with no active nonce generator streams.
+    pub fn new(account: Address, secrets: SecretStore) -> Self {
+        Self {
+            account,
+            secrets,
+            nonce_generator: NonceGenerator::new(),
+        }
+    }
+
     async fn try_perform_effect(&self, effect: Effect) -> Result<Resume, InternalError> {
         match effect {
             Effect::KeyGenSetup {
@@ -128,10 +173,20 @@ impl Handler {
                     secrets: Box::new(stored),
                 })
             }
+            Effect::StartNonceGeneration {
+                group_id,
+                key_share,
+            } => {
+                self.nonce_generator.start(group_id, key_share)?;
+                Ok(Resume::Noop)
+            }
             Effect::NonceTree {
                 group_id,
                 key_share,
-            } => self.sample_nonces(group_id, key_share).await,
+            } => {
+                self.nonce_generator.start(group_id, key_share)?;
+                self.next_nonce_tree(group_id).await
+            }
             Effect::LinkNonceTree {
                 group_id,
                 chunk,
@@ -164,6 +219,22 @@ impl Handler {
                     .unwrap_or(Resume::Noop);
                 Ok(result)
             }
+            Effect::RevealNonceCommitmentsByRoot {
+                signature_id,
+                message,
+                root,
+                offset,
+            } => Ok(self
+                .secrets
+                .nonces_reveal_by_root(root, offset)
+                .await?
+                .map(|(nonces, proof)| Resume::NonceCommitments {
+                    signature_id,
+                    message,
+                    nonces,
+                    proof,
+                })
+                .unwrap_or(Resume::Noop)),
             Effect::UseNonce {
                 group_id,
                 message,
@@ -184,6 +255,19 @@ impl Handler {
                     .unwrap_or(Resume::Noop);
                 Ok(result)
             }
+            Effect::UseNonceByRoot {
+                message,
+                root,
+                offset,
+            } => Ok(self
+                .secrets
+                .take_nonce_by_root(root, offset)
+                .await?
+                .map(|nonces| Resume::Nonce {
+                    message,
+                    nonces: Box::new(nonces),
+                })
+                .unwrap_or(Resume::Noop)),
             Effect::TopupNonces {
                 group_id,
                 key_share,
@@ -197,30 +281,26 @@ impl Handler {
                 if available >= NONCE_TOPUP_THRESHOLD {
                     return Ok(Resume::Noop);
                 }
-                return self.sample_nonces(group_id, key_share).await;
+                self.nonce_generator.start(group_id, key_share)?;
+                self.next_nonce_tree(group_id).await
             }
             Effect::PruneKeyGenSecrets { group_id } => {
                 self.secrets.prune_keygen_secrets(group_id).await?;
                 Ok(Resume::Noop)
             }
             Effect::PruneGroupNonces { group_id } => {
+                self.nonce_generator.stop(group_id);
                 self.secrets.prune_group_nonces(group_id).await?;
                 Ok(Resume::Noop)
             }
         }
     }
 
-    async fn sample_nonces(
-        &self,
-        group_id: B256,
-        key_share: Arc<KeyShare>,
-    ) -> Result<Resume, InternalError> {
-        let started = Instant::now();
-        let nonce_chunk = tokio::task::spawn_blocking(move || {
-            let mut rng = rand::thread_rng();
-            frost::preprocess::NonceChunk::generate(&key_share, &mut rng)
-        })
-        .await??;
+    async fn next_nonce_tree(&self, group_id: B256) -> Result<Resume, InternalError> {
+        let Some(nonce_chunk) = self.nonce_generator.next(group_id).await? else {
+            tracing::debug!(%group_id, "nonce chunk request already running; ignoring duplicate effect");
+            return Ok(Resume::Noop);
+        };
         let result = self
             .secrets
             .register_nonces_chunk(group_id, self.account, nonce_chunk)
@@ -232,11 +312,6 @@ impl Handler {
             // There is already a pending nonce chunk from an earlier
             // top-up; do not register a second one.
             .unwrap_or(Resume::Noop);
-        tracing::trace!(
-            %group_id,
-            elapsed_ms = started.elapsed().as_millis(),
-            "completed nonce tree sampling effect"
-        );
         Ok(result)
     }
 }

--- a/crates/validator/src/service/mod.rs
+++ b/crates/validator/src/service/mod.rs
@@ -107,7 +107,7 @@ impl Service for ValidatorService {
                 consensus,
                 config,
             },
-            effect::Handler { account, secrets },
+            effect::Handler::new(account, secrets),
             action::Encoder {
                 coordinator,
                 consensus: consensus_address,


### PR DESCRIPTION
Wire the background nonce generator into the validator effect handler and add effects for eager generation and root-indexed nonce access. Existing effects remain available so the state-machine migration can be implemented separately.

### Context and Motivation

See #724 and #745 for more context on _why_ we are changing how nonces are generated and accessed.

### Decisions and Tradeoffs

- In order to keep the old effects around, the legacy `NonceTree` and `TopupNonces` are implemented in function of the new `NonceGenerator` component.
- We create a tracing span and move it into the nonce generation background thread so we can more easily associate nonce generation logs with the group that they are for.
- We added a constructor function to the `Handler`, so its fields no longer need to be public.

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://docs.safefoundation.org/cla).
