### PR TITLE
[Phase 4] Introduce dao fee cut

### DIFF
--- a/contracts/script/DeploySentinelOracle.s.sol
+++ b/contracts/script/DeploySentinelOracle.s.sol
@@ -20,6 +20,7 @@ contract DeploySentinelOracleScript is Script {
         uint256 revealWindow = vm.envUint("SENTINEL_REVEAL_WINDOW");
         uint256 governanceDelay = vm.envUint("SENTINEL_GOVERNANCE_DELAY");
         uint256 bondMultiplier = vm.envUint("SENTINEL_BOND_MULTIPLIER");
+        uint256 initialDaoFeeShare = vm.envUint("SENTINEL_INITIAL_DAO_FEE_SHARE");
 
         DeterministicDeployment.Factory factory = getFactory(vm);
 
@@ -38,7 +39,8 @@ contract DeploySentinelOracleScript is Script {
                 commitWindow,
                 revealWindow,
                 governanceDelay,
-                bondMultiplier
+                bondMultiplier,
+                initialDaoFeeShare
             )
         );
 

--- a/contracts/src/SentinelOracle.sol
+++ b/contracts/src/SentinelOracle.sol
@@ -47,6 +47,12 @@ contract SentinelOracle is IOracle {
     uint256 public immutable GOVERNANCE_DELAY;
 
     // ============================================================
+    // CONSTANTS
+    // ============================================================
+
+    uint256 public constant FEE_SHARE_DENOMINATOR = 100_000;
+
+    // ============================================================
     // STORAGE
     // ============================================================
 
@@ -58,6 +64,9 @@ contract SentinelOracle is IOracle {
 
     // forge-lint: disable-next-line(mixed-case-variable)
     DelayedUint256.T private $feeConfig;
+
+    // forge-lint: disable-next-line(mixed-case-variable)
+    DelayedUint256.T private $daoFeeShareConfig;
 
     // forge-lint: disable-next-line(mixed-case-variable)
     SentinelMap.T private $sentinelMap;
@@ -80,6 +89,7 @@ contract SentinelOracle is IOracle {
     error ZeroWindow();
     error SentinelNotActive();
     error NotRevealed();
+    error InvalidFeeShare();
 
     // ============================================================
     // MODIFIERS
@@ -113,7 +123,8 @@ contract SentinelOracle is IOracle {
         uint256 commitWindow,
         uint256 revealWindow,
         uint256 governanceDelay,
-        uint256 initialMultiplier
+        uint256 initialMultiplier,
+        uint256 initialDaoFeeShare
     ) {
         require(arbitrator != address(0), InvalidAddress());
         require(governance != address(0), InvalidAddress());
@@ -123,6 +134,7 @@ contract SentinelOracle is IOracle {
         require(requestFee > 0, ZeroFee());
         require(commitWindow > 0, ZeroWindow());
         require(revealWindow > 0, ZeroWindow());
+        require(initialDaoFeeShare <= FEE_SHARE_DENOMINATOR, InvalidFeeShare());
         ARBITRATOR = arbitrator;
         GOVERNANCE = governance;
         CONSENSUS = consensus;
@@ -133,6 +145,7 @@ contract SentinelOracle is IOracle {
         $bondConfig.init(initialMultiplier);
         $protocolFundsReceiverConfig.init(initialProtocolFundsReceiver);
         $feeConfig.init(requestFee);
+        $daoFeeShareConfig.init(initialDaoFeeShare);
     }
 
     // ============================================================
@@ -143,9 +156,12 @@ contract SentinelOracle is IOracle {
         require(msg.sender == CONSENSUS, NotConsensus());
         uint256 currentFee = $feeConfig.applyPending();
         uint256 bondTarget = currentFee * $bondConfig.applyPending();
+        uint256 currentDaoFeeShare = $daoFeeShareConfig.applyPending();
         uint256 commitDeadline = block.number + COMMIT_WINDOW;
         uint256 revealDeadline = commitDeadline + REVEAL_WINDOW;
-        $requests.create(requestId, proposer, currentFee, bondTarget, commitDeadline, revealDeadline);
+        $requests.create(
+            requestId, proposer, currentFee, bondTarget, currentDaoFeeShare, commitDeadline, revealDeadline
+        );
         FEE_TOKEN.safeTransferFrom(proposer, address(this), currentFee);
     }
 
@@ -184,25 +200,35 @@ contract SentinelOracle is IOracle {
         address proposer = req.proposer;
         (SentinelOracleRequest.State newState, uint256 refundFee, uint256 unrevealedBond) = req.finalize();
 
+        address fundsReceiver = $protocolFundsReceiverConfig.applyPending();
         if (unrevealedBond > 0) {
-            FEE_TOKEN.safeTransfer($protocolFundsReceiverConfig.applyPending(), unrevealedBond);
+            FEE_TOKEN.safeTransfer(fundsReceiver, unrevealedBond);
         }
 
         if (newState == SentinelOracleRequest.State.FROZEN) {
             return;
         }
 
+        if (newState == SentinelOracleRequest.State.TIMED_OUT) {
+            FEE_TOKEN.safeTransfer(proposer, refundFee);
+            emit OracleResult(requestId, proposer, abi.encode(SentinelOracleRequest.ResolveReason.TIMEOUT), false);
+            return;
+        }
+
+        uint256 daoCut = req.fee * req.daoFeeShare / FEE_SHARE_DENOMINATOR;
+        req.fee -= daoCut;
+        if (daoCut > 0) {
+            FEE_TOKEN.safeTransfer(fundsReceiver, daoCut);
+        }
+
         if (newState == SentinelOracleRequest.State.RESOLVED_APPROVED) {
             emit OracleResult(
                 requestId, proposer, abi.encode(SentinelOracleRequest.ResolveReason.UNANIMOUS_APPROVE), true
             );
-        } else if (newState == SentinelOracleRequest.State.RESOLVED_DENIED) {
+        } else {
             emit OracleResult(
                 requestId, proposer, abi.encode(SentinelOracleRequest.ResolveReason.UNANIMOUS_DENY), false
             );
-        } else {
-            FEE_TOKEN.safeTransfer(proposer, refundFee);
-            emit OracleResult(requestId, proposer, abi.encode(SentinelOracleRequest.ResolveReason.TIMEOUT), false);
         }
     }
 
@@ -237,9 +263,11 @@ contract SentinelOracle is IOracle {
         uint256 slashed = req.resolveDispute(approveWins);
         SentinelOracleRequest.State outcome = req.state;
         uint256 refundFee = req.fee;
+        uint256 daoCut = refundFee * req.daoFeeShare / FEE_SHARE_DENOMINATOR;
+        req.fee -= daoCut;
         address fundsReceiver = $protocolFundsReceiverConfig.applyPending();
         FEE_TOKEN.safeTransfer(proposer, refundFee);
-        FEE_TOKEN.safeTransfer(fundsReceiver, slashed - refundFee);
+        FEE_TOKEN.safeTransfer(fundsReceiver, slashed - refundFee + daoCut);
         emit DisputeResolved(requestId, outcome, slashed, context);
         emit OracleResult(requestId, proposer, abi.encode(SentinelOracleRequest.ResolveReason.ARBITRATION), approveWins);
     }
@@ -280,6 +308,15 @@ contract SentinelOracle is IOracle {
 
     function applyFee() external {
         $feeConfig.applyPending();
+    }
+
+    function scheduleDaoFeeShare(uint256 newValue) external onlyGovernance {
+        require(newValue <= FEE_SHARE_DENOMINATOR, InvalidFeeShare());
+        $daoFeeShareConfig.schedule(newValue, GOVERNANCE_DELAY);
+    }
+
+    function applyDaoFeeShare() external {
+        $daoFeeShareConfig.applyPending();
     }
 
     // ============================================================
@@ -324,6 +361,18 @@ contract SentinelOracle is IOracle {
 
     function pendingFeeActiveAt() external view returns (uint256) {
         return $feeConfig.pendingActiveAt;
+    }
+
+    function daoFeeShare() external view returns (uint256) {
+        return $daoFeeShareConfig.current();
+    }
+
+    function pendingDaoFeeShare() external view returns (uint256) {
+        return $daoFeeShareConfig.pendingValue;
+    }
+
+    function pendingDaoFeeShareActiveAt() external view returns (uint256) {
+        return $daoFeeShareConfig.pendingActiveAt;
     }
 
     function getRequest(bytes32 requestId) external view returns (SentinelOracleRequest.Request memory) {

--- a/contracts/src/libraries/SentinelOracleRequests.sol
+++ b/contracts/src/libraries/SentinelOracleRequests.sol
@@ -31,6 +31,7 @@ library SentinelOracleRequest {
         address proposer;
         uint256 fee;
         uint256 bondTarget;
+        uint256 daoFeeShare;
         uint256 commitDeadline;
         uint256 revealDeadline;
         State state;
@@ -195,6 +196,7 @@ library SentinelOracleRequestMap {
         address proposer,
         uint256 fee,
         uint256 bondTarget,
+        uint256 daoFeeShare,
         uint256 commitDeadline,
         uint256 revealDeadline
     ) internal {
@@ -206,6 +208,7 @@ library SentinelOracleRequestMap {
             proposer: proposer,
             fee: fee,
             bondTarget: bondTarget,
+            daoFeeShare: daoFeeShare,
             commitDeadline: commitDeadline,
             revealDeadline: revealDeadline,
             state: SentinelOracleRequest.State.PENDING,

--- a/contracts/test/SentinelOracle.t.sol
+++ b/contracts/test/SentinelOracle.t.sol
@@ -19,6 +19,7 @@ contract SentinelOracleTest is Test {
     uint256 constant COMMIT_WINDOW = 12;
     uint256 constant REVEAL_WINDOW = 12;
     uint256 constant GOVERNANCE_DELAY = 100;
+    uint256 constant INITIAL_DAO_FEE_SHARE = 0;
 
     bytes32 constant REQUEST_ID = keccak256("request-1");
     bytes32 constant SALT_1 = keccak256("salt-1");
@@ -66,7 +67,8 @@ contract SentinelOracleTest is Test {
             COMMIT_WINDOW,
             REVEAL_WINDOW,
             GOVERNANCE_DELAY,
-            BOND_MULTIPLIER
+            BOND_MULTIPLIER,
+            INITIAL_DAO_FEE_SHARE
         );
 
         // Fund accounts
@@ -194,6 +196,21 @@ contract SentinelOracleTest is Test {
 
         vm.prank(governance);
         oracle.scheduleFee(REQUEST_FEE + 1);
+    }
+
+    function test_ScheduleDaoFeeShare_OnlyGovernance() public {
+        address randomAddress = vm.createWallet("random").addr;
+
+        vm.expectRevert(SentinelOracle.NotGovernance.selector);
+        vm.prank(arbitrator);
+        oracle.scheduleDaoFeeShare(10_000);
+
+        vm.expectRevert(SentinelOracle.NotGovernance.selector);
+        vm.prank(randomAddress);
+        oracle.scheduleDaoFeeShare(10_000);
+
+        vm.prank(governance);
+        oracle.scheduleDaoFeeShare(10_000);
     }
 
     function test_ScheduleProtocolFundsReceiver_OnlyGovernance() public {
@@ -341,6 +358,82 @@ contract SentinelOracleTest is Test {
     }
 
     // ============================================================
+    // DAO FEE SHARE SCHEDULE/APPLY
+    // ============================================================
+
+    function test_ScheduleDaoFeeShare_AboveDenominator_Reverts() public {
+        // Precompute before arming expectRevert -- `FEE_SHARE_DENOMINATOR()` is itself an
+        // external call, and vm.expectRevert only intercepts the very next one.
+        uint256 tooHigh = oracle.FEE_SHARE_DENOMINATOR() + 1;
+        vm.expectRevert(SentinelOracle.InvalidFeeShare.selector);
+        vm.prank(governance);
+        oracle.scheduleDaoFeeShare(tooHigh);
+    }
+
+    function test_DaoFeeShare_ScheduleApplyRoundTrip() public {
+        uint256 newShare = 10_000;
+
+        assertEq(oracle.daoFeeShare(), INITIAL_DAO_FEE_SHARE, "starts at the constructor value");
+
+        vm.prank(governance);
+        oracle.scheduleDaoFeeShare(newShare);
+
+        assertEq(oracle.pendingDaoFeeShare(), newShare);
+        assertEq(oracle.daoFeeShare(), INITIAL_DAO_FEE_SHARE, "not active until the delay elapses");
+
+        // Applying too early is a no-op, not a revert -- it's permissionless and harmless to call
+        // speculatively.
+        oracle.applyDaoFeeShare();
+        assertEq(oracle.daoFeeShare(), INITIAL_DAO_FEE_SHARE, "still not active after an early apply");
+        assertEq(oracle.pendingDaoFeeShare(), newShare, "pending value survives an early apply");
+
+        vm.roll(block.number + GOVERNANCE_DELAY);
+        oracle.applyDaoFeeShare();
+
+        assertEq(oracle.daoFeeShare(), newShare, "takes effect once the delay has elapsed");
+        assertEq(oracle.pendingDaoFeeShare(), 0);
+        assertEq(oracle.pendingDaoFeeShareActiveAt(), 0);
+    }
+
+    function test_DaoFeeShare_RescheduleBeforeMaturity_OverwritesPending() public {
+        uint256 firstShare = 10_000;
+        uint256 secondShare = 20_000;
+
+        vm.startPrank(governance);
+        oracle.scheduleDaoFeeShare(firstShare);
+
+        // Governance notices the mistake before `firstShare` matures and corrects it -- this must
+        // overwrite the still-pending schedule, not revert.
+        oracle.scheduleDaoFeeShare(secondShare);
+        vm.stopPrank();
+
+        assertEq(oracle.pendingDaoFeeShare(), secondShare, "second schedule overwrites the first");
+        assertEq(oracle.daoFeeShare(), INITIAL_DAO_FEE_SHARE, "not active until the delay elapses");
+
+        vm.roll(block.number + GOVERNANCE_DELAY);
+        oracle.applyDaoFeeShare();
+
+        assertEq(oracle.daoFeeShare(), secondShare, "corrected value takes effect, not the mistake");
+    }
+
+    function test_ScheduleDaoFeeShare_RequestsInFlightKeepSnapshottedShare() public {
+        uint256 newShare = 10_000;
+
+        _postRequest();
+
+        vm.prank(governance);
+        oracle.scheduleDaoFeeShare(newShare);
+        vm.roll(block.number + GOVERNANCE_DELAY);
+
+        // The in-flight request was created before the new share matured -- its snapshotted
+        // `daoFeeShare` must not retroactively change even though `oracle.daoFeeShare()` now
+        // reports the new value.
+        assertEq(oracle.daoFeeShare(), newShare, "governed share has matured");
+        SentinelOracleRequest.Request memory req = oracle.getRequest(REQUEST_ID);
+        assertEq(req.daoFeeShare, INITIAL_DAO_FEE_SHARE, "in-flight request keeps its originally snapshotted share");
+    }
+
+    // ============================================================
     // EAGER APPLY ON ACTIVITY (NO EXPLICIT apply* CALL NEEDED)
     // ============================================================
 
@@ -381,6 +474,25 @@ contract SentinelOracleTest is Test {
 
         SentinelOracleRequest.Request memory req = oracle.getRequest(REQUEST_ID);
         assertEq(req.bondTarget, REQUEST_FEE * newMultiplier, "new request snapshots the newly-applied multiplier");
+    }
+
+    function test_PostRequest_EagerlyAppliesPendingDaoFeeShare() public {
+        uint256 newShare = 10_000;
+
+        vm.prank(governance);
+        oracle.scheduleDaoFeeShare(newShare);
+        vm.roll(block.number + GOVERNANCE_DELAY);
+
+        // Nobody ever calls `applyDaoFeeShare()` -- `postRequest` itself must flip the matured
+        // pending value into storage as a side effect of touching `$daoFeeShareConfig`.
+        _postRequest();
+
+        assertEq(oracle.daoFeeShare(), newShare, "postRequest applies the pending share");
+        assertEq(oracle.pendingDaoFeeShare(), 0, "pending slot cleared without a separate apply call");
+        assertEq(oracle.pendingDaoFeeShareActiveAt(), 0);
+
+        SentinelOracleRequest.Request memory req = oracle.getRequest(REQUEST_ID);
+        assertEq(req.daoFeeShare, newShare, "new request snapshots the newly-applied share");
     }
 
     function test_Finalize_EagerlyAppliesPendingProtocolFundsReceiver() public {
@@ -470,6 +582,52 @@ contract SentinelOracleTest is Test {
         );
         assertEq(
             token.balanceOf(sentinel2), sentinel2BalBefore + BOND_TARGET + REQUEST_FEE / 2, "sentinel2 claim incorrect"
+        );
+    }
+
+    function test_UnanimousApprove_DaoFeeShareCutGoesToProtocolFundsReceiver() public {
+        uint256 daoShare = 10_000; // 10% of the fee
+        vm.prank(governance);
+        oracle.scheduleDaoFeeShare(daoShare);
+        vm.roll(block.number + GOVERNANCE_DELAY);
+
+        _postRequest();
+        _commit(sentinel1, true, SALT_1);
+        _commit(sentinel2, true, SALT_2);
+        _advancePastCommitDeadline();
+        _reveal(sentinel1, true, SALT_1);
+        _reveal(sentinel2, true, SALT_2);
+
+        uint256 receiverBalBefore = token.balanceOf(protocolFundsReceiver);
+        uint256 expectedCut = REQUEST_FEE * daoShare / oracle.FEE_SHARE_DENOMINATOR();
+
+        oracle.finalize(REQUEST_ID);
+
+        assertEq(
+            token.balanceOf(protocolFundsReceiver),
+            receiverBalBefore + expectedCut,
+            "DAO's cut reaches the protocol funds receiver"
+        );
+
+        uint256 sentinel1BalBefore = token.balanceOf(sentinel1);
+        uint256 sentinel2BalBefore = token.balanceOf(sentinel2);
+
+        vm.prank(sentinel1);
+        oracle.claim(REQUEST_ID);
+        vm.prank(sentinel2);
+        oracle.claim(REQUEST_ID);
+
+        // Winning sentinels split only the post-cut remainder of the fee.
+        uint256 remainingFee = REQUEST_FEE - expectedCut;
+        assertEq(
+            token.balanceOf(sentinel1),
+            sentinel1BalBefore + BOND_TARGET + remainingFee / 2,
+            "sentinel1's reward reflects the post-cut fee"
+        );
+        assertEq(
+            token.balanceOf(sentinel2),
+            sentinel2BalBefore + BOND_TARGET + remainingFee / 2,
+            "sentinel2's reward reflects the post-cut fee"
         );
     }
 
@@ -587,6 +745,50 @@ contract SentinelOracleTest is Test {
         vm.prank(sentinel2);
         oracle.claim(REQUEST_ID);
         assertEq(token.balanceOf(sentinel2), s2Before, "sentinel2 bond slashed");
+    }
+
+    function test_Conflict_ArbitrationDaoFeeShare_ProposerRefundUnaffected() public {
+        uint256 daoShare = 10_000; // 10% of the fee
+        vm.prank(governance);
+        oracle.scheduleDaoFeeShare(daoShare);
+        vm.roll(block.number + GOVERNANCE_DELAY);
+
+        uint256 proposerBalBefore = token.balanceOf(proposer);
+        _postRequest();
+
+        _commit(sentinel1, true, SALT_1);
+        _commit(sentinel2, false, SALT_2);
+        _advancePastCommitDeadline();
+        _reveal(sentinel1, true, SALT_1);
+        _reveal(sentinel2, false, SALT_2);
+
+        oracle.finalize(REQUEST_ID);
+
+        uint256 receiverBalBefore = token.balanceOf(protocolFundsReceiver);
+        uint256 expectedCut = REQUEST_FEE * daoShare / oracle.FEE_SHARE_DENOMINATOR();
+
+        vm.prank(arbitrator);
+        oracle.resolveDispute(REQUEST_ID, true, "sentinel1's evidence was conclusive");
+
+        // The proposer's arbitration refund stays whole -- the DAO's cut comes only out of the
+        // winning sentinel's fee-equivalent reward, not this refund.
+        assertEq(
+            token.balanceOf(proposer), proposerBalBefore, "proposer balance fully restored, unaffected by daoFeeShare"
+        );
+        assertEq(
+            token.balanceOf(protocolFundsReceiver),
+            receiverBalBefore + BOND_TARGET - REQUEST_FEE + expectedCut,
+            "arbitration remainder and DAO's cut both land on the protocol funds receiver"
+        );
+
+        uint256 s1Before = token.balanceOf(sentinel1);
+        vm.prank(sentinel1);
+        oracle.claim(REQUEST_ID);
+        assertEq(
+            token.balanceOf(sentinel1),
+            s1Before + BOND_TARGET + (REQUEST_FEE - expectedCut),
+            "winning sentinel's fee reward reflects the DAO's cut"
+        );
     }
 
     function test_ResolveDispute_EmptyContext_Accepted() public {

--- a/epics/2026_08_12_oracle_governance.md
+++ b/epics/2026_08_12_oracle_governance.md
@@ -157,7 +157,11 @@ Phase 1 is the only hard prerequisite for Phases 2-5 (they all gate new function
 
 `SentinelOracle.sol` (`ARBITRATION_TIMEOUT` immutable + constructor param; `timeoutArbitration()`; `ResolveReason.ARBITRATION_TIMEOUT`), `SentinelOracleRequests.sol` (`Request.arbitrationDeadline`; set when `finalize()` decides `FROZEN`; new `timeoutArbitration` library function reusing the no-reveal `TIMED_OUT` refund logic), deploy script + devnet wiring, tests (`timeoutArbitration` reverts before the deadline and while not `FROZEN`; after the deadline, fee refunds to the proposer and every committed bond returns in full via `claim`, matching the existing no-reveal timeout test's assertions).
 
-### Phase 9 — Remove this plan
+### Phase 9 — Optimizations
+
+So far the contract has not been gas optimized. As part of this phase the code should be analyzed where types could be limited and combined into one slot and reorderd to optimize loading less slots on likely code paths. It should be checked if the delayed config types can be abstracted to avoid code duplication. Also this should include to adjust fetching the pending configs. Each delayed type should have a `pending` method that returns the value and block number for the pending value if it is present, otherwise it should return zero values. If not done before methods with many parameters should be refactored to use structs as input (i.e. the oracle constructor).
+
+### Phase 10 — Remove this plan
 
 Delete `epics/2026_08_12_oracle_governance.md`.
 

--- a/scripts/run_devnet.sh
+++ b/scripts/run_devnet.sh
@@ -41,6 +41,8 @@ SENTINEL_COMMIT_WINDOW=5
 SENTINEL_REVEAL_WINDOW=5
 SENTINEL_GOVERNANCE_DELAY=0
 SENTINEL_BOND_MULTIPLIER=2
+# 0%: no DAO cut by default on devnet.
+SENTINEL_INITIAL_DAO_FEE_SHARE=0
 # $10 of the fee token per sentinel: comfortably above the 80-cent bond
 # target across more than one request.
 SENTINEL_FUNDING_TOKEN=10000000000000000000
@@ -316,7 +318,8 @@ sentinel_oracle="$(parse_address "$(simulate_forge_script DeploySentinelOracleSc
     -e SENTINEL_COMMIT_WINDOW="$SENTINEL_COMMIT_WINDOW" \
     -e SENTINEL_REVEAL_WINDOW="$SENTINEL_REVEAL_WINDOW" \
     -e SENTINEL_GOVERNANCE_DELAY="$SENTINEL_GOVERNANCE_DELAY" \
-    -e SENTINEL_BOND_MULTIPLIER="$SENTINEL_BOND_MULTIPLIER")" 'SentinelOracle deployed at')"
+    -e SENTINEL_BOND_MULTIPLIER="$SENTINEL_BOND_MULTIPLIER" \
+    -e SENTINEL_INITIAL_DAO_FEE_SHARE="$SENTINEL_INITIAL_DAO_FEE_SHARE")" 'SentinelOracle deployed at')"
 
 # Write each validator's TOML config into `$config_dir`, following the shape
 # established by `run_validator_integration_test.sh`'s `validator_config()`
@@ -403,7 +406,8 @@ forge_script DeploySentinelOracleScript \
     -e SENTINEL_COMMIT_WINDOW="$SENTINEL_COMMIT_WINDOW" \
     -e SENTINEL_REVEAL_WINDOW="$SENTINEL_REVEAL_WINDOW" \
     -e SENTINEL_GOVERNANCE_DELAY="$SENTINEL_GOVERNANCE_DELAY" \
-    -e SENTINEL_BOND_MULTIPLIER="$SENTINEL_BOND_MULTIPLIER" >/dev/null
+    -e SENTINEL_BOND_MULTIPLIER="$SENTINEL_BOND_MULTIPLIER" \
+    -e SENTINEL_INITIAL_DAO_FEE_SHARE="$SENTINEL_INITIAL_DAO_FEE_SHARE" >/dev/null
 
 for sentinel in "${SENTINELS[@]}"; do
     parts=(${sentinel//:/ })

--- a/scripts/run_sentinel_integration_test.sh
+++ b/scripts/run_sentinel_integration_test.sh
@@ -26,6 +26,7 @@ BOND_MULTIPLIER=2
 COMMIT_WINDOW=5
 REVEAL_WINDOW=5
 GOVERNANCE_DELAY=0
+INITIAL_DAO_FEE_SHARE=0
 FUNDING_ETH=1ether
 FUNDING_TOKEN=1000000
 # Anvil account 0 — deployer, MyToken owner, and SentinelOracle arbitrator.
@@ -82,6 +83,7 @@ env \
 	SENTINEL_REVEAL_WINDOW="$REVEAL_WINDOW" \
 	SENTINEL_GOVERNANCE_DELAY="$GOVERNANCE_DELAY" \
 	SENTINEL_BOND_MULTIPLIER="$BOND_MULTIPLIER" \
+	SENTINEL_INITIAL_DAO_FEE_SHARE="$INITIAL_DAO_FEE_SHARE" \
 	forge script --root "$ROOT/contracts" DeploySentinelOracleScript --rpc-url "$RPC_URL" --private-key "$DEPLOYER_PK" --broadcast
 ORACLE=$(jq -r '.returns.sentinelOracle.value' "$ROOT/contracts/build/broadcast/DeploySentinelOracle.s.sol/$CHAIN_ID/run-latest.json")
 echo "Sentinel oracle deployed at $ORACLE"
@@ -203,9 +205,9 @@ done
 REQUEST=""
 for _ in $(seq 1 10); do
 	REQUEST=$(cast call --rpc-url "$RPC_URL" --json "$ORACLE" \
-		"getRequest(bytes32)((address,uint256,uint256,uint256,uint256,uint8,uint256,uint256,uint256,uint256))" \
+		"getRequest(bytes32)((address,uint256,uint256,uint256,uint256,uint256,uint8,uint256,uint256,uint256,uint256))" \
 		"$REQUEST_ID" 2>/dev/null) || true
-	STATE=$(echo "$REQUEST" | jq -r '.[0][5]' 2>/dev/null) || true
+	STATE=$(echo "$REQUEST" | jq -r '.[0][6]' 2>/dev/null) || true
 	[ "$STATE" = "2" ] && break
 	sleep "$BLOCK_TIME_SECONDS"
 done
@@ -215,7 +217,7 @@ if [ "$STATE" != "2" ]; then
 	echo "FAILED: expected state RESOLVED_APPROVED (2), got $STATE"
 	exit 1
 fi
-DENY_SENTINEL_COUNT=$(echo "$REQUEST" | jq -r '.[0][9]')
+DENY_SENTINEL_COUNT=$(echo "$REQUEST" | jq -r '.[0][10]')
 if [ "$DENY_SENTINEL_COUNT" != "0" ]; then
 	echo "FAILED: expected a unanimous approve vote, but denySentinelCount is $DENY_SENTINEL_COUNT"
 	exit 1


### PR DESCRIPTION
Introduce a doa fee cut that is taken from the fee paid to the sentinels. It is possible to set this to 0. The denominator is 100_000, so it is possible to set percentages with a presicion of three decimals.

The fee cut is set when the request is created. To track this currently the fee cut percentage is stored as part of the request. Gas optimizations for this will be handled in the new Phase 9 that covers optimizations.

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://docs.safefoundation.org/cla).
