### PR TITLE
[Phase 5] Introduce partial slashing

### DIFF
--- a/contracts/foundry.toml
+++ b/contracts/foundry.toml
@@ -11,6 +11,7 @@ compilation_restrictions = [
   { paths = "src/Consensus.sol", via_ir = true },
   { paths = "src/FROSTCoordinator.sol", via_ir = true },
   { paths = "src/guard/SafenetGuard.sol", via_ir = true },
+  { paths = "src/SentinelOracle.sol", via_ir = true },
 ]
 
 remappings = [

--- a/contracts/script/DeploySentinelOracle.s.sol
+++ b/contracts/script/DeploySentinelOracle.s.sol
@@ -20,6 +20,7 @@ contract DeploySentinelOracleScript is Script {
         uint256 revealWindow = vm.envUint("SENTINEL_REVEAL_WINDOW");
         uint256 governanceDelay = vm.envUint("SENTINEL_GOVERNANCE_DELAY");
         uint256 bondMultiplier = vm.envUint("SENTINEL_BOND_MULTIPLIER");
+        uint256 initialSlashingMultiplier = vm.envUint("SENTINEL_INITIAL_SLASHING_MULTIPLIER");
         uint256 initialDaoFeeShare = vm.envUint("SENTINEL_INITIAL_DAO_FEE_SHARE");
 
         DeterministicDeployment.Factory factory = getFactory(vm);
@@ -40,6 +41,7 @@ contract DeploySentinelOracleScript is Script {
                 revealWindow,
                 governanceDelay,
                 bondMultiplier,
+                initialSlashingMultiplier,
                 initialDaoFeeShare
             )
         );

--- a/contracts/src/SentinelOracle.sol
+++ b/contracts/src/SentinelOracle.sol
@@ -88,7 +88,6 @@ contract SentinelOracle is IOracle {
     error ZeroFee();
     error ZeroWindow();
     error SentinelNotActive();
-    error NotRevealed();
     error InvalidFeeShare();
 
     // ============================================================
@@ -123,7 +122,8 @@ contract SentinelOracle is IOracle {
         uint256 commitWindow,
         uint256 revealWindow,
         uint256 governanceDelay,
-        uint256 initialMultiplier,
+        uint256 initialBondMultiplier,
+        uint256 initialSlashingMultiplier,
         uint256 initialDaoFeeShare
     ) {
         require(arbitrator != address(0), InvalidAddress());
@@ -142,7 +142,7 @@ contract SentinelOracle is IOracle {
         COMMIT_WINDOW = commitWindow;
         REVEAL_WINDOW = revealWindow;
         GOVERNANCE_DELAY = governanceDelay;
-        $bondConfig.init(initialMultiplier);
+        $bondConfig.init(initialBondMultiplier, initialSlashingMultiplier);
         $protocolFundsReceiverConfig.init(initialProtocolFundsReceiver);
         $feeConfig.init(requestFee);
         $daoFeeShareConfig.init(initialDaoFeeShare);
@@ -155,12 +155,14 @@ contract SentinelOracle is IOracle {
     function postRequest(bytes32 requestId, address proposer, bytes calldata) external override(IOracle) {
         require(msg.sender == CONSENSUS, NotConsensus());
         uint256 currentFee = $feeConfig.applyPending();
-        uint256 bondTarget = currentFee * $bondConfig.applyPending();
+        (uint256 currentBondMultiplier, uint256 currentSlashingMultiplier) = $bondConfig.applyPending();
+        uint256 bondTarget = currentFee * currentBondMultiplier;
+        uint256 slashAmount = currentFee * currentSlashingMultiplier;
         uint256 currentDaoFeeShare = $daoFeeShareConfig.applyPending();
         uint256 commitDeadline = block.number + COMMIT_WINDOW;
         uint256 revealDeadline = commitDeadline + REVEAL_WINDOW;
         $requests.create(
-            requestId, proposer, currentFee, bondTarget, currentDaoFeeShare, commitDeadline, revealDeadline
+            requestId, proposer, currentFee, bondTarget, currentDaoFeeShare, slashAmount, commitDeadline, revealDeadline
         );
         FEE_TOKEN.safeTransferFrom(proposer, address(this), currentFee);
     }
@@ -234,18 +236,12 @@ contract SentinelOracle is IOracle {
 
     function claim(bytes32 requestId) external {
         SentinelOracleRequest.Request storage req = $requests.get(requestId);
-        SentinelOracleRequest.State state = req.requireResolved();
+        req.requireResolved();
         SentinelOracleCommitment.Commitment storage commitment = $commitments.get(requestId, msg.sender);
         SentinelOracleCommitment.Vote vote = commitment.vote;
-        // Only allow claiming of pending votes in case of a timeout
-        require(
-            vote == SentinelOracleCommitment.Vote.APPROVED || vote == SentinelOracleCommitment.Vote.DENIED
-                || state == SentinelOracleRequest.State.TIMED_OUT,
-            NotRevealed()
-        );
         commitment.markClaimed();
         uint256 feeReward = req.calcFeeReward(vote);
-        uint256 bondReturn = req.isBondSlashed(vote) ? 0 : commitment.bondAmount;
+        uint256 bondReturn = commitment.bondAmount - req.slashAmountFor(vote);
         uint256 totalClaim = bondReturn + feeReward;
         if (totalClaim > 0) {
             FEE_TOKEN.safeTransfer(msg.sender, totalClaim);
@@ -284,11 +280,11 @@ contract SentinelOracle is IOracle {
         $sentinelMap.remove(sentinel);
     }
 
-    function scheduleBondMultiplier(uint256 newValue) external onlyGovernance {
-        $bondConfig.schedule(newValue, GOVERNANCE_DELAY);
+    function scheduleBondConfig(uint256 newBondMultiplier, uint256 newSlashingMultiplier) external onlyGovernance {
+        $bondConfig.schedule(newBondMultiplier, newSlashingMultiplier, GOVERNANCE_DELAY);
     }
 
-    function applyBondMultiplier() external {
+    function applyBondConfig() external {
         $bondConfig.applyPending();
     }
 
@@ -336,7 +332,15 @@ contract SentinelOracle is IOracle {
     }
 
     function pendingBondMultiplierActiveAt() external view returns (uint256) {
-        return $bondConfig.pendingBondMultiplierActiveAt;
+        return $bondConfig.pendingActiveAt;
+    }
+
+    function slashingMultiplier() external view returns (uint256) {
+        return $bondConfig.currentSlashingMultiplier();
+    }
+
+    function pendingSlashingMultiplier() external view returns (uint256) {
+        return $bondConfig.pendingSlashingMultiplier;
     }
 
     function protocolFundsReceiver() external view returns (address) {

--- a/contracts/src/libraries/BondConfig.sol
+++ b/contracts/src/libraries/BondConfig.sol
@@ -8,58 +8,80 @@ library BondConfig {
 
     struct T {
         uint256 bondMultiplier;
+        uint256 slashingMultiplier;
         uint256 pendingBondMultiplier;
-        uint256 pendingBondMultiplierActiveAt;
+        uint256 pendingSlashingMultiplier;
+        uint256 pendingActiveAt;
     }
 
     // ============================================================
     // EVENTS
     // ============================================================
 
-    event BondMultiplierScheduled(uint256 newMultiplier, uint256 activeAtBlock);
-    event BondMultiplierApplied(uint256 newMultiplier);
+    event BondConfigScheduled(uint256 newBondMultiplier, uint256 newSlashingMultiplier, uint256 activeAtBlock);
+    event BondConfigApplied(uint256 newBondMultiplier, uint256 newSlashingMultiplier);
 
     // ============================================================
     // ERRORS
     // ============================================================
 
-    error InvalidMultiplier();
+    error InvalidBondMultiplier();
+    error InvalidSlashingMultiplier();
 
     // ============================================================
     // INTERNAL FUNCTIONS
     // ============================================================
 
-    function init(T storage self, uint256 initialMultiplier) internal {
-        require(initialMultiplier > 0, InvalidMultiplier());
-        self.bondMultiplier = initialMultiplier;
+    function init(T storage self, uint256 initialBondMultiplier, uint256 initialSlashingMultiplier) internal {
+        require(initialBondMultiplier > 0, InvalidBondMultiplier());
+        require(
+            initialSlashingMultiplier > 0 && initialSlashingMultiplier <= initialBondMultiplier,
+            InvalidSlashingMultiplier()
+        );
+        self.bondMultiplier = initialBondMultiplier;
+        self.slashingMultiplier = initialSlashingMultiplier;
     }
 
-    function schedule(T storage self, uint256 newValue, uint256 governanceDelay) internal {
-        require(newValue > 0, InvalidMultiplier());
+    function schedule(T storage self, uint256 newBondMultiplier, uint256 newSlashingMultiplier, uint256 governanceDelay)
+        internal
+    {
+        require(newBondMultiplier > 0, InvalidBondMultiplier());
+        require(newSlashingMultiplier > 0 && newSlashingMultiplier <= newBondMultiplier, InvalidSlashingMultiplier());
         applyPending(self);
 
         uint256 activeAt = block.number + governanceDelay;
-        self.pendingBondMultiplier = newValue;
-        self.pendingBondMultiplierActiveAt = activeAt;
-        emit BondMultiplierScheduled(newValue, activeAt);
+        self.pendingBondMultiplier = newBondMultiplier;
+        self.pendingSlashingMultiplier = newSlashingMultiplier;
+        self.pendingActiveAt = activeAt;
+        emit BondConfigScheduled(newBondMultiplier, newSlashingMultiplier, activeAt);
     }
 
-    function applyPending(T storage self) internal returns (uint256) {
-        if (self.pendingBondMultiplierActiveAt == 0) return self.bondMultiplier;
-        if (block.number < self.pendingBondMultiplierActiveAt) return self.bondMultiplier;
+    function applyPending(T storage self) internal returns (uint256 bondMultiplier, uint256 slashingMultiplier) {
+        if (self.pendingActiveAt == 0 || block.number < self.pendingActiveAt) {
+            return (self.bondMultiplier, self.slashingMultiplier);
+        }
 
-        uint256 newValue = self.pendingBondMultiplier;
-        self.bondMultiplier = newValue;
+        bondMultiplier = self.pendingBondMultiplier;
+        slashingMultiplier = self.pendingSlashingMultiplier;
+        self.bondMultiplier = bondMultiplier;
+        self.slashingMultiplier = slashingMultiplier;
         self.pendingBondMultiplier = 0;
-        self.pendingBondMultiplierActiveAt = 0;
-        emit BondMultiplierApplied(newValue);
-        return newValue;
+        self.pendingSlashingMultiplier = 0;
+        self.pendingActiveAt = 0;
+        emit BondConfigApplied(bondMultiplier, slashingMultiplier);
     }
 
     function currentMultiplier(T storage self) internal view returns (uint256) {
-        if (self.pendingBondMultiplierActiveAt != 0 && block.number >= self.pendingBondMultiplierActiveAt) {
+        if (self.pendingActiveAt != 0 && block.number >= self.pendingActiveAt) {
             return self.pendingBondMultiplier;
         }
         return self.bondMultiplier;
+    }
+
+    function currentSlashingMultiplier(T storage self) internal view returns (uint256) {
+        if (self.pendingActiveAt != 0 && block.number >= self.pendingActiveAt) {
+            return self.pendingSlashingMultiplier;
+        }
+        return self.slashingMultiplier;
     }
 }

--- a/contracts/src/libraries/SentinelOracleRequests.sol
+++ b/contracts/src/libraries/SentinelOracleRequests.sol
@@ -32,6 +32,7 @@ library SentinelOracleRequest {
         uint256 fee;
         uint256 bondTarget;
         uint256 daoFeeShare;
+        uint256 slashAmount;
         uint256 commitDeadline;
         uint256 revealDeadline;
         State state;
@@ -99,9 +100,9 @@ library SentinelOracleRequest {
                 newState = State.RESOLVED_DENIED;
             }
             // An established side exists, so a non-revealer's silence can only be griefing (stalling
-            // a request whose outcome their own commit already contributed to) -- slash their bond to
-            // `ARBITRATOR`.
-            unrevealedBond = (self.committedCount - self.revealedCount) * self.bondTarget;
+            // a request whose outcome their own commit already contributed to) -- slash the governed
+            // slash amount from their bond to the protocol funds receiver.
+            unrevealedBond = (self.committedCount - self.revealedCount) * self.slashAmount;
         } else {
             // Nobody revealed (or nobody even committed): there is no established side, so no
             // misbehavior can be proven against any committer -- bonds are returned in full via
@@ -134,23 +135,23 @@ library SentinelOracleRequest {
         return self.fee / winningSideCount;
     }
 
-    function isBondSlashed(Request storage self, SentinelOracleCommitment.Vote vote) internal view returns (bool) {
+    function slashAmountFor(Request storage self, SentinelOracleCommitment.Vote vote) internal view returns (uint256) {
         State state = requireResolved(self);
-        if (state == State.TIMED_OUT) return false;
+        if (state == State.TIMED_OUT) return 0;
         // A pending (never revealed) vote in a resolved request is unrevealed griefing -- slash it
         // regardless of which side won.
         if (vote != SentinelOracleCommitment.Vote.APPROVED && vote != SentinelOracleCommitment.Vote.DENIED) {
-            return true;
+            return self.slashAmount;
         }
         // Slashing only applies to requests resolved via arbitration (both sides had votes).
-        if (self.approveSentinelCount == 0 || self.denySentinelCount == 0) return false;
+        if (self.approveSentinelCount == 0 || self.denySentinelCount == 0) return 0;
         bool approved = vote == SentinelOracleCommitment.Vote.APPROVED;
-        return approved != (state == State.RESOLVED_APPROVED);
+        return approved != (state == State.RESOLVED_APPROVED) ? self.slashAmount : 0;
     }
 
     function resolveDispute(Request storage self, bool approveWins) internal returns (uint256 slashed) {
         require(self.state == State.FROZEN, RequestNotFrozen());
-        slashed = (approveWins ? self.denySentinelCount : self.approveSentinelCount) * self.bondTarget;
+        slashed = (approveWins ? self.denySentinelCount : self.approveSentinelCount) * self.slashAmount;
         self.state = approveWins ? State.RESOLVED_APPROVED : State.RESOLVED_DENIED;
     }
 }
@@ -197,6 +198,7 @@ library SentinelOracleRequestMap {
         uint256 fee,
         uint256 bondTarget,
         uint256 daoFeeShare,
+        uint256 slashAmount,
         uint256 commitDeadline,
         uint256 revealDeadline
     ) internal {
@@ -209,6 +211,7 @@ library SentinelOracleRequestMap {
             fee: fee,
             bondTarget: bondTarget,
             daoFeeShare: daoFeeShare,
+            slashAmount: slashAmount,
             commitDeadline: commitDeadline,
             revealDeadline: revealDeadline,
             state: SentinelOracleRequest.State.PENDING,

--- a/contracts/test/SentinelOracle.t.sol
+++ b/contracts/test/SentinelOracle.t.sol
@@ -3,6 +3,7 @@ pragma solidity ^0.8.30;
 
 import {Test} from "@forge-std/Test.sol";
 import {IOracle} from "@/interfaces/IOracle.sol";
+import {BondConfig} from "@/libraries/BondConfig.sol";
 import {SentinelOracle} from "@/SentinelOracle.sol";
 import {SentinelOracleRequest} from "@/libraries/SentinelOracleRequests.sol";
 import {SentinelOracleCommitment, SentinelOracleCommitmentMap} from "@/libraries/SentinelOracleCommitments.sol";
@@ -16,6 +17,8 @@ contract SentinelOracleTest is Test {
     uint256 constant REQUEST_FEE = 10_000; // 1 cent in a 6-decimal token (e.g. USDC)
     uint256 constant BOND_MULTIPLIER = 2;
     uint256 constant BOND_TARGET = REQUEST_FEE * BOND_MULTIPLIER; // 20_000
+    uint256 constant SLASHING_MULTIPLIER = 2;
+    uint256 constant SLASH_AMOUNT = REQUEST_FEE * SLASHING_MULTIPLIER; // 20_000, equal to BOND_TARGET by default
     uint256 constant COMMIT_WINDOW = 12;
     uint256 constant REVEAL_WINDOW = 12;
     uint256 constant GOVERNANCE_DELAY = 100;
@@ -68,6 +71,7 @@ contract SentinelOracleTest is Test {
             REVEAL_WINDOW,
             GOVERNANCE_DELAY,
             BOND_MULTIPLIER,
+            SLASHING_MULTIPLIER,
             INITIAL_DAO_FEE_SHARE
         );
 
@@ -168,19 +172,19 @@ contract SentinelOracleTest is Test {
         oracle.removeSentinel(sentinel1);
     }
 
-    function test_ScheduleBondMultiplier_OnlyGovernance() public {
+    function test_ScheduleBondConfig_OnlyGovernance() public {
         address randomAddress = vm.createWallet("random").addr;
 
         vm.expectRevert(SentinelOracle.NotGovernance.selector);
         vm.prank(arbitrator);
-        oracle.scheduleBondMultiplier(BOND_MULTIPLIER + 1);
+        oracle.scheduleBondConfig(BOND_MULTIPLIER + 1, SLASHING_MULTIPLIER + 1);
 
         vm.expectRevert(SentinelOracle.NotGovernance.selector);
         vm.prank(randomAddress);
-        oracle.scheduleBondMultiplier(BOND_MULTIPLIER + 1);
+        oracle.scheduleBondConfig(BOND_MULTIPLIER + 1, SLASHING_MULTIPLIER + 1);
 
         vm.prank(governance);
-        oracle.scheduleBondMultiplier(BOND_MULTIPLIER + 1);
+        oracle.scheduleBondConfig(BOND_MULTIPLIER + 1, SLASHING_MULTIPLIER + 1);
     }
 
     function test_ScheduleFee_OnlyGovernance() public {
@@ -283,6 +287,98 @@ contract SentinelOracleTest is Test {
         oracle.applyProtocolFundsReceiver();
 
         assertEq(oracle.protocolFundsReceiver(), secondReceiver, "corrected value takes effect, not the mistake");
+    }
+
+    // ============================================================
+    // BOND CONFIG (BOND MULTIPLIER + SLASHING MULTIPLIER) SCHEDULE/APPLY
+    // ============================================================
+
+    function test_ScheduleBondConfig_ZeroBondMultiplier_Reverts() public {
+        vm.expectRevert(BondConfig.InvalidBondMultiplier.selector);
+        vm.prank(governance);
+        oracle.scheduleBondConfig(0, 0);
+    }
+
+    function test_ScheduleBondConfig_SlashingMultiplierBelowOne_Reverts() public {
+        vm.expectRevert(BondConfig.InvalidSlashingMultiplier.selector);
+        vm.prank(governance);
+        oracle.scheduleBondConfig(BOND_MULTIPLIER, 0);
+    }
+
+    function test_ScheduleBondConfig_SlashingMultiplierAboveBondMultiplier_Reverts() public {
+        vm.expectRevert(BondConfig.InvalidSlashingMultiplier.selector);
+        vm.prank(governance);
+        oracle.scheduleBondConfig(BOND_MULTIPLIER, BOND_MULTIPLIER + 1);
+    }
+
+    function test_BondConfig_ScheduleApplyRoundTrip() public {
+        uint256 newMultiplier = BOND_MULTIPLIER + 2;
+        uint256 newSlashingMultiplier = 1;
+
+        assertEq(oracle.bondMultiplier(), BOND_MULTIPLIER, "starts at the constructor value");
+        assertEq(oracle.slashingMultiplier(), SLASHING_MULTIPLIER, "starts at the constructor value");
+
+        vm.prank(governance);
+        oracle.scheduleBondConfig(newMultiplier, newSlashingMultiplier);
+
+        assertEq(oracle.pendingBondMultiplier(), newMultiplier);
+        assertEq(oracle.pendingSlashingMultiplier(), newSlashingMultiplier);
+        assertEq(oracle.bondMultiplier(), BOND_MULTIPLIER, "not active until the delay elapses");
+        assertEq(oracle.slashingMultiplier(), SLASHING_MULTIPLIER, "not active until the delay elapses");
+
+        // Applying too early is a no-op, not a revert -- it's permissionless and harmless to call
+        // speculatively.
+        oracle.applyBondConfig();
+        assertEq(oracle.bondMultiplier(), BOND_MULTIPLIER, "still not active after an early apply");
+        assertEq(oracle.pendingBondMultiplier(), newMultiplier, "pending value survives an early apply");
+
+        vm.roll(block.number + GOVERNANCE_DELAY);
+        oracle.applyBondConfig();
+
+        assertEq(oracle.bondMultiplier(), newMultiplier, "takes effect once the delay has elapsed");
+        assertEq(oracle.slashingMultiplier(), newSlashingMultiplier, "takes effect once the delay has elapsed");
+        assertEq(oracle.pendingBondMultiplier(), 0);
+        assertEq(oracle.pendingSlashingMultiplier(), 0);
+        assertEq(oracle.pendingBondMultiplierActiveAt(), 0);
+    }
+
+    function test_BondConfig_RescheduleBeforeMaturity_OverwritesPending() public {
+        vm.startPrank(governance);
+        oracle.scheduleBondConfig(BOND_MULTIPLIER + 1, 1);
+
+        // Governance notices the mistake before the first schedule matures and corrects it -- this
+        // must overwrite the still-pending schedule, not revert.
+        oracle.scheduleBondConfig(BOND_MULTIPLIER + 3, 2);
+        vm.stopPrank();
+
+        assertEq(oracle.pendingBondMultiplier(), BOND_MULTIPLIER + 3, "second schedule overwrites the first");
+        assertEq(oracle.pendingSlashingMultiplier(), 2, "second schedule overwrites the first");
+        assertEq(oracle.bondMultiplier(), BOND_MULTIPLIER, "not active until the delay elapses");
+
+        vm.roll(block.number + GOVERNANCE_DELAY);
+        oracle.applyBondConfig();
+
+        assertEq(oracle.bondMultiplier(), BOND_MULTIPLIER + 3, "corrected value takes effect, not the mistake");
+        assertEq(oracle.slashingMultiplier(), 2, "corrected value takes effect, not the mistake");
+    }
+
+    function test_ScheduleBondConfig_RequestsInFlightKeepSnapshottedSlashAmount() public {
+        uint256 newMultiplier = BOND_MULTIPLIER + 1;
+        uint256 newSlashingMultiplier = 1;
+
+        _postRequest();
+
+        vm.prank(governance);
+        oracle.scheduleBondConfig(newMultiplier, newSlashingMultiplier);
+        vm.roll(block.number + GOVERNANCE_DELAY);
+
+        // The in-flight request was created before the new config matured -- its snapshotted
+        // `slashAmount`/`bondTarget` must not retroactively change even though the oracle now
+        // reports the new values.
+        assertEq(oracle.slashingMultiplier(), newSlashingMultiplier, "governed slashing multiplier has matured");
+        SentinelOracleRequest.Request memory req = oracle.getRequest(REQUEST_ID);
+        assertEq(req.slashAmount, SLASH_AMOUNT, "in-flight request keeps its originally snapshotted slash amount");
+        assertEq(req.bondTarget, BOND_TARGET, "in-flight request keeps its originally snapshotted bond target");
     }
 
     // ============================================================
@@ -459,21 +555,31 @@ contract SentinelOracleTest is Test {
 
     function test_PostRequest_EagerlyAppliesPendingBondMultiplier() public {
         uint256 newMultiplier = BOND_MULTIPLIER + 1;
+        uint256 newSlashingMultiplier = SLASHING_MULTIPLIER + 1;
 
         vm.prank(governance);
-        oracle.scheduleBondMultiplier(newMultiplier);
+        oracle.scheduleBondConfig(newMultiplier, newSlashingMultiplier);
         vm.roll(block.number + GOVERNANCE_DELAY);
 
-        // Nobody ever calls `applyBondMultiplier()` -- `postRequest` itself must flip the
+        // Nobody ever calls `applyBondConfig()` -- `postRequest` itself must flip the
         // matured pending value into storage as a side effect of touching `$bondConfig`.
         _postRequest();
 
         assertEq(oracle.bondMultiplier(), newMultiplier, "postRequest applies the pending multiplier");
         assertEq(oracle.pendingBondMultiplier(), 0, "pending slot cleared without a separate apply call");
         assertEq(oracle.pendingBondMultiplierActiveAt(), 0);
+        assertEq(
+            oracle.slashingMultiplier(), newSlashingMultiplier, "postRequest applies the pending slashing multiplier"
+        );
+        assertEq(oracle.pendingSlashingMultiplier(), 0, "pending slot cleared without a separate apply call");
 
         SentinelOracleRequest.Request memory req = oracle.getRequest(REQUEST_ID);
         assertEq(req.bondTarget, REQUEST_FEE * newMultiplier, "new request snapshots the newly-applied multiplier");
+        assertEq(
+            req.slashAmount,
+            REQUEST_FEE * newSlashingMultiplier,
+            "new request snapshots the newly-applied slashing multiplier"
+        );
     }
 
     function test_PostRequest_EagerlyAppliesPendingDaoFeeShare() public {
@@ -805,6 +911,155 @@ contract SentinelOracleTest is Test {
     }
 
     // ============================================================
+    // PARTIAL BOND SLASHING (ARBITRATION PATH)
+    // ============================================================
+
+    function test_Conflict_MinimumSlashingMultiplier_LosingSentinelReclaimsRemainder() public {
+        // Minimum allowed slashing multiplier (1): the slash covers exactly the fee, and the
+        // losing sentinel reclaims everything above that out of its bond via claim().
+        vm.prank(governance);
+        oracle.scheduleBondConfig(BOND_MULTIPLIER, 1);
+        vm.roll(block.number + GOVERNANCE_DELAY);
+
+        _postRequest();
+        _commit(sentinel1, true, SALT_1);
+        _commit(sentinel2, false, SALT_2);
+        _advancePastCommitDeadline();
+        _reveal(sentinel1, true, SALT_1);
+        _reveal(sentinel2, false, SALT_2);
+        oracle.finalize(REQUEST_ID);
+
+        vm.prank(arbitrator);
+        oracle.resolveDispute(REQUEST_ID, true, "sentinel1's evidence was conclusive");
+
+        uint256 s2Before = token.balanceOf(sentinel2);
+        vm.prank(sentinel2);
+        oracle.claim(REQUEST_ID);
+        assertEq(
+            token.balanceOf(sentinel2),
+            s2Before + (BOND_TARGET - REQUEST_FEE),
+            "losing sentinel reclaims its bond above the fee-covering slash"
+        );
+    }
+
+    function test_Conflict_MidRangeSlashingMultiplier_LosingSentinelReclaimsPartialRemainder() public {
+        uint256 newBondMultiplier = 4;
+        uint256 newSlashingMultiplier = 2;
+        vm.prank(governance);
+        oracle.scheduleBondConfig(newBondMultiplier, newSlashingMultiplier);
+        vm.roll(block.number + GOVERNANCE_DELAY);
+
+        _postRequest();
+        SentinelOracleRequest.Request memory posted = oracle.getRequest(REQUEST_ID);
+        assertEq(posted.bondTarget, REQUEST_FEE * newBondMultiplier);
+        assertEq(posted.slashAmount, REQUEST_FEE * newSlashingMultiplier);
+
+        _commit(sentinel1, true, SALT_1);
+        _commit(sentinel2, false, SALT_2);
+        _advancePastCommitDeadline();
+        _reveal(sentinel1, true, SALT_1);
+        _reveal(sentinel2, false, SALT_2);
+        oracle.finalize(REQUEST_ID);
+
+        uint256 receiverBalBefore = token.balanceOf(protocolFundsReceiver);
+        vm.prank(arbitrator);
+        oracle.resolveDispute(REQUEST_ID, true, "sentinel1's evidence was conclusive");
+
+        assertEq(
+            token.balanceOf(protocolFundsReceiver),
+            receiverBalBefore + (REQUEST_FEE * newSlashingMultiplier) - REQUEST_FEE,
+            "arbitration remainder reflects the governed slash amount, not the full bond"
+        );
+
+        uint256 s2Before = token.balanceOf(sentinel2);
+        vm.prank(sentinel2);
+        oracle.claim(REQUEST_ID);
+        assertEq(
+            token.balanceOf(sentinel2),
+            s2Before + (REQUEST_FEE * newBondMultiplier - REQUEST_FEE * newSlashingMultiplier),
+            "losing sentinel reclaims the unslashed remainder of its bond"
+        );
+    }
+
+    function test_Conflict_WithUnrevealedCommitter_NoFundsTrappedOrDoubleSlashed() public {
+        // A partial slashing multiplier makes each committer's unslashed remainder nonzero, so a
+        // double-slash of sentinel3's bond (once swept as `unrevealedBond`, again deducted in
+        // `claim()`) would be visible instead of masked by an already-zero remainder.
+        uint256 newBondMultiplier = 4;
+        uint256 newSlashingMultiplier = 2;
+        vm.prank(governance);
+        oracle.scheduleBondConfig(newBondMultiplier, newSlashingMultiplier);
+        vm.roll(block.number + GOVERNANCE_DELAY);
+
+        _postRequest();
+        SentinelOracleRequest.Request memory posted = oracle.getRequest(REQUEST_ID);
+        uint256 bondTarget = posted.bondTarget;
+        uint256 slashAmount = posted.slashAmount;
+
+        // sentinel1 approves, sentinel2 denies (conflict -> FROZEN), sentinel3 commits but never
+        // reveals. `finalize()` already sweeps sentinel3's `unrevealedBond` slash to the protocol
+        // funds receiver unconditionally -- including on the path to FROZEN, before the
+        // `newState == FROZEN` early return -- so `resolveDispute` must not additionally count
+        // sentinel3 in `slashed`, or its bond would be slashed twice and later claims would revert
+        // for lack of contract balance.
+        _commit(sentinel1, true, SALT_1);
+        _commit(sentinel2, false, SALT_2);
+        _commit(sentinel3, true, SALT_3);
+        _advancePastCommitDeadline();
+        _reveal(sentinel1, true, SALT_1);
+        _reveal(sentinel2, false, SALT_2);
+        _advancePastRevealDeadline();
+
+        uint256 receiverBalBefore = token.balanceOf(protocolFundsReceiver);
+        oracle.finalize(REQUEST_ID);
+
+        SentinelOracleRequest.Request memory req = oracle.getRequest(REQUEST_ID);
+        assertEq(uint256(req.state), uint256(SentinelOracleRequest.State.FROZEN));
+        assertEq(
+            token.balanceOf(protocolFundsReceiver),
+            receiverBalBefore + slashAmount,
+            "sentinel3's unrevealed bond is swept to the protocol funds receiver even while FROZEN"
+        );
+
+        vm.prank(arbitrator);
+        oracle.resolveDispute(REQUEST_ID, true, "sentinel1's evidence was conclusive");
+
+        // `slashed` in `resolveDispute` must only cover sentinel2 (the revealed loser) --
+        // sentinel3's slash was already swept above and must not be counted again.
+        assertEq(
+            token.balanceOf(protocolFundsReceiver),
+            receiverBalBefore + slashAmount + (slashAmount - REQUEST_FEE),
+            "resolveDispute's remainder covers only the revealed loser, not the already-swept unrevealed bond"
+        );
+
+        uint256 s1Before = token.balanceOf(sentinel1);
+        vm.prank(sentinel1);
+        oracle.claim(REQUEST_ID);
+        assertEq(token.balanceOf(sentinel1), s1Before + bondTarget + REQUEST_FEE, "winner claims bond + full fee");
+
+        uint256 s2Before = token.balanceOf(sentinel2);
+        vm.prank(sentinel2);
+        oracle.claim(REQUEST_ID);
+        assertEq(
+            token.balanceOf(sentinel2), s2Before + (bondTarget - slashAmount), "loser reclaims unslashed remainder"
+        );
+
+        // sentinel3 never revealed -- its slash was already swept via `unrevealedBond`, so
+        // `claim()` must not deduct it again; it reclaims exactly `bondTarget - slashAmount`, and
+        // the contract must have the balance on hand to pay it (no trapped/missing funds).
+        uint256 s3Before = token.balanceOf(sentinel3);
+        vm.prank(sentinel3);
+        oracle.claim(REQUEST_ID);
+        assertEq(
+            token.balanceOf(sentinel3),
+            s3Before + (bondTarget - slashAmount),
+            "non-revealer reclaims its unslashed remainder without being slashed twice"
+        );
+
+        assertEq(token.balanceOf(address(oracle)), 0, "every deposited token was accounted for -- nothing trapped");
+    }
+
+    // ============================================================
     // COMMIT-REVEAL EDGE CASES
     // ============================================================
 
@@ -961,10 +1216,53 @@ contract SentinelOracleTest is Test {
         oracle.claim(REQUEST_ID);
         assertEq(token.balanceOf(sentinel2), s2Before + BOND_TARGET + REQUEST_FEE / 2, "sentinel2 claim incorrect");
 
-        // sentinel3 never revealed — its commitment is still PENDING, so claim must revert.
-        vm.expectRevert(SentinelOracle.NotRevealed.selector);
+        // sentinel3 never revealed and its whole bond was slashed (slashingMultiplier ==
+        // bondMultiplier here) -- claim() now succeeds regardless, but returns nothing.
+        uint256 s3Before = token.balanceOf(sentinel3);
         vm.prank(sentinel3);
         oracle.claim(REQUEST_ID);
+        assertEq(token.balanceOf(sentinel3), s3Before, "fully slashed bond leaves nothing to claim");
+    }
+
+    function test_PartialReveal_PartialSlashingMultiplier_NonRevealerReclaimsRemainder() public {
+        uint256 newSlashingMultiplier = 1;
+        vm.prank(governance);
+        oracle.scheduleBondConfig(BOND_MULTIPLIER, newSlashingMultiplier);
+        vm.roll(block.number + GOVERNANCE_DELAY);
+
+        _postRequest();
+
+        // Three commit approve, but only two ever reveal.
+        _commit(sentinel1, true, SALT_1);
+        _commit(sentinel2, true, SALT_2);
+        _commit(sentinel3, true, SALT_3);
+
+        _advancePastCommitDeadline();
+        _reveal(sentinel1, true, SALT_1);
+        _reveal(sentinel2, true, SALT_2);
+        _advancePastRevealDeadline();
+
+        uint256 receiverBalBefore = token.balanceOf(protocolFundsReceiver);
+        oracle.finalize(REQUEST_ID);
+
+        // Only the governed slash amount (fee-covering, at multiplier 1) is forfeited, not the
+        // whole bond.
+        assertEq(
+            token.balanceOf(protocolFundsReceiver),
+            receiverBalBefore + REQUEST_FEE * newSlashingMultiplier,
+            "unrevealed bond partially slashed"
+        );
+
+        // sentinel3 never revealed, but can now reclaim the unslashed remainder of its bond --
+        // previously this reverted with NotRevealed().
+        uint256 s3Before = token.balanceOf(sentinel3);
+        vm.prank(sentinel3);
+        oracle.claim(REQUEST_ID);
+        assertEq(
+            token.balanceOf(sentinel3),
+            s3Before + (BOND_TARGET - REQUEST_FEE * newSlashingMultiplier),
+            "non-revealer reclaims the unslashed remainder of its bond"
+        );
     }
 
     // ============================================================

--- a/scripts/run_devnet.sh
+++ b/scripts/run_devnet.sh
@@ -41,6 +41,9 @@ SENTINEL_COMMIT_WINDOW=5
 SENTINEL_REVEAL_WINDOW=5
 SENTINEL_GOVERNANCE_DELAY=0
 SENTINEL_BOND_MULTIPLIER=2
+# Equal to the bond multiplier: a losing/never-revealed bond is slashed in
+# full by default, matching pre-governed-slashing behavior.
+SENTINEL_INITIAL_SLASHING_MULTIPLIER=2
 # 0%: no DAO cut by default on devnet.
 SENTINEL_INITIAL_DAO_FEE_SHARE=0
 # $10 of the fee token per sentinel: comfortably above the 80-cent bond
@@ -319,6 +322,7 @@ sentinel_oracle="$(parse_address "$(simulate_forge_script DeploySentinelOracleSc
     -e SENTINEL_REVEAL_WINDOW="$SENTINEL_REVEAL_WINDOW" \
     -e SENTINEL_GOVERNANCE_DELAY="$SENTINEL_GOVERNANCE_DELAY" \
     -e SENTINEL_BOND_MULTIPLIER="$SENTINEL_BOND_MULTIPLIER" \
+    -e SENTINEL_INITIAL_SLASHING_MULTIPLIER="$SENTINEL_INITIAL_SLASHING_MULTIPLIER" \
     -e SENTINEL_INITIAL_DAO_FEE_SHARE="$SENTINEL_INITIAL_DAO_FEE_SHARE")" 'SentinelOracle deployed at')"
 
 # Write each validator's TOML config into `$config_dir`, following the shape
@@ -407,6 +411,7 @@ forge_script DeploySentinelOracleScript \
     -e SENTINEL_REVEAL_WINDOW="$SENTINEL_REVEAL_WINDOW" \
     -e SENTINEL_GOVERNANCE_DELAY="$SENTINEL_GOVERNANCE_DELAY" \
     -e SENTINEL_BOND_MULTIPLIER="$SENTINEL_BOND_MULTIPLIER" \
+    -e SENTINEL_INITIAL_SLASHING_MULTIPLIER="$SENTINEL_INITIAL_SLASHING_MULTIPLIER" \
     -e SENTINEL_INITIAL_DAO_FEE_SHARE="$SENTINEL_INITIAL_DAO_FEE_SHARE" >/dev/null
 
 for sentinel in "${SENTINELS[@]}"; do

--- a/scripts/run_sentinel_integration_test.sh
+++ b/scripts/run_sentinel_integration_test.sh
@@ -26,6 +26,7 @@ BOND_MULTIPLIER=2
 COMMIT_WINDOW=5
 REVEAL_WINDOW=5
 GOVERNANCE_DELAY=0
+INITIAL_SLASHING_MULTIPLIER=2
 INITIAL_DAO_FEE_SHARE=0
 FUNDING_ETH=1ether
 FUNDING_TOKEN=1000000
@@ -83,6 +84,7 @@ env \
 	SENTINEL_REVEAL_WINDOW="$REVEAL_WINDOW" \
 	SENTINEL_GOVERNANCE_DELAY="$GOVERNANCE_DELAY" \
 	SENTINEL_BOND_MULTIPLIER="$BOND_MULTIPLIER" \
+	SENTINEL_INITIAL_SLASHING_MULTIPLIER="$INITIAL_SLASHING_MULTIPLIER" \
 	SENTINEL_INITIAL_DAO_FEE_SHARE="$INITIAL_DAO_FEE_SHARE" \
 	forge script --root "$ROOT/contracts" DeploySentinelOracleScript --rpc-url "$RPC_URL" --private-key "$DEPLOYER_PK" --broadcast
 ORACLE=$(jq -r '.returns.sentinelOracle.value' "$ROOT/contracts/build/broadcast/DeploySentinelOracle.s.sol/$CHAIN_ID/run-latest.json")
@@ -205,9 +207,9 @@ done
 REQUEST=""
 for _ in $(seq 1 10); do
 	REQUEST=$(cast call --rpc-url "$RPC_URL" --json "$ORACLE" \
-		"getRequest(bytes32)((address,uint256,uint256,uint256,uint256,uint256,uint8,uint256,uint256,uint256,uint256))" \
+		"getRequest(bytes32)((address,uint256,uint256,uint256,uint256,uint256,uint256,uint8,uint256,uint256,uint256,uint256))" \
 		"$REQUEST_ID" 2>/dev/null) || true
-	STATE=$(echo "$REQUEST" | jq -r '.[0][6]' 2>/dev/null) || true
+	STATE=$(echo "$REQUEST" | jq -r '.[0][7]' 2>/dev/null) || true
 	[ "$STATE" = "2" ] && break
 	sleep "$BLOCK_TIME_SECONDS"
 done
@@ -217,7 +219,7 @@ if [ "$STATE" != "2" ]; then
 	echo "FAILED: expected state RESOLVED_APPROVED (2), got $STATE"
 	exit 1
 fi
-DENY_SENTINEL_COUNT=$(echo "$REQUEST" | jq -r '.[0][10]')
+DENY_SENTINEL_COUNT=$(echo "$REQUEST" | jq -r '.[0][11]')
 if [ "$DENY_SENTINEL_COUNT" != "0" ]; then
 	echo "FAILED: expected a unanimous approve vote, but denySentinelCount is $DENY_SENTINEL_COUNT"
 	exit 1


### PR DESCRIPTION
To allow adjusting the slashing risk a slashing multiplier is added. The multiplier is between 1 and the bond multiplier (inclusive). The slashing amount is set at the point of request creation (similar to the bond target) and is persisted in the request.

Now that partial slashing applies it is important to ensure that sentinels can always claim left over bonds.

For this PR the increased number construction parameters is not handled, as this will happen in a follow up.

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://docs.safefoundation.org/cla).
