### PR TITLE
[Phase 6] Sentinel always claim

### DIFF
--- a/crates/sentinel/src/service.rs
+++ b/crates/sentinel/src/service.rs
@@ -4,7 +4,7 @@ use crate::{
     bindings::{
         SentinelEvents,
         consensus::Consensus,
-        oracle::{ERC20, RequestState as OnchainRequestState, SentinelOracle},
+        oracle::{ERC20, SentinelOracle},
     },
     checker::CheckOutcome,
     cow::CowChecker,
@@ -474,7 +474,7 @@ impl SentinelTransition {
                     }
                 }
             }
-            RequestState::WaitingForDisputeResolution { .. } => true,
+            RequestState::WaitingForDisputeResolution => true,
         });
 
         (state, actions)
@@ -482,15 +482,17 @@ impl SentinelTransition {
 
     /// Resolves a genuine dispute — `DisputeResolved` is only ever emitted by
     /// `resolveDispute`, i.e. only for a request that reached
-    /// `WaitingForDisputeResolution` — by claiming iff our own revealed vote
-    /// matches the arbitrator's outcome; drops the request either way.
+    /// `WaitingForDisputeResolution` — by always claiming, regardless of
+    /// which side won: bond slashing is partial, so even a losing vote can
+    /// leave an unslashed remainder (`bondTarget - slashAmount`) to reclaim,
+    /// and `claim()` pays out `0` extra on the losing side without reverting.
     fn handle_resolved(
         &self,
         mut state: State,
         event: SentinelOracle::DisputeResolved,
     ) -> (State, Commands<State, Self>) {
-        let approve = match state.0.remove(&event.requestId) {
-            Some(RequestState::WaitingForDisputeResolution { approve }) => approve,
+        match state.0.remove(&event.requestId) {
+            Some(RequestState::WaitingForDisputeResolution) => {}
             Some(entry) => {
                 tracing::warn!(
                     request_id = %event.requestId,
@@ -508,20 +510,15 @@ impl SentinelTransition {
                 return (state, Vec::new());
             }
         };
-        let approved = event.outcome == OnchainRequestState::RESOLVED_APPROVED;
-        let actions = if approved == approve {
-            vec![
-                SentinelAction {
-                    kind: SentinelActionKind::Claim {
-                        id: event.requestId,
-                    },
-                    expires_at: None,
-                }
-                .into(),
-            ]
-        } else {
-            Vec::new()
-        };
+        let actions = vec![
+            SentinelAction {
+                kind: SentinelActionKind::Claim {
+                    id: event.requestId,
+                },
+                expires_at: None,
+            }
+            .into(),
+        ];
         (state, actions)
     }
 
@@ -543,7 +540,6 @@ impl SentinelTransition {
         request_id: B256,
     ) -> (Option<RequestState>, Commands<State, Self>) {
         let RequestState::CollectingVotes {
-            approve,
             revealed_count,
             approve_count,
             deny_count,
@@ -553,7 +549,6 @@ impl SentinelTransition {
         else {
             return (None, Vec::new());
         };
-        let approve = *approve;
         let dispute = *approve_count > 0 && *deny_count > 0;
         let timed_out = *revealed_count == 0;
 
@@ -574,10 +569,7 @@ impl SentinelTransition {
         // In case of a dispute it is not a timeout, so this sentinel participated.
         // Finalize the request and wait for a dispute resolution by the arbitrator.
         if dispute {
-            return (
-                Some(RequestState::WaitingForDisputeResolution { approve }),
-                actions,
-            );
+            return (Some(RequestState::WaitingForDisputeResolution), actions);
         }
 
         // Unanimity plus our own counted vote guarantees this sentinel is on the
@@ -759,6 +751,7 @@ impl Service for SentinelService {
 mod tests {
     use super::*;
     use crate::bindings::consensus::{Operation, SafeTransaction};
+    use crate::bindings::oracle::RequestState as OnchainRequestState;
     use alloy::{
         primitives::{Bytes, address, keccak256},
         providers::Provider as _,
@@ -1283,10 +1276,7 @@ mod tests {
                 .into(),
             ],
         );
-        assert_eq!(
-            state.0[&id],
-            RequestState::WaitingForDisputeResolution { approve: true },
-        );
+        assert_eq!(state.0[&id], RequestState::WaitingForDisputeResolution);
 
         (svc, id, state)
     }
@@ -1311,15 +1301,27 @@ mod tests {
         );
     }
 
+    /// Bond slashing is partial, so a losing vote still leaves an unslashed
+    /// remainder to reclaim — `handle_resolved` must claim unconditionally,
+    /// not only when our own revealed vote matches the arbitration outcome.
     #[test]
-    fn flow_dispute_drops_without_claim_when_arbitration_contradicts_our_vote() {
+    fn flow_dispute_still_claims_when_arbitration_contradicts_our_vote() {
         let (svc, id, state) = setup_dispute();
         let event = dispute_resolved_event(id, OnchainRequestState::RESOLVED_DENIED, U256::ZERO);
 
         let (state, commands) = svc.apply_transition(state, Message::Event(log(50, event)));
 
         assert!(!state.0.contains_key(&id));
-        assert!(commands.is_empty());
+        assert_eq!(
+            commands,
+            vec![
+                SentinelAction {
+                    kind: SentinelActionKind::Claim { id },
+                    expires_at: None,
+                }
+                .into(),
+            ],
+        );
     }
 
     /// Nobody reveals at all — a genuine timeout with no other sentinel's

--- a/crates/sentinel/src/state.rs
+++ b/crates/sentinel/src/state.rs
@@ -61,9 +61,9 @@ pub enum SentinelRequestState {
         self_revealed: bool,
     },
     /// The local tally showed both sides had revealed votes (a dispute);
-    /// only our own vote needs to survive, to compare against the eventual
-    /// arbitration outcome.
-    WaitingForDisputeResolution { approve: bool },
+    /// nothing further needs tracking here, since `handle_resolved` always
+    /// claims once the arbitrator settles it, regardless of which side won.
+    WaitingForDisputeResolution,
 }
 
 impl SentinelRequestState {
@@ -74,7 +74,7 @@ impl SentinelRequestState {
             Self::WaitingForRequest { .. } => "waiting_for_request",
             Self::CollectingCommitments { .. } => "collecting_commitments",
             Self::CollectingVotes { .. } => "collecting_votes",
-            Self::WaitingForDisputeResolution { .. } => "waiting_for_dispute_resolution",
+            Self::WaitingForDisputeResolution => "waiting_for_dispute_resolution",
         }
     }
 }

--- a/scripts/run_sentinel_integration_test.sh
+++ b/scripts/run_sentinel_integration_test.sh
@@ -22,10 +22,12 @@ RPC_URL="http://127.0.0.1:8545"
 CHAIN_ID=31337
 BLOCK_TIME_SECONDS=1
 REQUEST_FEE=1000
-BOND_MULTIPLIER=2
+BOND_MULTIPLIER=4
 COMMIT_WINDOW=5
 REVEAL_WINDOW=5
 GOVERNANCE_DELAY=0
+# Deliberately less than BOND_MULTIPLIER, so the dispute scenario below
+# exercises a *partial* bond slash rather than the full bond.
 INITIAL_SLASHING_MULTIPLIER=2
 INITIAL_DAO_FEE_SHARE=0
 FUNDING_ETH=1ether
@@ -33,6 +35,10 @@ FUNDING_TOKEN=1000000
 # Anvil account 0 — deployer, MyToken owner, and SentinelOracle arbitrator.
 DEPLOYER=0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266
 DEPLOYER_PK=0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80
+# Only sentinel B blocklists this address, so the two sentinels are
+# guaranteed to cast opposing votes on a request proposing a call to it —
+# the genuine dispute exercised in step 10 below.
+DISPUTED_TX_TO=0x3333333333333333333333333333333333333333
 
 # --- 1. Build the Rust sentinel ---
 # Built up front, before Anvil or anything else starts, so a compile error
@@ -128,11 +134,25 @@ balance_of() {
 SENTINEL_A_BALANCE_BEFORE=$(balance_of "$SENTINEL_A_ADDR")
 SENTINEL_B_BALANCE_BEFORE=$(balance_of "$SENTINEL_B_ADDR")
 
+# `Request`'s tuple shape, field-for-field with `SentinelOracleRequest.Request`
+# (`proposer, fee, bondTarget, daoFeeShare, slashAmount, commitDeadline,
+# revealDeadline, state, committedCount, revealedCount, approveSentinelCount,
+# denySentinelCount`) — every field must be listed or `cast` silently
+# misaligns the ones after the omission.
+get_request() {
+	cast call --rpc-url "$RPC_URL" --json "$ORACLE" \
+		"getRequest(bytes32)((address,uint256,uint256,uint256,uint256,uint256,uint256,uint8,uint256,uint256,uint256,uint256))" \
+		"$1" 2>/dev/null
+}
+REQUEST_STATE_INDEX=7
+REQUEST_DENY_SENTINEL_COUNT_INDEX=11
+
 # --- 5. Spin up both Rust sentinels ---
 # Already built in step 1, so this just runs it — twice, once per account,
 # each with its own config file and in-memory database.
 sentinel_config() {
 	local signer=$1
+	local blocklist=$2
 	cat <<EOF
 rpc = "$RPC_URL"
 signer = "$signer"
@@ -143,7 +163,7 @@ consensus = "$CONSENSUS"
 [sentinel]
 fee_token = "$FEE_TOKEN"
 voting_window = $((COMMIT_WINDOW + REVEAL_WINDOW))
-blocklist = []
+blocklist = $blocklist
 address_poisoning_lookback_blocks = 1000
 
 [index]
@@ -152,9 +172,12 @@ EOF
 }
 
 SENTINEL_A_CONFIG=$(mktemp)
-sentinel_config "$SENTINEL_A_PK" >"$SENTINEL_A_CONFIG"
+sentinel_config "$SENTINEL_A_PK" "[]" >"$SENTINEL_A_CONFIG"
 SENTINEL_B_CONFIG=$(mktemp)
-sentinel_config "$SENTINEL_B_PK" >"$SENTINEL_B_CONFIG"
+# Sentinel B alone blocklists $DISPUTED_TX_TO, so it denies a request
+# proposing a call to it while Sentinel A approves — the genuine dispute
+# exercised in step 10 below.
+sentinel_config "$SENTINEL_B_PK" "[\"$DISPUTED_TX_TO\"]" >"$SENTINEL_B_CONFIG"
 
 echo "Starting sentinel A..."
 cargo run --package sentinel -- --config-file "$SENTINEL_A_CONFIG" >"$ROOT/sentinel_a_logs.txt" 2>&1 &
@@ -206,10 +229,8 @@ done
 # the script on a transient RPC hiccup.
 REQUEST=""
 for _ in $(seq 1 10); do
-	REQUEST=$(cast call --rpc-url "$RPC_URL" --json "$ORACLE" \
-		"getRequest(bytes32)((address,uint256,uint256,uint256,uint256,uint256,uint256,uint8,uint256,uint256,uint256,uint256))" \
-		"$REQUEST_ID" 2>/dev/null) || true
-	STATE=$(echo "$REQUEST" | jq -r '.[0][7]' 2>/dev/null) || true
+	REQUEST=$(get_request "$REQUEST_ID") || true
+	STATE=$(echo "$REQUEST" | jq -r ".[0][$REQUEST_STATE_INDEX]" 2>/dev/null) || true
 	[ "$STATE" = "2" ] && break
 	sleep "$BLOCK_TIME_SECONDS"
 done
@@ -219,7 +240,7 @@ if [ "$STATE" != "2" ]; then
 	echo "FAILED: expected state RESOLVED_APPROVED (2), got $STATE"
 	exit 1
 fi
-DENY_SENTINEL_COUNT=$(echo "$REQUEST" | jq -r '.[0][11]')
+DENY_SENTINEL_COUNT=$(echo "$REQUEST" | jq -r ".[0][$REQUEST_DENY_SENTINEL_COUNT_INDEX]")
 if [ "$DENY_SENTINEL_COUNT" != "0" ]; then
 	echo "FAILED: expected a unanimous approve vote, but denySentinelCount is $DENY_SENTINEL_COUNT"
 	exit 1
@@ -271,5 +292,114 @@ if [ "$ORACLE_BALANCE_AFTER" -gt 2 ]; then
 	exit 1
 fi
 echo "OK: bonds were returned in full and the request fee was split between the sentinels."
+
+# --- 10. Propose a disputed transaction: sentinel B denies, sentinel A approves ---
+# Exercises Phase 6 of the oracle-governance epic — the sentinel client must
+# claim after arbitration regardless of which side it was on, since bond
+# slashing is only partial (INITIAL_SLASHING_MULTIPLIER < BOND_MULTIPLIER).
+echo "Approving the oracle to pull the request fee for the disputed request..."
+cast send --rpc-url "$RPC_URL" --private-key "$PROPOSER_PK" \
+	"$FEE_TOKEN" "approve(address,uint256)" "$ORACLE" "$REQUEST_FEE" >/dev/null
+
+echo "Proposing a transaction sentinel B's blocklist denies (to trigger a genuine dispute)..."
+env \
+	CONSENSUS_ADDRESS="$CONSENSUS" \
+	ORACLE_ADDRESS="$ORACLE" \
+	TX_CHAIN_ID=1 \
+	TX_SAFE=0x1111111111111111111111111111111111111111 \
+	TX_TO="$DISPUTED_TX_TO" \
+	TX_NONCE=1 \
+	forge script --root "$ROOT/contracts" ProposeTransactionScript --rpc-url "$RPC_URL" --private-key "$PROPOSER_PK" --broadcast
+
+DISPUTE_REQUEST_ID=$(cast logs --rpc-url "$RPC_URL" --json --from-block 0 --address "$ORACLE" \
+	'NewRequest(bytes32,address,uint256,uint256,uint256,uint256)' | jq -r '.[-1].topics[1]')
+echo "Disputed request id: $DISPUTE_REQUEST_ID"
+
+DISPUTE_SENTINEL_A_BALANCE_BEFORE=$(balance_of "$SENTINEL_A_ADDR")
+DISPUTE_SENTINEL_B_BALANCE_BEFORE=$(balance_of "$SENTINEL_B_ADDR")
+
+# --- 11. Wait for both sentinels to commit, reveal opposing votes, and freeze ---
+echo "Waiting for the disputed request to freeze..."
+TIMEOUT_SECONDS=30
+ELAPSED_SECONDS=0
+STATE=""
+while true; do
+	REQUEST=$(get_request "$DISPUTE_REQUEST_ID") || true
+	STATE=$(echo "$REQUEST" | jq -r ".[0][$REQUEST_STATE_INDEX]" 2>/dev/null) || true
+	[ "$STATE" = "1" ] && break
+	if [ "$ELAPSED_SECONDS" -ge "$TIMEOUT_SECONDS" ]; then
+		echo "FAILED: timed out waiting for the disputed request to freeze; last state was $STATE"
+		echo "Request: $REQUEST"
+		exit 1
+	fi
+	sleep "$BLOCK_TIME_SECONDS"
+	ELAPSED_SECONDS=$((ELAPSED_SECONDS + BLOCK_TIME_SECONDS))
+done
+echo "OK: both sentinels revealed opposing votes and the request froze."
+
+# --- 12. Arbitrate: rule for the approving side (sentinel A), against sentinel B ---
+echo "Resolving the dispute in favor of the approving side..."
+cast send --rpc-url "$RPC_URL" --private-key "$DEPLOYER_PK" "$ORACLE" \
+	"resolveDispute(bytes32,bool,string)" "$DISPUTE_REQUEST_ID" true "sentinel B's blocklisted destination" >/dev/null
+
+# --- 13. Wait for both the winning and the losing sentinel to claim ---
+# Before Phase 6, a losing sentinel never claimed (nothing to claim, since the
+# whole bond was forfeited); now slashing is partial, so sentinel B must claim
+# its unslashed remainder too.
+A_CLAIMED=""
+B_CLAIMED=""
+for _ in $(seq 1 10); do
+	REQUEST=$(get_request "$DISPUTE_REQUEST_ID") || true
+	STATE=$(echo "$REQUEST" | jq -r ".[0][$REQUEST_STATE_INDEX]" 2>/dev/null) || true
+	SENTINEL_A_COMMITMENT=$(cast call --rpc-url "$RPC_URL" --json "$ORACLE" \
+		"getCommitment(bytes32,address)((bytes32,uint256,uint8,bool))" "$DISPUTE_REQUEST_ID" "$SENTINEL_A_ADDR") || true
+	SENTINEL_B_COMMITMENT=$(cast call --rpc-url "$RPC_URL" --json "$ORACLE" \
+		"getCommitment(bytes32,address)((bytes32,uint256,uint8,bool))" "$DISPUTE_REQUEST_ID" "$SENTINEL_B_ADDR") || true
+	A_CLAIMED=$(echo "$SENTINEL_A_COMMITMENT" | jq -r '.[0][3]' 2>/dev/null) || true
+	B_CLAIMED=$(echo "$SENTINEL_B_COMMITMENT" | jq -r '.[0][3]' 2>/dev/null) || true
+	[ "$A_CLAIMED" = "true" ] && [ "$B_CLAIMED" = "true" ] && break
+	sleep "$BLOCK_TIME_SECONDS"
+done
+
+echo "Disputed request state after arbitration: $REQUEST"
+if [ "$STATE" != "2" ]; then
+	echo "FAILED: expected state RESOLVED_APPROVED (2), got $STATE"
+	exit 1
+fi
+if [ "$A_CLAIMED" != "true" ] || [ "$B_CLAIMED" != "true" ]; then
+	echo "FAILED: expected both the winning and the losing sentinel to have claimed"
+	echo "Sentinel A commitment: $SENTINEL_A_COMMITMENT"
+	echo "Sentinel B commitment: $SENTINEL_B_COMMITMENT"
+	exit 1
+fi
+echo "OK: arbitration resolved the dispute and both sentinels claimed, including the losing one."
+
+# --- 14. Check the partial bond slash reconciles ---
+SLASH_AMOUNT=$((REQUEST_FEE * INITIAL_SLASHING_MULTIPLIER))
+DISPUTE_SENTINEL_A_BALANCE_AFTER=$(balance_of "$SENTINEL_A_ADDR")
+DISPUTE_SENTINEL_B_BALANCE_AFTER=$(balance_of "$SENTINEL_B_ADDR")
+DISPUTE_ORACLE_BALANCE_AFTER=$(balance_of "$ORACLE")
+DISPUTE_SENTINEL_A_CHANGE=$((DISPUTE_SENTINEL_A_BALANCE_AFTER - DISPUTE_SENTINEL_A_BALANCE_BEFORE))
+DISPUTE_SENTINEL_B_CHANGE=$((DISPUTE_SENTINEL_B_BALANCE_AFTER - DISPUTE_SENTINEL_B_BALANCE_BEFORE))
+echo "Sentinel A (won the dispute) balance change: $DISPUTE_SENTINEL_A_CHANGE"
+echo "Sentinel B (lost the dispute) balance change: $DISPUTE_SENTINEL_B_CHANGE"
+
+# The sole winner's bond returns in full (net 0) plus the whole request fee as
+# its reward (no other winner to split it with, no DAO cut configured).
+if [ "$DISPUTE_SENTINEL_A_CHANGE" != "$REQUEST_FEE" ]; then
+	echo "FAILED: expected the winning sentinel to net exactly the request fee ($REQUEST_FEE), got $DISPUTE_SENTINEL_A_CHANGE"
+	exit 1
+fi
+# The sole loser forfeits only the governed slash amount, not its whole bond —
+# the partial-slashing behavior this scenario exists to exercise.
+if [ "$DISPUTE_SENTINEL_B_CHANGE" != "-$SLASH_AMOUNT" ]; then
+	echo "FAILED: expected the losing sentinel to net exactly -$SLASH_AMOUNT (a partial, not full, bond forfeiture), got $DISPUTE_SENTINEL_B_CHANGE"
+	exit 1
+fi
+if [ "$DISPUTE_ORACLE_BALANCE_AFTER" -gt 2 ]; then
+	echo "FAILED: expected the oracle to hold no more than rounding dust after arbitration, got $DISPUTE_ORACLE_BALANCE_AFTER"
+	exit 1
+fi
+echo "OK: the losing sentinel's bond was slashed only partially and both sides' balances reconcile."
 
 echo "Sentinel integration test finished successfully."


### PR DESCRIPTION
Due to partial slashing it always makes sense that Sentinels call claim. Before the change Sentinels didn't have anything to claim when they are on the losing side. With the partial slashing this change. Currently it is assumed that it is always partial slashing, as this is the plan for the initial launch. If full slashing becomes the default then it should be implemented that the slashing amount is checked.

The integration tests have been extended with a dispute case, to ensure correct behavior.

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://docs.safefoundation.org/cla).
