### PR TITLE
[Nonces 4c]: Reconcile Groups with State Machine

### DIFF
--- a/crates/validator/src/secrets/nonces.rs
+++ b/crates/validator/src/secrets/nonces.rs
@@ -65,6 +65,21 @@ impl NonceGenerator {
     pub fn stop(&mut self, group_id: B256) {
         self.groups.remove(&group_id);
     }
+
+    /// Stops the background stream of every group that does not match the
+    /// `keep` predicate.
+    ///
+    /// Outstanding requests for the stopped groups fail with
+    /// [`Error::Unavailable`].
+    pub fn retain(&mut self, mut keep: impl FnMut(&B256) -> bool) {
+        self.groups.retain(|group_id, _| {
+            let keep = keep(group_id);
+            if !keep {
+                tracing::debug!(%group_id, "stopping nonce stream for group");
+            }
+            keep
+        });
+    }
 }
 
 /// Parameters for sampling random nonce chunks.

--- a/crates/validator/src/secrets/store.rs
+++ b/crates/validator/src/secrets/store.rs
@@ -145,13 +145,6 @@ impl SecretStore {
     /// Specifying an empty `groups` will remove all DKG secrets.
     ///
     /// Idempotent.
-    #[cfg_attr(
-        not(test),
-        expect(
-            dead_code,
-            reason = "introduced ahead of state-machine secret reconciliation"
-        )
-    )]
     pub async fn retain_keygen_secrets(
         &self,
         groups: impl IntoIterator<Item = B256>,
@@ -450,13 +443,6 @@ impl SecretStore {
     /// Specifying an empty `groups` will remove all nonce trees and nonces.
     ///
     /// Idempotent.
-    #[cfg_attr(
-        not(test),
-        expect(
-            dead_code,
-            reason = "introduced ahead of state-machine secret reconciliation"
-        )
-    )]
     pub async fn retain_nonces(&self, groups: impl IntoIterator<Item = B256>) -> Result<(), Error> {
         self.retain_groups("nonces_chunks", groups).await
     }

--- a/crates/validator/src/service/effect.rs
+++ b/crates/validator/src/service/effect.rs
@@ -12,6 +12,7 @@ use crate::{
 use alloy::primitives::{Address, B256};
 use safenet_core::effects::EffectHandler;
 use std::{
+    collections::BTreeMap,
     error::Error,
     fmt::{self, Display, Formatter},
     sync::Arc,
@@ -102,6 +103,17 @@ pub enum Effect {
     PruneKeyGenSecrets { group_id: B256 },
     /// Prune a retired group's registered nonce trees.
     PruneGroupNonces { group_id: B256 },
+    /// Reconcile the process-local and persisted secrets with the groups
+    /// retained by the state machine, dropping all secret material belonging to
+    /// other groups. A key share starts or retains a nonce generator; `None`
+    /// retains the group's DKG secrets without running one.
+    #[expect(
+        dead_code,
+        reason = "introduced ahead of state-machine secret reconciliation"
+    )]
+    ReconcileGroupSecrets {
+        groups: BTreeMap<B256, Option<Arc<KeyShare>>>,
+    },
 }
 
 /// The remaining usable nonce count, per participating group, below which a
@@ -301,6 +313,36 @@ impl Handler {
             Effect::PruneGroupNonces { group_id } => {
                 self.nonce_generator.lock().await.stop(group_id);
                 self.secrets.prune_group_nonces(group_id).await?;
+                Ok(Resume::Noop)
+            }
+            Effect::ReconcileGroupSecrets { groups } => {
+                self.secrets
+                    .retain_keygen_secrets(
+                        groups
+                            .iter()
+                            .filter_map(|(group_id, key_share)| {
+                                key_share.is_none().then_some(*group_id)
+                            })
+                            // Collecting here is unfortunately required for the
+                            // compiler to correctly resolve lifetimes of our
+                            // future; in theory it should not be needed.
+                            .collect::<Vec<_>>(),
+                    )
+                    .await?;
+                self.secrets.retain_nonces(groups.keys().copied()).await?;
+
+                let mut nonce_generator = self.nonce_generator.lock().await;
+                nonce_generator.retain(|group_id| {
+                    groups
+                        .get(group_id)
+                        .is_some_and(|key_share| key_share.is_some())
+                });
+                for (group_id, key_share) in groups {
+                    let Some(key_share) = key_share else {
+                        continue;
+                    };
+                    nonce_generator.start(group_id, key_share)?;
+                }
                 Ok(Resume::Noop)
             }
         }

--- a/crates/validator/src/service/effect.rs
+++ b/crates/validator/src/service/effect.rs
@@ -12,7 +12,7 @@ use crate::{
 use alloy::primitives::{Address, B256};
 use safenet_core::effects::EffectHandler;
 use std::{
-    collections::BTreeMap,
+    collections::{BTreeMap, BTreeSet},
     error::Error,
     fmt::{self, Display, Formatter},
     sync::Arc,
@@ -316,33 +316,32 @@ impl Handler {
                 Ok(Resume::Noop)
             }
             Effect::ReconcileGroupSecrets { groups } => {
-                self.secrets
-                    .retain_keygen_secrets(
-                        groups
-                            .iter()
-                            .filter_map(|(group_id, key_share)| {
-                                key_share.is_none().then_some(*group_id)
-                            })
-                            // Collecting here is unfortunately required for the
-                            // compiler to correctly resolve lifetimes of our
-                            // future; in theory it should not be needed.
-                            .collect::<Vec<_>>(),
-                    )
-                    .await?;
-                self.secrets.retain_nonces(groups.keys().copied()).await?;
+                // We only need to keep keygen secrets for groups that are still
+                // in DKG and do not yet have a key share, and nonces (both in
+                // the secret store and the nonce generator) for groups that
+                // have completed DKG to the point that their key share is
+                // constructed.
+                let (keygen, nonces) = groups.into_iter().fold(
+                    (BTreeSet::new(), BTreeMap::new()),
+                    |(mut keygen, mut nonces), (group_id, key_share)| {
+                        if let Some(key_share) = key_share {
+                            nonces.insert(group_id, key_share);
+                        } else {
+                            keygen.insert(group_id);
+                        }
+                        (keygen, nonces)
+                    },
+                );
 
-                let mut nonce_generator = self.nonce_generator.lock().await;
-                nonce_generator.retain(|group_id| {
-                    groups
-                        .get(group_id)
-                        .is_some_and(|key_share| key_share.is_some())
-                });
-                for (group_id, key_share) in groups {
-                    let Some(key_share) = key_share else {
-                        continue;
-                    };
-                    nonce_generator.start(group_id, key_share)?;
+                self.secrets.retain_keygen_secrets(keygen).await?;
+                self.secrets.retain_nonces(nonces.keys().copied()).await?;
+
+                let mut generator = self.nonce_generator.lock().await;
+                generator.retain(|group_id| nonces.contains_key(group_id));
+                for (group_id, key_share) in nonces {
+                    generator.start(group_id, key_share)?;
                 }
+
                 Ok(Resume::Noop)
             }
         }


### PR DESCRIPTION
### Context and Motivation

A followup to #754, this PR adds a new effect to reconcile groups between the state machine and the effect handler.

### Decisions and Tradeoffs

- We needed to work around a borrow checker implementation where passing in an iterator without collecting it would cause the future to require different lifetime bounds that it could not guarantee (it would cause the reference to `groups` to be held across await boundaries). I don't believe it is an actual issue (rather a borrow checker limitation), but we work around it by collecting the groups needed for DKG into a `Vec`.
- We do not use the new effect yet, this will happen in the following PR.

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://docs.safefoundation.org/cla).
