### PR TITLE
[Phase 9a] Rename proposer

### DIFF
--- a/contracts/script/DeploySentinelOracle.s.sol
+++ b/contracts/script/DeploySentinelOracle.s.sol
@@ -13,7 +13,10 @@ contract DeploySentinelOracleScript is Script {
         address arbitrator = vm.envAddress("SENTINEL_ARBITRATOR");
         address governance = vm.envAddress("SENTINEL_GOVERNANCE");
         address protocolFundsReceiver = vm.envAddress("SENTINEL_PROTOCOL_FUNDS_RECEIVER");
-        address consensus = vm.envAddress("SENTINEL_CONSENSUS");
+        // The trusted contract allowed to call `postRequest` -- in production, the Consensus
+        // contract itself, hence the env var name; the constructor field is `proposer` since that
+        // is the role being filled, not necessarily always the Consensus contract.
+        address proposer = vm.envAddress("SENTINEL_CONSENSUS");
         address feeToken = vm.envAddress("SENTINEL_FEE_TOKEN");
         uint256 requestFee = vm.envUint("SENTINEL_REQUEST_FEE");
         uint256 commitWindow = vm.envUint("SENTINEL_COMMIT_WINDOW");
@@ -36,7 +39,7 @@ contract DeploySentinelOracleScript is Script {
                 arbitrator,
                 governance,
                 protocolFundsReceiver,
-                consensus,
+                proposer,
                 feeToken,
                 requestFee,
                 commitWindow,

--- a/contracts/src/AlwaysApproveOracle.sol
+++ b/contracts/src/AlwaysApproveOracle.sol
@@ -13,7 +13,7 @@ contract AlwaysApproveOracle is IOracle {
     /**
      * @inheritdoc IOracle
      */
-    function postRequest(bytes32 requestId, address proposer, bytes calldata) external {
-        emit OracleResult(requestId, proposer, "", true);
+    function postRequest(bytes32 requestId, address sponsor, bytes calldata) external {
+        emit OracleResult(requestId, sponsor, "", true);
     }
 }

--- a/contracts/src/SentinelOracle.sol
+++ b/contracts/src/SentinelOracle.sol
@@ -39,7 +39,9 @@ contract SentinelOracle is IOracle {
 
     address public immutable ARBITRATOR;
     address public immutable GOVERNANCE;
-    address public immutable CONSENSUS;
+    // The trusted contract (typically Consensus) allowed to call `postRequest` -- distinct from a
+    // request's `sponsor`, the address that funds a given request's fee and is refunded on timeout.
+    address public immutable PROPOSER;
     IERC20 public immutable FEE_TOKEN;
     uint256 public immutable COMMIT_WINDOW;
     uint256 public immutable REVEAL_WINDOW;
@@ -92,7 +94,7 @@ contract SentinelOracle is IOracle {
 
     error NotArbitrator();
     error NotGovernance();
-    error NotConsensus();
+    error NotProposer();
     error InvalidAddress();
     error ZeroFee();
     error ZeroWindow();
@@ -125,7 +127,7 @@ contract SentinelOracle is IOracle {
         address arbitrator,
         address governance,
         address initialProtocolFundsReceiver,
-        address consensus,
+        address proposer,
         address feeToken,
         uint256 requestFee,
         uint256 commitWindow,
@@ -140,7 +142,7 @@ contract SentinelOracle is IOracle {
         require(arbitrator != address(0), InvalidAddress());
         require(governance != address(0), InvalidAddress());
         require(initialProtocolFundsReceiver != address(0), InvalidAddress());
-        require(consensus != address(0), InvalidAddress());
+        require(proposer != address(0), InvalidAddress());
         require(feeToken != address(0), InvalidAddress());
         require(requestFee > 0, ZeroFee());
         require(commitWindow > 0, ZeroWindow());
@@ -149,7 +151,7 @@ contract SentinelOracle is IOracle {
         require(arbitrationTimeout > 0, ZeroWindow());
         ARBITRATOR = arbitrator;
         GOVERNANCE = governance;
-        CONSENSUS = consensus;
+        PROPOSER = proposer;
         FEE_TOKEN = IERC20(feeToken);
         COMMIT_WINDOW = commitWindow;
         REVEAL_WINDOW = revealWindow;
@@ -166,8 +168,8 @@ contract SentinelOracle is IOracle {
     // IOracle IMPLEMENTATION
     // ============================================================
 
-    function postRequest(bytes32 requestId, address proposer, bytes calldata) external override(IOracle) {
-        require(msg.sender == CONSENSUS, NotConsensus());
+    function postRequest(bytes32 requestId, address sponsor, bytes calldata) external override(IOracle) {
+        require(msg.sender == PROPOSER, NotProposer());
         uint256 currentFee = $feeConfig.applyPending();
         (uint256 currentBondMultiplier, uint256 currentSlashingMultiplier) = $bondConfig.applyPending();
         uint256 bondTarget = currentFee * currentBondMultiplier;
@@ -176,9 +178,9 @@ contract SentinelOracle is IOracle {
         uint256 commitDeadline = block.number + COMMIT_WINDOW;
         uint256 revealDeadline = commitDeadline + REVEAL_WINDOW;
         $requests.create(
-            requestId, proposer, currentFee, bondTarget, currentDaoFeeShare, slashAmount, commitDeadline, revealDeadline
+            requestId, sponsor, currentFee, bondTarget, currentDaoFeeShare, slashAmount, commitDeadline, revealDeadline
         );
-        FEE_TOKEN.safeTransferFrom(proposer, address(this), currentFee);
+        FEE_TOKEN.safeTransferFrom(sponsor, address(this), currentFee);
     }
 
     // ============================================================
@@ -213,7 +215,7 @@ contract SentinelOracle is IOracle {
 
     function finalize(bytes32 requestId) external {
         SentinelOracleRequest.Request storage req = $requests.get(requestId);
-        address proposer = req.proposer;
+        address sponsor = req.sponsor;
         (SentinelOracleRequest.State newState, uint256 refundFee, uint256 unrevealedBond) =
             req.finalize(ARBITRATION_TIMEOUT);
 
@@ -227,7 +229,7 @@ contract SentinelOracle is IOracle {
         }
 
         if (newState == SentinelOracleRequest.State.TIMED_OUT) {
-            FEE_TOKEN.safeTransfer(proposer, refundFee);
+            FEE_TOKEN.safeTransfer(sponsor, refundFee);
             return;
         }
 
@@ -237,11 +239,7 @@ contract SentinelOracle is IOracle {
             FEE_TOKEN.safeTransfer(fundsReceiver, daoCut);
         }
 
-        if (newState == SentinelOracleRequest.State.RESOLVED_APPROVED) {
-            emit OracleResult(requestId, proposer, "", true);
-        } else {
-            emit OracleResult(requestId, proposer, "", false);
-        }
+        emit OracleResult(requestId, sponsor, "", newState == SentinelOracleRequest.State.RESOLVED_APPROVED);
     }
 
     function claim(bytes32 requestId) external {
@@ -265,14 +263,14 @@ contract SentinelOracle is IOracle {
 
     function resolveDispute(bytes32 requestId, bool approveWins, string calldata context) external onlyArbitrator {
         SentinelOracleRequest.Request storage req = $requests.get(requestId);
-        address proposer = req.proposer;
+        address sponsor = req.sponsor;
         uint256 slashed = req.resolveDispute(approveWins);
         SentinelOracleRequest.State outcome = req.state;
         uint256 refundFee = req.fee;
         uint256 daoCut = refundFee * req.daoFeeShare / FEE_SHARE_DENOMINATOR;
         req.fee -= daoCut;
         address fundsReceiver = $protocolFundsReceiverConfig.applyPending();
-        FEE_TOKEN.safeTransfer(proposer, refundFee);
+        FEE_TOKEN.safeTransfer(sponsor, refundFee);
         FEE_TOKEN.safeTransfer(fundsReceiver, slashed - refundFee + daoCut);
         emit DisputeResolved(requestId, outcome, slashed, context);
     }
@@ -282,9 +280,9 @@ contract SentinelOracle is IOracle {
     // full via `claim()` -- identical to the no-reveal timeout path.
     function timeoutArbitration(bytes32 requestId) external {
         SentinelOracleRequest.Request storage req = $requests.get(requestId);
-        address proposer = req.proposer;
+        address sponsor = req.sponsor;
         uint256 refundFee = req.timeoutArbitration();
-        FEE_TOKEN.safeTransfer(proposer, refundFee);
+        FEE_TOKEN.safeTransfer(sponsor, refundFee);
     }
 
     // ============================================================

--- a/contracts/src/SimpleOracle.sol
+++ b/contracts/src/SimpleOracle.sol
@@ -6,7 +6,7 @@ import {IOracle} from "@/interfaces/IOracle.sol";
 /**
  * @title Simple Oracle
  * @notice A proof-of-concept oracle where a designated approver manually approves or rejects requests.
- * @dev postRequest records the caller (typically the Consensus contract) as the proposer. The approver
+ * @dev postRequest records the caller (typically the Consensus contract) as the sponsor. The approver
  *      must then call approve() or reject() to emit the OracleResult. This is suitable for testing and
  *      for use cases that require explicit human review of each transaction.
  */
@@ -21,11 +21,11 @@ contract SimpleOracle is IOracle {
     address public immutable APPROVER;
 
     /**
-     * @notice Mapping from request ID to the proposer address that posted the request.
+     * @notice Mapping from request ID to the sponsor address that posted the request.
      * @dev A non-zero value indicates the request is pending approval.
      */
     // forge-lint: disable-next-line(mixed-case-variable)
-    mapping(bytes32 requestId => address proposer) private $proposers;
+    mapping(bytes32 requestId => address sponsor) private $sponsors;
 
     // ============================================================
     // ERRORS
@@ -65,9 +65,9 @@ contract SimpleOracle is IOracle {
     /**
      * @inheritdoc IOracle
      */
-    function postRequest(bytes32 requestId, address proposer, bytes calldata) external {
-        require($proposers[requestId] == address(0), RequestAlreadyPending());
-        $proposers[requestId] = proposer;
+    function postRequest(bytes32 requestId, address sponsor, bytes calldata) external {
+        require($sponsors[requestId] == address(0), RequestAlreadyPending());
+        $sponsors[requestId] = sponsor;
     }
 
     // ============================================================
@@ -80,10 +80,10 @@ contract SimpleOracle is IOracle {
      */
     function approve(bytes32 requestId) external {
         require(msg.sender == APPROVER, NotApprover());
-        address proposer = $proposers[requestId];
-        require(proposer != address(0), RequestNotPending());
-        delete $proposers[requestId];
-        emit OracleResult(requestId, proposer, "", true);
+        address sponsor = $sponsors[requestId];
+        require(sponsor != address(0), RequestNotPending());
+        delete $sponsors[requestId];
+        emit OracleResult(requestId, sponsor, "", true);
     }
 
     /**
@@ -92,9 +92,9 @@ contract SimpleOracle is IOracle {
      */
     function reject(bytes32 requestId) external {
         require(msg.sender == APPROVER, NotApprover());
-        address proposer = $proposers[requestId];
-        require(proposer != address(0), RequestNotPending());
-        delete $proposers[requestId];
-        emit OracleResult(requestId, proposer, "", false);
+        address sponsor = $sponsors[requestId];
+        require(sponsor != address(0), RequestNotPending());
+        delete $sponsors[requestId];
+        emit OracleResult(requestId, sponsor, "", false);
     }
 }

--- a/contracts/src/interfaces/IOracle.sol
+++ b/contracts/src/interfaces/IOracle.sol
@@ -13,11 +13,11 @@ interface IOracle {
     /**
      * @notice Emitted when an oracle produces a result for a request.
      * @param requestId A unique id that allows fetching additional information related to the request.
-     * @param proposer The address that posted the request (typically the Consensus contract).
+     * @param sponsor The address that funded the request's fee and to whom any refund is owed.
      * @param result Arbitrary result data (oracle-specific encoding).
      * @param approved Whether the oracle approves the transaction.
      */
-    event OracleResult(bytes32 indexed requestId, address indexed proposer, bytes result, bool approved);
+    event OracleResult(bytes32 indexed requestId, address indexed sponsor, bytes result, bool approved);
 
     // ============================================================
     // EXTERNAL FUNCTIONS
@@ -26,12 +26,14 @@ interface IOracle {
     /**
      * @notice Post a signing request to the oracle for evaluation.
      * @param requestId A unique id that allows fetching additional information related to the request.
-     * @param proposer The address that offered the reward and to whom any refund is owed.
+     * @param sponsor The address that offered the reward and to whom any refund is owed -- distinct
+     *                from `msg.sender` (the trusted contract, typically Consensus, that is calling
+     *                this function on the sponsor's behalf).
      * @param oracleData Arbitrary oracle-specific data passed by the proposer; bound into the
      *                   signed message hash. The oracle may decode this however it sees fit.
      * @dev Transaction data is not passed here; the oracle is expected to fetch it independently
      *      from the TransactionProposed event. The oracle pulls the fee directly from
-     *      proposer and refunds to proposer on resolution when applicable.
+     *      sponsor and refunds to sponsor on resolution when applicable.
      */
-    function postRequest(bytes32 requestId, address proposer, bytes calldata oracleData) external;
+    function postRequest(bytes32 requestId, address sponsor, bytes calldata oracleData) external;
 }

--- a/contracts/src/libraries/SentinelOracleRequests.sol
+++ b/contracts/src/libraries/SentinelOracleRequests.sol
@@ -21,7 +21,7 @@ library SentinelOracleRequest {
     // ============================================================
 
     struct Request {
-        address proposer;
+        address sponsor;
         uint256 fee;
         uint256 bondTarget;
         uint256 daoFeeShare;
@@ -188,7 +188,7 @@ library SentinelOracleRequestMap {
 
     event NewRequest(
         bytes32 indexed requestId,
-        address indexed proposer,
+        address indexed sponsor,
         uint256 fee,
         uint256 bondTarget,
         uint256 commitDeadline,
@@ -211,7 +211,7 @@ library SentinelOracleRequestMap {
     function create(
         T storage self,
         bytes32 requestId,
-        address proposer,
+        address sponsor,
         uint256 fee,
         uint256 bondTarget,
         uint256 daoFeeShare,
@@ -219,12 +219,12 @@ library SentinelOracleRequestMap {
         uint256 commitDeadline,
         uint256 revealDeadline
     ) internal {
-        require(self.requests[requestId].proposer == address(0), RequestAlreadyExists());
+        require(self.requests[requestId].sponsor == address(0), RequestAlreadyExists());
         require(commitDeadline > block.number, CommitDeadlineInPast());
         require(revealDeadline > commitDeadline, RevealDeadlineNotAfterCommit());
 
         self.requests[requestId] = SentinelOracleRequest.Request({
-            proposer: proposer,
+            sponsor: sponsor,
             fee: fee,
             bondTarget: bondTarget,
             daoFeeShare: daoFeeShare,
@@ -239,11 +239,11 @@ library SentinelOracleRequestMap {
             denySentinelCount: 0
         });
 
-        emit NewRequest(requestId, proposer, fee, bondTarget, commitDeadline, revealDeadline);
+        emit NewRequest(requestId, sponsor, fee, bondTarget, commitDeadline, revealDeadline);
     }
 
     function get(T storage self, bytes32 requestId) internal view returns (SentinelOracleRequest.Request storage) {
-        require(self.requests[requestId].proposer != address(0), RequestNotFound());
+        require(self.requests[requestId].sponsor != address(0), RequestNotFound());
         return self.requests[requestId];
     }
 }

--- a/contracts/test/AlwaysApproveOracle.t.sol
+++ b/contracts/test/AlwaysApproveOracle.t.sol
@@ -7,47 +7,47 @@ import {AlwaysApproveOracle} from "@/AlwaysApproveOracle.sol";
 
 contract AlwaysApproveOracleTest is Test {
     AlwaysApproveOracle public oracle;
-    address public requester;
+    address public sponsor;
 
     bytes32 constant REQUEST_ID = keccak256("requestId");
 
     function setUp() public {
-        requester = vm.createWallet("requester").addr;
+        sponsor = vm.createWallet("sponsor").addr;
         oracle = new AlwaysApproveOracle();
     }
 
     function test_PostRequest_EmitsOracleResult_Immediately() public {
         vm.expectEmit(true, true, false, true);
-        emit IOracle.OracleResult(REQUEST_ID, requester, "", true);
+        emit IOracle.OracleResult(REQUEST_ID, sponsor, "", true);
 
-        oracle.postRequest(REQUEST_ID, requester, "");
+        oracle.postRequest(REQUEST_ID, sponsor, "");
     }
 
     function test_PostRequest_EmitsApprovedTrue() public {
         vm.recordLogs();
 
-        oracle.postRequest(REQUEST_ID, requester, "");
+        oracle.postRequest(REQUEST_ID, sponsor, "");
 
         Vm.Log[] memory logs = vm.getRecordedLogs();
         assertEq(logs.length, 1);
 
-        // topic[0] = event selector, topic[1] = requestId, topic[2] = proposer
+        // topic[0] = event selector, topic[1] = requestId, topic[2] = sponsor
         assertEq(logs[0].topics[1], REQUEST_ID);
-        assertEq(logs[0].topics[2], bytes32(uint256(uint160(requester))));
+        assertEq(logs[0].topics[2], bytes32(uint256(uint160(sponsor))));
 
         // data = abi.encode(result, approved) — last word is the bool
         (, bool approved) = abi.decode(logs[0].data, (bytes, bool));
         assertTrue(approved);
     }
 
-    function test_PostRequest_ProposerIsPassedAddress() public {
-        address proposer = vm.createWallet("proposer").addr;
+    function test_PostRequest_SponsorIsPassedAddress() public {
+        address otherSponsor = vm.createWallet("otherSponsor").addr;
         address caller = vm.createWallet("caller").addr;
 
         vm.expectEmit(true, true, false, true);
-        emit IOracle.OracleResult(REQUEST_ID, proposer, "", true);
+        emit IOracle.OracleResult(REQUEST_ID, otherSponsor, "", true);
 
         vm.prank(caller);
-        oracle.postRequest(REQUEST_ID, proposer, "");
+        oracle.postRequest(REQUEST_ID, otherSponsor, "");
     }
 }

--- a/contracts/test/SentinelOracle.t.sol
+++ b/contracts/test/SentinelOracle.t.sol
@@ -41,8 +41,8 @@ contract SentinelOracleTest is Test {
     address public arbitrator;
     address public governance;
     address public protocolFundsReceiver;
-    address public consensus;
     address public proposer;
+    address public sponsor;
     address public sentinel1;
     address public sentinel2;
     address public sentinel3;
@@ -55,8 +55,8 @@ contract SentinelOracleTest is Test {
         arbitrator = vm.createWallet("arbitrator").addr;
         governance = vm.createWallet("governance").addr;
         protocolFundsReceiver = vm.createWallet("protocolFundsReceiver").addr;
-        consensus = vm.createWallet("consensus").addr;
         proposer = vm.createWallet("proposer").addr;
+        sponsor = vm.createWallet("sponsor").addr;
         sentinel1 = vm.createWallet("sentinel1").addr;
         sentinel2 = vm.createWallet("sentinel2").addr;
         sentinel3 = vm.createWallet("sentinel3").addr;
@@ -66,7 +66,7 @@ contract SentinelOracleTest is Test {
             arbitrator,
             governance,
             protocolFundsReceiver,
-            consensus,
+            proposer,
             address(token),
             REQUEST_FEE,
             COMMIT_WINDOW,
@@ -80,13 +80,13 @@ contract SentinelOracleTest is Test {
         );
 
         // Fund accounts
-        token.mint(proposer, 100_000);
+        token.mint(sponsor, 100_000);
         token.mint(sentinel1, 100_000);
         token.mint(sentinel2, 100_000);
         token.mint(sentinel3, 100_000);
 
         // Approve oracle for fee/bond pulls
-        vm.prank(proposer);
+        vm.prank(sponsor);
         token.approve(address(oracle), type(uint256).max);
         vm.prank(sentinel1);
         token.approve(address(oracle), type(uint256).max);
@@ -110,8 +110,8 @@ contract SentinelOracleTest is Test {
     // ============================================================
 
     function _postRequest() internal {
-        vm.prank(consensus);
-        oracle.postRequest(REQUEST_ID, proposer, "");
+        vm.prank(proposer);
+        oracle.postRequest(REQUEST_ID, sponsor, "");
     }
 
     function _commit(address sentinel, bool approve, bytes32 salt) internal {
@@ -669,14 +669,14 @@ contract SentinelOracleTest is Test {
         SentinelOracleRequest.Request memory pending = oracle.getRequest(REQUEST_ID);
         assertLt(block.number, pending.revealDeadline, "should be finalizing early, before the reveal deadline");
 
-        uint256 proposerBalBefore = token.balanceOf(proposer);
+        uint256 proposerBalBefore = token.balanceOf(sponsor);
 
         vm.expectEmit(true, true, false, true);
-        emit IOracle.OracleResult(REQUEST_ID, proposer, "", true);
+        emit IOracle.OracleResult(REQUEST_ID, sponsor, "", true);
         oracle.finalize(REQUEST_ID);
 
-        // Proposer's fee was NOT refunded (it's distributed to sentinels).
-        assertEq(token.balanceOf(proposer), proposerBalBefore, "proposer should not receive fee on approve");
+        // Sponsor's fee was NOT refunded (it's distributed to sentinels).
+        assertEq(token.balanceOf(sponsor), proposerBalBefore, "sponsor should not receive fee on approve");
 
         SentinelOracleRequest.Request memory req = oracle.getRequest(REQUEST_ID);
         assertEq(uint256(req.state), uint256(SentinelOracleRequest.State.RESOLVED_APPROVED));
@@ -760,7 +760,7 @@ contract SentinelOracleTest is Test {
         _reveal(sentinel1, false, SALT_1);
 
         vm.expectEmit(true, true, false, true);
-        emit IOracle.OracleResult(REQUEST_ID, proposer, "", false);
+        emit IOracle.OracleResult(REQUEST_ID, sponsor, "", false);
 
         oracle.finalize(REQUEST_ID);
 
@@ -783,7 +783,7 @@ contract SentinelOracleTest is Test {
     // ============================================================
 
     function test_NoCommitments_FeeRefunded() public {
-        uint256 proposerBalBefore = token.balanceOf(proposer);
+        uint256 proposerBalBefore = token.balanceOf(sponsor);
         _postRequest();
 
         // Zero commits resolve as soon as commitDeadline passes, without waiting for revealDeadline.
@@ -792,7 +792,7 @@ contract SentinelOracleTest is Test {
         assertLt(block.number, pending.revealDeadline, "should finalize before the reveal deadline");
 
         oracle.finalize(REQUEST_ID);
-        assertEq(token.balanceOf(proposer), proposerBalBefore);
+        assertEq(token.balanceOf(sponsor), proposerBalBefore);
 
         SentinelOracleRequest.Request memory req = oracle.getRequest(REQUEST_ID);
         assertEq(uint256(req.state), uint256(SentinelOracleRequest.State.TIMED_OUT));
@@ -803,7 +803,7 @@ contract SentinelOracleTest is Test {
     // ============================================================
 
     function test_Conflict_SetsStateFrozen() public {
-        uint256 proposerBalBefore = token.balanceOf(proposer);
+        uint256 proposerBalBefore = token.balanceOf(sponsor);
         _postRequest();
 
         // sentinel1 approves, sentinel2 denies — both sides have revealed votes → conflict
@@ -832,7 +832,7 @@ contract SentinelOracleTest is Test {
         vm.prank(arbitrator);
         oracle.resolveDispute(REQUEST_ID, true, context);
 
-        assertEq(token.balanceOf(proposer), proposerBalBefore, "proposer balance fully restored");
+        assertEq(token.balanceOf(sponsor), proposerBalBefore, "sponsor balance fully restored");
         assertEq(
             token.balanceOf(protocolFundsReceiver),
             receiverBalBefore + BOND_TARGET - REQUEST_FEE,
@@ -840,7 +840,7 @@ contract SentinelOracleTest is Test {
         );
         assertEq(token.balanceOf(arbitrator), 0, "arbitrator itself receives nothing from resolveDispute");
 
-        // Unlike the unanimous-resolution path, the proposer's refund and the protocol funds
+        // Unlike the unanimous-resolution path, the sponsor's refund and the protocol funds
         // receiver's cut are carved out of the losing side's slashed bonds — the original fee is
         // untouched by resolveDispute and still flows to the winning revealer via calcFeeReward,
         // exactly as it would without a dispute. (Sole winner here, so it gets the whole fee.)
@@ -863,7 +863,7 @@ contract SentinelOracleTest is Test {
         oracle.scheduleDaoFeeShare(daoShare);
         vm.roll(block.number + GOVERNANCE_DELAY);
 
-        uint256 proposerBalBefore = token.balanceOf(proposer);
+        uint256 proposerBalBefore = token.balanceOf(sponsor);
         _postRequest();
 
         _commit(sentinel1, true, SALT_1);
@@ -880,10 +880,10 @@ contract SentinelOracleTest is Test {
         vm.prank(arbitrator);
         oracle.resolveDispute(REQUEST_ID, true, "sentinel1's evidence was conclusive");
 
-        // The proposer's arbitration refund stays whole -- the DAO's cut comes only out of the
+        // The sponsor's arbitration refund stays whole -- the DAO's cut comes only out of the
         // winning sentinel's fee-equivalent reward, not this refund.
         assertEq(
-            token.balanceOf(proposer), proposerBalBefore, "proposer balance fully restored, unaffected by daoFeeShare"
+            token.balanceOf(sponsor), proposerBalBefore, "sponsor balance fully restored, unaffected by daoFeeShare"
         );
         assertEq(
             token.balanceOf(protocolFundsReceiver),
@@ -1274,7 +1274,7 @@ contract SentinelOracleTest is Test {
     // ============================================================
 
     function test_NoReveals_BondsAndFeeRefundedInFull() public {
-        uint256 proposerBalBefore = token.balanceOf(proposer);
+        uint256 proposerBalBefore = token.balanceOf(sponsor);
         _postRequest();
 
         // Both commit, but neither ever reveals.
@@ -1295,7 +1295,7 @@ contract SentinelOracleTest is Test {
 
         SentinelOracleRequest.Request memory req = oracle.getRequest(REQUEST_ID);
         assertEq(uint256(req.state), uint256(SentinelOracleRequest.State.TIMED_OUT));
-        assertEq(token.balanceOf(proposer), proposerBalBefore, "proposer fee refunded");
+        assertEq(token.balanceOf(sponsor), proposerBalBefore, "sponsor fee refunded");
 
         // No established side exists, so no misbehavior can be proven against either committer —
         // nothing is slashed to the protocol funds receiver.
@@ -1366,7 +1366,7 @@ contract SentinelOracleTest is Test {
     }
 
     function test_TimeoutArbitration_RefundsFeeAndBondsInFull() public {
-        uint256 proposerBalBefore = token.balanceOf(proposer);
+        uint256 proposerBalBefore = token.balanceOf(sponsor);
         _freezeRequest();
 
         vm.roll(block.number + ARBITRATION_TIMEOUT + 1);
@@ -1377,7 +1377,7 @@ contract SentinelOracleTest is Test {
 
         SentinelOracleRequest.Request memory req = oracle.getRequest(REQUEST_ID);
         assertEq(uint256(req.state), uint256(SentinelOracleRequest.State.TIMED_OUT));
-        assertEq(token.balanceOf(proposer), proposerBalBefore, "proposer fee refunded in full");
+        assertEq(token.balanceOf(sponsor), proposerBalBefore, "sponsor fee refunded in full");
         assertEq(
             token.balanceOf(protocolFundsReceiver),
             receiverBalBefore,

--- a/contracts/test/SimpleOracle.t.sol
+++ b/contracts/test/SimpleOracle.t.sol
@@ -8,19 +8,19 @@ import {SimpleOracle} from "@/SimpleOracle.sol";
 contract SimpleOracleTest is Test {
     SimpleOracle public oracle;
     address public approver;
-    address public requester;
+    address public sponsor;
 
     bytes32 constant REQUEST_ID = keccak256("requestId");
 
     function setUp() public {
         approver = vm.createWallet("approver").addr;
-        requester = vm.createWallet("requester").addr;
+        sponsor = vm.createWallet("sponsor").addr;
         oracle = new SimpleOracle(approver);
     }
 
-    function test_PostRequest_RecordsProposer() public {
-        vm.prank(requester);
-        oracle.postRequest(REQUEST_ID, requester, "");
+    function test_PostRequest_RecordsSponsor() public {
+        vm.prank(sponsor);
+        oracle.postRequest(REQUEST_ID, sponsor, "");
 
         // Verify by successfully approving — would revert with RequestNotPending if not recorded.
         vm.prank(approver);
@@ -28,47 +28,47 @@ contract SimpleOracleTest is Test {
     }
 
     function test_PostRequest_AlreadyPending_Reverts() public {
-        vm.prank(requester);
-        oracle.postRequest(REQUEST_ID, requester, "");
+        vm.prank(sponsor);
+        oracle.postRequest(REQUEST_ID, sponsor, "");
 
         vm.expectRevert(SimpleOracle.RequestAlreadyPending.selector);
-        vm.prank(requester);
-        oracle.postRequest(REQUEST_ID, requester, "");
+        vm.prank(sponsor);
+        oracle.postRequest(REQUEST_ID, sponsor, "");
     }
 
     function test_Approve_EmitsOracleResult_True() public {
-        vm.prank(requester);
-        oracle.postRequest(REQUEST_ID, requester, "");
+        vm.prank(sponsor);
+        oracle.postRequest(REQUEST_ID, sponsor, "");
 
         vm.expectEmit(true, true, false, true);
-        emit IOracle.OracleResult(REQUEST_ID, requester, "", true);
+        emit IOracle.OracleResult(REQUEST_ID, sponsor, "", true);
 
         vm.prank(approver);
         oracle.approve(REQUEST_ID);
     }
 
     function test_Reject_EmitsOracleResult_False() public {
-        vm.prank(requester);
-        oracle.postRequest(REQUEST_ID, requester, "");
+        vm.prank(sponsor);
+        oracle.postRequest(REQUEST_ID, sponsor, "");
 
         vm.expectEmit(true, true, false, true);
-        emit IOracle.OracleResult(REQUEST_ID, requester, "", false);
+        emit IOracle.OracleResult(REQUEST_ID, sponsor, "", false);
 
         vm.prank(approver);
         oracle.reject(REQUEST_ID);
     }
 
     function test_Approve_NotApprover_Reverts() public {
-        vm.prank(requester);
-        oracle.postRequest(REQUEST_ID, requester, "");
+        vm.prank(sponsor);
+        oracle.postRequest(REQUEST_ID, sponsor, "");
 
         vm.expectRevert(SimpleOracle.NotApprover.selector);
         oracle.approve(REQUEST_ID);
     }
 
     function test_Reject_NotApprover_Reverts() public {
-        vm.prank(requester);
-        oracle.postRequest(REQUEST_ID, requester, "");
+        vm.prank(sponsor);
+        oracle.postRequest(REQUEST_ID, sponsor, "");
 
         vm.expectRevert(SimpleOracle.NotApprover.selector);
         oracle.reject(REQUEST_ID);
@@ -87,8 +87,8 @@ contract SimpleOracleTest is Test {
     }
 
     function test_Approve_ClearsRequest() public {
-        vm.prank(requester);
-        oracle.postRequest(REQUEST_ID, requester, "");
+        vm.prank(sponsor);
+        oracle.postRequest(REQUEST_ID, sponsor, "");
 
         vm.prank(approver);
         oracle.approve(REQUEST_ID);
@@ -100,8 +100,8 @@ contract SimpleOracleTest is Test {
     }
 
     function test_Reject_ClearsRequest() public {
-        vm.prank(requester);
-        oracle.postRequest(REQUEST_ID, requester, "");
+        vm.prank(sponsor);
+        oracle.postRequest(REQUEST_ID, sponsor, "");
 
         vm.prank(approver);
         oracle.reject(REQUEST_ID);

--- a/crates/sentinel/src/bindings.rs
+++ b/crates/sentinel/src/bindings.rs
@@ -20,7 +20,7 @@ pub mod oracle {
         contract SentinelOracle {
             event NewRequest(
                 bytes32 indexed requestId,
-                address indexed proposer,
+                address indexed sponsor,
                 uint256 fee,
                 uint256 bondTarget,
                 uint256 commitDeadline,

--- a/crates/sentinel/src/service.rs
+++ b/crates/sentinel/src/service.rs
@@ -892,7 +892,7 @@ mod tests {
         SentinelEvents::Oracle(SentinelOracle::SentinelOracleEvents::NewRequest(
             SentinelOracle::NewRequest {
                 requestId: id,
-                proposer: SAFE,
+                sponsor: SAFE,
                 fee,
                 bondTarget: bond_target,
                 commitDeadline: U256::from(commit_deadline),

--- a/scripts/run_sentinel_integration_test.sh
+++ b/scripts/run_sentinel_integration_test.sh
@@ -101,20 +101,20 @@ ORACLE=$(jq -r '.returns.sentinelOracle.value' "$ROOT/contracts/build/broadcast/
 echo "Sentinel oracle deployed at $ORACLE"
 
 # --- 4. Fund the required accounts ---
-echo "Generating sentinel and proposer accounts..."
+echo "Generating sentinel and sponsor accounts..."
 WALLETS=$(cast wallet new --json --number 3)
 SENTINEL_A_ADDR=$(echo "$WALLETS" | jq -r '.[0].address')
 SENTINEL_A_PK=$(echo "$WALLETS" | jq -r '.[0].private_key')
 SENTINEL_B_ADDR=$(echo "$WALLETS" | jq -r '.[1].address')
 SENTINEL_B_PK=$(echo "$WALLETS" | jq -r '.[1].private_key')
-PROPOSER_ADDR=$(echo "$WALLETS" | jq -r '.[2].address')
-PROPOSER_PK=$(echo "$WALLETS" | jq -r '.[2].private_key')
+SPONSOR_ADDR=$(echo "$WALLETS" | jq -r '.[2].address')
+SPONSOR_PK=$(echo "$WALLETS" | jq -r '.[2].private_key')
 echo "Sentinel A: $SENTINEL_A_ADDR"
 echo "Sentinel B: $SENTINEL_B_ADDR"
-echo "Proposer:   $PROPOSER_ADDR"
+echo "Sponsor:    $SPONSOR_ADDR"
 
 echo "Funding accounts with ETH and the fee token..."
-for addr in "$SENTINEL_A_ADDR" "$SENTINEL_B_ADDR" "$PROPOSER_ADDR"; do
+for addr in "$SENTINEL_A_ADDR" "$SENTINEL_B_ADDR" "$SPONSOR_ADDR"; do
 	cast send --rpc-url "$RPC_URL" --private-key "$DEPLOYER_PK" --value "$FUNDING_ETH" "$addr" >/dev/null
 	cast send --rpc-url "$RPC_URL" --private-key "$DEPLOYER_PK" \
 		"$FEE_TOKEN" "transfer(address,uint256)" "$addr" "$FUNDING_TOKEN" >/dev/null
@@ -124,8 +124,8 @@ echo "Registering both sentinels..."
 cast send --rpc-url "$RPC_URL" --private-key "$DEPLOYER_PK" "$ORACLE" "addSentinel(address)" "$SENTINEL_A_ADDR" >/dev/null
 cast send --rpc-url "$RPC_URL" --private-key "$DEPLOYER_PK" "$ORACLE" "addSentinel(address)" "$SENTINEL_B_ADDR" >/dev/null
 
-echo "Approving the oracle to pull the request fee from the proposer..."
-cast send --rpc-url "$RPC_URL" --private-key "$PROPOSER_PK" \
+echo "Approving the oracle to pull the request fee from the sponsor..."
+cast send --rpc-url "$RPC_URL" --private-key "$SPONSOR_PK" \
 	"$FEE_TOKEN" "approve(address,uint256)" "$ORACLE" "$REQUEST_FEE" >/dev/null
 
 # Balances just before either sentinel commits a bond, to measure the fee/bond
@@ -139,7 +139,7 @@ SENTINEL_A_BALANCE_BEFORE=$(balance_of "$SENTINEL_A_ADDR")
 SENTINEL_B_BALANCE_BEFORE=$(balance_of "$SENTINEL_B_ADDR")
 
 # `Request`'s tuple shape, field-for-field with `SentinelOracleRequest.Request`
-# (`proposer, fee, bondTarget, daoFeeShare, slashAmount, commitDeadline,
+# (`sponsor, fee, bondTarget, daoFeeShare, slashAmount, commitDeadline,
 # revealDeadline, state, committedCount, revealedCount, approveSentinelCount,
 # denySentinelCount`) — every field must be listed or `cast` silently
 # misaligns the ones after the omission.
@@ -205,7 +205,7 @@ env \
 	TX_SAFE=0x1111111111111111111111111111111111111111 \
 	TX_TO=0x2222222222222222222222222222222222222222 \
 	TX_NONCE=0 \
-	forge script --root "$ROOT/contracts" ProposeTransactionScript --rpc-url "$RPC_URL" --private-key "$PROPOSER_PK" --broadcast
+	forge script --root "$ROOT/contracts" ProposeTransactionScript --rpc-url "$RPC_URL" --private-key "$SPONSOR_PK" --broadcast
 
 REQUEST_ID=$(cast logs --rpc-url "$RPC_URL" --json --from-block 0 --address "$ORACLE" \
 	'NewRequest(bytes32,address,uint256,uint256,uint256,uint256)' | jq -r '.[0].topics[1]')
@@ -302,7 +302,7 @@ echo "OK: bonds were returned in full and the request fee was split between the 
 # claim after arbitration regardless of which side it was on, since bond
 # slashing is only partial (INITIAL_SLASHING_MULTIPLIER < BOND_MULTIPLIER).
 echo "Approving the oracle to pull the request fee for the disputed request..."
-cast send --rpc-url "$RPC_URL" --private-key "$PROPOSER_PK" \
+cast send --rpc-url "$RPC_URL" --private-key "$SPONSOR_PK" \
 	"$FEE_TOKEN" "approve(address,uint256)" "$ORACLE" "$REQUEST_FEE" >/dev/null
 
 echo "Proposing a transaction sentinel B's blocklist denies (to trigger a genuine dispute)..."
@@ -313,7 +313,7 @@ env \
 	TX_SAFE=0x1111111111111111111111111111111111111111 \
 	TX_TO="$DISPUTED_TX_TO" \
 	TX_NONCE=1 \
-	forge script --root "$ROOT/contracts" ProposeTransactionScript --rpc-url "$RPC_URL" --private-key "$PROPOSER_PK" --broadcast
+	forge script --root "$ROOT/contracts" ProposeTransactionScript --rpc-url "$RPC_URL" --private-key "$SPONSOR_PK" --broadcast
 
 DISPUTE_REQUEST_ID=$(cast logs --rpc-url "$RPC_URL" --json --from-block 0 --address "$ORACLE" \
 	'NewRequest(bytes32,address,uint256,uint256,uint256,uint256)' | jq -r '.[-1].topics[1]')


### PR DESCRIPTION
To clearly differentiate roles the current proposed is renamed to sponsor, indicating the address paying the fee, and the current consensus variable is renamed to proposer, to indicate the address that can propose requests.

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://docs.safefoundation.org/cla).
