### PR TITLE
[Nonces 5]: Nonce Topup in State Machine

### DIFF
--- a/crates/validator/src/secrets/store.rs
+++ b/crates/validator/src/secrets/store.rs
@@ -371,51 +371,6 @@ impl SecretStore {
         .map_err(Error::from)
     }
 
-    /// Returns the number of unused nonces in `me`'s trees for `group` from
-    /// sequence `(chunk, offset)` onward (inclusive), summed across every
-    /// linked chunk from `chunk` on, plus any not-yet-linked pending chunk.
-    ///
-    /// A single chunk's count is not enough to answer "how many usable
-    /// nonces are left": the group's sequence counter is shared by every
-    /// participant and only ever advances, so once it moves past `chunk`,
-    /// this validator must draw from later chunks regardless of whatever is
-    /// still sitting unused in earlier ones. Summing forward from the given
-    /// position is what actually reflects the remaining usable supply.
-    /// Including the pending (registered but not yet onchain-linked) chunk,
-    /// if any, avoids sampling and registering a needless extra one while a
-    /// top-up is already in flight.
-    pub async fn available_nonce_count(
-        &self,
-        group: B256,
-        me: Address,
-        chunk: u64,
-        offset: u64,
-    ) -> Result<u64, Error> {
-        let chunk = i64::try_from(chunk)?;
-        let offset = i64::try_from(offset)?;
-
-        let count = sqlx::query_scalar::<_, i64>(
-            "SELECT COUNT(*)
-             FROM nonces AS nonce
-             JOIN nonces_chunks AS chunks ON chunks.root = nonce.root
-             WHERE chunks.group_id = ?
-               AND chunks.address = ?
-               AND (
-                   chunks.chunk IS NULL
-                   OR chunks.chunk > ?
-                   OR (chunks.chunk = ? AND nonce.offs >= ?)
-               )",
-        )
-        .bind(key(group))
-        .bind(key(me))
-        .bind(chunk)
-        .bind(chunk)
-        .bind(offset)
-        .fetch_one(&self.pool)
-        .await?;
-        Ok(u64::try_from(count)?)
-    }
-
     /// Deletes the nonce trees of every group other than `groups` (cascading to
     /// their nonces), reconciling the stored nonces with the groups the state
     /// machine still tracks.
@@ -652,70 +607,6 @@ mod tests {
         assert_eq!(count_chunk_nonces(&store, 0).await, 0);
         assert_eq!(count_chunk_nonces(&store, 1).await, 11);
         assert_eq!(count_chunk_nonces(&store, 2).await, 13);
-    }
-
-    #[tokio::test]
-    async fn available_nonce_count_sums_forward_and_includes_pending() {
-        let store = store().await;
-        let root0 = store
-            .register_nonces_chunk(GROUP, ME, nonce_chunk(11))
-            .await
-            .unwrap()
-            .unwrap();
-        store.link_nonces_chunk(GROUP, ME, 0, root0).await.unwrap();
-        let root1 = store
-            .register_nonces_chunk(GROUP, ME, nonce_chunk(13))
-            .await
-            .unwrap()
-            .unwrap();
-        store.link_nonces_chunk(GROUP, ME, 1, root1).await.unwrap();
-
-        // Counting from chunk 0 sums every linked chunk from there on, not
-        // just chunk 0's own count.
-        assert_eq!(
-            store.available_nonce_count(GROUP, ME, 0, 0).await.unwrap(),
-            11 + 13
-        );
-        assert_eq!(
-            store.available_nonce_count(GROUP, ME, 1, 0).await.unwrap(),
-            13
-        );
-        assert_eq!(
-            store.available_nonce_count(GROUP, ME, 2, 0).await.unwrap(),
-            0
-        );
-
-        // An offset into the starting chunk deducts the nonces already
-        // behind it.
-        assert_eq!(
-            store.available_nonce_count(GROUP, ME, 0, 5).await.unwrap(),
-            (11 - 5) + 13
-        );
-
-        // A registered-but-not-yet-linked chunk counts too, regardless of
-        // position, so a top-up in flight is not needlessly duplicated.
-        store
-            .register_nonces_chunk(GROUP, ME, nonce_chunk(7))
-            .await
-            .unwrap()
-            .unwrap();
-        assert_eq!(
-            store.available_nonce_count(GROUP, ME, 0, 0).await.unwrap(),
-            11 + 13 + 7
-        );
-        assert_eq!(
-            store.available_nonce_count(GROUP, ME, 2, 0).await.unwrap(),
-            7
-        );
-
-        // A displaced (orphaned) chunk from a reorg drops out of the running
-        // count entirely: a validator only ever counts forward from its
-        // current position, and the orphan no longer occupies a slot there.
-        store.link_nonces_chunk(GROUP, ME, 1, root0).await.unwrap();
-        assert_eq!(
-            store.available_nonce_count(GROUP, ME, 0, 0).await.unwrap(),
-            11 + 7
-        );
     }
 
     #[tokio::test]

--- a/crates/validator/src/service/effect.rs
+++ b/crates/validator/src/service/effect.rs
@@ -87,14 +87,6 @@ pub enum Effect {
         root: B256,
         offset: u64,
     },
-    /// Check that at least [`NONCE_TOPUP_THRESHOLD`] nonces remain usable for
-    /// `key_share`'s group from `(chunk, offset)` onward, generating and
-    /// registering a fresh chunk if not.
-    TopupNonces {
-        group_id: B256,
-        key_share: Arc<KeyShare>,
-        sequence: u64,
-    },
     /// Reconcile the process-local and persisted secrets with the groups
     /// retained by the state machine, dropping all secret material belonging to
     /// other groups. A key share starts or retains a nonce generator; `None`
@@ -103,10 +95,6 @@ pub enum Effect {
         groups: BTreeMap<B256, Option<Arc<KeyShare>>>,
     },
 }
-
-/// The remaining usable nonce count, per participating group, below which a
-/// fresh nonce chunk is generated and registered.
-const NONCE_TOPUP_THRESHOLD: u64 = 100;
 
 /// The result of performing an [`Effect`], resumed into the state machine.
 #[derive(Debug, Clone, Default)]
@@ -275,25 +263,6 @@ impl Handler {
                     nonces: Box::new(nonces),
                 })
                 .unwrap_or(Resume::Noop)),
-            Effect::TopupNonces {
-                group_id,
-                key_share,
-                sequence,
-            } => {
-                let (chunk, offset) = frost::preprocess::decode_sequence(sequence);
-                let available = self
-                    .secrets
-                    .available_nonce_count(group_id, self.account, chunk, offset)
-                    .await?;
-                if available >= NONCE_TOPUP_THRESHOLD {
-                    return Ok(Resume::Noop);
-                }
-                self.nonce_generator
-                    .lock()
-                    .await
-                    .start(group_id, key_share)?;
-                self.next_nonce_tree(group_id).await
-            }
             Effect::ReconcileGroupSecrets { groups } => {
                 // We only need to keep keygen secrets for groups that are still
                 // in DKG and do not yet have a key share, and nonces (both in

--- a/crates/validator/src/state/keygen.rs
+++ b/crates/validator/src/state/keygen.rs
@@ -1,6 +1,6 @@
 use super::{
-    ConfirmationDeadlines, Epoch, KeyGenConfirmation, KeyGenParticipation, Packet, RolloverState,
-    SigningState, State, Transition,
+    ConfirmationDeadlines, Epoch, KeyGenConfirmation, KeyGenParticipation, NonceState, Packet,
+    RolloverState, SigningState, State, Transition,
 };
 use crate::{
     bindings::{Consensus, Coordinator},
@@ -1167,11 +1167,16 @@ impl Transition {
         // part of the DKG ceremony and key share), register the epoch in our
         // participating epochs map and generate a nonces chunk.
         let commands = if let Some(key_share) = key_share {
+            let mut nonces = NonceState::default();
+            let chunk = nonces.reserve_chunk();
+            debug_assert_eq!(chunk, Some(0));
+
             state.epochs.insert(
                 epoch,
                 Epoch {
                     group,
                     key_share: key_share.clone(),
+                    nonces,
                 },
             );
             vec![Command::Effect(Effect::NonceTree {

--- a/crates/validator/src/state/mod.rs
+++ b/crates/validator/src/state/mod.rs
@@ -60,6 +60,18 @@ struct Epoch {
     group: Group,
     /// This validator's key share.
     key_share: Arc<KeyShare>,
+    /// This validator's canonical nonce-tree assignments for the epoch.
+    nonces: NonceState,
+}
+
+/// Canonical nonce state for one participating epoch.
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
+struct NonceState {
+    /// The next signing sequence expected for the group.
+    next_sequence: u64,
+    /// Canonical nonce roots by sequence chunk. `None` reserves a chunk while
+    /// its locally generated root is waiting to be registered onchain.
+    chunks: BTreeMap<u64, Option<B256>>,
 }
 
 /// The epoch-rollover / DKG state machine. Each active variant carries the
@@ -443,6 +455,7 @@ impl StateTransition<State> for Transition {
                 let (state, rollover_commands) = self.handle_rollover_new_block(state, block);
                 let (state, keygen_timeout_commands) = self.handle_key_gen_timeouts(state, block);
                 let (state, signing_timeout_commands) = self.handle_signing_timeouts(state, block);
+                let (state, nonce_topup_commands) = self.handle_nonce_topup(state);
                 let (state, reconciliation_commands) = self.handle_group_reconciliation(state);
                 (
                     state,
@@ -450,6 +463,7 @@ impl StateTransition<State> for Transition {
                         rollover_commands,
                         keygen_timeout_commands,
                         signing_timeout_commands,
+                        nonce_topup_commands,
                         reconciliation_commands,
                     ]
                     .concat(),

--- a/crates/validator/src/state/preprocess.rs
+++ b/crates/validator/src/state/preprocess.rs
@@ -1,12 +1,19 @@
-use super::{KeyGenConfirmation, KeyGenParticipation, RolloverState, State, Transition};
+use super::{
+    KeyGenConfirmation, KeyGenParticipation, NonceState, RolloverState, State, Transition,
+};
 use crate::{
     bindings::Coordinator,
     consensus::epoch::EpochId,
+    frost::preprocess::{self, SEQUENCE_CHUNK_SIZE},
     service::{Action, Effect},
 };
 use alloy::primitives::B256;
 use safenet_core::state::{Command, Commands};
 use std::collections::BTreeMap;
+
+/// The remaining canonical nonce capacity below which another chunk is
+/// requested.
+const NONCE_TOPUP_THRESHOLD: u64 = 100;
 
 impl Transition {
     /// Publishes this validator's freshly sampled nonce tree commitment once
@@ -35,18 +42,26 @@ impl Transition {
         )
     }
 
-    /// Links a committed nonce tree to its assigned onchain chunk. This can
-    /// happen regardless of the current rollover/signing state. Only this
-    /// validator's own commitment is linked; other participants' commitments
-    /// are for their own local secret stores.
+    /// Links a committed nonce tree to its assigned onchain chunk for the
+    /// current validator. This can happen regardless of the current rollover
+    /// or signing state.
     pub(super) fn handle_preprocess(
         &self,
-        state: State,
+        mut state: State,
         event: &Coordinator::Preprocess,
     ) -> (State, Commands<State, Self>) {
         if event.participant != self.account {
             return (state, Vec::new());
         }
+
+        let Some(epoch) = state
+            .epochs
+            .values_mut()
+            .find(|epoch| epoch.group.id() == event.gid)
+        else {
+            tracing::warn!(group_id = %event.gid, "nonce preprocess event for unknown epoch");
+            return (state, Vec::new());
+        };
 
         tracing::debug!(
             group_id = %event.gid,
@@ -54,12 +69,44 @@ impl Transition {
             root = %event.commitment,
             "linking nonce tree to onchain chunk"
         );
+        epoch.nonces.link(event.chunk, event.commitment);
+
         (
             state,
             vec![Command::Effect(Effect::LinkNonceTree {
                 group_id: event.gid,
                 chunk: event.chunk,
                 root: event.commitment,
+            })],
+        )
+    }
+
+    /// Requests another nonce tree for the active epoch when its canonical
+    /// supply falls below the top-up threshold.
+    pub(super) fn handle_nonce_topup(&self, mut state: State) -> (State, Commands<State, Self>) {
+        let active_epoch = state.active_epoch;
+        let Some(epoch) = state.epochs.get_mut(&active_epoch) else {
+            return (state, Vec::new());
+        };
+
+        if epoch.nonces.available() >= NONCE_TOPUP_THRESHOLD {
+            return (state, Vec::new());
+        }
+
+        let group_id = epoch.group.id();
+        let Some(chunk) = epoch.nonces.reserve_chunk() else {
+            tracing::warn!(?active_epoch, %group_id, "nonce chunk sequence exhausted; cannot top up");
+            return (state, Vec::new());
+        };
+
+        tracing::debug!(?active_epoch, %group_id, chunk, "requesting nonce tree top-up");
+        let key_share = epoch.key_share.clone();
+
+        (
+            state,
+            vec![Command::Effect(Effect::NonceTree {
+                group_id,
+                key_share,
             })],
         )
     }
@@ -128,5 +175,56 @@ impl Transition {
             state,
             vec![Command::Effect(Effect::ReconcileGroupSecrets { groups })],
         )
+    }
+}
+
+impl NonceState {
+    /// Advances the observed sequence and forgets past roots for nonce chunks
+    /// that can no longer used for signing.
+    pub(super) fn observe(&mut self, sequence: u64) {
+        self.next_sequence = sequence.saturating_add(1);
+        let (chunk, _) = preprocess::decode_sequence(self.next_sequence);
+        self.chunks = self.chunks.split_off(&chunk);
+    }
+
+    /// Reserves the next chunk, marking it as pending in the nonce state.
+    ///
+    /// Returns `None` if all nonce chunks have been exhausted.
+    pub(super) fn reserve_chunk(&mut self) -> Option<u64> {
+        let chunk = self.expected_chunk()?;
+        self.chunks.insert(chunk, None);
+        Some(chunk)
+    }
+
+    /// Records an onchain assignment.
+    pub(super) fn link(&mut self, chunk: u64, root: B256) {
+        self.chunks.insert(chunk, Some(root));
+    }
+
+    /// Returns the chunk the onchain contract is expected to assign to the
+    /// next commitment.
+    ///
+    /// Returns `None` in case we've reached the very last chunk.
+    fn expected_chunk(&self) -> Option<u64> {
+        let (chunk, _) = preprocess::decode_sequence(self.next_sequence);
+        match self.chunks.last_key_value() {
+            Some((last, _)) => last.checked_add(1).map(|next| next.max(chunk)),
+            None => Some(chunk),
+        }
+    }
+
+    /// Counts canonical and pending nonce capacity from `next_sequence`.
+    fn available(&self) -> u64 {
+        let (chunk, offset) = preprocess::decode_sequence(self.next_sequence);
+        self.chunks
+            .range(chunk..)
+            .map(|(key, _)| {
+                if *key == chunk {
+                    SEQUENCE_CHUNK_SIZE.saturating_sub(offset)
+                } else {
+                    SEQUENCE_CHUNK_SIZE
+                }
+            })
+            .sum()
     }
 }

--- a/crates/validator/src/state/sign.rs
+++ b/crates/validator/src/state/sign.rs
@@ -27,23 +27,15 @@ impl Transition {
     ) -> (State, Commands<State, Self>) {
         let mut commands = Vec::new();
 
-        // Unconditionally top up the group's nonce stock, regardless of
-        // whether this validator is one of the selected signers: the
-        // sequence is shared by every participant and only ever advances, so
-        // it can run past this validator's local nonces even for signing
-        // ceremonies it was never asked to take part in. `epochs` is small
-        // (a handful of entries at most in regular operation), so a linear
-        // scan for the matching group is fine.
+        // Unconditionally observe the group's sequence, regardless of whether
+        // this validator is one of the selected signers. The sequence is shared
+        // by every participant and advances for every signing ceremony.
         if let Some(epoch) = state
             .epochs
-            .values()
+            .values_mut()
             .find(|epoch| epoch.group.id() == event.gid)
         {
-            commands.push(Command::Effect(Effect::TopupNonces {
-                group_id: event.gid,
-                key_share: epoch.key_share.clone(),
-                sequence: event.sequence,
-            }));
+            epoch.nonces.observe(event.sequence);
         }
 
         match state.signing.remove(&event.message) {

--- a/scripts/run_validator_integration_test.sh
+++ b/scripts/run_validator_integration_test.sh
@@ -249,7 +249,7 @@ while [ "$SECONDS" -lt "$DEADLINE" ]; do
             exit 1
         fi
     done
-    sleep 2
+    sleep "$BLOCK_TIME"
 done
 
 EXIT_MESSAGE="TIMEOUT: genesis confirmations: $GENESIS_CONFIRMATIONS; epoch 1 confirmations: $EPOCH_ONE_CONFIRMATIONS; staged: $STAGED; rolled over: $ROLLED_OVER; transaction proposed: $TRANSACTION_PROPOSED; transaction attested: $TRANSACTION_ATTESTED." >&2


### PR DESCRIPTION
### Context and Motivation

This PR moves the decision to topup nonces to the state machine. This is done as part of a larger change to track nonces in the state machine (since nonce chunk linking must be reorg aware). Note that nonce linking still happens at the storage level, in order to keep this PR shorter and more reviewable.

### Decisions and Tradeoffs

Instead of running every signing request, we decide if a topup is needed once per block.

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://docs.safefoundation.org/cla).
